### PR TITLE
scrubs all build prefixes

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -85,6 +85,7 @@ def have_prefix_files(files):
     alt_prefix = prefix.replace('\\', '/')
     alt_prefix_bytes = alt_prefix.encode('utf-8')
 
+    prefix_placeholder_bytes = prefix_placeholder.encode('utf-8')
     alt_prefix_placeholder = '/installation_prefix_placeholder'
     alt_prefix_placeholder_bytes = alt_prefix_placeholder.encode('utf-8')
     if sys.platform == 'win32':

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -85,7 +85,14 @@ def have_prefix_files(files):
     alt_prefix = prefix.replace('\\', '/')
     alt_prefix_bytes = alt_prefix.encode('utf-8')
 
+    # backward compatibility:
+    # support the old prefix_placeholder (/opt/anaconda1anaconda2anaconda3),
+    # replaced with install prefix containing native path separators
     prefix_placeholder_bytes = prefix_placeholder.encode('utf-8')
+    # more explicitly: replace build prefixes with a placeholder using
+    # path separators consistent with what was found in the build prefix.
+    # this allows conda to replace the placeholder with an install prefix
+    # containing the same path separator appearing in the original build prefix
     alt_prefix_placeholder = '/installation_prefix_placeholder'
     alt_prefix_placeholder_bytes = alt_prefix_placeholder.encode('utf-8')
     if sys.platform == 'win32':
@@ -113,9 +120,8 @@ def have_prefix_files(files):
                     path, data, prefix_bytes, prefix_placeholder_bytes
                     )
             if sys.platform == 'win32' and alt_prefix_bytes in data:
-                # use placeholder with unix-style path separators
-                # this tells conda to replace it with an installation prefix
-                # that uses unix-style path separators
+                # build prefix contains unix-style path separators
+                # use placeholder with unix-style path separators as well
                 data = rewrite_file_with_new_prefix(
                     path, data, alt_prefix_bytes, alt_prefix_placeholder_bytes
                     )

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -124,7 +124,7 @@ def have_prefix_files(files):
             yield (prefix, mode, f)
         if prefix_placeholder_bytes in data:
             # backwards compatibility for recipes manually adding files with
-            # /opt/anaconda1/anaconda2/anaconda3 prefix
+            # /opt/anaconda1anaconda2anaconda3 prefix
             yield (prefix_placeholder, mode, f)
         if new_prefix_placeholder_bytes in data:
             yield (new_prefix_placeholder, mode, f)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -23,7 +23,7 @@ import conda.plan as plan
 from conda.api import get_index
 from conda.compat import PY3
 from conda.fetch import fetch_index
-from conda.install import linked
+from conda.install import prefix_placeholder, linked
 from conda.utils import url_path
 from conda.resolve import Resolve, MatchSpec
 
@@ -88,10 +88,10 @@ def have_prefix_files(files):
     alt_prefix_placeholder = '/installation_prefix_placeholder'
     alt_prefix_placeholder_bytes = alt_prefix_placeholder.encode('utf-8')
     if sys.platform == 'win32':
-        prefix_placeholder = 'C:\\installation_prefix_placeholder'
+        new_prefix_placeholder = 'C:\\installation_prefix_placeholder'
     else:
-        prefix_placeholder = alt_prefix_placeholder
-    prefix_placeholder_bytes = prefix_placeholder.encode('utf-8')
+        new_prefix_placeholder = alt_prefix_placeholder
+    new_prefix_placeholder_bytes = new_prefix_placeholder.encode('utf-8')
 
     for f in files:
         if f.endswith(('.pyc', '.pyo', '.a', '.dylib')):
@@ -122,7 +122,11 @@ def have_prefix_files(files):
         if prefix_bytes in data:
             yield (prefix, mode, f)
         if prefix_placeholder_bytes in data:
+            # backwards compatibility for recipes manually adding files with
+            # /opt/anaconda1/anaconda2/anaconda3 prefix
             yield (prefix_placeholder, mode, f)
