### PR TITLE
Changed line numbers in patch of distutils

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 2014-XX-XX   1.9.1:
 -------------------
   * set PYTHONNOUSERSITE=1 while running build scripts
+  * fix patch of distutils because of problem on Windows, see issue #119
 
 
 2014-10-22   1.9.0:

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -128,7 +128,7 @@ DISTUTILS_PATCH = '''\
 diff core.py core.py
 --- core.py
 +++ core.py
-@@ -166,5 +167,39 @@ def setup (**attrs):
+@@ -169,2 +170,36 @@ def setup (**attrs):
  \n
 +# ====== BEGIN CONDA SKELETON PYPI PATCH ======
 +


### PR DESCRIPTION
Currently on Windows I have the problem that 
```
  conda skeleton pypi <package name>
```
fails because there is a patch of disutils which cannot be applied. See #119.
It seems that adjusting the line specifications in the patch code fixes
this issue for me. After the modifcations the distuils patch can still be applied by Linux' `patch` tool.
What I don't understand is why the previous lines numbers worked with GNU patch.