### PR TITLE
Removed conda-build's circluar dependency.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -24,7 +24,7 @@ from conda.compat import PY3
 from conda.fetch import fetch_index
 from conda.install import prefix_placeholder, linked
 from conda.utils import url_path
-from conda.resolve import Resolve, MatchSpec
+from conda.resolve import Resolve, MatchSpec, NoPackagesFound
 
 from conda_build import environ, source, tarcheck
 from conda_build.config import config
@@ -277,8 +277,9 @@ def warn_on_old_conda_build(index):
         print("WARNING: Could not detect installed version of conda-build", file=sys.stderr)
         return
     r = Resolve(index)
-    pkgs = sorted(r.get_pkgs(MatchSpec('conda-build')))
-    if not pkgs:
+    try:
+        pkgs = sorted(r.get_pkgs(MatchSpec('conda-build')))
+    except NoPackagesFound:
         print("WARNING: Could not find any versions of conda-build in the channels", file=sys.stderr)
         return
     if pkgs[-1].version != vers_inst[0]:


### PR DESCRIPTION
Currently, conda-build depends on finding a conda-build package in the index. 

I think this was introduced in https://github.com/conda/conda/commit/f231ad67c1f18e84f9f70cc68ffb352096f63617.