### PR TITLE
Fixed crash when using `--skip-existing` while conda-bld is empty

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -255,6 +255,7 @@ def execute(args, parser):
     import shutil
     import tarfile
     import tempfile
+    from os import makedirs
     from os.path import abspath, isdir, isfile
 
     from conda.lock import Locked
@@ -308,8 +309,9 @@ def execute(args, parser):
                     (conda_version[lang], version))
 
     if args.skip_existing:
-        if exists(config.bldpkgs_dir):
-            update_index(config.bldpkgs_dir)
+        if not isdir(config.bldpkgs_dir):
+            makedirs(config.bldpkgs_dir)
+        update_index(config.bldpkgs_dir)
         index = build.get_build_index(clear_cache=True,
             channel_urls=channel_urls,
             override_channels=args.override_channels)

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -308,7 +308,8 @@ def execute(args, parser):
                     (conda_version[lang], version))
 
     if args.skip_existing:
-        update_index(config.bldpkgs_dir)
+        if exists(config.bldpkgs_dir):
+            update_index(config.bldpkgs_dir)
         index = build.get_build_index(clear_cache=True,
             channel_urls=channel_urls,
             override_channels=args.override_channels)


### PR DESCRIPTION
The following command crashes if `$CONDA_ROOT/conda-bld/$PLATFORM` does not exist.

```
$ conda build --skip-existing conda.recipe
```