### PR TITLE
FIX: build/script section of meta.yaml on Windows

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -118,6 +118,15 @@ def build(m):
 
     src_dir = source.get_dir()
     bld_bat = join(m.path, 'bld.bat')
+
+    if not exists(bld_bat):
+        script = m.get_value('build/script', None)
+        if script:
+            if isinstance(script, list):
+                script = '\n'.join(script)
+            with open(bld_bat, 'w') as bf:
+                bf.write(script)
+
     if exists(bld_bat):
         with open(bld_bat) as fi:
             data = fi.read()


### PR DESCRIPTION
The section `build/script` of the `meta.yaml` was being ignored completely on Windows. No errors/warning messages were given to the user, the build process simply stopped there.

I'm proposing to create the `bld.bat` with the commands contained on that section and proceed with the building process normally.