### PR TITLE
Added a build/skip entry to MetaData.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -349,6 +349,11 @@ def build(m, get_src=True, verbose=True, post=None, channel_urls=(),
         # In case there are multiple builds in the same process
         config.use_long_build_prefix = False
 
+    if m.skip():
+        print("Skipped: The %s recipe defines build/skip for this "
+              "configuration." % m.dist())
+        sys.exit(0)
+
     if post in [False, None]:
         print("Removing old build environment")
         if on_win:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -207,7 +207,7 @@ FIELDS = {
               'no_link', 'binary_relocation', 'script', 'noarch_python',
               'has_prefix_files', 'binary_has_prefix_files', 'script_env',
               'detect_binary_files_with_prefix', 'rpaths',
-              'always_include_files'],
+              'always_include_files', 'skip'],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
@@ -471,6 +471,9 @@ class MetaData(object):
             if any('\\' in i for i in ret):
                 raise RuntimeError("build/binary_has_prefix_files paths must use / as the path delimiter on Windows")
         return ret
+
+    def skip(self):
+        return self.get_value('build/skip', False)
 
     def __unicode__(self):
         '''

--- a/tests/test-recipes/metadata/build_skip/meta.yaml
+++ b/tests/test-recipes/metadata/build_skip/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: conda-build-skip
+  version: 1.0
+
+build:
+  skip: True
+
+requirements:
+  run:
+    - python

--- a/tests/test-recipes/metadata/build_skip/run_test.py
+++ b/tests/test-recipes/metadata/build_skip/run_test.py
@@ -1,0 +1,1 @@
+raise ValueError("This shouldn't have built. We skipped it! :(")


### PR DESCRIPTION
Implements #399 slightly differently (but I used that as a template). (ping @rmcgibbo)

This will be really useful for tools such as ObviousCI which look at a collection of recipes and figure out which ones to build (and the appropriate build matrix of py and npy versions).

If would be useful to know if this is a go-er or not, if not, my backup is to use something like:


```
package:
   name: conda-build-skip
...
extra:
   skip: True  # [not py2k]
```

Or even:

```
package:
   name: conda-build-skip
...
extra:
   skip_if: python > 2
```
