### PR TITLE
Don't use "metadata.name" as an import to test with bdist_conda

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -235,9 +235,8 @@ class bdist_conda(install):
 
             if metadata.conda_import_tests:
                 if metadata.conda_import_tests is True:
-                    d['test']['imports'] = [metadata.name]
                     if self.distribution.packages:
-                        d['test']['imports'].extend(self.distribution.packages)
+                        d['test']['imports'] = self.distribution.packages
                 else:
                     d['test']['imports'] = metadata.conda_import_tests
 


### PR DESCRIPTION
My understanding is that "packages" is already a required argument in
a setup.py to set packages to install, so I don't think there is any
benefit to adding "metadata.name" as a test import. If the name of the
project is a valid import, it should already be included in "packages".

For more context:

We commonly give internal packages names that are not valid imports
(e.g., 'companyname-myproject') and this is not unheard of in the
broader python world (e.g., consider scikit-learn).

By the way, bdist_conda does look like it will be a very nice feature
for us. Thanks!
