### PR TITLE
Never auto-add spec for 'python' to the test environment.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -526,15 +526,8 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
     specs = ['%s %s %s' % (m.name(), m.version(), m.build_id())]
 
     # add packages listed in test/requires
-    specs_include_python = False
-    for spec in m.get_value('test/requires', []):
-        specs.append(spec)
-        if spec.startswith('python ') or spec == 'python':
-            specs_include_python = True
+    specs += m.get_value('test/requires', [])
 
-    if py_files and not specs_include_python:
-        # as the tests are run by python, we need to specify it
-        specs += ['python %s*' % environ.get_py_ver()]
     if pl_files:
         # as the tests are run by perl, we need to specify it
         specs += ['perl %s*' % environ.get_perl_ver()]


### PR DESCRIPTION
Recipes are required to list it in either `requirements:run` or `test:requires`.

This is an alternative 'fix' for #587 (instead of PR #588).  But I'm probably missing something -- I don't understand why `python` was being auto-added to the test env in the first place (see [comments](https://github.com/conda/conda-build/pull/588#issuecomment-139900742) in #588.)