### PR TITLE
Fix-up post-processing to handle name-space packages

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -89,7 +89,14 @@ def remove_easy_install_pth(preserve_egg_dir=False):
                 if fn == '__pycache__':
                     utils.rm_rf(join(egg_path, fn))
                 else:
-                    os.rename(join(egg_path, fn), join(sp_dir, fn))
+                    # this might be a name-space package
+                    # so the package directory already exists
+                    # from another installed dependency
+                    if os.path.exists(join(sp_dir, fn)):
+                        utils.copy_into(join(egg_path, fn), join(sp_dir, fn))
+                        utils.rm_rf(join(egg_path, fn))
+                    else:
+                        os.rename(join(egg_path, fn), join(sp_dir, fn))
 
         elif isfile(egg_path):
             print('found egg:', egg_path)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -18,6 +18,19 @@ from conda_build import external
 # Backwards compatibility import. Do not remove.
 from conda.install import rm_rf
 
+def copy_into(src, dst):
+    "Copy all the files and directories in src to the directory dst"
+
+    tocopy = os.listdir(src)
+    for afile in tocopy:
+        srcname = os.path.join(src, afile)
+        dstname = os.path.join(dst, afile)
+
+        if os.path.isdir(srcname):
+            shutil.copytree(srcname, dstname)
+        else:
+            shutil.copy2(srcname, dstname)
+
 
 def rel_lib(f):
     assert not f.startswith('/')


### PR DESCRIPTION
If preserve_egg_dir is False, and conda build were building a name-space package this would cause a problem as the directory already existed. 

This patch adds a utility:  copy_into  and checks to see if the destination directory exists and if so, copies the files from the egg directory into the destination directory.   

Tested with zope.event, zope.interface, and zope.component