+        if new_prefix_placeholder_bytes in data:
+            yield (new_prefix_placeholder, mode, f)
         if (sys.platform == 'win32') and (alt_prefix_placeholder_bytes in data):
             yield (alt_prefix_placeholder, mode, f)
 

--- a/tests/test-recipes/metadata/has_prefix_files/bld.bat
+++ b/tests/test-recipes/metadata/has_prefix_files/bld.bat
@@ -1,4 +1,5 @@
 echo %PREFIX% > "%PREFIX%\automatic-prefix"
-echo /opt/anaconda1anaconda2anaconda3 > "%PREFIX%\has-prefix"
+echo /opt/anaconda1anaconda2anaconda3 > "%PREFIX%\has-anaconda-prefix"
+echo C:\installation_prefix_placeholder > "%PREFIX%\has-prefix"
 python "%RECIPE_DIR%\write_binary_has_prefix.py"
 python "%RECIPE_DIR%\write_forward_slash_prefix.py"

--- a/tests/test-recipes/metadata/has_prefix_files/build.sh
+++ b/tests/test-recipes/metadata/has_prefix_files/build.sh
@@ -1,3 +1,4 @@
 echo $PREFIX > $PREFIX/automatic-prefix
-echo /opt/anaconda1anaconda2anaconda3 > $PREFIX/has-prefix
+echo /opt/anaconda1anaconda2anaconda3 > $PREFIX/has-anaconda-prefix
+echo /installation_prefix_placeholder >> $PREFIX/has-prefix
 python $RECIPE_DIR/write_binary_has_prefix.py

--- a/tests/test-recipes/metadata/has_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/has_prefix_files/run_test.py
@@ -12,6 +12,13 @@ def main():
     print(data)
     assert prefix in data
 
+    with open(join(prefix, 'has-anaconda-prefix')) as f:
+        data = f.read()
+
+    print('has-anaconda-prefix')
+    print(data)
+    assert prefix in data
+
     with open(join(prefix, 'has-prefix')) as f:
         data = f.read()
 
@@ -33,7 +40,9 @@ def main():
 
         print('forward-slash-prefix')
         print(data)
-        assert forward_slash_prefix in data
+        assert data.count(forward_slash_prefix) == 2
+        assert 'C:\\installation_prefix_placeholder' not in data
+        assert 'C:/installation_prefix_placeholder' not in data
 
 if __name__ == '__main__':
     main()

--- a/tests/test-recipes/metadata/has_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/has_prefix_files/run_test.py
@@ -40,7 +40,8 @@ def main():
 
         print('forward-slash-prefix')
         print(data)
-        assert data.count(forward_slash_prefix) == 2
+        assert forward_slash_prefix in data
+        assert prefix in data
         assert 'C:\\installation_prefix_placeholder' not in data
         assert 'C:/installation_prefix_placeholder' not in data
 

--- a/tests/test-recipes/metadata/has_prefix_files/write_forward_slash_prefix.py
+++ b/tests/test-recipes/metadata/has_prefix_files/write_forward_slash_prefix.py
@@ -1,7 +1,8 @@
 import os
 
 prefix = os.environ['PREFIX']
-fn = '%s/forward-slash-prefix' % prefix
+fn = os.path.join('%s' % prefix, 'forward-slash-prefix')
 
 with open(fn, 'w') as f:
+    f.write(prefix)
     f.write(prefix.replace('\\', '/'))


### PR DESCRIPTION
This pull request scrubs unix-style build prefixes in windows conda packages.

It also explicitly lists all files containing a build prefix placeholder, and does not use the `/opt/anaconda1anaconda2anaconda3` default placeholder. The handling of `/opt/anaconda1anaconda2anaconda3` is somewhat anomolous, since it is not explicitly recorded in `has_prefix`, and it is a unix-style path that gets replaced with a windows style path at installation time.

I don't see any backward compatibility consequences for not producing packages with the old default placholder.
