### PR TITLE
Introduce build/use_destdir option in meta.yaml

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -336,6 +336,14 @@ def build(m, get_src=True, verbose=True, post=None):
     :type post: bool or None. None means run the whole build. True means run
     post only. False means stop just before the post.
     '''
+    if (m.get_value('build/detect_binary_files_with_prefix')
+        or m.binary_has_prefix_files()):
+        # We must use a long prefix here as the package will only be
+        # installable into prefixes shorter than this one.
+        config.use_long_build_prefix = True
+    else:
+        # In case there are multiple builds in the same process
+        config.use_long_build_prefix = False
     if m.get_value('build/use_destdir'):
         config.install_prefix = config.destdir
     else:
@@ -344,15 +352,6 @@ def build(m, get_src=True, verbose=True, post=None):
     if post in [False, None]:
         rm_rf(config.short_build_prefix)
         rm_rf(config.long_build_prefix)
-
-        if (m.get_value('build/detect_binary_files_with_prefix')
-            or m.binary_has_prefix_files()):
-            # We must use a long prefix here as the package will only be
-            # installable into prefixes shorter than this one.
-            config.use_long_build_prefix = True
-        else:
-            # In case there are multiple builds in the same process
-            config.use_long_build_prefix = False
 
         # Display the name only
         # Version number could be missing due to dependency on source info.

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -37,19 +37,40 @@ from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
 
-def prefix_files():
+def prefix_files(prefix=None):
     '''
     Returns a set of all files in prefix.
     '''
+    if prefix is None:
+        prefix = config.build_prefix
     res = set()
-    for root, dirs, files in os.walk(config.build_prefix):
+    for root, dirs, files in os.walk(prefix):
         for fn in files:
-            res.add(join(root, fn)[len(config.build_prefix) + 1:])
+            res.add(join(root, fn)[len(prefix) + 1:])
         for dn in dirs:
             path = join(root, dn)
             if islink(path):
-                res.add(path[len(config.build_prefix) + 1:])
+                res.add(path[len(prefix) + 1:])
     return res
+
+
+def installed_files(prev_files, m):
+    """Return a set of all the files installed by the build script.
+
+    If build/use_destdir is false this will look at the current prefix
+    files and ignore those which where already present.  Otherwise all
+    files in config.destdir are used.
+
+    :param prev_files: The set of files which where present before
+       the build was executed but after the build environment was set
+       up.
+    :param m: The recipe metadata.
+
+    """
+    files = prefix_files(config.install_prefix)
+    if not m.get_value('build/use_destdir'):
+        files = files - prev_files
+    return files
 
 
 def create_post_scripts(m):
@@ -62,7 +83,7 @@ def create_post_scripts(m):
         src = join(recipe_dir, tp + ext)
         if not isfile(src):
             continue
-        dst_dir = join(config.build_prefix,
+        dst_dir = join(config.install_prefix,
                        'Scripts' if sys.platform == 'win32' else 'bin')
         if not isdir(dst_dir):
             os.makedirs(dst_dir, int('755', 8))
@@ -87,7 +108,7 @@ def have_prefix_files(files):
     for f in files:
         if f.endswith(('.pyc', '.pyo', '.a')):
             continue
-        path = join(prefix, f)
+        path = join(config.install_prefix, f)
         if isdir(path):
             continue
         if sys.platform != 'darwin' and islink(path):
@@ -168,11 +189,15 @@ def create_info_files(m, files, include_recipe=True):
         # make sure we use '/' path separators in metadata
         files = [f.replace('\\', '/') for f in files]
 
+    build_prefix = config.build_prefix.strip('/')
+    prefix_len = len(build_prefix) + 1
     with open(join(config.info_dir, 'files'), 'w') as fo:
         if m.get_value('build/noarch') and 'py_' in m.dist():
             fo.write('\n')
         else:
             for f in files:
+                if m.get_value('build/use_destdir'):
+                    f = f[prefix_len:]
                 fo.write(f + '\n')
 
     files_with_prefix = sorted(have_prefix_files(files))
@@ -192,19 +217,23 @@ def create_info_files(m, files, include_recipe=True):
             fmt_str = '%s %s %s\n'
         with open(join(config.info_dir, 'has_prefix'), 'w') as fo:
             for pfix, mode, fn in files_with_prefix:
+                if m.get_value('build/use_destdir'):
+                    ifn = fn[prefix_len:]
+                else:
+                    ifn = fn
                 if (fn in text_has_prefix_files):
                     # register for text replacement, regardless of mode
-                    fo.write(fmt_str % (pfix, 'text', fn))
+                    fo.write(fmt_str % (pfix, 'text', ifn))
                     text_has_prefix_files.remove(fn)
                 elif ((mode == 'binary') and (fn in binary_has_prefix_files)):
-                    print("Detected hard-coded path in binary file %s" % fn)
-                    fo.write(fmt_str % (pfix, mode, fn))
+                    print("Detected hard-coded path in binary file %s" % ifn)
+                    fo.write(fmt_str % (pfix, mode, ifn))
                     binary_has_prefix_files.remove(fn)
                 elif (auto_detect or (mode == 'text')):
-                    print("Detected hard-coded path in %s file %s" % (mode, fn))
-                    fo.write(fmt_str % (pfix, mode, fn))
+                    print("Detected hard-coded path in %s file %s" % (mode, ifn))
+                    fo.write(fmt_str % (pfix, mode, ifn))
                 else:
-                    print("Ignored hard-coded path in %s" % fn)
+                    print("Ignored hard-coded path in %s file %s" % (mode, ifn))
 
     # make sure we found all of the files expected
     errstr = ""
@@ -307,6 +336,11 @@ def build(m, get_src=True, verbose=True, post=None):
     :type post: bool or None. None means run the whole build. True means run
     post only. False means stop just before the post.
     '''
