### PR TITLE
Fix issue where 'conda index' with old packages would create bad metadata

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -107,5 +107,8 @@ Error:
             except KeyError:
                 pass
 
+        if 'requires' in info and 'depends' not in info:
+            info['depends'] = info['requires']
+
     repodata = {'packages': index, 'info': {}}
     write_repodata(repodata, dir_path)


### PR DESCRIPTION
This issue is also described here:
https://groups.google.com/a/continuum.io/forum/#!topic/conda/UXX9E7LkVMA

If necessary, this could also issue warnings about old style packages, or only fix them when an option is given.