### PR TITLE
Don't include the numpy version in dependencies by default

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ test_script:
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
              if ($LastExitCode -ne 0) {
-                 echo $Error[0].CategoryInfo
+                 echo $Error[0].Exception
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,12 @@ install:
 
 test_script:
   # This will be effectively a no-op for recipes without bld.bat
-  - cmd: |
-         for /D %%f in ("tests\test-recipes\metadata\*") do (
-             C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
-             if errorlevel 1 exit 1
-         )
+  - ps: |
+         cd tests\test-recipes\metadata
+         $files = Get-ChildItem .
+         for ($i=0; $i -lt $files.Count; $i++) {
+             C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
+             if (!$?) {
+                 exit 1
+             }
+         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,9 @@ install:
 test_script:
   # This will be effectively a no-op for recipes without bld.bat
   - set PATH=C:\Miniconda\Scripts;C:\Miniconda;%PATH%
+  # If we don't do this, the git tests will fail because the executable bit is
+  # set incorrectly, making the checkout be dirty.
+  - git config core.fileMode false
   - ps: |
          cd tests\test-recipes\metadata
          $files = Get-ChildItem .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,9 +27,9 @@ install:
   - C:\Miniconda\Scripts\conda list
 
 test_script:
-  - cd tests\test-recipes\metadata
   # This will be effectively a no-op for recipes without bld.bat
   - |
-    for /D %%f in (*) do (
+    for /D %%f in ("tests\test-recipes\metadata\*") do (
         C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
-        if errorlevel 1 exit 1 )
+        if errorlevel 1 exit 1
+    )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ test_script:
   - set PATH=C:\Miniconda\Scripts;C:\Miniconda;%PATH%
   # If we don't do this, the git tests will fail because the executable bit is
   # set incorrectly, making the checkout be dirty.
-  - git config --global core.fileMode false
+  - git config --add --global core.fileMode false
   - ps: |
          cd tests\test-recipes\metadata
          $files = Get-ChildItem .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,9 @@ init:
   - cmd: C:\Miniconda.exe /S /D=C:\Miniconda
   - ps: ls C:\Miniconda/Scripts
   - C:\Miniconda\Scripts\conda config --set always_yes yes
-  - C:\Miniconda\Scripts\conda install pytest requests conda-build ndg-httpsclient jinja2 --quiet
+  - C:\Miniconda\Scripts\conda install pytest requests conda-build jinja2 --quiet
+  - cmd: if "%PYTHON%"=="2.7" C:\Miniconda\Scripts\conda install ndg-httpsclient
+
 
 install:
   - C:\Miniconda\python.exe setup.py install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ test_script:
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
              if ($LastExitCode -ne 0) {
-                 echo $Error[0].InvocationInfo
+                 echo $error[0].ToString() + $error[0].InvocationInfo.PositionMessage
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ init:
   - cmd: C:\Miniconda.exe /S /D=C:\Miniconda
   - ps: ls C:\Miniconda/Scripts
   - C:\Miniconda\Scripts\conda config --set always_yes yes
-  - C:\Miniconda\Scripts\conda install pytest requests conda-build --quiet
+  - C:\Miniconda\Scripts\conda install pytest requests conda-build ndg-httpsclient jinja2 --quiet
 
 install:
   - C:\Miniconda\python.exe setup.py install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
 
 test_script:
   # This will be effectively a no-op for recipes without bld.bat
+  - set PATH=C:\Miniconda\Scripts;C:\Miniconda;%PATH%
   - ps: |
          cd tests\test-recipes\metadata
          $files = Get-ChildItem .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,4 +29,6 @@ install:
 test_script:
   - cd tests\test-recipes\metadata
   # This will be effectively a no-op for recipes without bld.bat
-  - for /D %%f in (*) do (C:\Miniconda\Scripts\conda-build --no-binstar-upload %%~nf)
+  - |
+    for /D %%f in (*) do (C:\Miniconda\Scripts\conda-build --no-binstar-upload %%~nf
+    if errorlevel1 exit 1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,5 @@ test_script:
   - cd tests\test-recipes\metadata
   # This will be effectively a no-op for recipes without bld.bat
   - |
-    for /D %%f in (*) do (C:\Miniconda\Scripts\conda-build --no-binstar-upload %%~nf
-    if errorlevel1 exit 1)
+    for /D %%f in (*) do (C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
+    if errorlevel 1 exit 1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ install:
 
 test_script:
   # This will be effectively a no-op for recipes without bld.bat
-  - |
-    for /D %%f in ("tests\test-recipes\metadata\*") do (
-        C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
-        if errorlevel 1 exit 1
-    )
+  - cmd: |
+         for /D %%f in ("tests\test-recipes\metadata\*") do (
+             C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
+             if errorlevel 1 exit 1
+         )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ test_script:
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
              if ($LastExitCode -ne 0) {
-                 echo $Error[0]
+                 echo $Error[0].CategoryInfo
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,6 @@ test_script:
   - cd tests\test-recipes\metadata
   # This will be effectively a no-op for recipes without bld.bat
   - |
-    for /D %%f in (*) do (C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
-    if errorlevel 1 exit 1)
+    for /D %%f in (*) do (
+    C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
+    if errorlevel 1 exit 1 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ test_script:
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
              if ($LastExitCode -ne 0) {
+                 echo $Error[0]
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ test_script:
          $files = Get-ChildItem .
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
-             if (!$?) {
+             if ($LastExitCode -ne 0) {
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ test_script:
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
              if ($LastExitCode -ne 0) {
-                 echo $Error[0].ErrorDetails
+                 echo $Error[0].InvocationInfo
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ test_script:
          for ($i=0; $i -lt $files.Count; $i++) {
              C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
              if ($LastExitCode -ne 0) {
-                 echo $Error[0].Exception
+                 echo $Error[0].ErrorDetails
                  exit 1
              }
          }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,5 @@ test_script:
   # This will be effectively a no-op for recipes without bld.bat
   - |
     for /D %%f in (*) do (
-    C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
-    if errorlevel 1 exit 1 )
+        C:\Miniconda\Scripts\conda-build --no-binstar-upload "%%~nf"
+        if errorlevel 1 exit 1 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ test_script:
   - set PATH=C:\Miniconda\Scripts;C:\Miniconda;%PATH%
   # If we don't do this, the git tests will fail because the executable bit is
   # set incorrectly, making the checkout be dirty.
-  - git config core.fileMode false
+  - git config --global core.fileMode false
   - ps: |
          cd tests\test-recipes\metadata
          $files = Get-ChildItem .

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -500,6 +500,8 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
     env['PATH'] = (join(config.test_prefix, bin_dirname) + os.pathsep +
                    os.getenv('PATH'))
 
+    if sys.placeholder == 'win32':
+        env['PATH'] = config.test_prefix + os.pathsep + env['PATH']
     for varname in 'CONDA_PY', 'CONDA_NPY', 'CONDA_PERL':
         env[varname] = str(getattr(config, varname))
     env['PREFIX'] = config.test_prefix

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -500,7 +500,7 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
     env['PATH'] = (join(config.test_prefix, bin_dirname) + os.pathsep +
                    os.getenv('PATH'))
 
-    if sys.placeholder == 'win32':
+    if sys.platform == 'win32':
         env['PATH'] = config.test_prefix + os.pathsep + env['PATH']
     for varname in 'CONDA_PY', 'CONDA_NPY', 'CONDA_PERL':
         env[varname] = str(getattr(config, varname))

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -21,7 +21,7 @@ class Config(object):
     CONDA_PERL = os.getenv('CONDA_PERL', '5.18.2')
     CONDA_PY = int(os.getenv('CONDA_PY', cc.default_python.replace('.',
         '')).replace('.', ''))
-    CONDA_NPY = int(os.getenv('CONDA_NPY', '19').replace('.', ''))
+    CONDA_NPY = int(os.getenv('CONDA_NPY', '0').replace('.', '')) or None
     CONDA_R = os.getenv("CONDA_R", "3.2.0")
 
     PY3K = int(bool(CONDA_PY >= 30))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -36,8 +36,7 @@ def ns_cfg():
     py = config.CONDA_PY
     np = config.CONDA_NPY
     pl = config.CONDA_PERL
-    for x in py, np:
-        assert isinstance(x, int), x
+    assert isinstance(py, int), py
     d = dict(
         linux = plat.startswith('linux-'),
         linux32 = bool(plat == 'linux-32'),
@@ -344,6 +343,9 @@ class MetaData(object):
                 if ms.name == name:
                     if (ms.strictness != 1 or
                              self.get_value('build/noarch_python')):
+                        continue
+                    if ver is None:
+                        ms = MatchSpec(name)
                         continue
                     str_ver = text_type(ver)
                     if '.' not in str_ver:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -105,7 +105,7 @@ def git_source(meta, recipe_dir):
     cache_repo = cache_repo_arg = join(GIT_CACHE, git_dn)
     if sys.platform == 'win32':
         p = Popen(['uname', '-s'], stderr=PIPE, stdout=PIPE)
-        uname = p.communicate().decode('utf-8').lower()
+        uname = p.communicate()[0].decode('utf-8').lower()
         is_cygwin = 'cygwin' in uname
         cache_repo_arg = cache_repo_arg.replace('\\', '/')
         if is_cygwin:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -104,7 +104,12 @@ def git_source(meta, recipe_dir):
         git_dn = git_url.split(':')[-1].replace('/', '_')
     cache_repo = cache_repo_arg = join(GIT_CACHE, git_dn)
     if sys.platform == 'win32':
+        p = Popen(['uname -s'], stderr=PIPE, stdout=PIPE)
+        uname = p.communicate().decode('utf-8').lower()
+        is_cygwin = 'cygwin' in uname
         cache_repo_arg = cache_repo_arg.replace('\\', '/')
+        if is_cygwin:
+            cache_repo_arg = '/cygdrive/c/' + cache_repo_arg[3:]
 
     # update (or create) the cache repo
     if isdir(cache_repo):

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -104,7 +104,7 @@ def git_source(meta, recipe_dir):
         git_dn = git_url.split(':')[-1].replace('/', '_')
     cache_repo = cache_repo_arg = join(GIT_CACHE, git_dn)
     if sys.platform == 'win32':
-        p = Popen(['uname -s'], stderr=PIPE, stdout=PIPE)
+        p = Popen(['uname', '-s'], stderr=PIPE, stdout=PIPE)
         uname = p.communicate().decode('utf-8').lower()
         is_cygwin = 'cygwin' in uname
         cache_repo_arg = cache_repo_arg.replace('\\', '/')

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -104,9 +104,7 @@ def git_source(meta, recipe_dir):
         git_dn = git_url.split(':')[-1].replace('/', '_')
     cache_repo = cache_repo_arg = join(GIT_CACHE, git_dn)
     if sys.platform == 'win32':
-        p = Popen(['uname', '-s'], stderr=PIPE, stdout=PIPE)
-        uname = p.communicate()[0].decode('utf-8').lower()
-        is_cygwin = 'cygwin' in uname
+        is_cygwin = 'cygwin' in git.lower()
         cache_repo_arg = cache_repo_arg.replace('\\', '/')
         if is_cygwin:
             cache_repo_arg = '/cygdrive/c/' + cache_repo_arg[3:]

--- a/tests/test-recipes/metadata/always_include_files_glob/meta.yaml
+++ b/tests/test-recipes/metadata/always_include_files_glob/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: always_include_files_regex
-  version: 0.1
+  version: 1.0
 
 build:
   number: 0

--- a/tests/test-recipes/metadata/always_include_files_glob/meta.yaml
+++ b/tests/test-recipes/metadata/always_include_files_glob/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: always_include_files_regex
+  name: conda-build-test-always_include_files-glob
   version: 1.0
 
 build:

--- a/tests/test-recipes/metadata/always_include_files_glob/run_test.py
+++ b/tests/test-recipes/metadata/always_include_files_glob/run_test.py
@@ -15,7 +15,7 @@ def main():
     elif sys.platform.startswith('linux'):
         assert set(info['files']) == {'lib/libpng.so', 'lib/libpng16.so', 'lib/libpng16.so.16', 'lib/libpng16.so.16.17.0'}, info['files']
     elif sys.platform == 'win32':
-        assert sorted(info['files']) == ['Library/lib/libpng.lib', 'Library/lib/libpng16.lib', 'Library/lib/libpng16_static.lib', 'libpng_static.lib']
+        assert sorted(info['files']) == ['Library/lib/libpng.lib', 'Library/lib/libpng16.lib', 'Library/lib/libpng16_static.lib', 'Library/lib/libpng_static.lib']
 
 if __name__ == '__main__':
     main()

--- a/tests/test-recipes/metadata/always_include_files_glob/run_test.py
+++ b/tests/test-recipes/metadata/always_include_files_glob/run_test.py
@@ -15,7 +15,7 @@ def main():
     elif sys.platform.startswith('linux'):
         assert set(info['files']) == {'lib/libpng.so', 'lib/libpng16.so', 'lib/libpng16.so.16', 'lib/libpng16.so.16.17.0'}, info['files']
     elif sys.platform == 'win32':
-        assert sorted(info['files']) == [r'Library\lib\libpng.lib', r'Library\lib\libpng16.lib', r'Library\lib\libpng16_static.lib', r'libpng_static.lib']
+        assert sorted(info['files']) == ['Library/lib/libpng.lib', 'Library/lib/libpng16.lib', 'Library/lib/libpng16_static.lib', 'libpng_static.lib']
 
 if __name__ == '__main__':
     main()

--- a/tests/test-recipes/metadata/always_include_files_glob/run_test.py
+++ b/tests/test-recipes/metadata/always_include_files_glob/run_test.py
@@ -6,7 +6,7 @@ import json
 def main():
     prefix = os.environ['PREFIX']
     info_file = os.path.join(prefix, 'conda-meta',
-                             'always_include_files_regex-0.1-0.json')
+                             'always_include_files_regex-1.0-0.json')
     with open(info_file, 'r') as fh:
         info = json.load(fh)
 

--- a/tests/test-recipes/metadata/always_include_files_glob/run_test.py
+++ b/tests/test-recipes/metadata/always_include_files_glob/run_test.py
@@ -6,7 +6,7 @@ import json
 def main():
     prefix = os.environ['PREFIX']
     info_file = os.path.join(prefix, 'conda-meta',
-                             'always_include_files_regex-1.0-0.json')
+                             'conda-build-test-always_include_files-glob-1.0-0.json')
     with open(info_file, 'r') as fh:
         info = json.load(fh)
 

--- a/tests/test-recipes/metadata/always_include_files_regex/meta.yaml
+++ b/tests/test-recipes/metadata/always_include_files_regex/meta.yaml
@@ -5,10 +5,10 @@ package:
 build:
   number: 0
   always_include_files:
-    - lib/libpng.*\.dylib$  [osx]
-    - lib/libpng\d*\.so     [linux]
+    - lib/libpng.*\.dylib$    [osx]
+    - lib/libpng\d*\.so       [linux]
+    - Library\lib\libpng*.lib [win]
 
 requirements:
     build:
         - libpng
-

--- a/tests/test-recipes/metadata/always_include_files_regex/run_test.py
+++ b/tests/test-recipes/metadata/always_include_files_regex/run_test.py
@@ -14,6 +14,8 @@ def main():
         assert sorted(info['files']) == [u'lib/libpng.dylib', u'lib/libpng16.16.dylib', u'lib/libpng16.dylib']
     elif sys.platform == 'linux2':
         assert sorted(info['files']) == ['lib/libpng.so', 'lib/libpng16.so', 'lib/libpng16.so.16', 'lib/libpng16.so.16.17.0']
+    elif sys.platform == 'win32':
+        assert sorted(info['files']) == [r'Library\lib\libpng.lib', r'Library\lib\libpng16.lib', r'Library\lib\libpng16_static.lib', r'libpng_static.lib']
 
 if __name__ == '__main__':
     main()

--- a/tests/test-recipes/metadata/numpy_build/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: conda-build-test-numpy-build
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy

--- a/tests/test-recipes/metadata/numpy_build/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-1.0-0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-1.0-0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build/run_test.bat
@@ -1,6 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-1.0-0"
 if errorlevel 1 exit 1
-echo "%condalist%"
-if not "%condalist%"=="conda-build-test-numpy-build-1.0-0" exit 1

--- a/tests/test-recipes/metadata/numpy_build/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-numpy-build-1.0-0" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-1.0-0.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-1.0-0.json" | grep -v 'numpy'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build/run_test.bat
@@ -4,7 +4,3 @@ for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalis
 if errorlevel 1 exit 1
 echo "%condalist%"
 if not "%condalist%"=="conda-build-test-numpy-build-1.0-0" exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-1.0-0.json"
-if errorlevel 1 exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-1.0-0.json" | grep -v 'numpy'
-if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build/run_test.sh
@@ -1,0 +1,6 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should not contain Numpy
+[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-numpy-build-1.0-0" ]
+
+cat $PREFIX/conda-meta/conda-build-test-numpy-build-1.0-0.json
+cat $PREFIX/conda-meta/conda-build-test-numpy-build-1.0-0.json | grep -v 'numpy'

--- a/tests/test-recipes/metadata/numpy_build/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build/run_test.sh
@@ -1,6 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should not contain Numpy
-[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-numpy-build-1.0-0" ]
-
-cat $PREFIX/conda-meta/conda-build-test-numpy-build-1.0-0.json
-cat $PREFIX/conda-meta/conda-build-test-numpy-build-1.0-0.json | grep -v 'numpy'
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-1.0-0"

--- a/tests/test-recipes/metadata/numpy_build_run/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_run/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-numpy-build-run
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy
+  run:
+    - python
+    - numpy

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -1,3 +1,4 @@
+@echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
 for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-numpy-build-run-1.0-0" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-run-1.0-0.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-run-1.0-0.json" | grep -v 'numpy'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -1,5 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -4,7 +4,3 @@ for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalis
 if errorlevel 1 exit 1
 echo "%condalist%"
 if not "%condalist%"=="conda-build-test-numpy-build-run-1.0-0" exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-run-1.0-0.json"
-if errorlevel 1 exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-numpy-build-run-1.0-0.json" | grep -v 'numpy'
-if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -1,7 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
 if errorlevel 1 exit 1
-echo "%condalist%"
-if not "%condalist%"=="conda-build-test-numpy-build-run-1.0-0" exit 1

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.sh
@@ -1,0 +1,7 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
+
+cat $PREFIX/conda-meta/conda-build-test-numpy-build-run-1.0-nppy*_0.json
+cat $PREFIX/conda-meta/conda-build-test-numpy-build-run-1.0-nppy*_0.json | grep 'numpy'
+cat $PREFIX/conda-meta/conda-build-test-numpy-build-run-1.0-nppy*_0.json | grep -v 'numpy .\..\*'

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.sh
@@ -1,7 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain NumPy, but not the version
 conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
-
-cat $PREFIX/conda-meta/conda-build-test-numpy-build-run-1.0-nppy*_0.json
-cat $PREFIX/conda-meta/conda-build-test-numpy-build-run-1.0-nppy*_0.json | grep 'numpy'
-cat $PREFIX/conda-meta/conda-build-test-numpy-build-run-1.0-nppy*_0.json | grep -v 'numpy .\..\*'

--- a/tests/test-recipes/metadata/numpy_run/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_run/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: conda-build-test-numpy-run
+  version: 1.0
+
+requirements:
+  run:
+    - python
+    - numpy

--- a/tests/test-recipes/metadata/numpy_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_run/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-numpy-run-1.0-0" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-numpy-run-1.0-0.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-numpy-run-1.0-0.json" | grep -v 'numpy'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_run/run_test.bat
@@ -1,6 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
 if errorlevel 1 exit 1
-echo "%condalist%"
-if not "%condalist%"=="conda-build-test-numpy-run-1.0-0" exit 1

--- a/tests/test-recipes/metadata/numpy_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_run/run_test.bat
@@ -4,7 +4,3 @@ for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalis
 if errorlevel 1 exit 1
 echo "%condalist%"
 if not "%condalist%"=="conda-build-test-numpy-run-1.0-0" exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-numpy-run-1.0-0.json"
-if errorlevel 1 exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-numpy-run-1.0-0.json" | grep -v 'numpy'
-if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_run/run_test.sh
@@ -1,0 +1,7 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should contian NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
+
+cat $PREFIX/conda-meta/conda-build-test-numpy-run-1.0-nppy*_0.json
+cat $PREFIX/conda-meta/conda-build-test-numpy-run-1.0-nppy*_0.json | grep 'numpy'
+cat $PREFIX/conda-meta/conda-build-test-numpy-run-1.0-nppy*_0.json | grep -v 'numpy .\..\*'

--- a/tests/test-recipes/metadata/numpy_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_run/run_test.sh
@@ -1,7 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contian NumPy, but not the version
 conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
-
-cat $PREFIX/conda-meta/conda-build-test-numpy-run-1.0-nppy*_0.json
-cat $PREFIX/conda-meta/conda-build-test-numpy-run-1.0-nppy*_0.json | grep 'numpy'
-cat $PREFIX/conda-meta/conda-build-test-numpy-run-1.0-nppy*_0.json | grep -v 'numpy .\..\*'

--- a/tests/test-recipes/metadata/python_build/meta.yaml
+++ b/tests/test-recipes/metadata/python_build/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: conda-build-test-python-build
+  version: 1.0
+
+requirements:
+  build:
+    - python

--- a/tests/test-recipes/metadata/python_build/run_test.bat
+++ b/tests/test-recipes/metadata/python_build/run_test.bat
@@ -1,6 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
 if errorlevel 1 exit 1
-echo "%condalist%"
-if not "%condalist%"=="conda-build-test-python-build-1.0-0" exit 1

--- a/tests/test-recipes/metadata/python_build/run_test.bat
+++ b/tests/test-recipes/metadata/python_build/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build/run_test.bat
+++ b/tests/test-recipes/metadata/python_build/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-build-1.0-0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build/run_test.bat
+++ b/tests/test-recipes/metadata/python_build/run_test.bat
@@ -4,7 +4,3 @@ for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalis
 if errorlevel 1 exit 1
 echo "%condalist%"
 if not "%condalist%"=="conda-build-test-python-build-1.0-0" exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-python-build-1.0-0.json"
-if errorlevel 1 exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-python-build-1.0-0.json" | grep -v 'python'
-if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build/run_test.bat
+++ b/tests/test-recipes/metadata/python_build/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-python-build-1.0-0" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-python-build-1.0-0.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-python-build-1.0-0.json" | grep -v 'python'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build/run_test.sh
+++ b/tests/test-recipes/metadata/python_build/run_test.sh
@@ -1,6 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should not contain Python
-[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-python-build-1.0-0" ]
-
-cat $PREFIX/conda-meta/conda-build-test-python-build-1.0-0.json
-cat $PREFIX/conda-meta/conda-build-test-python-build-1.0-0.json | grep -v 'python'
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-1.0-0"

--- a/tests/test-recipes/metadata/python_build/run_test.sh
+++ b/tests/test-recipes/metadata/python_build/run_test.sh
@@ -1,0 +1,6 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should not contain Python
+[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-python-build-1.0-0" ]
+
+cat $PREFIX/conda-meta/conda-build-test-python-build-1.0-0.json
+cat $PREFIX/conda-meta/conda-build-test-python-build-1.0-0.json | grep -v 'python'

--- a/tests/test-recipes/metadata/python_build_run/meta.yaml
+++ b/tests/test-recipes/metadata/python_build_run/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: conda-build-test-python-build-run
+  version: 1.0
+
+requirements:
+  build:
+    - python
+  run:
+    - python

--- a/tests/test-recipes/metadata/python_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_build_run/run_test.bat
@@ -1,6 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"
 if errorlevel 1 exit 1
-echo "%condalist%"
-if not "%condalist%"=="conda-build-test-python-build-run-1.0-0" exit 1

--- a/tests/test-recipes/metadata/python_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_build_run/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-python-build-run-1.0-0" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-python-build-run-1.0-0.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-python-build-run-1.0-0.json" | grep -v 'python'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_build_run/run_test.bat
@@ -4,7 +4,3 @@ for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalis
 if errorlevel 1 exit 1
 echo "%condalist%"
 if not "%condalist%"=="conda-build-test-python-build-run-1.0-0" exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-python-build-run-1.0-0.json"
-if errorlevel 1 exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-python-build-run-1.0-0.json" | grep -v 'python'
-if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_build_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/python_build_run/run_test.sh
@@ -1,6 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain Python
 conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"
-
-cat $PREFIX/conda-meta/conda-build-test-python-build-run-1.0-py*_0.json
-cat $PREFIX/conda-meta/conda-build-test-python-build-run-1.0-py*_0.json | grep 'python .\..\*'

--- a/tests/test-recipes/metadata/python_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/python_build_run/run_test.sh
@@ -1,0 +1,6 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain Python
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"
+
+cat $PREFIX/conda-meta/conda-build-test-python-build-run-1.0-py*_0.json
+cat $PREFIX/conda-meta/conda-build-test-python-build-run-1.0-py*_0.json | grep 'python .\..\*'

--- a/tests/test-recipes/metadata/python_run/meta.yaml
+++ b/tests/test-recipes/metadata/python_run/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: conda-build-test-python-run
+  version: 1.0
+
+requirements:
+  run:
+    - python

--- a/tests/test-recipes/metadata/python_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_run/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-python-run-1.0-0" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-python-run-1.0-0.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-python-run-1.0-0.json" | grep -v 'python'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_run/run_test.bat
@@ -1,6 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
 if errorlevel 1 exit 1
-echo "%condalist%"
-if not "%condalist%"=="conda-build-test-python-run-1.0-0" exit 1

--- a/tests/test-recipes/metadata/python_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_run/run_test.bat
@@ -4,7 +4,3 @@ for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalis
 if errorlevel 1 exit 1
 echo "%condalist%"
 if not "%condalist%"=="conda-build-test-python-run-1.0-0" exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-python-run-1.0-0.json"
-if errorlevel 1 exit 1
-cat "%PREFIX%\conda-meta\conda-build-test-python-run-1.0-0.json" | grep -v 'python'
-if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_run/run_test.sh
+++ b/tests/test-recipes/metadata/python_run/run_test.sh
@@ -1,6 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain Python
 conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
-
-cat $PREFIX/conda-meta/conda-build-test-python-run-1.0-py*_0.json
-cat $PREFIX/conda-meta/conda-build-test-python-run-1.0-py*_0.json | grep 'python .\..\*'

--- a/tests/test-recipes/metadata/python_run/run_test.sh
+++ b/tests/test-recipes/metadata/python_run/run_test.sh
@@ -1,0 +1,6 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain Python
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-py.._0"
+
+cat $PREFIX/conda-meta/conda-build-test-python-run-1.0-py*_0.json
+cat $PREFIX/conda-meta/conda-build-test-python-run-1.0-py*_0.json | grep 'python .\..\*'

--- a/tests/test-recipes/metadata/source_git/bld.bat
+++ b/tests/test-recipes/metadata/source_git/bld.bat
@@ -1,5 +1,5 @@
 if not exist .git exit 1
-git describe
+git describe --tags --dirty
 if errorlevel 1 exit 1
 for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/source_git/bld.bat
+++ b/tests/test-recipes/metadata/source_git/bld.bat
@@ -1,4 +1,6 @@
 if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
 git describe --tags --dirty
 if errorlevel 1 exit 1
 for /f "delims=" %%i in ('git describe') do set gitdesc=%%i

--- a/tests/test-recipes/metadata/source_git/bld.bat
+++ b/tests/test-recipes/metadata/source_git/bld.bat
@@ -5,6 +5,8 @@ for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
 if errorlevel 1 exit 1
 echo "%gitdesc%"
 if not "%gitdesc%"=="1.8.1" exit 1
+git status
+if errorlevel 1 exit 1
 set PYTHONPATH=.
 python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/source_git/bld.bat
+++ b/tests/test-recipes/metadata/source_git/bld.bat
@@ -7,6 +7,8 @@ echo "%gitdesc%"
 if not "%gitdesc%"=="1.8.1" exit 1
 git status
 if errorlevel 1 exit 1
+git diff
+if errorlevel 1 exit 1
 set PYTHONPATH=.
 python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/source_git/bld.bat
+++ b/tests/test-recipes/metadata/source_git/bld.bat
@@ -6,5 +6,5 @@ if errorlevel 1 exit 1
 echo "%gitdesc%"
 if not "%gitdesc%"=="1.8.1" exit 1
 set PYTHONPATH=.
-python -c "import conda_build; assert conda_build.__version__ == '1.8.1'"
+python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/source_git/build.sh
+++ b/tests/test-recipes/metadata/source_git/build.sh
@@ -4,4 +4,4 @@
 [ -d .git ]
 git describe
 [ "$(git describe)" = 1.8.1 ]
-PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.8.1'"
+PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"


### PR DESCRIPTION
It will still be included if CONDA_NPY or --numpy is specified, but by
default, numpy is now treated just as any other package.