### PR TITLE
ENH: added ability to specify script inline

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -195,7 +195,15 @@ def build(m, get_src=True, pypi=False):
         windows.build(m)
     else:
         env = environ.get_dict(m)
-        cmd = ['/bin/bash', '-x', '-e', join(m.path, 'build.sh')]
+        build_file = join(m.path, 'build.sh')
+        script = m.get_value('build/script', None)
+        if script:
+            if isinstance(script, list): script = '\n'.join(script)
+            with open(build_file, 'w') as bf:
+                bf.write(script)
+            os.chmod(build_file, 0o766)
+        cmd = ['/bin/bash', '-x', '-e', build_file]
+
         _check_call(cmd, env=env, cwd=source.get_dir())
 
     create_post_scripts(m)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -110,7 +110,7 @@ FIELDS = {
                'patches'],
     'build': ['number', 'string', 'entry_points', 'osx_is_app', 'rm_py',
               'features', 'track_features', 'preserve_egg_dir',
-              'no_softlink'],
+              'no_softlink', 'script'],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts'],
     'test': ['requires', 'commands', 'files', 'imports'],


### PR DESCRIPTION
Added build/script field to meta.yaml

For simple python builds it is superfluous to create a one line build.sh file. If the build/script field is given, that will be used instead of build.sh
eg:

```
... snip ...
build:
  script: python setup.py install
```
