### PR TITLE
Fix relative symlink creation

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -6,7 +6,8 @@ import os
 import sys
 import stat
 from glob import glob
-from os.path import (basename, join, splitext, isdir, isfile, exists, islink, realpath, relpath)
+from os.path import (basename, dirname, join, splitext, isdir, isfile, exists,
+                     islink, realpath, relpath)
 from os import readlink
 import io
 from subprocess import call, Popen, PIPE
@@ -255,7 +256,7 @@ def check_symlinks(files):
                     # such crazy things don't happen.
                     print("Making absolute symlink %s -> %s relative" % (f, link_path))
                     os.unlink(path)
-                    os.symlink(relpath(real_link_path, path), path)
+                    os.symlink(relpath(real_link_path, dirname(path)), path)
             else:
                 # Symlinks to absolute paths on the system (like /usr) are fine.
                 if real_link_path.startswith(config.croot):


### PR DESCRIPTION
Within `post.py` there is a function called `check_symlinks()`. This function makes sure any symlinks to files within the build are relative. If it thinks they are not relative, it unlinks the symlink and replaces it with a new relative version. I believe the change introduced in https://github.com/conda/conda-build/commit/37a0d8ab2bca4b3b4cec72cb34099e5b1c6ec68c contains an error. To illustrate the problem consider a symlink to another file in the same directory:
```
bob@localhost ~/tmp/linkfun/a/b/c $ ll
total 8
drwxr-xr-x  4 bob  users   136B 24 Dec 13:57 ./
drwxr-xr-x  3 bob  users   102B 24 Dec 13:30 ../
-rw-r--r--  1 bob  users     0B 24 Dec 11:02 file.dat
lrwxr-xr-x  1 bob  users    49B 24 Dec 11:04 filelink@ -> /Users/bob/tmp/linkfun/a/b/c/file.dat
```
The code uses `relpath(real_link_path, path)` to set the new "relative" `src`. Here:
```
from os.path import realpath, relpath
path = '/Users/bob/tmp/linkfun/a/b/c/filelink'
real_link_path = realpath(path)
print real_link_path
'/Users/bob/tmp/linkfun/a/b/c/file.dat'
src = relpath(real_link_path, path)
```
resulting in:
```
src = '../file.dat'
```
This is incorrect as it has added an unwanted `../`, resulting in a broken link. The problem is the start of the `relpath` should be the directory not the file. This PR fixes this issue.