### PR TITLE
Allow non-python packages to be converted to different platforms

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -199,12 +199,13 @@ def get_pure_py_file_map(t, platform):
         raise RuntimeError("Found more than one Python dependency in package %s"
             % t.name)
     if len(pythons) == 0:
-        raise RuntimeError("Package %s does not appear to be a Python package"
-            % t.name)
-    pyver = pythons[0].group(1)
+        # not a Python package
+        mapping = []
+    else:
+        pyver = pythons[0].group(1)
 
-    mapping = [(re.compile(i[0].format(pyver=pyver)),
-        i[1].format(pyver=pyver)) for i in mapping]
+        mapping = [(re.compile(i[0].format(pyver=pyver)),
+            i[1].format(pyver=pyver)) for i in mapping]
 
     members = t.getmembers()
     file_map = {}


### PR DESCRIPTION
@asmeurer Could you take a look at this?  I'm creating a number of non-python packages and it is very useful to not have to tar and transfer everything to a linux machine when testing linux-64 packages.

Thanks!
