### PR TITLE
Correctly fix egg dirs that are part of the package

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -80,7 +80,7 @@ def remove_easy_install_pth(files, preserve_egg_dir=False):
     sp_dir = environ.get_sp_dir()
     for egg_path in glob(join(sp_dir, '*-py*.egg')):
         if isdir(egg_path):
-            if preserve_egg_dir or not any(i in absfiles for i in walk_prefix(egg_path, False)):
+            if preserve_egg_dir or not any(join(egg_path, i) in absfiles for i in walk_prefix(egg_path, False)):
                 write_pth(egg_path)
                 continue
 


### PR DESCRIPTION
The logic that was intended to skip egg dirs that were not part of the package
was incorrect and ended up skipping all egg dirs.