### PR TITLE
Allow jinja2 templates to be located in current conda environment

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -14,6 +14,7 @@ import sys
 import tarfile
 from os.path import exists, isdir, isfile, islink, join
 import fnmatch
+import time
 
 
 import conda.config as cc
@@ -500,6 +501,8 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
 
     tmp_dir = join(config.croot, 'test-tmp_dir')
     rm_rf(tmp_dir)
+    time.sleep(2)  # give the OS some time to complete the rm_rf() command
+                   # (otherwise, makedirs() occasionally failed on Windows)
     os.makedirs(tmp_dir)
     create_files(tmp_dir, m)
     # Make Perl or Python-specific test files

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -277,7 +277,6 @@ def get_contents(meta_path):
     
     # search relative to current conda environment directory
     conda_env_path = os.environ.get('CONDA_ENV_PATH',  # path to current conda environment
-                     os.environ.get('CONDA_PATH',      # else: path to conda root environment
                                     ''))               # else: nothing
     conda_env_path = conda_env_path.replace('\\', '/') # need unix-style path
     if conda_env_path:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -269,9 +269,21 @@ def get_contents(meta_path):
     from conda_build.jinja_context import context_processor
 
     path, filename = os.path.split(meta_path)
-    loaders = [jinja2.PackageLoader('conda_build'),
+    loaders = [# search relative to '<conda_root>/Lib/site-packages/conda_build/templates'
+               jinja2.PackageLoader('conda_build'),
+               # search relative to RECIPE_DIR
                jinja2.FileSystemLoader(path)
                ]
+    
+    # search relative to current conda environment directory
+    conda_env_path = os.environ.get('CONDA_ENV_PATH',  # path to current conda environment
+                     os.environ.get('CONDA_PATH',      # else: path to conda root environment
+                                    ''))               # else: nothing
+    conda_env_path = conda_env_path.replace('\\', '/') # need unix-style path
+    if conda_env_path:
+        env_loader = jinja2.FileSystemLoader(conda_env_path)
+        loaders.append(jinja2.PrefixLoader({'CONDA_ENVIRONMENT': env_loader}))
+
     env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders))
     env.globals.update(ns_cfg())
     env.globals.update(context_processor())

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -276,8 +276,7 @@ def get_contents(meta_path):
                ]
     
     # search relative to current conda environment directory
-    conda_env_path = os.environ.get('CONDA_ENV_PATH',  # path to current conda environment
-                                    ''))               # else: nothing
+    conda_env_path = os.environ.get('CONDA_ENV_PATH', '')  # path to current conda environment
     conda_env_path = conda_env_path.replace('\\', '/') # need unix-style path
     if conda_env_path:
         env_loader = jinja2.FileSystemLoader(conda_env_path)


### PR DESCRIPTION
Use case: Suppose one wants to build a set of packages with exactly identical toolset settings (same compiler options, tool versions etc.). This is easy to achieve by performing the build in a suitably prepared conda environment. However, conda does not yet provide a general method to query information about the current environment within `meta.yaml`. The present PR adds this capability. For example, let's say that installation of the toolset package places a template `toolset-info.yaml` in the environment's root directory. This template can now be loaded in `meta.yaml` via
```yaml
{% import 'CONDA_ENVIRONMENT/toolset-info.yaml' as toolset %}
```
and later be accessed via `{{ toolset.name }}`.

[At present, templates must be located in either `<conda_root>/Lib/site-packages/conda_build/templates` or `RECIPE_DIR`, which won't serve the above use case.]
