### PR TITLE
Use PyPi XMLRCP client search in order to ignore case for PyPi package n...

### DIFF
--- a/conda_build/main_pipbuild.py
+++ b/conda_build/main_pipbuild.py
@@ -335,6 +335,13 @@ def execute(args, parser):
         all_versions = True
         version = args.release[0]
 
+    search = client.search({'name':package})
+    if search:
+        r_name = filter(lambda x: x.has_key('name') and package.lower()==x['name'].lower(),search)
+        if r_name: 
+            print('Package search: %s' % r_name[0])
+            package=r_name[0]['name']
+      
     releases = client.package_releases(package, all_versions)
     if not releases:
         sys.exit("Error:  PyPI does not have a package named %s" % package)


### PR DESCRIPTION
main_pipbuild is modified in order to search PyPi for a package with the same name as the supplied argument (ignoring case).  If there is a match then pipbuild will install the correct package instead of reporting that the package is not in PyPi.  Example - conda pipbuild flask-admin will properly install the Flask-Admin package from PyPi