### PR TITLE
bugfix: symlinks not made relative if build_prefix contains a symlink

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -347,12 +347,13 @@ def check_symlinks(files):
     if readlink is False:
         return  # Not on Unix system
     msgs = []
+    real_build_prefix = realpath(config.build_prefix)
     for f in files:
-        path = join(config.build_prefix, f)
+        path = join(real_build_prefix, f)
         if islink(path):
             link_path = readlink(path)
             real_link_path = realpath(path)
-            if real_link_path.startswith(config.build_prefix):
+            if real_link_path.startswith(real_build_prefix):
                 # If the path is in the build prefix, this is fine, but
                 # the link needs to be relative
                 if not link_path.startswith('.'):


### PR DESCRIPTION
This PR fixes an issue where absolute symlinks in the built binaries are not recognized as such and made relative if conda's build environment path contains a symlink.

This is because the path to which the tested symlink is pointing to is resolved with `os.path.realpath()` (which expands _all_ symlinks that are in it), but `config.build_prefix` isn't. I've encountered this bug on a system where `/home` is a symlink to `/nsf/home` (and I've had conda installed in my home directory).