### PR TITLE
update metadata to use env variables in selectors

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -56,6 +56,7 @@ def ns_cfg():
         py34 = bool(py == 34),
         np = np,
         os = os,
+        environ = os.environ,
     )
     d.update(os.environ)
     return d


### PR DESCRIPTION
Currently, to use environment variables in selectors in `meta.yaml` files one has to go through the following import gymnastics:

``` yaml
source:
  fn: develop.tar.gz # [__import__('os').getenv('MY_ENV_VAR')]
```

It would be much more natural to use the environment variable directly:

``` yaml
source:
  fn: develop.tar.gz # [MY_ENV_VAR]
```

This PR fixes this problem by added `os.environ` to the eval'd namespace. The implementation is pretty simple so the env var must exist to be used.  If the string is empty, it will be False and otherwise will be True. If the variable does not exist it will return False via the default dict.
