### PR TITLE
Add ability to add license file in info/license.txt

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -150,6 +150,20 @@ def create_info_files(m, files, include_recipe=True):
             else:
                 shutil.copy(src_path, dst_path)
 
+    license_file =  m.get_value('build/license_file')
+    if license_file:
+        filenames = 'LICENSE', 'LICENSE.txt', 'license.txt'
+        if license_file is True:
+            for fn in filenames:
+                src = join(source.get_dir(), fn)
+                if isfile(src):
+                    break
+            else:
+                sys.exit("Error: could not locate license file")
+        else:
+            src = join(source.get_dir(), license_file)
+        shutil.copy(src, join(config.info_dir, 'license.txt'))
+
     readme = m.get_value('about/readme')
     if readme:
         src = join(source.get_dir(), readme)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -150,7 +150,7 @@ def create_info_files(m, files, include_recipe=True):
             else:
                 shutil.copy(src_path, dst_path)
 
-    license_file = m.get_value('build/license_file')
+    license_file = m.get_value('about/license_file')
     if license_file:
         filenames = 'LICENSE', 'LICENSE.txt', 'license', 'license.txt'
         if license_file is True:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -150,16 +150,18 @@ def create_info_files(m, files, include_recipe=True):
             else:
                 shutil.copy(src_path, dst_path)
 
-    license_file =  m.get_value('build/license_file')
+    license_file = m.get_value('build/license_file')
     if license_file:
-        filenames = 'LICENSE', 'LICENSE.txt', 'license.txt'
+        filenames = 'LICENSE', 'LICENSE.txt', 'license', 'license.txt'
         if license_file is True:
             for fn in filenames:
                 src = join(source.get_dir(), fn)
                 if isfile(src):
                     break
             else:
-                sys.exit("Error: could not locate license file")
+                sys.exit("Error: could not locate license file (any of "
+                         "%s) in: %s" % (', '.join(filenames),
+                                         source.get_dir()))
         else:
             src = join(source.get_dir(), license_file)
         shutil.copy(src, join(config.info_dir, 'license.txt'))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -207,12 +207,12 @@ FIELDS = {
               'no_link', 'binary_relocation', 'script', 'noarch_python',
               'has_prefix_files', 'binary_has_prefix_files', 'script_env',
               'detect_binary_files_with_prefix', 'rpaths',
-              'always_include_files', 'license_file'],
+              'always_include_files'],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
     'test': ['requires', 'commands', 'files', 'imports'],
-    'about': ['home', 'license', 'summary', 'readme'],
+    'about': ['home', 'license', 'summary', 'readme', 'license_file' ],
 }
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -207,7 +207,7 @@ FIELDS = {
               'no_link', 'binary_relocation', 'script', 'noarch_python',
               'has_prefix_files', 'binary_has_prefix_files', 'script_env',
               'detect_binary_files_with_prefix', 'rpaths',
-              'always_include_files', ],
+              'always_include_files', 'license_file'],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],


### PR DESCRIPTION
Using (in `meta.yaml`) the field `about/license_file`, allows adding a license file to conda package under `info/license.txt`.  Possible values are:
  * `True`: will search the root of the source tree for the following files (in that order): `LICENSE`, `LICENSE.txt`, `license`, 'license.txt`
  * `<filename>`: you can specify the filename of the license file explicitly.
  * `Flase`: meaning no license file will be included under `info/license.txt`, which is the default.

For example, if the source tree has `LICENSE` in its root,
```
build:
  license_file: True
```
will add this file under `info/license.txt` in in the conda package.