### PR TITLE
support build:script for win32, fixes issue #270

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -347,17 +347,17 @@ def build(m, get_src=True, verbose=True, post=None):
             f.write(u'\n'.join(sorted(list(files1))))
             f.write(u'\n')
 
+        script = m.get_value('build/script', None)
+        if isinstance(script, list):
+            script = '\n'.join(script)
         if sys.platform == 'win32':
             import conda_build.windows as windows
-            windows.build(m)
+            windows.build(m, script=script)
         else:
             env = environ.get_dict(m)
             build_file = join(m.path, 'build.sh')
 
-            script = m.get_value('build/script', None)
             if script:
-                if isinstance(script, list):
-                    script = '\n'.join(script)
                 with open(build_file, 'w') as bf:
                     bf.write(script)
                 os.chmod(build_file, 0o766)

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -90,7 +90,7 @@ def kill_processes():
             continue
 
 
-def build(m):
+def build(m, script=None):
     env = dict(os.environ)
     env.update(environ.get_dict(m))
 
@@ -101,6 +101,9 @@ def build(m):
 
     src_dir = source.get_dir()
     bld_bat = join(m.path, 'bld.bat')
+    if script:
+        with open(bld_bat, 'w') as bf:
+            bf.write(script)
     if exists(bld_bat):
         with open(bld_bat) as fi:
             data = fi.read()


### PR DESCRIPTION
`build:script` defined in `meta.yaml` is currently only respected for non-win32. This pull request provides a fix.