+    if m.get_value('build/use_destdir'):
+        config.install_prefix = config.destdir
+    else:
+        config.install_prefix = config.build_prefix
+
     if post in [False, None]:
         rm_rf(config.short_build_prefix)
         rm_rf(config.long_build_prefix)
@@ -344,6 +378,7 @@ def build(m, get_src=True, verbose=True, post=None):
             print("no source")
 
         rm_rf(config.info_dir)
+        rm_rf(config.destdir)
         files1 = prefix_files().difference(set(m.always_include_files()))
         # Save this for later
         with open(join(config.croot, 'prefix_files.txt'), 'w') as f:
@@ -379,26 +414,31 @@ def build(m, get_src=True, verbose=True, post=None):
         create_post_scripts(m)
         create_entry_points(m.get_value('build/entry_points'))
         assert not exists(config.info_dir)
-        files2 = prefix_files()
+        files2 = installed_files(files1, m)
 
-        post_process(sorted(files2 - files1), preserve_egg_dir=bool(m.get_value('build/preserve_egg_dir')))
+        post_process(sorted(files2), preserve_egg_dir=bool(m.get_value('build/preserve_egg_dir')))
 
         # The post processing may have deleted some files (like easy-install.pth)
-        files2 = prefix_files()
-        post_build(m, sorted(files2 - files1))
-        create_info_files(m, sorted(files2 - files1),
+        files2 = installed_files(files1, m)
+        post_build(m, sorted(files2))
+        create_info_files(m, sorted(files2),
                           include_recipe=bool(m.path))
         if m.get_value('build/noarch'):
             import conda_build.noarch as noarch
-            noarch.transform(m, sorted(files2 - files1))
+            noarch.transform(m, sorted(files2))
 
-        files3 = prefix_files()
-        fix_permissions(files3 - files1)
+        files3 = installed_files(files1, m)
+        fix_permissions(files3)
 
         path = bldpkg_path(m)
+        prefix = config.build_prefix.strip('/')
+        prefix_len = len(prefix) + 1
         t = tarfile.open(path, 'w:bz2')
-        for f in sorted(files3 - files1):
-            t.add(join(config.build_prefix, f), f)
+        for f in sorted(files3):
+            if m.get_value('build/use_destdir') and f.startswith(prefix):
+                t.add(join(config.install_prefix, f), f[prefix_len:])
+            else:
+                t.add(join(config.install_prefix, f), f)
         t.close()
 
         print("BUILD END:", m.dist())

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -62,11 +62,48 @@ class Config(object):
 
     @property
     def build_prefix(self):
+        """The prefix of the build environment.
+
+        This is a conda environment with all the build-dependencies
+        installed into.  Normally the newly built package will install
+        files here, unless build/use_destdir is set to True in which
+        case install_prefix is used.
+
+        """
         if self.use_long_build_prefix is None:
             raise Exception("I don't know which build prefix to use yet")
         if self.use_long_build_prefix:
             return self.long_build_prefix
         return self.short_build_prefix
+
+    @property
+    def destdir(self):
+        """The location of $DESTDIR.
+
+        This is will always point to destdir whether build/use_destdir
+        is used or not.
+
+        """
+        return join(self.croot, 'work', 'destdir')
+
+    @property
+    def install_prefix(self):
+        """The prefix where files got installed into.
+
+        This is normally the same as build_prefix unless
+        build/use_destdir is used.  It is used by the post-processing
+        steps instead of build_prefix so that they work correctly when
+        build/use_destdir is used.
+
+        """
+        try:
+            return self._install_prefix
+        except Exception:
+            return self.build_prefix
+
+    @install_prefix.setter
+    def install_prefix(self, val):
+        self._install_prefix = val
 
     @property
     def build_python(self):
@@ -86,7 +123,7 @@ class Config(object):
 
     @property
     def info_dir(self):
-        return join(self.build_prefix, 'info')
+        return join(self.install_prefix, 'info')
 
     @property
     def broken_dir(self):

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -22,12 +22,14 @@ def get_py_ver():
 def get_npy_ver():
     return '.'.join(str(config.CONDA_NPY))
 
-def get_stdlib_dir():
-    return join(config.build_prefix, 'Lib' if sys.platform == 'win32' else
+def get_stdlib_dir(prefix=None):
+    if prefix is None:
+        prefix = config.build_prefix
+    return join(prefix, 'Lib' if sys.platform == 'win32' else
                                 'lib/python%s' % get_py_ver())
 
-def get_sp_dir():
-    return join(get_stdlib_dir(), 'site-packages')
+def get_sp_dir(prefix=None):
+    return join(get_stdlib_dir(prefix), 'site-packages')
 
 def get_git_build_info(src_dir):
     env = os.environ.copy()
@@ -87,6 +89,7 @@ def get_dict(m=None, prefix=None):
     d['PY_VER'] = get_py_ver()
     d['NPY_VER'] = get_npy_ver()
     d['SRC_DIR'] = source.get_dir()
+    d['DESTDIR'] = config.destdir
     if "LANG" in os.environ:
         d['LANG'] = os.environ['LANG']
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -188,7 +188,7 @@ FIELDS = {
               'no_link', 'binary_relocation', 'script', 'noarch',
               'has_prefix_files', 'binary_has_prefix_files',
               'detect_binary_files_with_prefix', 'rpaths',
-              'always_include_files', ],
+              'always_include_files', 'use_destdir'],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],

