### PR TITLE
[WIP] Improve yaml loading

### DIFF
--- a/conda_build/cran.py
+++ b/conda_build/cran.py
@@ -7,6 +7,13 @@ from __future__ import absolute_import, division, print_function
 import requests
 import yaml
 
+
+# try to import C dumper
+try:
+    from yaml import CSafeDumper as SafeDumper
+except ImportError:
+    from yaml import SafeDumper
+
 import re
 import sys
 from os import makedirs, listdir
@@ -263,7 +270,7 @@ def yaml_quote_string(string):
 
     Note that this function is NOT general.
     """
-    return yaml.dump(string).replace('\n...\n', '').replace('\n', '\n  ')
+    return yaml.dump(string, Dumper=SafeDumper).replace('\n...\n', '').replace('\n', '\n  ')
 
 def clear_trailing_whitespace(string):
     lines = []

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -173,11 +173,18 @@ def parse(data):
         section, key = field.split('/')
         if res.get(section) is None:
             res[section] = {}
-        val = res[section].get(key, '').lower()
+
+        try:
+            val = res[section].get(key, '').lower()
+        except AttributeError:
+            # val wasn't a string
+            continue
+
         if val in trues:
             res[section][key] = True
         elif val in falses:
             res[section][key] = False
+
     ensure_valid_license_family(res)
     return sanitize(res)
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -93,7 +93,7 @@ Error: Invalid selector in meta.yaml line %d:
 @memoized
 def yamlize(data):
     try:
-        return yaml.load(data, Loader=yaml.BaseLoader)
+        return yaml.load(data, Loader=BaseLoader)
     except yaml.parser.ParserError as e:
         if '{{' in data:
             try:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -15,17 +15,15 @@ from . import exceptions
 
 try:
     import yaml
-    from yaml import Loader, SafeLoader
+
+    # try to import C loader
+    try:
+        from yaml import CBaseLoader as BaseLoader
+    except ImportError:
+        from yaml import BaseLoader
 except ImportError:
     sys.exit('Error: could not import yaml (required to read meta.yaml '
              'files of conda recipes)')
-
-# Override the default string handling function to always return unicode
-# objects (taken from StackOverflow)
-def construct_yaml_str(self, node):
-    return self.construct_scalar(node)
-Loader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)
-SafeLoader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)
 
 from conda_build.config import config
 from conda_build.utils import comma_join
@@ -95,7 +93,7 @@ Error: Invalid selector in meta.yaml line %d:
 @memoized
 def yamlize(data):
     try:
-        return yaml.load(data)
+        return yaml.load(data, Loader=yaml.BaseLoader)
     except yaml.parser.ParserError as e:
         if '{{' in data:
             try:
@@ -165,6 +163,21 @@ def parse(data):
         if val is None:
             val = ''
         res[section][key] = text_type(val)
+
+    # ensure these fields are booleans
+    trues = {'y', 'on', 'true', 'yes'}
+    falses = {'n', 'no', 'false', 'off'}
+    for field in ('build/osx_is_app', 'build/preserve_egg_dir',
+                  'build/binary_relocation', 'build/detect_binary_files_with_prefix',
+                  'build/skip', 'app/own_environment'):
+        section, key = field.split('/')
+        if res.get(section) is None:
+            res[section] = {}
+        val = res[section].get(key, '').lower()
+        if val in trues:
+            res[section][key] = True
+        elif val in falses:
+            res[section][key] = False
     ensure_valid_license_family(res)
     return sanitize(res)
 
@@ -351,7 +364,8 @@ class MetaData(object):
 
     def get_value(self, field, default=None):
         section, key = field.split('/')
-        return self.get_section(section).get(key, default)
+        value = self.get_section(section).get(key, default)
+        return value
 
     def check_fields(self):
         for section, submeta in iteritems(self.meta):

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -159,7 +159,7 @@ diff core.py core.py
 +    data['classifiers'] = kwargs.get('classifiers', None)
 +    data['version'] = kwargs.get('version', '??PACKAGE-VERSION-UNKNOWN??')
 +    with io.open(os.path.join("{}", "pkginfo.yaml"), 'w', encoding='utf-8') as fn:
-+        fn.write(yaml.dump(data, encoding=None))
++        fn.write(yaml.safe_dump(data, encoding=None))
 +
 +
 +# ======= END CONDA SKELETON PYPI PATCH ======


### PR DESCRIPTION
This is a much safer way to load yaml (comparable to yaml.safe_load).  This removes the ability of yaml to construct arbitrary python objects.  We now do not use yaml's type conversions, doing our own conversions as needed.  This is better because the vast majority of our options are string options anyway.

We use yaml's C library if it is available.  This *significantly* speeds up yaml parsing.  It falls back to the python parser if the C library is not available.