### PR TITLE
Allow conda build to be run without arguments

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -56,7 +56,8 @@ def main():
         'recipe',
         action="store",
         metavar='RECIPE_PATH',
-        nargs='+',
+        nargs='?',
+        default='.',
         help="path to recipe directory"
     )
     p.add_argument(
@@ -79,7 +80,7 @@ def main():
     p.add_argument(
         '-V', '--version',
         action='version',
-        version = 'conda-build %s' % __version__,
+        version='conda-build %s' % __version__,
     )
     p.add_argument(
         '-q', "--quiet",


### PR DESCRIPTION
`conda build` == `conda build .`

I think this is a good default, like make and Makefile

cc @asmeurer @joelhullcio
