### PR TITLE
Rename temporary output folder before deleting and recreating

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -439,7 +439,11 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
     rm_pkgs_cache(m.dist())
 
     tmp_dir = join(config.croot, 'test-tmp_dir')
-    rm_rf(tmp_dir)
+    if os.path.exists(tmp_dir):
+        # rename it and then delete
+        tmp_dir_ = '{}_'.format(tmp_dir)
+        os.rename(tmp_dir, tmp_dir_)
+        rm_rf(tmp_dir_)
     os.makedirs(tmp_dir)
     create_files(tmp_dir, m)
     # Make Perl or Python-specific test files


### PR DESCRIPTION
Fixes #452 

Not sure how to test this. Here is what I did:

* ran the tests available:
```python
C:\dev\code\opensource\conda-build\tests [rename-before-delete]> nosetests
..........
----------------------------------------------------------------------
Ran 10 tests in 0.019s

OK
```
* built my branch and installed the resulting packages
* built a few packages successfully

