### PR TITLE
Better install_requires parsing for skeleton pypi command.

### DIFF
--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -454,11 +454,17 @@ def main(args, parser):
                     if isinstance(pkginfo['install_requires'], string_types):
                         pkginfo['install_requires'] = [pkginfo['install_requires']]
                     deps = []
-                    for dep in pkginfo['install_requires']:
-                        spec = spec_from_line(dep)
-                        if spec is None:
-                            sys.exit("Error: Could not parse: %s" % dep)
-                        deps.append(spec)
+                    for deptext in pkginfo['install_requires']:
+                        # Every item may be a single requirement
+                        #  or a multiline requirements string...
+                        for dep in deptext.split('\n'):
+                            #... and may also contain comments...
+                            dep = dep.split('#')[0].strip()
+                            if dep: #... and empty (or comment only) lines
+                                spec = spec_from_line(dep)
+                                if spec is None:
+                                    sys.exit("Error: Could not parse: %s" % dep)
+                                deps.append(spec)
 
                     if 'setuptools' in deps:
                         setuptools_build = False


### PR DESCRIPTION
`conda skeleton pypi` didn't work for my packages. It couldn't parse their requirements. The parsing in `pypi.main()` currently only works if `install_requires` is a sequence of single requirement strings. But setup also allows multiple newline separated requirements in one string. And also comments after `#`. I usually just pass the contents of my _requirements.txt_ files to `install_requires`. I extended the code to make that work.
