### PR TITLE
BUG: Scripts are copied even when directory does not exist.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -67,9 +67,11 @@ def create_post_scripts(m):
         src = join(recipe_dir, tp + ext)
         if not isfile(src):
             continue
-        dst = join(prefix,
-                   'Scripts' if sys.platform == 'win32' else 'bin',
-                   '.%s-%s%s' % (m.name(), tp, ext))
+        dst_dir = join(prefix,
+                       'Scripts' if sys.platform == 'win32' else 'bin')
+        if not isdir(dst_dir):
+            os.makedirs(dst_dir, int('755', 8))
+        dst = join(dst_dir, '.%s-%s%s' % (m.name(), tp, ext))
         shutil.copyfile(src, dst)
         os.chmod(dst, int('755', 8))
 


### PR DESCRIPTION
pre/post-link and unlink script are copied to the appropiate
directory (PREFIX/bin or PREFIX/Scripts) regardless of if the
directory exists.  When missing the directory is created.
