### PR TITLE
Halt build on YAML error without jinja2

### DIFF
--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -1,0 +1,46 @@
+import textwrap
+SEPARATOR = "-" * 70
+
+indent = lambda s: textwrap.fill(textwrap.dedent(s))
+
+
+class CondaBuildException(Exception):
+    pass
+
+
+class YamlParsingError(CondaBuildException):
+    pass
+
+
+class UnableToParse(YamlParsingError):
+    def __init__(self, original, *args, **kwargs):
+        super(UnableToParse, self).__init__(*args, **kwargs)
+        self.original = original
+
+    def error_msg(self):
+        return "\n".join([
+            SEPARATOR,
+            self.error_body(),
+            self.indented_exception(),
+        ])
+
+    def error_body(self):
+        return "\n".join([
+            "Unable to parse meta.yaml file\n",
+        ])
+
+    def indented_exception(self):
+        orig = str(self.original)
+        indent = lambda s: s.replace("\n", "\n--> ")
+        return "Error Message:\n--> {}\n\n".format(indent(orig))
+
+
+class UnableToParseMissingJinja2(UnableToParse):
+    def error_body(self):
+        return "\n".join([
+            super(UnableToParseMissingJinja2, self).error_body(),
+            indent("""\
+                It appears you are missing jinja2.  Please install that
+                package, then attempt to build.
+            """),
+        ])

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -16,7 +16,7 @@ from os.path import exists
 import conda.config as config
 from conda.compat import PY3
 
-from conda_build import __version__
+from conda_build import __version__, exceptions
 
 
 def main():
@@ -241,7 +241,11 @@ def execute(args, parser):
             if not isdir(recipe_dir):
                 sys.exit("Error: no such directory: %s" % recipe_dir)
 
-            m = MetaData(recipe_dir)
+            try:
+                m = MetaData(recipe_dir)
+            except exceptions.YamlParsingError as e:
+                sys.stderr.write(e.error_msg())
+                sys.exit(1)
             binstar_upload = False
             if args.check and len(args.recipe) > 1:
                 print(m.path)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -90,22 +90,21 @@ def yamlize(data):
     try:
         return yaml.load(data)
     except yaml.parser.ParserError as e:
+        sys.stderr.write(('-' * 70) + "\n")
+        sys.stderr.write("Unable to parse meta.yaml file\n\n")
         if e.problem == "expected ',' or '}', but got '<scalar>'":
             try:
                 import jinja2
-                raise e
             except ImportError:
-                sys.stderr.write(('-' * 70) + "\n")
-                sys.stderr.write("Unable to parse meta.yaml file\n\n")
                 sys.stderr.write(textwrap.fill(textwrap.dedent("""\
                     It appears you are missing jinja2.  Please install that
                     package, then attempt to build.
                     """)) + "\n\n")
-                indent = lambda s: s.replace("\n", "\n    ")
-                sys.stderr.write(
-                    "Error Message:\n    {}\n\n".format(indent(str(e)))
-                )
-                sys.exit(-1)
+        indent = lambda s: s.replace("\n", "\n---> ")
+        sys.stderr.write(
+            "Error Message:\n---> {}\n\n".format(indent(str(e)))
+        )
+        sys.exit(1)
 
 
 def parse(data):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -101,11 +101,7 @@ def yamlize(data):
 
 def parse(data):
     data = select_lines(data, ns_cfg())
-    try:
-        res = yamlize(data)
-    except exceptions.YamlParsingError as e:
-        sys.stderr.write(e.error_msg())
-        sys.exit(1)
+    res = yamlize(data)
     # ensure the result is a dict
     if res is None:
         res = {}


### PR DESCRIPTION
This fixes the issue described in both #247 and #137 by detecting parse errors related to "{{" inside a YAML file.  The major reason for those to be there is when doing template work.