### PR TITLE
Remove the work directory earlier in the build

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -322,7 +322,7 @@ def build(m, get_src=True, verbose=True, post=None):
         rm_rf(config.short_build_prefix)
         rm_rf(config.long_build_prefix)
         print("Removing old work directory")
-        rm_rf(config.WORK_DIR)
+        rm_rf(source.WORK_DIR)
 
         if (m.get_value('build/detect_binary_files_with_prefix')
             or m.binary_has_prefix_files()):

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -318,8 +318,11 @@ def build(m, get_src=True, verbose=True, post=None):
     post only. False means stop just before the post.
     '''
     if post in [False, None]:
+        print("Removing old build directory")
         rm_rf(config.short_build_prefix)
         rm_rf(config.long_build_prefix)
+        print("Removing old work directory")
+        rm_rf(config.WORK_DIR)
 
         if (m.get_value('build/detect_binary_files_with_prefix')
             or m.binary_has_prefix_files()):


### PR DESCRIPTION
See #322. The templating of the meta.yaml might pull in false information from
previous work directories.

Note that I left the removal in the provide() function because it
can be called from elsewhere.