### PR TITLE
Add GIT_ environment variables to conda-build

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -41,7 +41,7 @@ def get_git_build_info(src_dir):
     output = process.communicate()[0].strip()
     parts = output.rsplit('-', 2)
     parts_length = len(parts)
-    if parts_length is 3:
+    if parts_length == 3:
         d.update(dict(zip(keys, parts)))
 
     if key_name('NUMBER') in d and key_name('HASH') in d:


### PR DESCRIPTION
Adds the following new environment variables when building:
- ~~`GIT_BUILD` -- boolean denoting whether a git_url has been used (detects via presence of `.git` directory in `SRC_DIR`~~
- `GIT_DESCRIBE_VERSION` -- string denoting the version based solely on presence of a tag
- `GIT_DESCRIBE_NUMBER` -- string denoting the number of commits since the most recent tag
- `GIT_DESCRIBE_HASH` -- the current commit short-hash as displayed from `git describe --tags`
- `GIT_BUILD_STR` -- a string that joins `GIT_BUILD_NUMBER` and `GIT_BUILD_HASH` by an underscore.

These can be used in conjunction with templated `meta.yaml` files to set things like the build string based on the state of the Git repository.

For example, here's a modified wakari-app-workbench `meta.yaml` that would work with these values:

```
package:
  name: wakari-app-workbench
  version: {{ environ['GIT_BUILD_VERSION'] }}

build:
  number: {{ environ.get('GIT_BUILD_NUMBER', 0) }}
  string: {{ environ.get('GIT_BUILD_STR', '') }}

  entry_points:
    - wk-app-workbench = workbench.server:main

source:
  git_url: ../
```
