### PR TITLE
Refactor conda-skeleton pypi

### DIFF
--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -759,12 +759,12 @@ def run_setuppy(src_dir, temp_dir, args):
         env[str('PYTHONPATH')] = str(src_dir)
     cwd = getcwd()
     chdir(src_dir)
-    args = [config.build_python, 'setup.py', 'install']
+    cmdargs = [config.build_python, 'setup.py', 'install']
     try:
-        subprocess.check_call(args, env=env)
+        subprocess.check_call(cmdargs, env=env)
     except subprocess.CalledProcessError:
         print('$PYTHONPATH = %s' % env['PYTHONPATH'])
-        sys.exit('Error: command failed: %s' % ' '.join(args))
+        sys.exit('Error: command failed: %s' % ' '.join(cmdargs))
     finally:
         chdir(cwd)
 


### PR DESCRIPTION
Most of the heavy lifting of `conda-skeleton pypi` is done by the `get_package_metadata` function, this monolithic block of code is huge (~250 lines) which makes it hard to debug this code and reuse its parts in other. This PR factors out a few blocks into their own functions.