### PR TITLE
Add recipe for building conda-build with conda-build

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,79 +1,23 @@
-## The package attribure specifies a binstar package namespace to build the package to.
-## This can be specified here or on the command line
 package: conda-build
+user: conda
 
-## You can also specify the account to upload to,
-## you must be an admin of that account, this
-## defaults to your user account
-# user: USERNAME
-
-#===============================================================================
-# Build Matrix Options
-# Thes options may be a single item, a list or empty
-# The resulting number of builds is [platform * engine * env]
-#===============================================================================
-
-## The platforms to build on.
-## platform defaults to linux-64
 platform:
-  - win-64
-  - win-32
-## The engine are the inital conda packages you want to run with
+  # - linux-32
+  - linux-64
+  # - win-32
+  # - win-64
+  # - osx-64
+
 engine:
   - python=2
-  - python=3
-## The env param is an environment variable list
-# env:
-#  - MY_ENV=A CC=gcc
-#  - MY_ENV=B
+  - python=3.3
+  - python=3.4
 
-#===============================================================================
-# Script options
-# These options may be broken out into the before_script, script and after_script
-# or not, that is up to you
-#===============================================================================
-
-## Run before the script
-# before_script:
-#   - echo "before_script!"
-## Put your main computations here!
+# Can't test on binstar because it needs to be installed in root
+script:
+  - conda build --no-test ./conda.recipe/
 
 install:
-  # Use the provided conda and Python to run the install script. The order of these commands matters.
-  - conda install requests
-  - set "CONDA_DEFAULT_ENV="
-  - python tests\install_miniconda.py
+  - conda update --name root --yes --quiet conda-build
 
-test:
-  - cd tests\test-recipes\metadata
-  # This will be effectively a no-op for recipes without bld.bat
-  - for /D %%f in (*) do (C:\Users\binstar\conda-build-miniconda\Scripts\conda-build.exe --no-binstar-upload %%~nf)
-
-# script:
-#   - echo "This is my binstar build!"
-
-## This will run after the script regardless of the result of script
-## BINSTAR_BUILD_RESULT=[succcess|failure]
-# after_script:
-#   - echo "The build was a $BINSTAR_BUILD_RESULT" | tee artifact1.txt
-## This will be run only after a successfull build
-# after_success:
-#   - echo "after_success!"
-## This will be run only after a build failure
-# after_failure:
-#   - echo "after_failure!"
-
-#===============================================================================
-# Build Results
-# Build results are split into two categories: artifacts and targets
-# You may omit either key and stiff have a successfull build
-# They may be a string, list and contain any bash glob
-#===============================================================================
-
-## Build Targets: Upload these files to your binstar package
-## build targets may be a list of files (globs allows) to upload
-## The special build targets 'conda' and 'pypi' may be used to
-## upload conda builds
-## e.g. conda is an alias for /opt/anaconda/conda-bld/<os-arch>/*.tar.bz2
-# build_targets:
-#   - conda
+build_targets: conda

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -2,11 +2,11 @@ package: conda-build
 user: conda
 
 platform:
-  # - linux-32
+  - linux-32
   - linux-64
-  # - win-32
-  # - win-64
-  # - osx-64
+  - win-32
+  - win-64
+  - osx-64
 
 engine:
   - python=2

--- a/.binstar.yml
+++ b/.binstar.yml
@@ -6,7 +6,7 @@ platform:
   - linux-64
   - win-32
   - win-64
-  - osx-64
+  # - osx-64
 
 engine:
   - python=2

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,8 @@
+python setup.py install
+if errorlevel 1 exit 1
+
+del %SCRIPTS%\conda-init
+if errorlevel 1 exit 1
+
+copy bdist_conda.py %PREFIX%\Lib\distutils\command\
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+cp bdist_conda.py ${PREFIX}/lib/python${PY_VER}/distutils/command

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: conda-build
+  version: 1.9.1
+
+source:
+  git_url: ../
+
+build:
+{% if 'CONDA_RELEASE' in environ %}
+  number: {{ environ.get('CONDA_BUILD_NUMBER', 0) }}
+{% else %}
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}
+{% endif %}
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - conda
+    - patchelf      [linux]
+
+test:
+  commands:
+    - conda-build -h
+  imports:
+    - conda_build
+
+about:
+  home: https://github.com/conda/conda-build
+  license: BSD

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,3 @@
+import conda_build
+
+print('conda_build.__version__: %s' % conda_build.__version__)


### PR DESCRIPTION
Looking to automate this process to build conda-build on binstar so internal users can subscribe to a dev channel and work with early releases before actual releases occur.