### PR TITLE
enh: mark certain platforms to skip

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -265,6 +265,9 @@ def execute(args, parser):
             if args.output:
                 print(build.bldpkg_path(m))
                 continue
+            if m.skip():
+                print("SKIPPING BUILD (unsupported platform):", m.dist())
+                continue
             elif args.test:
                 build.test(m, verbose=not args.quiet)
             elif args.source:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -459,11 +459,10 @@ class MetaData(object):
         return ret
 
     def skip(self):
-        skip_expression = self.get_value('build/skip')
-        try:
+        skip_expression = self.get_value('build/skip', None)
+        if skip_expression is not None:
             return bool(eval(skip_expression, ns_cfg(), {}))
-        except:
-            return False
+        return False
 
     def __unicode__(self):
         '''


### PR DESCRIPTION
This is a 1st implementation of a feature I [mentioned on the mailing list](https://groups.google.com/a/continuum.io/forum/#!topic/conda/lrA5bX6V-2s) that extends the `meta.yaml` file to make it possible to mark certain platforms to be skipped by `conda-build`.

For example, if the meta.yaml file contains
```
build:
  skip: win-32
```
then all builds on win-32 of the recipe will exit with a note that this is an unsupported platform, without going through the circus of downloading all of the dependencies and trying to run the `bld.bat` file. Similarly, you can be more restrictive and write
```
build:
  skip: win-32_py27
```
to only skip win-32 for a particular version of python, or
```
build:
  skip:
    - py26
    - py27
```
to add more than one skip specification. 