### PR TITLE
Add parameter --msvc {9.0, 10.0} to choose MSVC version

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -23,6 +23,7 @@ class Config(object):
         '')).replace('.', ''))
     CONDA_NPY = int(os.getenv('CONDA_NPY', '19').replace('.', ''))
     CONDA_R = os.getenv("CONDA_R", "3.2.0")
+    CONDA_MSVC = os.getenv("CONDA_MSVC")
 
     PY3K = int(bool(CONDA_PY >= 30))
 


### PR DESCRIPTION
This PR adds an option to choose `--msvc` either `9.0` or `10.0`. This option is only available in windows.

I also made some changes to the way `conda-build` finds and configures MSVC, the main change being that it will now try to use `Microsoft SDK 7.1` if it is available (this is needed because `Visual Studio 2010 Express` fails silently when trying to configure an `amd64` environment through `vcvarsall.bat`

--

This might be a controversial one, since pretty much nobody else uses MSVC 2010 for Python 2.7

We do this in my company because we have a lot of C++ code linked with Python libraries, and our code needs newer versions of MSVC. Unfortunately, that means that we have to pretty much build Python and all external again, since the default compiler is always MSVC 2008