### PR TITLE
* add ability to find recipes in conda-recipes subfolders:

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,3 +4,5 @@
   * includes conda-build, conda-convert, conda-index, conda-skeleton
   * depends on new conda version 3
   * add license to info/index.json object
+  * add ability to find recipes in conda-recipes subfolders: 
+    with pre-check for ambiguities

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -124,6 +124,35 @@ Error:
 """ % (os.pathsep.join(external.dir_paths)))
 
 
+def check_conda_recipes(args):
+    import os
+    import tempfile
+    from os.path import abspath, isdir, isfile, join
+    main_recipes_dir = join(config.root_dir, 'conda-recipes')
+    all_recipies = {}
+    for root, dirs, files in os.walk(main_recipes_dir):
+        for any_dir in dirs:
+            any_dir_path = os.path.join(root, any_dir)
+            if os.path.isfile(os.path.join(any_dir_path, "meta.yaml")):
+                if any_dir not in all_recipies:
+                    all_recipies[any_dir] = [any_dir_path]
+                else:
+                    all_recipies[any_dir].append(any_dir_path)
+    # Check: ambiguities
+    for arg in args.recipe:
+        if not isfile(arg) and not isdir(abspath(arg)):
+            if arg not in all_recipies:
+                sys.exit("Error: did not find any recipes for: "
+                "<%s>: Recipes Root Dir: "
+                "<%s> " % (arg, main_recipes_dir))
+            elif len(all_recipies[arg]) > 1:
+                print('\nMultiple recipes with same name: <%s>' % arg)
+                for xrecipe in all_recipies[arg]:
+                    print('    ', xrecipe)
+                sys.exit('Ambiguities: specify full recipe path')
+    return all_recipies
+    
+    
 def execute(args, parser):
     import sys
     import shutil
@@ -140,6 +169,7 @@ def execute(args, parser):
     check_external()
 
     with Locked(croot):
+        all_recipies = check_conda_recipes(args)
         for arg in args.recipe:
             if isfile(arg):
                 if arg.endswith(('.tar', '.tar.gz', '.tgz', '.tar.bz2')):
@@ -156,10 +186,7 @@ def execute(args, parser):
                 need_cleanup = False
 
             if not isdir(recipe_dir):
-                # See if it's a spec and the directory is in conda-recipes
-                recipe_dir = join(config.root_dir, 'conda-recipes', arg)
-                if not isdir(recipe_dir):
-                    sys.exit("Error: no such directory: %s" % recipe_dir)
+                recipe_dir = abspath(all_recipies[arg][0])
 
             m = MetaData(recipe_dir)
             binstar_upload = False


### PR DESCRIPTION
- add ability to find recipes in anaconda_dir/conda-recipes subfolders: 
  with pre-check for ambiguities

I have put it in a separate function so that: main_build.py execute has not to be much changed

P

_output in case of ambiguities_

```
workerm@notebookpc:~/anaconda/bin$ ./conda-build appdirs 12_xtools-glibc

Multiple recipes with same name: <appdirs>
     /home/workerm/anaconda/conda-recipes/appdirs
     /home/workerm/anaconda/conda-recipes/Untitled Folder/appdirs
Ambiguities: specify full recipe path
workerm@notebookpc:~/anaconda/bin$ 

```
