### PR TITLE
skeleton pypi: add --manual-url argument

### DIFF
--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -94,6 +94,14 @@ def main():
         choices=['2.6', '2.7', '3.3', '3.4'],
         )
 
+    pypi.add_argument(
+        "--manual-url",
+        action='store_true',
+        default=False,
+        help="Manually choose source url when more than one urls are present." +
+             "Default is the one with least source size."
+        )
+
     cpan = repos.add_parser(
         "cpan",
         help="Create recipes from packages on CPAN",

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -346,11 +346,16 @@ def main(args, parser):
         if len(urls) > 1 and not args.noprompt:
             print("More than one source version is available for %s:" %
                   package)
-            for i, url in enumerate(urls):
-                print("%d: %s (%s) %s" % (i, url['url'],
-                                          human_bytes(url['size']),
-                                          url['comment_text']))
-            n = int(input("Which version should I use? "))
+            if args.manual_url:
+                for i, url in enumerate(urls):
+                    print("%d: %s (%s) %s" % (i, url['url'],
+                          human_bytes(url['size']), url['comment_text']))
+                n = int(input("which version should i use? "))
+            else:
+                print("Using the one with the least source size")
+                print("use --manual-url to override this behavior")
+                min_siz, n = min([(url['size'], i)
+                                  for (i, url) in enumerate(urls)])
         else:
             n = 0
 


### PR DESCRIPTION
Currently, when conda-skeleton has more than one sources to choose from, it asks
the users for the decision. The patch changes this behaviour to download from
the source with the least source size. This is because this former choice can
only add to the confusion of a _normal_ user. An informed user can override the
behaviour with the newly added `--manual-url` command line argument.

Signed-off-by: Harsh Gupta <gupta.harsh96@gmail.com>