### PR TITLE
do not attempt to import os.readlink on win32

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -7,7 +7,8 @@ import sys
 import stat
 from glob import glob
 from os.path import (basename, join, splitext, isdir, isfile, exists, islink, realpath, relpath)
-from os import readlink
+if sys.platform != 'win32':
+    from os import readlink
 import io
 from subprocess import call, Popen, PIPE
 


### PR DESCRIPTION
Fixes a minor bug recently introduced on master that breaks conda-build on win32