### PR TITLE
Change handling of numpy x.x so that it is only needed as a build requirement

### DIFF
--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -5,6 +5,12 @@ set -x
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# Set CONDA_NPY for all tests. Since CONDA_NPY should only affect recipes
+# that use a build requirement of 'numpy x.x' this should not affect
+# any existing tests that do not use that build requirement.
+
+export CONDA_NPY=1.9
+
 # Recipes that should fail and give some error
 
 for recipe in metadata/*/; do

--- a/tests/test-recipes/metadata/numpy_build_xx/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_xx/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: conda-build-test-numpy-build-xx
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy 1.9*

--- a/tests/test-recipes/metadata/numpy_build_xx/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_xx/run_test.bat
@@ -1,0 +1,4 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-1.0-0"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_xx/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_xx/run_test.py
@@ -1,0 +1,15 @@
+import os
+import json
+
+
+def main():
+    prefix = os.environ['PREFIX']
+    info_file = os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-numpy-build-xx-1.0-0.json')
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    assert len(info['depends']) == 0
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/numpy_build_xx/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_xx/run_test.sh
@@ -1,0 +1,3 @@
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain Numpy
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-xx-1.0-0"

--- a/tests/test-recipes/metadata/numpy_build_xx_run/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_xx_run/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-numpy-build-xx-run
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+  run:
+    - python
+    - numpy

--- a/tests/test-recipes/metadata/numpy_build_xx_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_xx_run/run_test.bat
@@ -1,0 +1,5 @@
+@echo on
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-py.._0"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_xx_run/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_xx_run/run_test.py
@@ -1,0 +1,22 @@
+import os
+import json
+import glob
+
+def main():
+    prefix = os.environ['PREFIX']
+    print(prefix)
+    info_files = glob.glob(os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-numpy-build-xx-run-1.0-np*py*0.json'))
+    assert len(info_files) == 1
+    info_file = info_files[0]
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    assert len(info['depends']) == 2
+    depends = sorted(info['depends'])
+    # With no version
+    assert depends[0].startswith('numpy ')
+    assert depends[1].startswith('python ')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/numpy_build_xx_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_xx_run/run_test.sh
@@ -1,0 +1,4 @@
+echo $PATH
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-xx-run-1.0-np..py.._0"

--- a/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-numpy-build-xx-run-different-spec
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+  run:
+    - python
+    - numpy >=1.7

--- a/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/run_test.bat
@@ -1,0 +1,5 @@
+@echo on
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-xx-run-different-spec-1\.0-np..py.._0"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/run_test.py
@@ -1,0 +1,22 @@
+import os
+import json
+import glob
+
+def main():
+    prefix = os.environ['PREFIX']
+    print(prefix)
+    info_files = glob.glob(os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-numpy-build-xx-run-different-spec-1.0-np*py*0.json'))
+    assert len(info_files) == 1
+    info_file = info_files[0]
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    assert len(info['depends']) == 2
+    depends = sorted(info['depends'])
+    # With no version
+    assert depends[0].startswith('numpy ')
+    assert depends[1].startswith('python ')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_different_spec/run_test.sh
@@ -1,0 +1,4 @@
+echo $PATH
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-xx-run-different-spec-1.0-np..py.._0"

--- a/tests/test-recipes/metadata/numpy_build_xx_run_xx/meta.yaml
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_xx/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-numpy-build-xx-run-xx
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+  run:
+    - python
+    - numpy x.x

--- a/tests/test-recipes/metadata/numpy_build_xx_run_xx/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_xx/run_test.bat
@@ -1,0 +1,5 @@
+@echo on
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-xx-run-xx-1\.0-np..py.._0"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_xx_run_xx/run_test.py
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_xx/run_test.py
@@ -1,0 +1,22 @@
+import os
+import json
+import glob
+
+def main():
+    prefix = os.environ['PREFIX']
+    print(prefix)
+    info_files = glob.glob(os.path.join(prefix, 'conda-meta',
+                             'conda-build-test-numpy-build-xx-run-xx-1.0-np*py*0.json'))
+    assert len(info_files) == 1
+    info_file = info_files[0]
+    with open(info_file, 'r') as fh:
+        info = json.load(fh)
+
+    assert len(info['depends']) == 2
+    depends = sorted(info['depends'])
+    # With no version
+    assert depends[0].startswith('numpy ')
+    assert depends[1].startswith('python ')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/numpy_build_xx_run_xx/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_xx_run_xx/run_test.sh
@@ -1,0 +1,4 @@
+echo $PATH
+conda list -p $PREFIX --canonical
+# Test the build string. Should contain NumPy, but not the version
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-xx-run-xx-1.0-np..py.._0"


### PR DESCRIPTION
I just noticed #650, which goes in the opposite direction to some extent. GIven that, let me start with an overview of what I see as the problem and solution...

The released implementation of `numpy x.x` (a desirable feature) is, arguably, broken because it is very easy to build a package which does not match its runtime dependencies as listed in `info/index.json` for the recipe, or has the wrong build id, or has a build id which indicate it was built against a different version of numpy than it was actually built against.

Some examples, organized by the numpy build/run requirements in `meta.yaml`:

+ Build requirement: `numpy x.x`; runtime requirement: `numpy` (or `numpy >1.7`  or anything except `numpy x.x`)
     + Builds against the numpy version in `CONDA_NPY`.
     + `build_id` is `_pyX.Y_0` and requirement in `info/index.json` is whatever the runtime numpy requirement was listed as (`numpy` or `numpy >=1.7` or whatever).
     + Result is probably not what the builder intended.
+ Build requirement: `numpy`; runtime requirement: `numpy x.x`
    + Builds against the latest numpy, or whatever numpy is matches the build requirement, which may not be `CONDA_NPY`
    + `build_id`  is `_npA.BpyX.Y_0` and requirement in `info/index.json` is `numpy A.B`, where the numpy version is `CONDA_NPY`.
    + Definitely NOT what the builder intended -- a package whose numpy requirement **does not match the build version of numpy**.

I don't know if this second case is addressed in #650, but would argue for this alternative syntax (convention?) instead, regardless of whether this PR is the right way to implement it:

+ If you want to build against a specific version of numpy that is determined by `CONDA_NPY` then put `numpy x.x` in the **build** requirement. This makes sense to me because `CONDA_NPY` is about how you build, not how you run.
+ Use the runtime numpy dependency specification to indicate which version(s) of numpy the package is compatible with, just as is done with other python packages. If `numpy x.x` is used as the runtime build spec then there is no way to express in the recipe what versions of numpy the package is, in principle, compatible with.
+ conda build must enforce `CONDA_NPY` in both build and run....this PR is one imlementation of that.

Pinging a few people on this who have comment on/raised issues related to the original `numpy x.x` (which is a good idea!): @pelson @Juanlu001 @seibert @rmcgibbo (please also look at #650).

Also, because I know they spend lots of time building: @ChrisBarker-NOAA @ocefpaf