### PR TITLE
Fixed compile all functionality.

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -111,15 +111,17 @@ def rm_py_along_so():
 
 def compile_missing_pyc():
     sp_dir = environ.get_sp_dir()
+    stdlib_dir = environ.get_stdlib_dir()
 
     need_compile = False
     for root, dirs, files in os.walk(sp_dir):
         for fn in files:
             if fn.endswith('.py') and fn + 'c' not in files:
                 need_compile = True
+                break
     if need_compile:
         print('compiling .pyc files...')
-        utils._check_call([config.build_python, '-Wi', join(environ.STDLIB_DIR,
+        utils._check_call([config.build_python, '-Wi', join(stdlib_dir,
                                                      'compileall.py'),
                            '-q', '-x', 'port_v3', sp_dir])
 


### PR DESCRIPTION
environ wasn't defined, and I broke the loop early - if any files don't have a `.pyc` compileall is now called.
