### PR TITLE
fix import_tests: module name != package name

### DIFF
--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -380,10 +380,7 @@ def main(args, parser):
             # TODO: 'package' won't work with unpack()
             d['filename'] = U.path.rsplit('/', 1)[-1] or 'package'
 
-        if is_url:
-            d['import_tests'] = 'PLACEHOLDER'
-        else:
-            d['import_tests'] = valid(package).lower()
+        d['import_tests'] = ''
 
         get_package_metadata(args, package, d, data)
 


### PR DESCRIPTION
conda-skeleton implicitly assumes that package name is same module name and adds an import test for that, it is not necessarily the case. For example the package dnspython installs a module named dns and the package factory_boy installs the package factory. The earier behavior was causing build failures for such packages.