### PR TITLE
develop options --build_ext, --clean_build_ext

### DIFF
--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -209,16 +209,17 @@ Error: environment does not exist: %s
 
     for path in args.source:
         pkg_path = abspath(expanduser(path))
-        setup_py = get_setup_py(pkg_path)
 
-        if args.clean:
-            clean(setup_py)
-            if not args.build_ext:
-                sys.exit()
+        if args.clean or args.build_ext:
+            setup_py = get_setup_py(pkg_path)
+            if args.clean:
+                clean(setup_py)
+                if not args.build_ext:
+                    sys.exit()
 
-        # build extensions before adding to conda.pth
-        if args.build_ext:
-            build_ext(setup_py)
+            # build extensions before adding to conda.pth
+            if args.build_ext:
+                build_ext(setup_py)
 
         if not args.no_pth_file:
             write_to_conda_pth(sp_dir, pkg_path)

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -46,11 +46,15 @@ This works by creating a conda.pth file in site-packages."""
     p.add_argument(
                    '-b', '--build_ext',
                    action='store_true',
-                   help=("Invoke clean, then build extensions inplace: "
-                         "python setup.py clean && "
+                   help=("Build extensions inplace, invoking: "
                          "python setup.py build_ext --inplace; "
                          "add to conda.pth; relink runtime libraries to "
                          "environment's lib/."))
+    p.add_argument(
+                   '-c', '--clean',
+                   action='store_true',
+                   help=("Used with build_ext; invoke clean before "
+                         "building extensions via build_ext"))
     add_parser_prefix(p)
     p.set_defaults(func=execute)
 
@@ -140,7 +144,7 @@ def get_setup_py(path_):
     return setup_py
 
 
-def build_ext(pkg_path):
+def build_ext(pkg_path, clean_=False):
     '''
     define a develop function - similar to build function
     todo: still need to test on win32 and linux
@@ -155,11 +159,12 @@ def build_ext(pkg_path):
     '''
     setup_py = get_setup_py(pkg_path)
 
-    # first call setup.py clean
-    cmd = ['python', setup_py, 'clean']
-    _check_call(cmd)
-    print("Completed: " + " ".join(cmd))
-    print("===============================================")
+    if clean_:
+        # first call setup.py clean
+        cmd = ['python', setup_py, 'clean']
+        _check_call(cmd)
+        print("Completed: " + " ".join(cmd))
+        print("===============================================")
 
     # next call setup.py develop
     cmd = ['python', setup_py, 'build_ext', '--inplace']
@@ -192,7 +197,7 @@ Error: environment does not exist: %s
 
         # build extensions before adding to conda.pth
         if args.build_ext:
-            build_ext(pkg_path)
+            build_ext(pkg_path, clean_=args.clean)
 
         if not args.no_pth_file:
             write_to_conda_pth(sp_dir, pkg_path)

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -107,14 +107,25 @@ def relink_sharedobjects(pkg_path, build_prefix):
 def write_to_conda_pth(sp_dir, pkg_path):
     '''
     append pkg_path to conda.pth in site-packages directory for current
-    environment
+    environment. Only add path if it doens't already exist.
 
     :param sp_dir: path to site-packages/. directory
     :param pkg_path: the package path to append to site-packes/. dir.
     '''
-    with open(join(sp_dir, 'conda.pth'), 'a') as f:
-        f.write(pkg_path + '\n')
-        print("added " + pkg_path)
+    c_file = join(sp_dir, 'conda.pth')
+    with open(c_file, 'a') as f:
+        with open(c_file, 'r') as cf:
+            # make sure file exists, before we try to read from it hence nested
+            # in append with block
+            # expect conda.pth to be small so read it all in at once
+            pkgs_in_dev_mode = cf.readlines()
+
+        # only append pkg_path if it doesn't already exist in conda.pth
+        if pkg_path + '\n' in pkgs_in_dev_mode:
+            print("path exits, skipping " + pkg_path)
+        else:
+            f.write(pkg_path + '\n')
+            print("added " + pkg_path)
 
 
 def get_site_pkg(prefix, py_ver):

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -51,10 +51,13 @@ This works by creating a conda.pth file in site-packages."""
                          "add to conda.pth; relink runtime libraries to "
                          "environment's lib/."))
     p.add_argument(
-                   '-c', '--clean',
+                   '-c', '--clean_build_ext',
                    action='store_true',
-                   help=("Used with build_ext; invoke clean before "
-                         "building extensions via build_ext"))
+                   help=("Invoke clean then build_ext: "
+                         "python setup.py clean && "
+                         "python setup.py build_ext --inplace; "
+                         "add to conda.pth; relink runtime libraries to "
+                         "environment's lib/."))
     add_parser_prefix(p)
     p.set_defaults(func=execute)
 
@@ -207,8 +210,8 @@ Error: environment does not exist: %s
         pkg_path = abspath(expanduser(path))
 
         # build extensions before adding to conda.pth
-        if args.build_ext:
-            build_ext(pkg_path, clean_=args.clean)
+        if args.build_ext or args.clean_build_ext:
+            build_ext(pkg_path, clean_=args.clean_build_ext)
 
         if not args.no_pth_file:
             write_to_conda_pth(sp_dir, pkg_path)


### PR DESCRIPTION
1. Added options to conda develop to build extensions
    `conda develop --build_ext pkg_path`
    Looks for setup.py in pkg_path, then invokes python setup.py build_ext --inplace
    No exception handling here, so if this fails then user should be alerted since their setup.py is broken. If setup.py not found, then simply exit.

2. Added option to clean and build extensions
    `conda develop --clean_build_ext pkg_path`
    This will invoke python setup.py clean && python setup.py build_ext --inplace

3. Both options above will fix the linkages in extensions after building so they first search in current conda environment's lib/. for dependencies.

4. Also updated write_to_conda_pth() so a path is only appended to conda.pth if the path does not already exist in the file.