### PR TITLE
* export PKG Build Number

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,3 +3,4 @@
   * initial release
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
+  * export PKG Build Number

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -58,7 +58,9 @@ def get_dict(m=None):
     if m:
         d['PKG_NAME'] = m.name()
         d['PKG_VERSION'] = m.version()
+        d['PKG_BUILDNUM'] = str(m.build_number())
         d['RECIPE_DIR'] = m.path
+        
 
     return d
 


### PR DESCRIPTION
- export PKG Build Number

PKG_NAME, PKG_VERSION are already exported: added `PKG_BUILDNUM` cause I use it sometimes in the build.sh
