### PR TITLE
Supported freeform content in the meta.yaml.

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -296,6 +296,8 @@ class MetaData(object):
 
     def check_fields(self):
         for section, submeta in iteritems(self.meta):
+            if section == 'extra':
+                continue
             if section not in FIELDS:
                 sys.exit("Error: unknown section: %s" % section)
             for key in submeta:

--- a/tests/test-recipes/metadata/extra_freeform_metadata/meta.yaml
+++ b/tests/test-recipes/metadata/extra_freeform_metadata/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: conda-build-test-extra-metadata
+  version: 0.1
+
+extra:
+  custom: metadata
+  however: {we: want}

--- a/tests/test-recipes/metadata/extra_freeform_metadata/run_test.py
+++ b/tests/test-recipes/metadata/extra_freeform_metadata/run_test.py
@@ -1,0 +1,21 @@
+import os
+import json
+
+
+def main():
+    prefix = os.environ['PREFIX']
+    info_file = os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-extra-metadata-0.1-0.json')
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    source_file = os.path.join(info['link']['source'], 'info', 'recipe.json')
+    with open(source_file, 'r') as fh:
+        source = json.load(fh)
+
+    assert source['extra'] == {"custom": "metadata",
+                               "however": {"we": "want"}}
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Allow the meta.yml to have arbitrary metadata in the recipe.
This is useful for all the things that conda doesn't/shouldn't really care about.