### PR TITLE
ENH: Added 'build_dest' option to conda rc.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -31,7 +31,8 @@ from conda_build.create_test import create_files, create_shell_files, create_py_
 
 prefix = config.build_prefix
 info_dir = join(prefix, 'info')
-bldpkgs_dir = os.path.expanduser(cc.rc.get('build_dest', join(config.croot, cc.subdir)))
+
+bldpkgs_dir = os.path.expanduser(cc.rc.get('conda-build', {}).get('build_dest', join(config.croot, cc.subdir)))
 broken_dir = join(config.croot, "broken")
 
 


### PR DESCRIPTION
`build_dest` must be a directory, where conda will place all build products.

Example condarc:

``` yaml
#~/.condarc
build_dest: ~/.conda-builds
```

```
$conda build --output 
/home/sean/.conda-builds
```

This is used to help binstar build.

cc @ilanschnell @asmeurer 
