### PR TITLE
Ensure '\' are still escaped when creating patch file

### DIFF
--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -552,7 +552,7 @@ def run_setuppy(src_dir, temp_dir, args):
 
     patch = join(temp_dir, 'pypi-distutils.patch')
     with open(patch, 'w') as f:
-        f.write(DISTUTILS_PATCH.format(temp_dir))
+        f.write(DISTUTILS_PATCH.format(temp_dir.replace('\\','\\\\')))
 
     if exists(join(stdlib_dir, 'distutils', 'core.py-copy')):
         rm_rf(join(stdlib_dir, 'distutils', 'core.py'))


### PR DESCRIPTION
I got an error using conda skeleton. It was caused by '\' not being escaped correctly when creating the patch file for distutils.core.py

I think this pr solves this. 

---

patching file `core.py'
Hunk #1 succeeded at 169 with fuzz 2 (offset 2 lines).
Traceback (most recent call last):
  File "setup.py", line 39, in <module>
    url="http://github.com/Julian/jsonschema",
  File "C:\Users\Morten\Anaconda\envs_build\lib\distutils\core.py", line 192, in setup
    with io.open(os.path.join("c:\users\morten\appdata\local\temp\tmpnt7iciconda_skeleton_jsonschema", "pkginfo.yaml"), 'w', encodin
g='utf-8') as fn:
IOError: [Errno 22] Invalid argument: 'c:\users\morten\x07ppdata\local\temp\tmpnt7iciconda_skeleton_jsonschema\pkginfo.yaml'
$PYTHONPATH = c:\users\morten\appdata\local\temp\tmpnt7iciconda_skeleton_jsonschema\jsonschema-2.3.0
Error: command failed: C:\Users\Morten\Anaconda\envs_build\python.exe setup.py install
