### PR TITLE
Test help on CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - py.test tests
   - tests/test-recipes/build_recipes.sh
   - tests/test-skeleton/test-skeleton.sh
+  - conda build --help
 
 notifications:
     flowdock: ef3821a08a791106512ccfc04c92eccb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ init:
 
 install:
   - C:\Miniconda\python.exe setup.py install
+  - C:\Miniconda\Scripts\conda build --help
   - C:\Miniconda\Scripts\conda info -a
   - C:\Miniconda\Scripts\conda list
 


### PR DESCRIPTION
It would be nice to catch issues with `conda build --help` in advance of a release. This is an easy way to do so.

Ultimately, something like this would be good, as well ( https://github.com/conda/conda-build/pull/400 ). Though it may need more work.