### PR TITLE
Try setting sudo: false in the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,5 @@ notifications:
 
 git:
   depth: 10000
+
+sudo: false


### PR DESCRIPTION
I'm not sure if we need sudo, but if we don't, this should make the builds use
docker, so they will start faster.