### PR TITLE
Disable user site directory when running tests.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -403,7 +403,7 @@ def test(m, verbose=True):
     env = {str(key): str(value) for key, value in env.items()}
     if py_files:
         try:
-            subprocess.check_call([config.test_python,
+            subprocess.check_call([config.test_python, '-s',
                                    join(tmp_dir, 'run_test.py')],
                                   env=env, cwd=tmp_dir)
         except subprocess.CalledProcessError:


### PR DESCRIPTION
This change stops the contents of the user site directory (e.g. `~/.local/lib/python2.7/site-packages`) interfering with the build tests.
