### PR TITLE
skeleton: remove --no-download option

### DIFF
--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -83,16 +83,6 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
         help="URL to use for PyPI (default: %(default)s).",
     )
     pypi.add_argument(
-        "--no-download",
-        action="store_false",
-        dest="download",
-        default=True,
-        help="""Don't download the package. This will keep the recipe from finding the
-                right dependencies and entry points if the package uses
-                distribute.  WARNING: Without this flag, conda skeleton pypi
-                downloads and runs the package's setup.py script."""
-    )
-    pypi.add_argument(
         "--no-prompt",
         action="store_true",
         default=False,

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -462,7 +462,7 @@ def get_package_metadata(args, package, d, data):
     # distribute itself already works by monkeypatching distutils.
 
     import yaml
-    print("Downloading %s (use --no-download to skip this step)" % package)
+    print("Downloading %s" % package)
     tempdir = mkdtemp('conda_skeleton_' + d['filename'])
 
     [output_dir] = args.output_dir


### PR DESCRIPTION
The `--no-download` option of `conda-skeleton pypi` is non-functional. Presently conda-skeleton derives important metadata from the packages setup.py file with this setup there is no way to create any recipe  without the downloading the package source.