### PR TITLE
Access is denined when removing markupsafe/_speedups.pyd

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -269,8 +269,11 @@ def create_env(prefix, specs, clear_cache=True, verbose=True, channel_urls=(),
             new_link = []
             for pkg in actions["LINK"]:
                 dist, pkgs_dir, lt = inst.split_linkarg(pkg)
-                lt = ci.LINK_COPY
-                new_link.append("%s %s %d" % (dist, pkgs_dir, lt))
+                if dist.split('-')[0] == 'markupsafe':
+                    lt = ci.LINK_COPY
+                    new_link.append("%s %s %d" % (dist, pkgs_dir, lt))
+                else:
+                    new_link.append(pkg)
             actions["LINK"] = new_link
         plan.display_actions(actions, index)
         plan.execute_actions(actions, index, verbose=verbose)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -23,6 +23,8 @@ from conda.compat import PY3
 from conda.fetch import fetch_index
 from conda.install import prefix_placeholder, linked
 from conda.utils import url_path
+import conda.instructions as inst
+import conda.install as ci
 from conda.resolve import Resolve, MatchSpec, NoPackagesFound
 
 from conda_build import environ, source, tarcheck
@@ -35,6 +37,8 @@ from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
 from conda_build.exceptions import indent
+on_win = bool(sys.platform == 'win32')
+
 
 def prefix_files():
     '''
@@ -248,6 +252,8 @@ def create_env(prefix, specs, clear_cache=True, verbose=True, channel_urls=(),
     '''
     Create a conda envrionment for the given prefix and specs.
     '''
+    copy = on_win
+
     if not isdir(config.bldpkgs_dir):
         os.makedirs(config.bldpkgs_dir)
     update_index(config.bldpkgs_dir)
@@ -259,6 +265,13 @@ def create_env(prefix, specs, clear_cache=True, verbose=True, channel_urls=(),
 
         cc.pkgs_dirs = cc.pkgs_dirs[:1]
         actions = plan.install_actions(prefix, index, specs)
+        if copy:
+            new_link = []
+            for pkg in actions["LINK"]:
+                dist, pkgs_dir, lt = inst.split_linkarg(pkg)
+                lt = ci.LINK_COPY
+                new_link.append("%s %s %d" % (dist, pkgs_dir, lt))
+            actions["LINK"] = new_link
         plan.display_actions(actions, index)
         plan.execute_actions(actions, index, verbose=verbose)
     # ensure prefix exists, even if empty, i.e. when specs are empty

--- a/tests/test-recipes/metadata/jinja2/meta.yaml
+++ b/tests/test-recipes/metadata/jinja2/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: conda-build-test-jinja2-in-recipe
+  version: 1.0
+
+build:
+  number: 0
+
+requirements:
+    build:
+        - jinja2


### PR DESCRIPTION
On Windows, we consistently get errors from not being able to clean up the `_build` directory due to a file `_speedups.pyd` inside the build directory being undeleteable. This only happens when: 
 - markupsafe/jinja2 is imported by the main process (always)
 - the recipe being build or tested depends on markupsafe / jinja2

This has stumped me for a while -- I can drop an interactive shell at this point and consistently get the error and can't delete the file any which way, including by renaming it or using send2trash.

I believe the problem is related to the windows hard links. Essentially, I think you cannot delete a hard link to a loaded DLL on windows, which is what happens when you clean out the build directory if the main process has imported one of the libraries that uses a C extension that's linked into the build environment.

The error is, for example, like this build on appveyor (https://ci.appveyor.com/project/rmcgibbo/conda-recipes/build/1.0.190/job/y0qjfmxhaanqpbvf), is:

```
BUILD END: openmmtools-0.7.1-py34_0
TEST START: openmmtools-0.7.1-py34_0
Traceback (most recent call last):
  File "C:\Python34_32\Scripts\conda-build-script.py", line 4, in <module>
    sys.exit(main())
  File "C:\Python34_32\lib\site-packages\conda_build\main_build.py", line 173, in main
    args_func(args, p)
  File "C:\Python34_32\lib\site-packages\conda_build\main_build.py", line 400, in args_func
    args.func(args, p)
  File "C:\Python34_32\lib\site-packages\conda_build\main_build.py", line 387, in execute
    channel_urls=channel_urls, override_channels=args.override_channels)
  File "C:\Python34_32\lib\site-packages\conda_build\build.py", line 480, in test
    rm_rf(config.build_prefix)
  File "C:\Python34_32\lib\site-packages\conda\install.py", line 186, in rm_rf
    shutil.rmtree(path)
  File "C:\Python34_32\lib\shutil.py", line 478, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Python34_32\lib\shutil.py", line 368, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\Python34_32\lib\shutil.py", line 368, in _rmtree_unsafe
 
    _rmtree_unsafe(fullname, onerror)
  File "C:\Python34_32\lib\shutil.py", line 368, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\Python34_32\lib\shutil.py", line 373, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Python34_32\lib\shutil.py", line 371, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: 'C:\\Python34_32\\envs\\_build\\Lib\\site-packages\\markupsafe\\_speedups.pyd'
```