### PR TITLE
environ: Fix NPY_VER for versions >= 1.10 (Should be '1.10', not '1.1.0')

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -21,7 +21,13 @@ def get_py_ver():
     return '.'.join(str(config.CONDA_PY))
 
 def get_npy_ver():
-    return '.'.join(str(config.CONDA_NPY or ''))
+    if config.CONDA_NPY:
+        # Convert int -> string, e.g.
+        #   17 -> '1.7'
+        #   110 -> '1.10'
+        conda_npy = str(config.CONDA_NPY)
+        return conda_npy[0] + '.' + conda_npy[1:]
+    return ''
 
 def get_stdlib_dir():
     return join(config.build_prefix, 'Lib' if sys.platform == 'win32' else

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -89,7 +89,8 @@ def get_dict(m=None, prefix=None):
     d['SYS_PYTHON'] = sys.executable
     d['PERL_VER'] = get_perl_ver()
     d['PY_VER'] = get_py_ver()
-    d['NPY_VER'] = get_npy_ver()
+    if get_npy_ver():
+        d['NPY_VER'] = get_npy_ver()
     d['SRC_DIR'] = source.get_dir()
     if "LANG" in os.environ:
         d['LANG'] = os.environ['LANG']

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -98,6 +98,7 @@ def yamlize(data):
         if '{{' in data:
             try:
                 import jinja2
+                jinja2 # Avoid pyflakes failure: 'jinja2' imported but unused
             except ImportError:
                 raise exceptions.UnableToParseMissingJinja2(original=e)
         raise exceptions.UnableToParse(original=e)


### PR DESCRIPTION
Fixes a tiny bug in `environ.py`.  The `NPY_VER` environment variable was incorrect for numpy versions >= 1.10 (`NPY_VER`was evaluating to `1.1.0` instead of `1.10`).