### PR TITLE
Be more explicit when numpy version is included in dependency specs in metadata

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -282,7 +282,7 @@ def get_contents(meta_path):
     return contents
 
 
-def special_spec(ms, ver):
+def handle_config_version(ms, ver):
     """
     'ms' is an instance of MatchSpec, and 'ver' is the version from the
     configuration, e.g. for ms.name == 'python', ver = 26 or None,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -286,7 +286,7 @@ def special_spec(ms, ver):
     """
     'ms' is an instance of MatchSpec, and 'ver' is the version from the
     configuration, e.g. for ms.name == 'python', ver = 26 or None,
-    return the new MatchSpec object
+    return a (sometimes new) MatchSpec object
     """
     if ms.strictness == 3:
         return ms
@@ -295,13 +295,11 @@ def special_spec(ms, ver):
         if ms.spec.split()[1] == 'x.x':
             if ver is None:
                 raise RuntimeError("'%s' requires external setting" % ms.spec)
-        else: # normal version
+            # (no return here - proceeds below)
+        else: # regular version
             return ms
 
-    if ms.strictness == 1 and ms.name == 'numpy':
-        return MatchSpec(ms.name)
-
-    if ver is None:
+    if ver is None or (ms.strictness == 1 and ms.name == 'numpy'):
         return MatchSpec(ms.name)
 
     ver = text_type(ver)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -403,24 +403,7 @@ class MetaData(object):
                 if ms.name == name:
                     if self.get_value('build/noarch_python'):
                         continue
-                    if ms.strictness == 3:
-                        continue
-                    if ms.strictness == 2:
-                        if spec.split()[1] == 'x.x':
-                            if ver is None:
-                                raise RuntimeError('%s requires more input' % spec)
-                        else:
-                            continue
-                    if ms.strictness == 1 and name == 'numpy':
-                        ms = MatchSpec(name)
-                        continue
-                    if ver is None:
-                        ms = MatchSpec(name)
-                        continue
-                    str_ver = text_type(ver)
-                    if '.' not in str_ver:
-                        str_ver = '.'.join(str_ver)
-                    ms = MatchSpec('%s %s*' % (name, str_ver))
+                    ms = handle_config_version(ms, ver)
 
             for c in '=!@#$%^&*:;"\'\\|<>?/':
                 if c in ms.name:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -282,6 +282,34 @@ def get_contents(meta_path):
     return contents
 
 
+def special_spec(ms, ver):
+    """
+    'ms' is an instance of MatchSpec, and 'ver' is the version from the
+    configuration, e.g. for ms.name == 'python', ver = 26 or None,
+    return the new MatchSpec object
+    """
+    if ms.strictness == 3:
+        return ms
+
+    if ms.strictness == 2:
+        if ms.spec.split()[1] == 'x.x':
+            if ver is None:
+                raise RuntimeError("'%s' requires external setting" % ms.spec)
+        else: # normal version
+            return ms
+
+    if ms.strictness == 1 and ms.name == 'numpy':
+        return MatchSpec(ms.name)
+
+    if ver is None:
+        return MatchSpec(ms.name)
+
+    ver = text_type(ver)
+    if '.' not in ver:
+        ver = '.'.join(ver)
+    return MatchSpec('%s %s*' % (ms.name, ver))
+
+
 class MetaData(object):
 
     def __init__(self, path):
@@ -383,8 +411,8 @@ class MetaData(object):
                         if spec.split()[1] == 'x.x':
                             if ver is None:
                                 raise RuntimeError('%s requires more input' % spec)
-                            else:
-                                continue
+                        else:
+                            continue
                     if ms.strictness == 1 and name == 'numpy':
                         ms = MatchSpec(name)
                         continue

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -1,5 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.py
@@ -6,7 +6,7 @@ def main():
     prefix = os.environ['PREFIX']
 
     info_files = glob.glob(os.path.join(prefix, 'conda-meta',
-                             'conda-build-test-numpy-build-run-1.0-nppy*0.json'))
+                             'conda-build-test-numpy-build-run-1.0-py*0.json'))
     assert len(info_files) == 1
     info_file = info_files[0]
     with open(info_file, 'r') as fh:

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain NumPy, but not the version
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-nppy.._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-py.._0"

--- a/tests/test-recipes/metadata/numpy_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_run/run_test.py
+++ b/tests/test-recipes/metadata/numpy_run/run_test.py
@@ -5,7 +5,7 @@ import glob
 def main():
     prefix = os.environ['PREFIX']
     info_files = glob.glob(os.path.join(prefix, 'conda-meta',
-                             'conda-build-test-numpy-run-1.0-nppy*0.json'))
+                             'conda-build-test-numpy-run-1.0-py*0.json'))
     assert len(info_files) == 1
     info_file = info_files[0]
     with open(info_file, 'r') as fh:

--- a/tests/test-recipes/metadata/numpy_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contian NumPy, but not the version
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-nppy.._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-py.._0"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -49,3 +49,17 @@ class SpecialSpecTests(unittest.TestCase):
 
         self.assertRaises(RuntimeError,
                           special_spec, MatchSpec('python x.x'), None)
+
+    def test_numpy(self):
+        for spec, ver, res_spec in [
+            ('numpy',        None,  'numpy'),
+            ('numpy',        18,    'numpy'),
+            ('numpy x.x',    17,    'numpy 1.7*'),
+            ('numpy 1.9.1',  18,    'numpy 1.9.1'),
+            ('numpy 1.9.0 py27_2', None,  'numpy 1.9.0 py27_2'),
+            ]:
+            ms = MatchSpec(spec)
+            self.assertEqual(special_spec(ms, ver), MatchSpec(res_spec))
+
+        self.assertRaises(RuntimeError,
+                          special_spec, MatchSpec('numpy x.x'), None)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,7 @@ import unittest
 
 from conda.resolve import MatchSpec
 
-from conda_build.metadata import select_lines, special_spec
+from conda_build.metadata import select_lines, handle_config_version
 
 
 def test_select_lines():
@@ -45,10 +45,12 @@ class SpecialSpecTests(unittest.TestCase):
             ('python',        27,   'python 2.7*'),
             ]:
             ms = MatchSpec(spec)
-            self.assertEqual(special_spec(ms, ver), MatchSpec(res_spec))
+            self.assertEqual(handle_config_version(ms, ver),
+                             MatchSpec(res_spec))
 
         self.assertRaises(RuntimeError,
-                          special_spec, MatchSpec('python x.x'), None)
+                          handle_config_version,
+                          MatchSpec('python x.x'), None)
 
     def test_numpy(self):
         for spec, ver, res_spec in [
@@ -59,7 +61,9 @@ class SpecialSpecTests(unittest.TestCase):
             ('numpy 1.9.0 py27_2', None,  'numpy 1.9.0 py27_2'),
             ]:
             ms = MatchSpec(spec)
-            self.assertEqual(special_spec(ms, ver), MatchSpec(res_spec))
+            self.assertEqual(handle_config_version(ms, ver),
+                             MatchSpec(res_spec))
 
         self.assertRaises(RuntimeError,
-                          special_spec, MatchSpec('numpy x.x'), None)
+                          handle_config_version,
+                          MatchSpec('numpy x.x'), None)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,9 @@
-from conda_build.metadata import select_lines
+import unittest
+
+from conda.resolve import MatchSpec
+
+from conda_build.metadata import select_lines, special_spec
+
 
 def test_select_lines():
     lines = """
