### PR TITLE
report empty GIT_DESCRIBE env variables, fixes issue #266

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -312,7 +312,7 @@ def build(m, get_src=True, verbose=True, post=None):
 
         # Display the name only
         # Version number could be missing due to dependency on source info.
-        print("BUILD START:", m.dist())
+        print("BUILD START:", m.name())
         create_env(config.build_prefix,
                    [ms.spec for ms in m.ms_depends('build')],
                    verbose=verbose)

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -31,9 +31,17 @@ def get_sp_dir():
 
 def get_git_build_info(src_dir):
     env = os.environ.copy()
-    env['GIT_DIR'] = join(src_dir, '.git')
-
     d = {}
+    git_dir = join(src_dir, '.git')
+    if os.path.isdir(git_dir):
+        env['GIT_DIR'] = git_dir
+    else:
+        d['GIT_DIR'] = ''
+        d['GIT_DESCRIBE_TAG'] = ''
+        d['GIT_DESCRIBE_NUMBER'] = ''
+        d['GIT_DESCRIBE_HASH'] = ''
+        return d
+
     # grab information from describe
     key_name = lambda a: "GIT_DESCRIBE_{}".format(a)
     keys = [key_name("TAG"), key_name("NUMBER"), key_name("HASH")]
@@ -87,8 +95,7 @@ def get_dict(m=None, prefix=None):
     except NotImplementedError:
         d['CPU_COUNT'] = "1"
 
-    if os.path.isdir(os.path.join(d['SRC_DIR'], '.git')):
-        d.update(**get_git_build_info(d['SRC_DIR']))
+    d.update(**get_git_build_info(d['SRC_DIR']))
 
     if sys.platform == 'win32':         # -------- Windows
         d['PATH'] = (join(prefix, 'Library', 'bin') + ';' +


### PR DESCRIPTION
A `meta.yaml` file templated with `GIT_DESCRIBE` fails to parse the first time through, since the source is not available the first time it is parsed, and conda-build skips creating the environment variables if it doesn't find a `.git` directory in `SRC_DIR`. This pull request creates empty GIT_ environment variables if `.git` is not available, allowing `meta.yaml` to parse so the source can be provided for the second round of parsing (which already exists in conda-build).