### PR TITLE
Added path_ignore to meta.yaml for copying source files

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -100,6 +100,7 @@ def parse(data):
             raise RuntimeError("The %s field should be a dict, not %s" % (field, res[field].__class__.__name__))
     # ensure those are lists
     for field in ('source/patches',
+                  'source/path_ignore',
                   'build/entry_points',
                   'build/features', 'build/track_features',
                   'requirements/build', 'requirements/run',
@@ -178,7 +179,8 @@ def _git_clean(source_meta):
 # conda-docs/docs/source/build.rst
 FIELDS = {
     'package': ['name', 'version'],
-    'source': ['fn', 'url', 'md5', 'sha1', 'sha256', 'path',
+    'source': ['fn', 'url', 'md5', 'sha1', 'sha256',
+               'path', 'path_ignore',
                'git_url', 'git_tag', 'git_branch', 'git_rev',
                'hg_url', 'hg_tag',
                'svn_url', 'svn_rev', 'svn_ignore_externals',

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -254,8 +254,6 @@ def provide(recipe_dir, meta, patch=True):
                         result.append(fn)
             return result
 
-        print("ignorePatterns: {0}".format(ignorePatterns)) # TESTING
-
         print("Copying %s to %s" % (abspath(join(recipe_dir, meta.get('path'))), WORK_DIR))
         copytree(abspath(join(recipe_dir, meta.get('path'))), WORK_DIR, ignore=ignore)
     else: # no source

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -5,6 +5,7 @@ import sys
 from os.path import join, isdir, isfile, abspath, expanduser
 from shutil import copytree, ignore_patterns, copy2
 from subprocess import check_call, Popen, PIPE
+import fnmatch
 
 from conda.fetch import download
 from conda.utils import hashsum_file
@@ -239,8 +240,24 @@ def provide(recipe_dir, meta, patch=True):
     elif 'svn_url' in meta:
         svn_source(meta)
     elif 'path' in meta:
+        ignorePatterns = meta.get('path_ignore', None)
+        if not isinstance(ignorePatterns, list):
+            ignorePatterns = [ignorePatterns]
+        ignorePatterns = [abspath(join(recipe_dir, pat)) for pat in ignorePatterns]
+
+        def ignore(dirPath, fileList):
+            result = []
+            for pattern in ignorePatterns:
+                for fn in fileList:
+                    path = join(dirPath, fn)
+                    if fnmatch.fnmatch(path, pattern):
+                        result.append(fn)
+            return result
+
+        print("ignorePatterns: {0}".format(ignorePatterns)) # TESTING
+
         print("Copying %s to %s" % (abspath(join(recipe_dir, meta.get('path'))), WORK_DIR))
-        copytree(abspath(join(recipe_dir, meta.get('path'))), WORK_DIR)
+        copytree(abspath(join(recipe_dir, meta.get('path'))), WORK_DIR, ignore=ignore)
     else: # no source
         os.makedirs(WORK_DIR)
 


### PR DESCRIPTION
Allows you to ignore a list of files/folders that should not be copied from the source path.

Ex meta.yaml

```
path: ../
path_ignore: ../build
```

You can also use a list of patterns to exclude:

```
path_ignore:
    - ../build
    - ../dist
    - ../extra*
```

I'm currently working in an environment where my conda recipes are stored in the same repo as my source code.
With this, I want to be able to build my conda package in this same folder, just like python setuptools does.
This creates a build/conda folder in the root of my repo.
Without the ability to ignore this build folder, when conda copies the source files, it will include the build folder, creating a recursive loop.
