### PR TITLE
Fix: 'conda build' crashes when git output contains non-printable characters

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -153,6 +153,10 @@ def git_info(fo=None):
         p = Popen(cmd.split(), stdout=PIPE, stderr=PIPE, cwd=WORK_DIR, env=env)
         stdout, stderr = p.communicate()
         encoding = locale.getpreferredencoding() or 'utf-8'
+        if fo:
+            encoding = locale.getpreferredencoding() or 'utf-8'
+        else:
+            encoding = sys.stdout.encoding
         stdout = stdout.decode(encoding, 'ignore')
         stderr = stderr.decode(encoding, 'ignore')
         if check_error and stderr and stderr.strip():


### PR DESCRIPTION
The fix is easy: when writing to `sys.stdout`, strings should be encoded with `sys.stdout.encoding`.