### PR TITLE
Test binaries passed to `setup` via `scripts` keyword argument using `--help`

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -214,14 +214,15 @@ class bdist_conda(install):
                 if not isinstance(entry_points, dict):
                     raise DistutilsGetoptError("ERROR: Could not add entry points. They were:\n" + entry_points)
                 else:
+                    rs = entry_points.get('scripts', [])
                     cs = entry_points.get('console_scripts', [])
                     gs = entry_points.get('gui_scripts', [])
                     # We have *other* kinds of entry-points so we need
                     # setuptools at run-time
-                    if not cs and not gs and len(entry_points) > 1:
+                    if not rs and not cs and not gs and len(entry_points) > 1:
                         d['requirements']['run'].append('setuptools')
                         d['requirements']['build'].append('setuptools')
-                    entry_list = cs + gs
+                    entry_list = rs + cs + gs
                     if gs and conda.config.platform == 'osx':
                         d['build']['osx_is_app'] = True
                     if len(cs + gs) != 0:

--- a/tests/test-recipes/test-package/bin/test-script-setup.py
+++ b/tests/test-recipes/test-package/bin/test-script-setup.py
@@ -2,3 +2,7 @@
 import conda_build_test
 
 print("Test script setup.py")
+
+if __name__ == "__main__":
+    from conda_build_test import manual_entry
+    manual_entry.main()

--- a/tests/test-recipes/test-package/conda_build_test/manual_entry.py
+++ b/tests/test-recipes/test-package/conda_build_test/manual_entry.py
@@ -1,2 +1,10 @@
 def main():
+    import argparse
+
+    # Just picks them up from `sys.argv`.
+    parser = argparse.ArgumentParser(
+        description="Basic parser."
+    )
+    parser.parse_args()
+
     print("Manual entry point")


### PR DESCRIPTION
Just included everything passed to `scripts` in the `--help` tests. This will help improve testing for Python packages not leveraging the keyword arguments added by `bdist_conda`. Also, it applies a reasonable on all other Python packages (namely having basic help for command line tools).

As this is something `argparse` pretty much handles (or the deprecated `optparse`), this seems like a reasonable constraint.