### PR TITLE
* keep build folder even with tests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,4 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * keep build folder even with tests

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -239,7 +239,6 @@ def test(m):
         return
 
     print("TEST START:", m.dist())
-    rm_rf(prefix)
     rm_rf(config.test_prefix)
     specs = ['%s %s %s' % (m.name(), m.version(), m.build_id()),
              # as the tests are run by python, we need to specify it


### PR DESCRIPTION
normally the `_build` folder is kept which I find useful to track problems

but if the meta.yaml file defines a test it is deleted.

are there any good reason for this or could we make it consistent and keep it also in this case?

P
