### PR TITLE
Use tests_require to fill in test requirements in the setuptools template

### DIFF
--- a/conda_build/templates/setuptools.yaml
+++ b/conda_build/templates/setuptools.yaml
@@ -37,6 +37,10 @@ about:
 {%- endblock %}
 {% block test -%}
 test:
+  requires:
+    {% for req in data.get('tests_require', []) -%}
+    - {{req}}
+    {% endfor %}
   imports: {{data.get('packages')}}
 {%- endblock -%}
 {%- endblock %}


### PR DESCRIPTION
This lets me specify test specific dependencies without modifying the meta.yaml
template by simply adding "tests_require" to my setup.py file, e.g.,

```
from setuptools import setup, find_packages

setup(
    name="dummy_package",
    version="0.0.1.abc",
    packages=find_packages(),
    tests_require=['nose'],
)
```

I use this so I can run my tests with nose.

There are other setuptools specific keywords (such as "install_requires") that
it might also be worth supporting in the default template:
https://pythonhosted.org/setuptools/setuptools.html#new-and-changed-setup-keywords

Another example would be the "test_suite" keyword, which if provided could signal
conda to run tests via `setup.py test` instead of run_tests.py.
