### PR TITLE
Switch to from chrpath to patchelf on Linux (just like #11)

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -113,13 +113,13 @@ def check_external():
     import conda_build.external as external
 
     if sys.platform.startswith('linux'):
-        chrpath = external.find_executable('chrpath')
-        if chrpath is None:
+        patchelf = external.find_executable('patchelf')
+        if patchelf is None:
             sys.exit("""\
 Error:
-    Did not find 'chrpath' in: %s
-    'chrpath' is necessary for building conda packages on Linux with
-    relocatable ELF libraries.  You can install chrpath using apt-get,
+    Did not find 'patchelf' in: %s
+    'patchelf' is necessary for building conda packages on Linux with
+    relocatable ELF libraries.  You can install patchelf using apt-get,
     yum or conda.
 """ % (os.pathsep.join(external.dir_paths)))
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -161,8 +161,10 @@ def mk_relative(f):
     path = join(build_prefix, f)
     if sys.platform.startswith('linux') and is_obj(path):
         rpath = '$ORIGIN/' + utils.rel_lib(f)
-        chrpath = external.find_executable('chrpath')
-        call([chrpath, '-r', rpath, path])
+        patchelf = external.find_executable('patchelf')
+        print('patchelf: file: %s\n    setting rpath to: %s' % 
+              (path, rpath))
+        call([patchelf, '--set-rpath', rpath, path])
 
     if sys.platform == 'darwin' and is_obj(path):
         mk_relative_osx(path)


### PR DESCRIPTION
This is a do-over of #11 since @peter1000 deleted his original fork.

The main reason I'm doing this is that I can't successfully build a Perl Linux package without this switch. (See conda/conda-recipes#91).

`patchelf` doesn't suffer from the same limitation as `chrpath` that the `rpath` length can't increase when you're changing it. 

@ilanschnell, there is a `patchelf` recipe from @tpn in the conda-recipes repository already, which should probably be added to Anaconda if this PR gets merged. 