@@ -25,3 +30,22 @@ test
 test [abc] no
 
 """
+
+class SpecialSpecTests(unittest.TestCase):
+
+    def test_python(self):
+        for spec, ver, res_spec in [
+            ('python',       '3.4', 'python 3.4*'),
+            ('python 2.7.8', '2.7', 'python 2.7.8'),
+            ('python 2.7.8', '3.5', 'python 2.7.8'),
+            ('python 2.7.8', None,  'python 2.7.8'),
+            ('python',       None,  'python'),
+            ('python x.x',   '2.7', 'python 2.7*'),
+            ('python',       '27',  'python 2.7*'),
+            ('python',        27,   'python 2.7*'),
+            ]:
+            ms = MatchSpec(spec)
+            self.assertEqual(special_spec(ms, ver), MatchSpec(res_spec))
+
+        self.assertRaises(RuntimeError,
+                          special_spec, MatchSpec('python x.x'), None)


### PR DESCRIPTION
Currently, it is only possible to create a conda package, that just depends on `numpy`, by unsetting `CONDA_NPY` (and not using the `--numpy` option).  One can build two different packages depending on this setting (outside the recipe), which is undesirable.
This PR makes the numpy version being included in dependency specs in metadata much more explicit.  Listing just `numpy` as the runtime dependency, will *always* result in just that (setting `CONDA_NPY` won't change that.  In order to make a recipe independent of the numpy version actually set, one lists `numpy x.x` as a dependency, which will *require* using `CONDA_NPY` or `--numpy`.

Also, we add a new function, `handle_config_version()` to handle the confusing logic, as well as tests for this new function.