### PR TITLE
[pipbuild] fix references to scripts on windows

### DIFF
--- a/conda_build/main_pipbuild.py
+++ b/conda_build/main_pipbuild.py
@@ -7,6 +7,7 @@
 from __future__ import print_function, division, absolute_import
 
 import sys
+import os
 import os.path
 import subprocess
 import yaml
@@ -203,12 +204,21 @@ def get_all_dependencies(package, version):
     cmd1 = "conda create -n _pipbuild_ --yes python pip"
     print(cmd1)
     subprocess.Popen(cmd1.split()).wait()
+
     cmd2 = "%s/bin/pip install %s==%s" % (prefix, package, version)
+    cmd3args = ['%s/bin/python' % prefix, '__tmpfile__.py']
+
+    lsdir = os.listdir(prefix)
+    if not "bin" in lsdir and "Scripts" in lsdir:
+        # Windows
+        cmd2 = "{} install {}=={}".format(
+            os.path.join(prefix, "Scripts", "pip"), package, version)
+        cmd3args = [os.path.join(prefix, "python"), '__tmpfile__.py']
+
     print(cmd2)
     ret = subprocess.Popen(cmd2.split()).wait()
     if ret != 0:
         raise RuntimeError("Could not pip install %s==%s" % (package, version))
-    cmd3args = ['%s/bin/python' % prefix, '__tmpfile__.py']
     fid = open('__tmpfile__.py', 'w')
     fid.write("import pkg_resources;\n")
     fid.write("reqs = pkg_resources.get_distribution('%s').requires();\n" %


### PR DESCRIPTION
Got an error while running `conda pipbuild nose`:

```
Traceback (most recent call last):
  File "C:\Users\jlas\conda\Scripts\conda-pipbuild-script.py", line 4, in <module>
    sys.exit(main())
  File "C:\Users\jlas\conda\lib\site-packages\conda_build\main_pipbuild.py", line 80, in main
    args_func(args, p)
  File "C:\Users\jlas\conda\lib\site-packages\conda_build\main_build.py", line 349, in args_func
    args.func(args, p)
  File "C:\Users\jlas\conda\lib\site-packages\conda_build\main_pipbuild.py", line 360, in execute
    build_package(package, version, noarch_python=args.noarch_python)
  File "C:\Users\jlas\conda\lib\site-packages\conda_build\main_pipbuild.py", line 304, in build_package
    noarch_python=noarch_python)
  File "C:\Users\jlas\conda\lib\site-packages\conda_build\main_pipbuild.py", line 240, in make_recipe
    depends = get_all_dependencies(package, version)
  File "C:\Users\jlas\conda\lib\site-packages\conda_build\main_pipbuild.py", line 208, in get_all_dependencies
    ret = subprocess.Popen(cmd2.split()).wait()
  File "C:\Users\jlas\conda\lib\subprocess.py", line 710, in __init__
    errread, errwrite)
  File "C:\Users\jlas\conda\lib\subprocess.py", line 958, in _execute_child
    startupinfo)
WindowsError: [Error 2] The system cannot find the file specified
```

When I print out `cmd2` I get
```
C:\Users\jlas\conda\envs\_pipbuild_/bin/pip install nose==1.3.7
```

So it is just not setup to handle Windows directory structure I believe

This seems to be the same issue in #341

More info:

```
platform : win-64
conda version : 3.14.1
conda-build version : 1.14.1
python version : 2.7.8.final.0
requests version : 2.7.0
```