--- a/conda_build/noarch.py
+++ b/conda_build/noarch.py
@@ -36,17 +36,17 @@ def handle_file(f):
         return g
 
 def transform(m, files):
-    f1 = open(join(config.build_prefix,
+    f1 = open(join(config.install_prefix,
                    'bin/.%s-pre-link.sh' % m.name()), 'w')
     f1.write(BASH_HEAD)
     f1.write('''
 cp $SOURCE_DIR/bin/.%s-pre-unlink.sh $PREFIX/bin
 ''' % m.name())
-    f2 = open(join(config.build_prefix,
+    f2 = open(join(config.install_prefix,
                    'bin/.%s-pre-unlink.sh' % m.name()), 'w')
     f2.write(BASH_HEAD)
 
-    scripts_dir = join(config.build_prefix, 'Scripts')
+    scripts_dir = join(config.install_prefix, 'Scripts')
     if not isdir(scripts_dir):
         os.mkdir(scripts_dir)
 

--- a/conda_build/scripts.py
+++ b/conda_build/scripts.py
@@ -53,7 +53,7 @@ def create_entry_point(path, module, func):
 def create_entry_points(items):
     if not items:
         return
-    bin_dir = join(config.build_prefix, bin_dirname)
+    bin_dir = join(config.install_prefix, bin_dirname)
     if not isdir(bin_dir):
         os.mkdir(bin_dir)
     for cmd, module, func in iter_entry_points(items):


### PR DESCRIPTION
This introduces a build/use_destdir option to meta.yaml.  When this
option is set to true files should be installed into $DESTDIR
instead of $PREFIX.  Inside $DESTDIR the $PREFIX should still be
respected, e.g. $DESTDIR/$PREFIX/bin/my_binary is a valid file.

This is useful in case one needs to build a package which
build-depends on itself.  In this case the normal build system would
not detect the new files added.