### PR TITLE
Don't exclude .dylib from hard coded path fixing

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -85,7 +85,7 @@ def have_prefix_files(files):
     alt_prefix_bytes = alt_prefix.encode('utf-8')
     prefix_placeholder_bytes = prefix_placeholder.encode('utf-8')
     for f in files:
-        if f.endswith(('.pyc', '.pyo', '.a', '.dylib')):
+        if f.endswith(('.pyc', '.pyo', '.a')):
             continue
         path = join(prefix, f)
         if isdir(path):


### PR DESCRIPTION
I'm attempting to get a conda package (https://github.com/SciTools/conda-recipes-scitools/tree/master/ecmwf_grib) working under OSX for Iris (https://github.com/SciTools/iris). The problem I'm having is that one of the shared libraries built by the package contains a number of hard coded paths. Under linux this is auto detected and fixed. Under Mac OSX, it is skipped by logic in `have_prefix_files`. These are not install paths handled by `install_name_tool` but are paths to directories containing sample files and template files. This PR modifies the build.py script so that dylib files are no longer skipped by the prefix logic. This fixes my problem and the resulting package works under OSX.

I'm sure @ilanschnell had a reason for making the change (see https://github.com/conda/conda-build/commit/35aaf2ea1a90e23ae396a373b7ce481807ea4dcd), so I'd welcome his input.
