### PR TITLE
Switch to using MD5 for comparison in conda index

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -9,7 +9,7 @@ import bz2
 import sys
 import json
 import tarfile
-from os.path import join
+from os.path import join, getmtime
 
 from conda_build.utils import file_info
 from conda.compat import PY3
@@ -17,6 +17,7 @@ from conda.utils import md5_file
 
 
 def read_index_tar(tar_path):
+    """ Returns the index.json dict inside the given package tarball. """
     with tarfile.open(tar_path) as t:
         try:
             return json.loads(t.extractfile('info/index.json').read().decode('utf-8'))
@@ -27,6 +28,7 @@ def read_index_tar(tar_path):
             raise RuntimeError("Could not extract %s (%s)" % (tar_path, e))
 
 def write_repodata(repodata, dir_path):
+    """ Write updated repodata.json and repodata.json.bz2 """
     data = json.dumps(repodata, indent=2, sort_keys=True)
     # strip trailing whitespace
     data = '\n'.join(line.rstrip() for line in data.split('\n'))
@@ -38,7 +40,19 @@ def write_repodata(repodata, dir_path):
     with open(join(dir_path, 'repodata.json.bz2'), 'wb') as fo:
         fo.write(bz2.compress(data.encode('utf-8')))
 
-def update_index(dir_path, verbose=False, force=False):
+def update_index(dir_path, verbose=False, force=False, check_md5=False):
+    """
+    Update all index files in dir_path with changed packages.
+
+    :param verbose: Should detailed status messages be output?
+    :type verbose: bool
+    :param force: Whether to re-index all packages (including those that
+                  haven't changed) or not.
+    :type force: bool
+    :param check_md5: Whether to check MD5s instead of mtimes for determining
+                      if a package changed.
+    :type check_md5: bool
+    """
     if verbose:
         print("updating index in:", dir_path)
     index_path = join(dir_path, '.index.json')
@@ -62,8 +76,12 @@ Error:
 """)
     for fn in files:
         path = join(dir_path, fn)
-        if fn in index and index[fn]['md5'] == md5_file(path):
-            continue
+        if fn in index:
+            if check_md5:
+                if index[fn]['md5'] == md5_file(path):
+                    continue
+            elif index[fn]['mtime'] == getmtime(path):
+                continue
         if verbose:
             print('updating:', fn)
         d = read_index_tar(path)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -9,10 +9,12 @@ import bz2
 import sys
 import json
 import tarfile
-from os.path import join, getmtime
+from os.path import join
 
 from conda_build.utils import file_info
 from conda.compat import PY3
+from conda.utils import md5_file
+
 
 def read_index_tar(tar_path):
     with tarfile.open(tar_path) as t:
@@ -60,7 +62,7 @@ Error:
 """)
     for fn in files:
         path = join(dir_path, fn)
-        if fn in index and index[fn]['mtime'] == getmtime(path):
+        if fn in index and index[fn]['md5'] == md5_file(path):
             continue
         if verbose:
             print('updating:', fn)

--- a/conda_build/main_index.py
+++ b/conda_build/main_index.py
@@ -19,6 +19,12 @@ def main():
                    nargs='*',
                    default=[os.getcwd()])
 
+    p.add_argument('-c', "--check_md5",
+                   action="store_true",
+                   help="Use MD5 values instead of file modification times for\
+                         determining if a package's metadata needs to be \
+                         updated.")
+
     p.add_argument('-f', "--force",
                    action="store_true",
                    help="force reading all files")


### PR DESCRIPTION
It used to rely on exact `mtime` matches, which was problematic for distributed file systems like GlusterFS.

I considered switching just converting the times to ints to get around precision issues, but since we already calculate `MD5`, I thought that might be less controversial.