### PR TITLE
Use `splitlines` to break up multiple lines

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -194,7 +194,7 @@ class bdist_conda(install):
                 if isinstance(entry_points, string_types):
                     # makes sure it is left-shifted
                     newstr = "\n".join(x.strip() for x in
-                        entry_points.split('\n'))
+                        entry_points.splitlines())
                     c = configparser.ConfigParser()
                     entry_points = {}
                     try:

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -74,7 +74,7 @@ def has_nonpy_entry_points(t, unix_to_win=True, show=False, quiet=False):
                     print("Binary file %s" % m.path)
                 matched = True
             else:
-                firstline = r.split('\n')[0]
+                firstline = r.splitlines()[0]
                 if 'python' not in firstline:
                     if show:
                         print("Non-Python plaintext file %s" % m.path)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -34,7 +34,7 @@ def write_repodata(repodata, dir_path):
     """ Write updated repodata.json and repodata.json.bz2 """
     data = json.dumps(repodata, indent=2, sort_keys=True)
     # strip trailing whitespace
-    data = '\n'.join(line.rstrip() for line in data.split('\n'))
+    data = '\n'.join(line.rstrip() for line in data.splitlines())
     # make sure we have newline at the end
     if not data.endswith('\n'):
         data += '\n'

--- a/conda_build/main_pipbuild.py
+++ b/conda_build/main_pipbuild.py
@@ -143,7 +143,7 @@ def build_recipe(package, version=None):
         print(err.output)
         raise RuntimeError((" ".join(args)))
 
-    output = result.strip().split('\n')
+    output = result.strip().splitlines()
     if output[-1] == 'Done':
         direc = output[-2].split()[-1]
     else:

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -487,7 +487,7 @@ def get_package_metadata(args, package, d, data):
         if isinstance(entry_points, str):
             # makes sure it is left-shifted
             newstr = "\n".join(x.strip()
-                                for x in entry_points.split('\n'))
+                                for x in entry_points.splitlines())
             config = configparser.ConfigParser()
             entry_points = {}
             try:
@@ -537,7 +537,7 @@ def get_package_metadata(args, package, d, data):
             deps.append('setuptools')
         for deptext in requires:
             if isinstance(deptext, string_types):
-                deptext = deptext.split('\n')
+                deptext = deptext.splitlines()
             # Every item may be a single requirement
             #  or a multiline requirements string...
             for dep in deptext:


### PR DESCRIPTION
Fixes conda/conda#1425.

Also, grabbed a few more while I was at it.