### PR TITLE
Rename binstar -> anaconda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,20 +16,20 @@ Installation
 Building Your Own Packages
 --------------------------
 
-You can easily build your own packages for conda, and upload them to `Binstar
-<https://binstar.org>`_, a free service for hosting packages for conda, as
+You can easily build your own packages for conda, and upload them to `anaconda.org
+<https://anaconda.org>`_, a free service for hosting packages for conda, as
 well as other package managers.  To build a package, create a recipe.  See
 http://github.com/conda/conda-recipes for many example recipes, and
 http://conda.pydata.org/docs/build.html for documentation on how to build
 recipes.
 
-To upload to Binstar, create an account on binstar.org.  Then, install the
-binstar client and login
+To upload to anaconda.org, create an account.  Then, install the anaconda-client
+and login
 
 .. code-block:: bash
 
-   $ conda install binstar
-   $ binstar login
+   $ conda install anaconda-client
+   $ anaconda login
 
 Then, after you build your recipe
 
@@ -37,14 +37,14 @@ Then, after you build your recipe
 
    $ conda build <recipe-dir>
 
-you will be prompted to upload to binstar.
+you will be prompted to upload to anaconda.org.
 
-To add your Binstar channel, or the channel of others to conda so that ``conda
+To add your anaconda.org channel, or the channel of others to conda so that ``conda
 install`` will find and install their packages, run
 
 .. code-block:: bash
 
