### PR TITLE
fix for issue #178

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -462,7 +462,7 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
     specs_include_python = False
     for spec in m.get_value('test/requires', []):
         specs.append(spec)
-        if spec.startswith('python '):
+        if spec.startswith('python ') or spec == 'python':
             specs_include_python = True
 
     if py_files and not specs_include_python:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -458,15 +458,19 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
     rm_rf(config.test_prefix)
     specs = ['%s %s %s' % (m.name(), m.version(), m.build_id())]
 
-    if py_files:
+    # add packages listed in test/requires
+    specs_include_python = False
+    for spec in m.get_value('test/requires', []):
+        specs.append(spec)
+        if spec.startswith('python '):
+            specs_include_python = True
+
+    if py_files and not specs_include_python:
         # as the tests are run by python, we need to specify it
         specs += ['python %s*' % environ.get_py_ver()]
     if pl_files:
         # as the tests are run by perl, we need to specify it
         specs += ['perl %s*' % environ.get_perl_ver()]
-    # add packages listed in test/requires
-    for spec in m.get_value('test/requires', []):
-        specs.append(spec)
 
     create_env(config.test_prefix, specs, verbose=verbose,
         channel_urls=channel_urls, override_channels=override_channels)


### PR DESCRIPTION
This is a fix for issue #178 

Reordered building of package list for test environment. While adding package to list, if python is included, then ignore adding python to list for packages that test for valid python module/package imports.

I've manually tested this using miniconda3 for a build of a package that requires python 2. 
