### PR TITLE
update MACOSX_DEPLOYMENT_TARGET to 10.6

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -53,7 +53,7 @@ def get_dict(m=None, prefix=build_prefix):
         d['CFLAGS'] = '-arch %(OSX_ARCH)s' % d
         d['CXXFLAGS'] = d['CFLAGS']
         d['LDFLAGS'] = d['CFLAGS']
-        d['MACOSX_DEPLOYMENT_TARGET'] = '10.5'
+        d['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
 
     elif sys.platform.startswith('linux'):      # -------- Linux
         d['LD_RUN_PATH'] = prefix + '/lib'


### PR DESCRIPTION
10.5 can cause build problems, as the SDK is rarely present.

<!---
@huboard:{"order":4.4482818451526993e-41,"custom_state":""}
-->
