### PR TITLE
Moved the windows build echo command to after the environment variables.

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -106,10 +106,10 @@ def build(m):
             data = fi.read()
         with open(join(src_dir, 'bld.bat'), 'w') as fo:
             fo.write(msvc_env_cmd())
-            # more debuggable with echo on
-            fo.write('@echo on\n')
             for kv in iteritems(env):
                 fo.write('set %s=%s\n' % kv)
+            # more debuggable with echo on
+            fo.write('@echo on\n')
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)
 


### PR DESCRIPTION
The echo-ing of the environment when building windows distributions is exceedingly noisy, and often it is hard to see the wood from the trees. This change moves the echo on to be after the re-iteration of the build environment variables.