### PR TITLE
Support using patterns in binary_has_prefix_files

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tarfile
+import fnmatch
 from os.path import exists, isdir, isfile, islink, join
 import yaml
 
@@ -168,7 +169,10 @@ def create_info_files(m, files, include_recipe=True):
         json.dump(m.meta, fo, indent=2, sort_keys=True)
 
     files_with_prefix = m.has_prefix_files()
-    binary_files_with_prefix = m.binary_has_prefix_files()
+    binary_files_with_prefix_patterns = m.binary_has_prefix_files()
+    binary_files_with_prefix = [
+        filename for pattern in binary_files_with_prefix_patterns
+        for filename in fnmatch.filter(files, pattern)]
 
     for file in files_with_prefix:
         if file not in files:


### PR DESCRIPTION
I decided to open this up to start the discussion and see if you think this is a good idea. Here's my problem. I'm trying to build a fairly complex package (http://root.cern.ch), which has a bunch of shared libraries that it outputs. In the end, I want to use it through it's python interface, which is the main reason I want to provide a conda package for it. The problem is that it produces around 40 shared libraries, each of which have the prefix compiled in. I didn't want to have to list all 40 by hand, hence the code in this PR.

After making this enhancement (and commenting out the assertion discussed at https://groups.google.com/a/continuum.io/forum/#!topic/conda/OrMxRXauBuQ ), my recipe at https://github.com/mhworth/conda-recipes/tree/master/root works quite nicely.

I believe that you are in the process of making it so that we automatically detect which files we should do this for (https://github.com/conda/conda-build/pull/195). Don't know how this fits into that effort, if at all (I would guess this would not be necessary after that PR is merged in). If you think this is still useful, I'll make some tests for it and add support for files_with_prefix in the same manner. Otherwise, I'm happy to just keep it on my branch for the purposes of building my one package until the other feature rolls out. 
 