### PR TITLE
Clone git sources with --recursive option

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -113,7 +113,7 @@ def git_source(meta, recipe_dir):
     if checkout:
         print('checkout: %r' % checkout)
 
-    check_call([git, 'clone', cache_repo_arg, WORK_DIR])
+    check_call([git, 'clone', '--recursive', cache_repo_arg, WORK_DIR])
     if checkout:
         check_call([git, 'checkout', checkout], cwd=WORK_DIR)
 


### PR DESCRIPTION
This allows specifying a source as a git repository for projects using git submodules, as IPython does.

I'm not entirely convinced this is the right approach, but it made it work correctly for me.