### PR TITLE
* add ability to disable build make relative path

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,4 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * add ability to disable build make relative path

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -54,7 +54,8 @@ def get_dict(m=None):
 
     elif sys.platform.startswith('linux'):      # -------- Linux
         d['LD_RUN_PATH'] = build_prefix + '/lib'
-
+        d['BUILD_NO_RPATH'] = 'y' if cc.build_no_rpath else 'n'
+            
     if m:
         d['PKG_NAME'] = m.name()
         d['PKG_VERSION'] = m.version()

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -8,6 +8,8 @@ from glob import glob
 from subprocess import call, check_call
 from os.path import basename, join, splitext, isdir, isfile
 
+from conda.config import build_no_rpath
+
 from conda_build.config import build_prefix, build_python, PY3K
 from conda_build import external
 from conda_build import environ
@@ -158,14 +160,15 @@ def mk_relative(f):
     if f.startswith('bin/'):
         fix_shebang(f)
 
-    path = join(build_prefix, f)
-    if sys.platform.startswith('linux') and is_obj(path):
-        rpath = '$ORIGIN/' + utils.rel_lib(f)
-        chrpath = external.find_executable('chrpath')
-        call([chrpath, '-r', rpath, path])
+    if build_no_rpath == False:
+        path = join(build_prefix, f)
+        if sys.platform.startswith('linux') and is_obj(path):
+            rpath = '$ORIGIN/' + utils.rel_lib(f)
+            chrpath = external.find_executable('chrpath')
+            call([chrpath, '-r', rpath, path])
 
-    if sys.platform == 'darwin' and is_obj(path):
-        mk_relative_osx(path)
+        if sys.platform == 'darwin' and is_obj(path):
+            mk_relative_osx(path)
 
 
 def fix_permissions(files):

--- a/condarc
+++ b/condarc
@@ -1,0 +1,68 @@
+# This is a sample .condarc file
+
+# channel locations. These override conda defaults, i.e., conda will
+# search *only* the channels listed here, in the order given. Use "defaults" to
+# automatically include all default channels. Non-url channels will be
+# interpreted as binstar usernames (this can be changed by modifying the
+# channel_alias key; see below).
+channels:
+  - binstar_username
+  - http://repo.continuum.io/pkgs/free
+  - http://repo.continuum.io/pkgs/pro
+  - http://some.custom/channel
+  - defaults
+
+# Alias to use for non-url channels used with the -c flag. Default is https://conda.binstar.org/
+
+channel_alias: https://your.repo/
+
+# Proxy settings: http://[username]:[password]@[server]:[port]
+proxy_servers:
+    http: http://user:pass@corp.com:8080
+    https: https://user:pass@corp.com:8080
+
+# directory in which conda root is located (used by `conda init`)
+root_dir: ~/.local/conda_root
+
+# directories in which environments are located
+envs_dirs:
+  - ~/my-envs
+  - /opt/anaconda/envs
+
+# implies always using the --yes option whenever asked to proceed
+always_yes: True
+
+# disallow soft-linking (default is allow_softlinks: True,
+#                        i.e. soft-link when possible)
+allow_softlinks: False
+
+# change ps1 when using activate (default True)
+changeps1: False
+
+# use pip when installing and listing packages (default True)
+use_pip: False
+
+# binstar.org upload (not defined here means ask)
+binstar_upload: True
+# do not upload binstar packages to the public channel (default True)
+binstar_personal: True
+
+# when creating new environments add these packages by default
+create_default_packages:
+  - python
+  - pip
+
+# disallowed specification names
+disallow:
+  - anaconda
+
+# enable certain features to be tracked by default
+track_features:
+  - mkl
+
+
+# --- only conda-build related
+
+# this chould be set to False and only in special cases set to if True
+#   if True: the automatic post: mk_relative: rpath is skipped  
+build_no_rpath: False

--- a/condarc
+++ b/condarc
@@ -63,6 +63,6 @@ track_features:
 
 # --- only conda-build related
 
-# this chould be set to False and only in special cases set to if True
+# this chould be set to False and only in special cases set to True
 #   if True: the automatic post: mk_relative: rpath is skipped  
 build_no_rpath: False


### PR DESCRIPTION
https://github.com/conda/conda-build/issues/14




sometimes a package builder might want to set no rpath or a own one for internal usage.

it would be nice if one could have an option to disable the mk_relative rpath part.

build example something like
```
#CHECK: BUILD_NO_RPATH
if [ "${BUILD_NO_RPATH}" != "y" ]; then
    echo 'this recipes needs conda config: build_no_rpath: True'
    exit 1
fi

unset LD_RUN_PATH
./bootstrap.sh
LDFLAGS="-Wl,-rpath,${PREFIX}/usr" \
./configure --prefix=${PREFIX}
make
make install
```



<!---
@huboard:{"order":5.830451980078546e-36,"custom_state":""}
-->
