### PR TITLE
Added --post-link option to develop command

### DIFF
--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -14,7 +14,7 @@ import fnmatch
 from conda.cli.common import add_parser_prefix, get_prefix
 from conda.cli.conda_argparse import ArgumentParser
 from conda_build.main_build import args_func
-from conda_build.post import mk_relative_osx, mk_relative_linux
+from conda_build.post import mk_relative_osx
 
 from conda.install import linked
 
@@ -84,7 +84,7 @@ def relink_sharedobjects(pkg_path):
     for b_file in bin_files:
         if sys.platform.startswith('linux'):
             # mk_relative_linux(f, rpaths=m.get_value('build/rpaths', ['lib']))
-            raise NotImplementedError("setting rpath on linux is incomplete")
+            raise NotImplementedError("unclear what to do for this on linux")
         elif sys.platform == 'darwin':
             mk_relative_osx(b_file, develop=True)
 

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -90,6 +90,16 @@ def relink_sharedobjects(pkg_path):
             mk_relative_osx(b_file, develop=True)
 
 
+def write_to_conda_pth(sp_dir, pkg_path):
+    '''
+    site-packages directory for current environment
+    append pkg_path to conda.pth
+    '''
+    with open(join(sp_dir, 'conda.pth'), 'a') as f:
+        f.write(pkg_path + '\n')
+        print("added " + pkg_path)
+
+
 def execute(args, parser):
     prefix = get_prefix(args)
     if not isdir(prefix):
@@ -109,14 +119,14 @@ Error: environment does not exist: %s
     for path in args.source:
         pkg_path = abspath(expanduser(path))
         if not args.post_link:
-            # build the package if setup.py is found then 
             stdlib_dir = join(prefix, 'Lib' if sys.platform == 'win32' else
                               'lib/python%s' % py_ver)
             sp_dir = join(stdlib_dir, 'site-packages')
-            with open(join(sp_dir, 'conda.pth'), 'a') as f:
-                for path in args.source:
-                    f.write(pkg_path + '\n')
-                    print("added " + pkg_path)
+
+            # build the package if setup.py is found then invoke it with
+            # build_ext --inplace - this only exists for extensions
+
+            write_to_conda_pth(sp_dir, pkg_path)
 
         # go through the source looking for compiled extensions and make sure
         # they use the conda build environment for loading libraries at runtime

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -8,12 +8,16 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 from os.path import join, isdir, abspath, expanduser
+from os import walk
+import fnmatch
 
 from conda.cli.common import add_parser_prefix, get_prefix
 from conda.cli.conda_argparse import ArgumentParser
 from conda_build.main_build import args_func
+from conda_build.post import mk_relative_osx, mk_relative_linux
 
 from conda.install import linked
+
 
 def main():
     p = ArgumentParser(
@@ -32,11 +36,57 @@ This works by creating a conda.pth file in site-packages."""
         nargs='+',
         help="Path to the source directory."
     )
+    p.add_argument(
+                   '-l', '--post-link',
+                   action='store_true',
+                   help=("Look in source dir for compiled extensions and "
+                         "ensure they link against libraries found in conda "
+                         "env"))
     add_parser_prefix(p)
     p.set_defaults(func=execute)
 
     args = p.parse_args()
     args_func(args, p)
+
+
+def sharedobjects_list(pkg_path):
+    '''
+    return list of shared objects (*.so) found in package that was built in
+    develop mode. These are located in source directory.
+    '''
+    bin_files = []
+
+    # only relevant for mac/linux
+    pattern = '*.so'
+
+    for d_f in walk(pkg_path):
+        m = fnmatch.filter(d_f[2], pattern)
+        if m:
+            # list is not empty, append full path to binary, then add it
+            # to bin_files list
+            bin_files.extend([join(d_f[0], f) for f in m])
+
+    return bin_files
+
+
+def relink_sharedobjects(pkg_path):
+    '''
+    invokes functions in post module to relink to libraries in conda env
+
+    .. todo: implmenent/test call to mk_relative_linux for linux relinking.
+
+    .. note:: would be good to reuse post.post_build() or post.mk_relative()
+        but they require MetaData object which requires conda recipe: meta.yaml
+        Currently, develop mode doesn't use meta.yaml
+    '''
+    # find binaries in package dir and make them relocatable
+    bin_files = sharedobjects_list(pkg_path)
+    for b_file in bin_files:
+        if sys.platform.startswith('linux'):
+            # mk_relative_linux(f, rpaths=m.get_value('build/rpaths', ['lib']))
+            raise NotImplementedError("setting rpath on linux is incomplete")
+        elif sys.platform == 'darwin':
+            mk_relative_osx(b_file, develop=True)
 
 
 def execute(args, parser):
@@ -48,20 +98,29 @@ Error: environment does not exist: %s
 # Use 'conda create' to create the environment first.
 #""" % prefix)
     for package in linked(prefix):
