### PR TITLE
post.py fix_shebang() dies on symlinks

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -36,6 +36,8 @@ def fix_shebang(f, osx_is_app=False):
     path = join(build_prefix, f)
     if is_obj(path):
         return
+    elif os.path.islink(path):
+        return
     with open(path, encoding=locale.getpreferredencoding()) as fi:
         try:
             data = fi.read()


### PR DESCRIPTION
I am working with a package that makes symlinks from ./bin to ./libexec.  During packaging, conda-build dies when it hits these symlinks because it is trying to open() the symlinks during fix_shebang().  It seems that the expected behavior would be to skip symlinks.  Pull request coming with suggested fix.
