### PR TITLE
[WIP] Allow downloading of patches from github.

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import sys
-import urlparse
 from os.path import join, isdir, isfile, abspath, expanduser
 from shutil import copytree, ignore_patterns, copy2
 from subprocess import check_call, Popen, PIPE

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -7,6 +7,7 @@ import tarfile
 import zipfile
 import subprocess
 import operator
+import urlparse
 from os.path import dirname, getmtime, getsize, isdir, join
 from collections import defaultdict
 
@@ -18,6 +19,13 @@ from conda_build import external
 # Backwards compatibility import. Do not remove.
 from conda.install import rm_rf
 rm_rf
+
+def valid_url(url):
+    """ Check to see if url is valid by checking the scheme and netloc portions """
+    parts = urlparse.urlparse(url)
+    if parts.scheme and parts.netloc:
+        return True
+    return False
 
 def copy_into(src, dst):
     "Copy all the files and directories in src to the directory dst"

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -7,12 +7,11 @@ import tarfile
 import zipfile
 import subprocess
 import operator
-import urlparse
 from os.path import dirname, getmtime, getsize, isdir, join
 from collections import defaultdict
 
 from conda.utils import md5_file
-from conda.compat import PY3, iteritems
+from conda.compat import PY3, iteritems, urlparse
 
 from conda_build import external
 
@@ -22,7 +21,7 @@ rm_rf
 
 def valid_url(url):
     """ Check to see if url is valid by checking the scheme and netloc portions """
-    parts = urlparse.urlparse(url)
+    parts = urlparse(url)
     if parts.scheme and parts.netloc:
         return True
     return False


### PR DESCRIPTION
This PR adds a feature to conda to allow downloading pull requests from github as patches which will then be applied to the source tree.

There are a couple of approaches
1) Download patch to a temporary file and apply to source tree
2) Download patch to a regular file in recipe directory and apply to source tree.  This would make the builds more reproducible in case the PR went away (in which case, the patch should be re-examined).

TODO:
- [ ] Add error checking code.  This assume that the correct github url has been given.  If there is an error, it will most likely die.
- [ ] Add tests (when idea is finalized).
- [ ] Start discussion on how to best implement this.
