### PR TITLE
* add ability to install into a separate clean installdir instead of _build PREFIX

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,8 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * add ability to install into a separate clean installdir instead of
+    _build PREFIX
+    e.g. usage: ./configure --prefix=${INSTALLDIR}
+    for python apps:
+    $PYTHON setup.py install --prefix=./ --root=${INSTALLDIR} || exit 1

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -17,6 +17,7 @@ else:
     croot = abspath(expanduser('~/conda-bld'))
 
 build_prefix = join(cc.envs_dirs[0], '_build')
+build_installdir = join(build_prefix, '0_installdir')
 test_prefix = join(cc.envs_dirs[0], '_test')
 
 def _get_python(prefix):

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -6,7 +6,8 @@ from os.path import join
 
 import conda.config as cc
 
-from conda_build.config import CONDA_PY, PY3K, build_prefix, build_python
+from conda_build.config import (CONDA_PY, PY3K, build_prefix, 
+                                      build_installdir, build_python)
 from conda_build import source
 
 
@@ -20,6 +21,7 @@ def get_dict(m=None):
     d = {'CONDA_BUILD': '1'}
     d['ARCH'] = str(cc.bits)
     d['PREFIX'] = build_prefix
+    d['INSTALLDIR'] = build_installdir
     d['PYTHON'] = build_python
     d['PY3K'] = str(PY3K)
     d['STDLIB_DIR'] = stdlib_dir

--- a/conda_build/scripts.py
+++ b/conda_build/scripts.py
@@ -5,7 +5,7 @@ import os
 import sys
 from os.path import isdir, join
 
-from conda_build.config import build_prefix, build_python
+from conda_build.config import build_installdir, build_python
 
 
 BAT_PROXY = """\
@@ -53,7 +53,7 @@ def create_entry_point(path, module, func):
 def create_entry_points(items):
     if not items:
         return
-    bin_dir = join(build_prefix, bin_dirname)
+    bin_dir = join(build_installdir, bin_dirname)
     if not isdir(bin_dir):
         os.mkdir(bin_dir)
     for cmd, module, func in iter_entry_points(items):


### PR DESCRIPTION
  * add ability to install into a separate clean installdir instead of
    _build PREFIX where all the build required files are located.

as mentioned some times ago if one compile a package which requires itself (e.g. make, gcc, glibc, ect..) one ends up with an empty r nearly empty final conda package with only the info folder.

This is also understandable as files are only selected on a diff from the _build PREFIX folder.

In my opinion there are 3 options:
- leave it as it is and say that packages like make, gcc, glibc ect are not really the focus
- a better solution but not really fine: do a diff with time stamp check: so if a file gets installed into PREFIX it can still be included in the final conda pkg
- use a separate install folder: which I propose as a subfolder of PREFIX 

<i>e.g. usage: </i>
```
./configure --prefix=${INSTALLDIR}
make
make install
```
<i>or: </i>
```
/configure --prefix=whatever
make
make DESTDIR=${INSTALLDIR} install
```

<i>e.g. usage for python apps: </i>
```
    $PYTHON setup.py install --prefix=./ --root=${INSTALLDIR} || exit 1
```




<!---
@huboard:{"order":1.4576129950196365e-36,"custom_state":""}
-->
