### PR TITLE
Fix regression in always_include_files introduced in 1.12.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+2015-04-28   1.12.1:
+  * fix regression in always_include_files that causes build failure (#386)
+
+
 2015-04-10   1.12.0:
 --------------------
   * correctly fix egg directories that are part of the package

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -363,8 +363,8 @@ def build(m, get_src=True, verbose=True, post=None, channel_urls=(), override_ch
         files1 = prefix_files()
         for f in m.always_include_files():
             if f not in files1:
-                sys.exit("Error: File %s from always_include_files not found"
-                    % f)
+                print("Error: File %s from always_include_files not found" % f,
+                      file=sys.stderr)
         files1 = files1.difference(set(m.always_include_files()))
         # Save this for later
         with open(join(config.croot, 'prefix_files.txt'), 'w') as f:


### PR DESCRIPTION
Starting in version 1.12.0, this switched from including files if present to requiring those files to be present.  This breaks the conda-env build and any other build that used the original design.

Given that it is a backwards in-compatible change, this a break without bumping to version 2.0.0.  Reverting this change and changing to a simple error message.

Original Commit: f708dd0225b5292b644133afd190800e24e5e047