### PR TITLE
Added selectors and environment to jinja context

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -12,6 +12,7 @@ from io import open
 
 from conda.compat import PY3
 from conda_build import environ
+from .environ import get_dict as get_environ
 
 _setuptools_data = None
 
@@ -44,7 +45,10 @@ def load_npm():
 
 def context_processor():
     ctx = environ.get_dict()
+    environ = dict(os.environ)
+    environ.update(get_environ())
+
     ctx.update(load_setuptools=load_setuptools,
                load_npm=load_npm,
-               environ=os.environ)
+               environ=environ)
     return ctx

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -164,6 +164,7 @@ def get_contents(meta_path):
                ]
     env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders))
     env.globals.update(context_processor())
+    env.globals.update(ns_cfg())
 
     template = env.get_or_select_template(filename)
 


### PR DESCRIPTION
One can now conceivably do selection with jinja:

eg:

Selector:

``` yaml
source:
  fn: pyside-qt4.8+1.2.1.tar.bz2 [unix]
  md5: 34b05faa7cc44d3c24d5ccadd894bd3c      [unix]
  url: http://download.qt-project.org/official_releases/pyside/pyside-qt4.8+1.2.1.tar.bz2
  fn: PySide-1.1.2qt474.win32-py2.7.exe      [win32 and py27]
```

Jinja Selector:

``` jinja
source:
  {% if unix %}
  fn: pyside-qt4.8+1.2.1.tar.bz2
  md5: 34b05faa7cc44d3c24d5ccadd894bd3c
  {% elif win32 and py27 %}
  fn: PySide-1.1.2qt474.win32-py2.7.exe
  {% endif %}
  url: http://download.qt-project.org/official_releases/pyside/pyside-qt4.8+1.2.1.tar.bz2
```
