### PR TITLE
Conda build now checks for runtime requirements file

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -11,6 +11,7 @@ from conda.compat import iteritems, PY3
 from conda.utils import memoized, md5_file
 import conda.config as cc
 from conda.resolve import MatchSpec
+from conda.cli.common import specs_from_url
 
 try:
     import yaml
@@ -180,20 +181,7 @@ def get_contents(meta_path):
     contents = template.render(environment=env)
     return contents
 
-def read_requirements(requirements_file):
-    """
-    Parse a requirements file into a list
-    """
-    requirements = []
-    with open(requirements_file) as fd:
-        data = fd.read()
 
-    for line in data.split('\n'):
-        if not line.strip() or line.strip().startswith('#'):
-            continue
-        requirements.append(line)
-
-    return requirements
 class MetaData(object):
 
     def __init__(self, path):
@@ -218,7 +206,8 @@ class MetaData(object):
 
         if isfile(self.requirements_path):
             self.meta.setdefault('requirements', {})
-            self.meta['requirements']['run'] = read_requirements(self.requirements_path)
+            run_requirements = specs_from_url(self.requirements_path)
+            self.meta['requirements']['run'] = run_requirements
 
 
     @classmethod


### PR DESCRIPTION
With this pull request conda will check for a `requirements.txt` file beside the `meta.yaml` file in the recipe directory. If found the `requirements.run` will be set to the contents of `requirements.txt`

This is so that developers can run: 

```
conda install --file conda.recipe/requirements.txt
python setup.py develop
```

To develop a conda package locally.  When you want to build a package, the command is still:

```
conda build conda.recipe
```
