### PR TITLE
* use the more advanced patchelf instead of chrpath

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,5 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * use the more advanced patchelf instead of chrpath
+    http://nixos.org/patchelf.html

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -113,14 +113,13 @@ def check_external():
     import conda_build.external as external
 
     if sys.platform.startswith('linux'):
-        chrpath = external.find_executable('chrpath')
-        if chrpath is None:
+        patchelf = external.find_executable('patchelf')
+        if patchelf is None:
             sys.exit("""\
 Error:
-    Did not find 'chrpath' in: %s
-    'chrpath' is necessary for building conda packages on Linux with
-    relocatable ELF libraries.  You can install chrpath using apt-get,
-    yum or conda.
+    Did not find 'patchelf' in: %s
+    'patchelf' is necessary for building conda packages on Linux with
+    relocatable ELF libraries.  You can install patchelf using conda.
 """ % (os.pathsep.join(external.dir_paths)))
 
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -161,8 +161,10 @@ def mk_relative(f):
     path = join(build_prefix, f)
     if sys.platform.startswith('linux') and is_obj(path):
         rpath = '$ORIGIN/' + utils.rel_lib(f)
-        chrpath = external.find_executable('chrpath')
-        call([chrpath, '-r', rpath, path])
+        patchelf = external.find_executable('patchelf');
+        print('patchelf: file: %s\n    setting rpath to: %s' % 
+                                                        (path, rpath))
+        call([patchelf, '--set-rpath', rpath, path])
 
     if sys.platform == 'darwin' and is_obj(path):
         mk_relative_osx(path)


### PR DESCRIPTION
- use the more advanced patchelf instead of chrpath
  http://nixos.org/patchelf.html

patchelf has the ability to set a new rpath even if there was none before which chrpath seems to miss.

if a package is compiled using conda-build an initial rpath is set because of the LD_RUN_PATH: and so chrpath will work: except someone unset it in the build.sh.

patchelf advantage is: example to convert an otherwise compiled package to be used within conda.
e.g.: use a pre-compiled package and just extract in the build.sh to PREFIX.  if the original precompiled package had no rpath set: chrpath will fail but patchelf will do the job as designed.

This is a great plus in my opinion.

P

PS: the argument that it is not so widely used and available is not a real one: simply provide one so that it can be installed with conda.

<!---
@huboard:{"order":1.1660903960157092e-35,"custom_state":""}
-->
