### PR TITLE
Remove special logic if the username on Windows is "builder"

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -105,8 +105,6 @@ def git_source(meta, recipe_dir):
     cache_repo = cache_repo_arg = join(GIT_CACHE, git_dn)
     if sys.platform == 'win32':
         cache_repo_arg = cache_repo_arg.replace('\\', '/')
-        if os.getenv('USERNAME') == 'builder':
-            cache_repo_arg = '/cygdrive/c/' + cache_repo_arg[3:]
 
     # update (or create) the cache repo
     if isdir(cache_repo):


### PR DESCRIPTION
This is a remnant from the Anaconda build system. It does not belong in
conda-build.