### PR TITLE
Print jinja2 warning to stderr

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -156,8 +156,8 @@ def get_contents(meta_path):
     try:
         import jinja2
     except ImportError:
-        print("There was an error importing jinja2.")
-        print("Please run `conda install jinja2` to enable jinja template support")
+        print("There was an error importing jinja2.", file=sys.stderr)
+        print("Please run `conda install jinja2` to enable jinja template support", file=sys.stderr)
         with open(meta_path, encoding='utf-8') as fd:
             return fd.read()
 


### PR DESCRIPTION
I use travis-ci to build conda binaries for uploading to binstar. The most straightfoward way to do this is
something like

```
binstar upload $(conda build conda-recipe --output)
```

But this currently breaks without `jinja2`, because the warning about the `jinja2` failed output is printed to `stdout`, not `stderr`.
