### PR TITLE
remove buggy compiling_missing_pyc function

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -121,28 +121,9 @@ def rm_py_along_so():
                         os.unlink(join(root, name + ext))
 
 
-def compile_missing_pyc():
-    sp_dir = environ.get_sp_dir()
-    stdlib_dir = environ.get_stdlib_dir()
-
-    need_compile = False
-    for root, dirs, files in os.walk(sp_dir):
-        for fn in files:
-            if fn.endswith('.py') and fn + 'c' not in files:
-                need_compile = True
-                break
-    if need_compile:
-        print('compiling .pyc files...')
-        utils._check_call([config.build_python, '-Wi',
-                           join(stdlib_dir, 'compileall.py'),
-                           '-q', '-x', 'port_v3', sp_dir])
-
-
 def post_process(files, preserve_egg_dir=False):
     remove_easy_install_pth(files, preserve_egg_dir=preserve_egg_dir)
     rm_py_along_so()
-    if not config.PY3K:
-        compile_missing_pyc()
 
 
 def osx_ch_link(path, link):


### PR DESCRIPTION
this seems useless, fixes #380:
https://github.com/conda/conda/issues/380

and has been causing various troubles:
https://github.com/conda/conda-build/issues/181
https://github.com/conda/conda/issues/402
and seems to not work in win32 for package openturns: https://github.com/conda/conda-recipes/pull/235