### PR TITLE
Added current directory to exec

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -24,12 +24,16 @@ def load_setuptools():
             _setuptools_data.update(kw)
 
         import setuptools
+        #Add current directory to path
+        import sys
+        sys.path.append('.')
+
         #Patch setuptools
         setuptools_setup = setuptools.setup
         setuptools.setup = setup
         exec(open('setup.py', encoding='utf-8').read())
         setuptools.setup = setuptools_setup
-
+	del sys.path[-1]
     return _setuptools_data
 
 def load_npm():


### PR DESCRIPTION
I found the bug that prevented me from using conda build with jinja and setuptools.

conda.yaml
{% extends "setuptools.yaml" %}

The jinja_context.py does not include the current path before executing "exec"

The problem with this is that you cannot import custom commands from your own distribution in setup.py.
