### PR TITLE
Lightened up the requirement on recipes to define numpy x.x as runtime

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -304,7 +304,7 @@ def check_bad_chrs(s, field):
             sys.exit("Error: bad character '%s' in %s: %s" % (c, field, s))
 
 
-def handle_config_version(ms, ver):
+def handle_config_version(ms, ver, dep_type='run'):
     """
     'ms' is an instance of MatchSpec, and 'ver' is the version from the
     configuration, e.g. for ms.name == 'python', ver = 26 or None,
@@ -321,7 +321,13 @@ def handle_config_version(ms, ver):
         else:  # regular version
             return ms
 
-    if ver is None or (ms.strictness == 1 and ms.name == 'numpy'):
+    # If we don't have a configured version, or we are dealing with a simple
+    # numpy runtime dependency; just use "numpy"/the name of the package as
+    # the specification. In practice this means that a recipe which just
+    # defines numpy as a runtime dependency will match any version of numpy
+    # at install time.
+    if ver is None or (dep_type == 'run' and ms.strictness == 1 and
+                       ms.name == 'numpy'):
         return MatchSpec(ms.name)
 
     ver = text_type(ver)
@@ -467,7 +473,7 @@ class MetaData(object):
                 if ms.name == name:
                     if self.get_value('build/noarch_python'):
                         continue
-                    ms = handle_config_version(ms, ver)
+                    ms = handle_config_version(ms, ver, typ)
 
             for c in '=!@#$%^&*:;"\'\\|<>?/':
                 if c in ms.name:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -68,17 +68,18 @@ class HandleConfigVersionTests(unittest.TestCase):
                           MatchSpec('python x.x'), None)
 
     def test_numpy(self):
-        for spec, ver, res_spec in [
-                ('numpy', None, 'numpy'),
-                ('numpy', 18, 'numpy'),
-                ('numpy', 110, 'numpy'),
-                ('numpy x.x', 17, 'numpy 1.7*'),
-                ('numpy x.x', 110, 'numpy 1.10*'),
-                ('numpy 1.9.1', 18, 'numpy 1.9.1'),
-                ('numpy 1.9.0 py27_2', None, 'numpy 1.9.0 py27_2'),
+        for spec, ver, res_spec, kwargs in [
+                ('numpy', None, 'numpy', {}),
+                ('numpy', 18, 'numpy 1.8*', {'dep_type': 'build'}),
+                ('numpy', 18, 'numpy', {'dep_type': 'run'}),
+                ('numpy', 110, 'numpy', {}),
+                ('numpy x.x', 17, 'numpy 1.7*', {}),
+                ('numpy x.x', 110, 'numpy 1.10*', {}),
+                ('numpy 1.9.1', 18, 'numpy 1.9.1', {}),
+                ('numpy 1.9.0 py27_2', None, 'numpy 1.9.0 py27_2', {}),
         ]:
             ms = MatchSpec(spec)
-            self.assertEqual(handle_config_version(ms, ver),
+            self.assertEqual(handle_config_version(ms, ver, **kwargs),
                              MatchSpec(res_spec))
 
         self.assertRaises(RuntimeError,


### PR DESCRIPTION
Rolls back a little of #573 so that recipes are a little more friendly to write.
Currently one must effectively specify ``numpy x.x`` as both run and build dependencies in order to build a recipe which has a numpy ABI dependency against anything other than the latest numpy. With this change that is reduced to just specifying that as a runtime dependency.