### PR TITLE
Post build versioning

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -388,19 +388,20 @@ def check_symlinks(files):
         sys.exit(1)
 
 def get_build_metadata(m):
-    if exists(join(source.WORK_DIR, '__conda_version__.txt')):
-        with open(join(source.WORK_DIR, '__conda_version__.txt')) as f:
+    src_dir = source.get_dir()
+    if exists(join(src_dir, '__conda_version__.txt')):
+        with open(join(src_dir, '__conda_version__.txt')) as f:
             version = f.read().strip()
             print("Setting version from __conda_version__.txt: %s" % version)
             m.meta['package']['version'] = version
-    if exists(join(source.WORK_DIR, '__conda_buildnum__.txt')):
-        with open(join(source.WORK_DIR, '__conda_buildnum__.txt')) as f:
+    if exists(join(src_dir, '__conda_buildnum__.txt')):
+        with open(join(src_dir, '__conda_buildnum__.txt')) as f:
             build_number = f.read().strip()
             print("Setting build number from __conda_buildnum__.txt: %s" %
                   build_number)
             m.meta['build']['number'] = build_number
-    if exists(join(source.WORK_DIR, '__conda_buildstr__.txt')):
-        with open(join(source.WORK_DIR, '__conda_buildstr__.txt')) as f:
+    if exists(join(src_dir, '__conda_buildstr__.txt')):
+        with open(join(src_dir, '__conda_buildstr__.txt')) as f:
             buildstr = f.read().strip()
             print("Setting version from __conda_buildstr__.txt: %s" % buildstr)
             m.meta['build']['string'] = buildstr

--- a/tests/test-recipes/metadata/post_build_versioning/build.sh
+++ b/tests/test-recipes/metadata/post_build_versioning/build.sh
@@ -1,0 +1,1 @@
+echo "12.345.67" > __conda_version__.txt

--- a/tests/test-recipes/metadata/post_build_versioning/meta.yaml
+++ b/tests/test-recipes/metadata/post_build_versioning/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: post-build-versioning
+
+source:
+  fn: master.zip
+  url: https://github.com/conda/conda-build/archive/master.zip

--- a/tests/test-recipes/metadata/post_build_versioning/run_test.sh
+++ b/tests/test-recipes/metadata/post_build_versioning/run_test.sh
@@ -1,0 +1,2 @@
+cat $PREFIX/conda-meta/post-build-versioning-12.345.67-0.json
+cat $PREFIX/conda-meta/post-build-versioning-12.345.67-0.json | grep '"version": "12.345.67"'


### PR DESCRIPTION
Previously, search for `__conda_*__.txt` files fails when the source directory is at one directory down of WORK_DIR.  This is typically the case for a directory decompressed from zip or tar file.  This patch fixes the problem by replacing all occurrence of source.WORK_DIR in get_build_metadata() with source.get_dir().