### PR TITLE
Fix git describe when work directory is empty.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -266,12 +266,20 @@ def build(m, get_src=True, verbose=True, post=None):
     if post in [False, None]:
         rm_rf(prefix)
 
-        print("BUILD START:", m.dist())
+        # Display the name only
+        # Version number could be missing due to dependency on source info.
+        print("BUILD START:", m.name())
         create_env(prefix, [ms.spec for ms in m.ms_depends('build')],
                    verbose=verbose)
 
         if get_src:
             source.provide(m.path, m.get_section('source'))
+            # Parse our metadata again because we did not initialize the source
+            # information before.
+            m.parse_again()
+
+        print("Package:", m.dist())
+
         assert isdir(source.WORK_DIR)
         src_dir = source.get_dir()
         contents = os.listdir(src_dir)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -117,7 +117,10 @@ def parse(data):
         section, key = field.split('/')
         if res.get(section) is None:
             res[section] = {}
-        res[section][key] = str(res[section].get(key, ''))
+        val = res[section].get(key, '')
+        if val is None:
+            val = ''
+        res[section][key] = str(val)
     return res
 
 # If you update this please update the example in
@@ -187,6 +190,12 @@ class MetaData(object):
             if not isfile(self.meta_path):
                 sys.exit("Error: meta.yaml or conda.yaml not found in %s" % path)
 
+        self.meta = parse(get_contents(self.meta_path))
+
+    def parse_again(self):
+        """Redo parsing for key-value pairs that are not initialized in the
+        first pass.
+        """
         self.meta = parse(get_contents(self.meta_path))
 
     @classmethod


### PR DESCRIPTION
The "git describe" feature depends on the source information that is pulled after parsing the yaml file.  When the work directory is either empty or have garbage from previous build.  It fail to pick up the version or pick up a version from the previous build.  This patch fixes it by **parsing the yaml file again after pulling the source.  This is an ugly workaround; we should rethink how the parsing and the auto versioning work**.  

This patch also replaces `None` value in the yaml file (possible with templated yaml) with a empty string.
