### PR TITLE
Try extracting .tar.xz files with tar before requesting unxz

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -68,6 +68,16 @@ uncompress is required to unarchive .z source files.
         subprocess.check_call([uncompress, '-f', tarball])
         tarball = tarball[:-2]
     if not PY3 and tarball.endswith('.tar.xz'):
+        # try extracting directly with tar,
+        # which may be able to cope with xz compression
+        tar = external.find_executable('tar')
+        if tar:
+            try:
+                subprocess.check_call([tar, '-x', '-C', dir_path, '-f', tarball])
+                return
+            except:
+                # try another approach, using 'unxz' first.
+                pass
         unxz = external.find_executable('unxz')
         if not unxz:
             sys.exit("""\


### PR DESCRIPTION
Default Mac OS (10.10) has no 'unxz' installed, but the 'tar' can 
read .tar.xz files on its own so unxz is not needed.

I haven't been able to test this on other platforms, but it seems to work for me on MacOS.
