### PR TITLE
* add ability to export autoremove .la files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,4 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * add ability to export autoremove .la files

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -23,7 +23,7 @@ from conda_build import source
 from conda_build import tarcheck
 from conda_build.scripts import create_entry_points, bin_dirname
 from conda_build.post import (post_process, post_build, is_obj,
-                                fix_permissions)
+                                remove_la_files, fix_permissions)
 from conda_build.utils import rm_rf, _check_call
 from conda_build.index import update_index
 from conda_build.create_test import create_files
@@ -208,7 +208,8 @@ def build(m, get_src=True):
 
     assert not exists(info_dir)
     files2 = prefix_files()
-
+    remove_la_files(files2)
+    files2 = prefix_files()
     post_build(sorted(files2 - files1))
     create_info_files(m, sorted(files2 - files1))
     files3 = prefix_files()

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -8,6 +8,8 @@ from glob import glob
 from subprocess import call, check_call
 from os.path import basename, join, splitext, isdir, isfile
 
+from conda.config import build_remove_la_files
+
 from conda_build.config import build_prefix, build_python, PY3K
 from conda_build import external
 from conda_build import environ
@@ -168,6 +170,16 @@ def mk_relative(f):
         mk_relative_osx(path)
 
 
+def remove_la_files(files):
+    if build_remove_la_files:
+        if sys.platform.startswith('linux'):
+            for f in files:
+                if f.endswith(".la"):
+                    path = join(build_prefix, f)
+                    print('remove_la_files: file: %s' % path)
+                    os.remove(path)
+                    
+                    
 def fix_permissions(files):
     for root, dirs, unused_files in os.walk(build_prefix):
         for dn in dirs:

--- a/condarc
+++ b/condarc
@@ -1,0 +1,67 @@
+# This is a sample .condarc file
+
+# channel locations. These override conda defaults, i.e., conda will
+# search *only* the channels listed here, in the order given. Use "defaults" to
+# automatically include all default channels. Non-url channels will be
+# interpreted as binstar usernames (this can be changed by modifying the
+# channel_alias key; see below).
+channels:
+  - binstar_username
+  - http://repo.continuum.io/pkgs/free
+  - http://repo.continuum.io/pkgs/pro
+  - http://some.custom/channel
+  - defaults
+
+# Alias to use for non-url channels used with the -c flag. Default is https://conda.binstar.org/
+
+channel_alias: https://your.repo/
+
+# Proxy settings: http://[username]:[password]@[server]:[port]
+proxy_servers:
+    http: http://user:pass@corp.com:8080
+    https: https://user:pass@corp.com:8080
+
+# directory in which conda root is located (used by `conda init`)
+root_dir: ~/.local/conda_root
+
+# directories in which environments are located
+envs_dirs:
+  - ~/my-envs
+  - /opt/anaconda/envs
+
+# implies always using the --yes option whenever asked to proceed
+always_yes: True
+
+# disallow soft-linking (default is allow_softlinks: True,
+#                        i.e. soft-link when possible)
+allow_softlinks: False
+
+# change ps1 when using activate (default True)
+changeps1: False
+
+# use pip when installing and listing packages (default True)
+use_pip: False
+
+# binstar.org upload (not defined here means ask)
+binstar_upload: True
+# do not upload binstar packages to the public channel (default True)
+binstar_personal: True
+
+# when creating new environments add these packages by default
+create_default_packages:
+  - python
+  - pip
+
+# disallowed specification names
+disallow:
+  - anaconda
+
+# enable certain features to be tracked by default
+track_features:
+  - mkl
+
+
+# --- only conda-build related
+
+#   if True: new .la files will be removed  before the conda package is done
+build_remove_la_files: True


### PR DESCRIPTION
https://github.com/conda/conda-build/issues/16

auto-remove linux .la files

if one builds more apps **within the conda framework** like gmp, mpfr, gcc, glibc and the whole essential development apps one might run into a number of issues
one of them might be: .la

example of conda build gmp .la

libgmp.la

```
...
...

# Directory that this library needs to be installed in:
libdir='/opt/anaconda1anaconda2anaconda3/lib'
```

one can read more for instance here: http://www.metastatic.org/text/libtool.html

to avoid removing them individually I did a small function in conda-build

<!---
@huboard:{"order":2.915225990039273e-36,"custom_state":""}
-->
