### PR TITLE
Added git functions

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -9,8 +9,8 @@ import json
 import os
 
 from conda.compat import PY3
-from conda_build import environ
 from .environ import get_dict as get_environ
+from subprocess import check_output, CalledProcessError
 
 _setuptools_data = None
 
@@ -23,11 +23,11 @@ def load_setuptools(setup_file='setup.py'):
             _setuptools_data.update(kw)
 
         import setuptools
-        #Add current directory to path
+        # Add current directory to path
         import sys
         sys.path.append('.')
 
-        #Patch setuptools
+        # Patch setuptools
         setuptools_setup = setuptools.setup
         setuptools.setup = setup
         exec(open(setup_file).read())
@@ -41,12 +41,67 @@ def load_npm():
     with open('package.json', **mode_dict) as pkg:
         return json.load(pkg)
 
-def context_processor():
+def get_git_build_info(src_dir):
+    env = os.environ.copy()
+#     env['GIT_DIR'] = os.path.join(src_dir, '.git')
+
+    d = {}
+    # grab information from describe
+    key_name = lambda a: "GIT_DESCRIBE_{}".format(a)
+    keys = [key_name("TAG"), key_name("NUMBER"), key_name("HASH")]
+    env = {str(key): str(value) for key, value in env.items()}
+
+    try:
+        output = check_output(["git", "describe", "--tags", "--long", "HEAD"], env=env, cwd=src_dir)
+    except CalledProcessError:
+        return None
+
+    output = output.strip()
+    output = output.decode('utf-8')
+    parts = output.rsplit('-', 2)
+    parts_length = len(parts)
+    if parts_length == 3:
+        d.update(dict(zip(keys, parts)))
+    # get the _full_ hash of the current HEAD
+    try:
+        output = check_output(["git", "rev-parse", "HEAD"], env=env, cwd=src_dir)
+    except CalledProcessError:
+        return d
+
+    output = output.strip()
+    output = output.decode('utf-8')
+    d['GIT_FULL_HASH'] = output
+    # set up the build string
+    if key_name('NUMBER') in d and key_name('HASH') in d:
+        d['GIT_BUILD_STR'] = '{}_{}'.format(d[key_name('NUMBER')],
+                                            d[key_name('HASH')])
+
+    return d
+
+def git_describe_tag(src_dir=None, default=None):
+
+    if src_dir is None:
+        ctx = get_environ()
+        src_dir = ctx['SRC_DIR']
+
+    git_info = get_git_build_info(src_dir)
+    if git_info is None and default is None:
+        raise Exception("The git tag could not be gotten!")
+
+    tag = git_info.get('GIT_DESCRIBE_TAG', None)
+
+    if tag is None:
+        raise Exception("The git tag could not be gotten!")
+    return tag
+
+def context_processor(meta_path):
     ctx = get_environ()
+    ctx['RECIPE_DIR'] = os.path.dirname(meta_path)
     environ = dict(os.environ)
     environ.update(get_environ())
 
     ctx.update(load_setuptools=load_setuptools,
                load_npm=load_npm,
-               environ=environ)
+               environ=environ,
+               git_describe_tag=git_describe_tag)
     return ctx

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -37,26 +37,26 @@ def ns_cfg():
     for x in py, np:
         assert isinstance(x, int), x
     d = dict(
-        linux = plat.startswith('linux-'),
-        linux32 = bool(plat == 'linux-32'),
-        linux64 = bool(plat == 'linux-64'),
-        armv6 = bool(plat == 'linux-armv6l'),
-        osx = plat.startswith('osx-'),
-        unix = plat.startswith(('linux-', 'osx-')),
-        win = plat.startswith('win-'),
-        win32 = bool(plat == 'win-32'),
-        win64 = bool(plat == 'win-64'),
-        pl = pl,
-        py = py,
-        py3k = bool(30 <= py < 40),
-        py2k = bool(20 <= py < 30),
-        py26 = bool(py == 26),
-        py27 = bool(py == 27),
-        py33 = bool(py == 33),
-        py34 = bool(py == 34),
-        np = np,
-        os = os,
-        environ = os.environ,
+        linux=plat.startswith('linux-'),
+        linux32=bool(plat == 'linux-32'),
+        linux64=bool(plat == 'linux-64'),
+        armv6=bool(plat == 'linux-armv6l'),
+        osx=plat.startswith('osx-'),
+        unix=plat.startswith(('linux-', 'osx-')),
+        win=plat.startswith('win-'),
+        win32=bool(plat == 'win-32'),
+        win64=bool(plat == 'win-64'),
+        pl=pl,
+        py=py,
+        py3k=bool(30 <= py < 40),
+        py2k=bool(20 <= py < 30),
+        py26=bool(py == 26),
+        py27=bool(py == 27),
+        py33=bool(py == 33),
+        py34=bool(py == 34),
+        np=np,
+        os=os,
+        environ=os.environ,
     )
     d.update(os.environ)
     return d
@@ -227,7 +227,7 @@ def get_contents(meta_path):
                ]
     env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders))
     env.globals.update(ns_cfg())
-    env.globals.update(context_processor())
+    env.globals.update(context_processor(meta_path))
 
     template = env.get_or_select_template(filename)
 
@@ -382,14 +382,14 @@ class MetaData(object):
 
     def info_index(self):
         d = dict(
-            name = self.name(),
-            version = self.version(),
-            build = self.build_id(),
-            build_number = self.build_number(),
-            license = self.get_value('about/license'),
-            platform = cc.platform,
-            arch = cc.arch_name,
-            depends = sorted(ms.spec for ms in self.ms_depends())
+            name=self.name(),
+            version=self.version(),
+            build=self.build_id(),
+            build_number=self.build_number(),
+            license=self.get_value('about/license'),
+            platform=cc.platform,
+            arch=cc.arch_name,
+            depends=sorted(ms.spec for ms in self.ms_depends())
         )
         if self.get_value('build/features'):
             d['features'] = ' '.join(self.get_value('build/features'))


### PR DESCRIPTION
Hey, this POC of how to call `git_describe_tag` as a function so you don't need `source.gut_url` in your meta.yaml

This needs to be cleaned up but, I tested this on my mac with the following meta.yaml

```yaml
package:
  name: conda_test_package
  version: {{git_describe_tag(RECIPE_DIR)}}

build:
  number: 1

```

cc @tswicegood  @asmeurer 

