### PR TITLE
Fix `None` encoding bug

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -152,9 +152,10 @@ def git_info(fo=None):
                 ('git status', True)]:
         p = Popen(cmd.split(), stdout=PIPE, stderr=PIPE, cwd=WORK_DIR, env=env)
         stdout, stderr = p.communicate()
-        encoding = locale.getpreferredencoding() or 'utf-8'
+        encoding = locale.getpreferredencoding()
         if not fo:
-            encoding = sys.stdout.encoding or 'utf-8'
+            encoding = sys.stdout.encoding
+        encoding = encoding or 'utf-8'
         stdout = stdout.decode(encoding, 'ignore')
         stderr = stderr.decode(encoding, 'ignore')
         if check_error and stderr and stderr.strip():

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -153,9 +153,7 @@ def git_info(fo=None):
         p = Popen(cmd.split(), stdout=PIPE, stderr=PIPE, cwd=WORK_DIR, env=env)
         stdout, stderr = p.communicate()
         encoding = locale.getpreferredencoding() or 'utf-8'
-        if fo:
-            encoding = locale.getpreferredencoding() or 'utf-8'
-        else:
+        if not fo:
             encoding = sys.stdout.encoding or 'utf-8'
         stdout = stdout.decode(encoding, 'ignore')
         stderr = stderr.decode(encoding, 'ignore')

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -156,7 +156,7 @@ def git_info(fo=None):
         if fo:
             encoding = locale.getpreferredencoding() or 'utf-8'
         else:
-            encoding = sys.stdout.encoding
+            encoding = sys.stdout.encoding or 'utf-8'
         stdout = stdout.decode(encoding, 'ignore')
         stderr = stderr.decode(encoding, 'ignore')
         if check_error and stderr and stderr.strip():


### PR DESCRIPTION
Turns out `sys.stdout.encoding` can be `None`, as well. This normally happens when `stdout` is redirected. This fixes that bug and simplifies the logic around that region to hopefully avoid its recurrence.

For the curious ones, here's a bit more on why this happens ( http://www.macfreek.nl/memory/Encoding_of_Python_stdout ).

This encoding problem can be reproduced by a trivial docker container. Building this container will print `None`.

    FROM python:2

    RUN python -c "from sys import stdout as so; print(so.encoding)"