### PR TITLE
fixes RPATH for dynamically linked shared library so files on osx

### DIFF
--- a/conda_build/macho.py
+++ b/conda_build/macho.py
@@ -19,6 +19,20 @@ MAGIC = {
     b'\xfe\xed\xfa\xcf': 'MachO-ppc64',
 }
 
+FILETYPE = {
+    b'\x01\x00\x00\x00': 'MH_OBJECT',
+    b'\x02\x00\x00\x00': 'MH_EXECUTE',
+    b'\x03\x00\x00\x00': 'MH_FVMLIB',
+    b'\x04\x00\x00\x00': 'MH_CORE',
+    b'\x05\x00\x00\x00': 'MH_PRELOAD',
+    b'\x06\x00\x00\x00': 'MH_DYLIB',
+    b'\x07\x00\x00\x00': 'MH_DYLINKER',
+    b'\x08\x00\x00\x00': 'MH_BUNDLE',
+    b'\x09\x00\x00\x00': 'MH_DYLIB_STUB',
+    b'\x0a\x00\x00\x00': 'MH_DSYM',
+    b'\x0b\x00\x00\x00': 'MH_KEXT_BUNDLE',
+}
+
 
 def is_macho(path):
     if path.endswith(NO_EXT) or islink(path) or not isfile(path):
@@ -26,6 +40,12 @@ def is_macho(path):
     with open(path, 'rb') as fi:
         head = fi.read(4)
     return bool(head in MAGIC)
+
+
+def is_dylib(path):
+    with open(path, 'rb') as fi:
+        # file type indicated by fourth 32-bit constant in the mach header
+        return FILETYPE[fi.read(16)[-4:]] == 'MH_DYLIB'
 
 
 def otool(path):

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -145,17 +145,7 @@ def mk_relative_osx(path):
     assert sys.platform == 'darwin' and is_obj(path)
     macho.install_name_change(path, osx_ch_link)
 
-    if path.endswith(('.dylib', '.so')):
-        # note that not every MachO binaries is a "dynamically linked shared
-        # library" which have an identification name, a .so C extensions
-        # extensions is a "bundle".  One can verify this using the "file"
-        # command.
-        if path.endswith('.so'):
-            p = Popen(['file', path], stdout=PIPE)
-            stdout, stderr = p.communicate()
-            stdout = stdout.decode('utf-8')
-            if "dynamically linked shared library" not in stdout:
-                assert_relative_osx(path)
+    if macho.is_dylib(path):
         names = macho.otool(path)
         if names:
             args = ['install_name_tool', '-id', basename(names[0]), path]


### PR DESCRIPTION
In some cases, dynamically linked shared library .so files are produced on OS X (PyQt5 for example). `install_name_tool -id` needs to be called to remove the build path from the `RPATH`, but `post:mk_relative_osx` only makes that call for .dylib files. This pull request also makes the call for .so files that `file` reports to be dynamically linked shared libraries.