-   $ conda config --add channels https://conda.binstar.org/username
+   $ conda config --add channels https://conda.anaconda.org/username
 
 (replacing ``username`` with the user name of the person whose channel you want
 to add).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ test_script:
          cd tests\test-recipes\metadata
          $files = Get-ChildItem .
          for ($i=0; $i -lt $files.Count; $i++) {
-             C:\Miniconda\Scripts\conda-build.exe --no-binstar-upload $files[$i]
+             C:\Miniconda\Scripts\conda-build.exe --no-anaconda-upload $files[$i]
              if ($LastExitCode -ne 0) {
                  echo $error[0].ToString() + $error[0].InvocationInfo.PositionMessage
                  exit 1

--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -265,9 +265,9 @@ class bdist_conda(install):
                 handle_binstar_upload(build.bldpkg_path(m), args)
             else:
                 no_upload_message = """\
-# If you want to upload this package to binstar.org later, type:
+# If you want to upload this package to anaconda.org later, type:
 #
-# $ binstar upload %s
+# $ anaconda upload %s
 """ % build.bldpkg_path(m)
                 print(no_upload_message)
 
@@ -282,7 +282,7 @@ bdist_conda.user_options.extend([
     the conda package. Defaults to 0, or the conda_buildnum specified in the
     setup() function. The command line flag overrides the option to
     setup().''')),
-    (str('binstar-upload'), None, ("""Upload the finished package to binstar""")),
+    (str('anaconda-upload'), None, ("""Upload the finished package to anaconda.org""")),
     ])
 
-bdist_conda.boolean_options.extend([str('binstar-upload')])
+bdist_conda.boolean_options.extend([str('anaconda-upload')])

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -156,7 +156,7 @@ def create_info_files(m, files, include_recipe=True):
         dst = join(config.info_dir, readme)
         shutil.copy(src, dst)
         if os.path.split(readme)[1] not in {"README.md", "README.rst", "README"}:
-            print("WARNING: Binstar only recognizes about/readme as README.md and README.rst",
+            print("WARNING: anaconda.org only recognizes about/readme as README.md and README.rst",
                 file=sys.stderr)
 
     # Deal with Python 2 and 3's different json module type reqs

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -73,9 +73,16 @@ different sets of packages."""
         help="Only check (validate) the recipe.",
     )
     p.add_argument(
+        "--no-anaconda-upload",
+        action="store_false",
+        help="Do not ask to upload the package to anaconda.org.",
+        dest='binstar_upload',
+        default=config.binstar_upload,
+    )
+    p.add_argument(
         "--no-binstar-upload",
         action="store_false",
-        help="Do not ask to upload the package to binstar.",
+        help="Do not ask to upload the package to anaconda.org.",
         dest='binstar_upload',
         default=config.binstar_upload,
     )
@@ -113,12 +120,12 @@ different sets of packages."""
         '-b', '--build-only',
         action="store_true",
         help="""Only run the build, without any post processing or
-        testing. Implies --no-test and --no-binstar-upload.""",
+        testing. Implies --no-test and --no-anaconda-upload.""",
     )
     p.add_argument(
         '-p', '--post',
         action="store_true",
-        help="Run the post-build logic. Implies --no-test and --no-binstar-upload.",
+        help="Run the post-build logic. Implies --no-test and --no-anaconda-upload.",
     )
     p.add_argument(
         '--skip-existing',
@@ -189,7 +196,7 @@ def handle_binstar_upload(path, args):
         upload = args.binstar_upload
 
     no_upload_message = """\
-# If you want to upload this package to binstar.org later, type:
+# If you want to upload this package to anaconda.org later, type:
 #
 # $ binstar upload %s
 #
@@ -200,15 +207,15 @@ def handle_binstar_upload(path, args):
         print(no_upload_message)
         return
 
-    binstar = find_executable('binstar')
+    binstar = find_executable('anaconda')
     if binstar is None:
         print(no_upload_message)
         sys.exit('''
-Error: cannot locate binstar (required for upload)
+Error: cannot locate anaconda command (required for upload)
 # Try:
-# $ conda install binstar
+# $ conda install anaconda-client
 ''')
-    print("Uploading to binstar")
+    print("Uploading to anaconda.org")
     args = [binstar, 'upload', path]
     try:
         subprocess.call(args)

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import argparse
 import sys
 from collections import deque
 from glob import glob
@@ -82,7 +83,7 @@ different sets of packages."""
     p.add_argument(
         "--no-binstar-upload",
         action="store_false",
-        help="Do not ask to upload the package to anaconda.org.",
+        help=argparse.SUPPRESS,
         dest='binstar_upload',
         default=config.binstar_upload,
     )

--- a/conda_build/main_metapackage.py
+++ b/conda_build/main_metapackage.py
@@ -30,9 +30,16 @@ command line with the conda metapackage command.
     )
 
     p.add_argument(
+        "--no-anaconda-upload",
+        action="store_false",
+        help="Do not ask to upload the package to anaconda.org.",
+        dest='binstar_upload',
+        default=conda.config.binstar_upload,
+    )
+    p.add_argument(
         "--no-binstar-upload",
         action="store_false",
-        help="Do not ask to upload the package to binstar.",
+        help="Do not ask to upload the package to anaconda.org.",
         dest='binstar_upload',
         default=conda.config.binstar_upload,
     )

--- a/conda_build/main_metapackage.py
+++ b/conda_build/main_metapackage.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import argparse
 from collections import defaultdict
 
 import conda.config
@@ -39,7 +40,7 @@ command line with the conda metapackage command.
     p.add_argument(
         "--no-binstar-upload",
         action="store_false",
-        help="Do not ask to upload the package to anaconda.org.",
+        help=argparse.SUPPRESS,
         dest='binstar_upload',
         default=conda.config.binstar_upload,
     )

--- a/conda_build/main_pipbuild.py
+++ b/conda_build/main_pipbuild.py
@@ -36,16 +36,16 @@ PyPI is using conda skeleton pypi and conda build.
     )
 
     p.add_argument(
-        "--no-binstar-upload",
+        "--no-anaconda-upload",
         action="store_false",
-        help="Do not ask to upload the package to binstar.",
+        help="Do not ask to upload the package to anaconda.org.",
         dest='binstar_upload',
         default=cc.binstar_upload,
     )
     p.add_argument(
-        "--binstar-upload",
+        "--anaconda-upload",
         action="store_true",
-        help="Upload the package to binstar.",
+        help="Upload the package to anaconda.org.",
         dest='binstar_upload',
         default=cc.binstar_upload,
     )
@@ -82,14 +82,14 @@ PyPI is using conda skeleton pypi and conda build.
 
 def handle_binstar_upload(path):
     from conda_build.external import find_executable
-    binstar = find_executable('binstar')
+    binstar = find_executable('anaconda')
     if binstar is None:
         sys.exit('''
-Error: cannot locate binstar (required for upload)
+Error: cannot locate anaconda command (required for upload)
 # Try:
-# $ conda install binstar
+# $ conda install anaconda-client
 ''')
-    print("Uploading to binstar")
+    print("Uploading to anaconda.org")
     args = [binstar, 'upload', path]
     subprocess.call(args)
 
@@ -101,7 +101,7 @@ Error: cannot locate binstar (required for upload)
 
 skeleton_template = "conda skeleton pypi {0} --no-prompt"
 skeleton_template_wversion = "conda skeleton pypi {0} --version {1} --no-prompt"
-build_template = "conda build {0} --no-binstar-upload --no-test"
+build_template = "conda build {0} --no-anaconda-upload --no-test"
 
 meta_template = """package:
   name: {packagename}

--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -12,17 +12,17 @@ for recipe in metadata/*/; do
         if [[ $recipe =~ .*osx_is_app.* && $(uname) != "Darwin" ]]; then
             continue
         fi
-        conda build --no-binstar-upload $recipe
+        conda build --no-anaconda-upload $recipe
     fi
 done
 
 # We use 2>&1 as the error is printed to stderr. We could do >/dev/null to
 # ensure it is printed to stderr, but then we would hide the output of the
 # command from the test output.  The ! ensures that the command fails.
-! OUTPUT=$(conda build --no-binstar-upload fail/symlinks/ 2>&1)
+! OUTPUT=$(conda build --no-anaconda-upload fail/symlinks/ 2>&1)
 echo "$OUTPUT" | grep "Error" | wc -l | grep 6
 
-! OUTPUT=$(conda build --no-binstar-upload fail/conda-meta/ 2>&1)
+! OUTPUT=$(conda build --no-anaconda-upload fail/conda-meta/ 2>&1)
 echo "$OUTPUT" | grep 'Error: Untracked file(s) ('\''conda-meta/nope'\'',)'
 
 echo "TESTS PASSED"


### PR DESCRIPTION
This PR is similar to https://github.com/conda/conda/pull/1458.  Also, only externally visible changes are made, in particular the option `--no-binstar-upload` is renamed to `--no-anaconda-upload` (where the first is also being accepted for now.
