### PR TITLE
Fix for building dependencies

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -272,7 +272,7 @@ def execute(args, parser):
                     build.build(m, verbose=not args.quiet, post=post)
                 except RuntimeError as e:
                     error_str = str(e)
-                    if error_str.startswith('No packages found'):
+                    if error_str.startswith('No packages found') or error_str.startswith('Could not find some'):
                         # Build dependency if recipe exists
                         dep_pkg = error_str.split(': ')[1]
                         # Handle package names that contain version deps.


### PR DESCRIPTION
[Here](https://github.com/omnia-md/conda-recipes/issues/82), we observed that when building a large collection of packages, some of the packages did not build correctly. In the log file, I see things like

```
BUILD START: mixtape-0.2.2-np18py27_1
Fetching package metadata: ...
Solving package specifications: 
Error: Could not find some dependencies for mdtraj: scripttest
```

The issue is that "mixtape" has a build-time dependency on "mdtraj", and "mdtraj" has a _runtime_ dependency on "scripttest", but _not_ a build time dependency on "scripttest". If the "scriptest" package does not exist yet, then This results in [conda/resolve.py](https://github.com/conda/conda/blob/master/conda/resolve.py#L311-L313) throwing the observed `Error: Could not find some dependencies for mdtraj: scripttest`.

If possible, `conda-build` should catch this error and try to build the "scriptest" package.