### PR TITLE
Allow specifying files to always include

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -344,7 +344,7 @@ def build(m, get_src=True, verbose=True, post=None):
             print("no source")
 
         rm_rf(config.info_dir)
-        files1 = prefix_files()
+        files1 = prefix_files().difference(set(m.always_include_files()))
         # Save this for later
         with open(join(config.croot, 'prefix_files.txt'), 'w') as f:
             f.write(u'\n'.join(sorted(list(files1))))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -187,7 +187,8 @@ FIELDS = {
               'features', 'track_features', 'preserve_egg_dir',
               'no_link', 'binary_relocation', 'script', 'noarch',
               'has_prefix_files', 'binary_has_prefix_files',
-              'detect_binary_files_with_prefix', 'rpaths'],
+              'detect_binary_files_with_prefix', 'rpaths',
+              'always_include_files', ],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
@@ -414,6 +415,9 @@ class MetaData(object):
             if any('\\' in i for i in ret):
                 raise RuntimeError("build/has_prefix_files paths must use / as the path delimiter on Windows")
         return ret
+
+    def always_include_files(self):
+        return self.get_value('build/always_include_files', [])
 
     def binary_has_prefix_files(self):
         ret = self.get_value('build/binary_has_prefix_files', [])


### PR DESCRIPTION
This removes files from the list list of initial files so they are included.  It's required for building things like conda that are going to replace the `$PREFIX/bin/conda` file inside the build environment with their current version.

See also: https://github.com/conda/conda/pull/1086