-        name, ver, build = package.rsplit('-', 2)
+        name, ver, _ = package .rsplit('-', 2)
         if name == 'python':
             py_ver = ver[:3] # x.y
             break
     else:
         raise RuntimeError("python is not installed in %s" % prefix)
 
-    stdlib_dir = join(prefix, 'Lib' if sys.platform == 'win32' else
-        'lib/python%s' % py_ver)
-    sp_dir = join(stdlib_dir, 'site-packages')
-    with open(join(sp_dir, 'conda.pth'), 'a') as f:
-        for path in args.source:
-            f.write(abspath(expanduser(path)) + '\n')
+    for path in args.source:
+        pkg_path = abspath(expanduser(path))
+        if not args.post_link:
+            # build the package if setup.py is found then 
+            stdlib_dir = join(prefix, 'Lib' if sys.platform == 'win32' else
+                              'lib/python%s' % py_ver)
+            sp_dir = join(stdlib_dir, 'site-packages')
+            with open(join(sp_dir, 'conda.pth'), 'a') as f:
+                for path in args.source:
+                    f.write(pkg_path + '\n')
+                    print("added " + pkg_path)
 
+        # go through the source looking for compiled extensions and make sure
+        # they use the conda build environment for loading libraries at runtime
+        relink_sharedobjects(pkg_path)
+        print("completed operation for: " + pkg_path)
 
 if __name__ == '__main__':
     main()

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -84,7 +84,8 @@ def relink_sharedobjects(pkg_path):
     for b_file in bin_files:
         if sys.platform.startswith('linux'):
             # mk_relative_linux(f, rpaths=m.get_value('build/rpaths', ['lib']))
-            raise NotImplementedError("unclear what to do for this on linux")
+            print("unclear what to do for this on linux")
+
         elif sys.platform == 'darwin':
             mk_relative_osx(b_file, develop=True)
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -190,7 +190,6 @@ def find_lib(link, path=None):
     print("Don't know how to find %s, skipping" % link)
 
 def osx_ch_link(path, link):
-    assert path.startswith(config.build_prefix + '/')
     print("Fixing linking of %s in %s" % (link, path))
     link_loc = find_lib(link, path)
     if not link_loc:
@@ -226,7 +225,15 @@ def osx_ch_link(path, link):
     ret = ret.replace('/./', '/')
     return ret
 
-def mk_relative_osx(path):
+def mk_relative_osx(path, develop=False):
+    '''
+    if develop=True, do not check the object is in conda's build environment.
+    The assertion is valid in conda build mode, which is used prior to
+    installing packages
+    '''
+    if not develop:
+        assert path.startswith(config.build_prefix + '/')
+
     assert sys.platform == 'darwin' and is_obj(path)
     s = macho.install_name_change(path, osx_ch_link)
 


### PR DESCRIPTION
implemented --post-link option for develop command
- looks in package directory for *.so and ensures they link against
  libraries in conda environment
- useful for packages that include compiled/cython code that we wish to build in develop mode.
- after ./setup.py develop, user can invoke conda develop --post-link to setup links correctly. 