### PR TITLE
* add ability to export multi-processor-build flags

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,4 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * add ability to export multi-processor-build flags

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -54,7 +54,9 @@ def get_dict(m=None):
 
     elif sys.platform.startswith('linux'):      # -------- Linux
         d['LD_RUN_PATH'] = build_prefix + '/lib'
-
+        if cc.build_makeflags:
+            d['MAKEFLAGS'] = cc.build_makeflags
+            
     if m:
         d['PKG_NAME'] = m.name()
         d['PKG_VERSION'] = m.version()

--- a/condarc
+++ b/condarc
@@ -1,0 +1,68 @@
+# This is a sample .condarc file
+
+# channel locations. These override conda defaults, i.e., conda will
+# search *only* the channels listed here, in the order given. Use "defaults" to
+# automatically include all default channels. Non-url channels will be
+# interpreted as binstar usernames (this can be changed by modifying the
+# channel_alias key; see below).
+channels:
+  - binstar_username
+  - http://repo.continuum.io/pkgs/free
+  - http://repo.continuum.io/pkgs/pro
+  - http://some.custom/channel
+  - defaults
+
+# Alias to use for non-url channels used with the -c flag. Default is https://conda.binstar.org/
+
+channel_alias: https://your.repo/
+
+# Proxy settings: http://[username]:[password]@[server]:[port]
+proxy_servers:
+    http: http://user:pass@corp.com:8080
+    https: https://user:pass@corp.com:8080
+
+# directory in which conda root is located (used by `conda init`)
+root_dir: ~/.local/conda_root
+
+# directories in which environments are located
+envs_dirs:
+  - ~/my-envs
+  - /opt/anaconda/envs
+
+# implies always using the --yes option whenever asked to proceed
+always_yes: True
+
+# disallow soft-linking (default is allow_softlinks: True,
+#                        i.e. soft-link when possible)
+allow_softlinks: False
+
+# change ps1 when using activate (default True)
+changeps1: False
+
+# use pip when installing and listing packages (default True)
+use_pip: False
+
+# binstar.org upload (not defined here means ask)
+binstar_upload: True
+# do not upload binstar packages to the public channel (default True)
+binstar_personal: True
+
+# when creating new environments add these packages by default
+create_default_packages:
+  - python
+  - pip
+
+# disallowed specification names
+disallow:
+  - anaconda
+
+# enable certain features to be tracked by default
+track_features:
+  - mkl
+
+
+# --- only conda-build related
+
+# MAKEFLAGS: e.g. multi-core enviroment option for build.sh
+#     gnu make multi-core compile option: -j [N], --jobs[=N]  
+build_makeflags: "-j 4"


### PR DESCRIPTION
https://github.com/conda/conda-build/issues/9
adds the ability to export multi-processor-build flags for simple configurable increased build speed without the need of changing the recipes.

it needs a simple adjustment in conda too



<!---
@huboard:{"order":2.3321807920314184e-35,"custom_state":""}
-->
