### PR TITLE
always_include_files should error on files that aren't there

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -363,8 +363,7 @@ def build(m, get_src=True, verbose=True, post=None, channel_urls=(), override_ch
         files1 = prefix_files()
         for f in m.always_include_files():
             if f not in files1:
-                print("Error: File %s from always_include_files not found" % f,
-                      file=sys.stderr)
+                sys.exit("Error: File %s from always_include_files not found" % f)
         files1 = files1.difference(set(m.always_include_files()))
         # Save this for later
         with open(join(config.croot, 'prefix_files.txt'), 'w') as f:


### PR DESCRIPTION
This is to help avoid typos. If there are files that aren't always there, you
can filter them out with selectors.

See the discussion at
https://github.com/conda/conda-build/commit/f708dd0225b5292b644133afd190800e24e5e047