### PR TITLE
Make rpath added by conda develop an absolute path

### DIFF
--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -104,7 +104,11 @@ def relink_sharedobjects(pkg_path, build_prefix):
     bin_files = sharedobjects_list(pkg_path)
     for b_file in bin_files:
         if sys.platform == 'darwin':
-            mk_relative_osx(b_file, build_prefix)
+            try:
+                mk_relative_osx(b_file, build_prefix, rel_rpath=False)
+            except Exception as ex:
+                print("\nEncountered exception for " + b_file + " \n")
+                print(ex.message)
         else:
             print("Nothing to do on Linux or Windows.")
 


### PR DESCRIPTION
During conda build process, the package is placed inside site-packages
of the environment so it makes sense for @rpath to be a relative path.

However, conda develop adds the source path to conda.pth which could
be anywhere with respect to conda environment. conda develop also
relinks shared objects against the libraries installed in the
environment. There is no reason to make @rpath relative to source
folder since source folder could be anywhere, but making it an absolute
path does make it more readbale and makes the source folder
relocatable.
