### PR TITLE
metadata: Create jinja2 environment with 'strict' mode for undefined values

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -312,8 +312,10 @@ def get_contents(meta_path):
 
     template = env.get_or_select_template(filename)
 
-    contents = template.render(environment=env)
-    return contents
+    try:
+        return template.render(environment=env)
+    except jinja2.TemplateError as ex:
+        sys.exit("Error: Failed to parse jinja template in {}:\n{}".format(meta_path, ex.message))
 
 
 def handle_config_version(ms, ver):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -306,7 +306,7 @@ def get_contents(meta_path):
         env_loader = jinja2.FileSystemLoader(conda_env_path)
         loaders.append(jinja2.PrefixLoader({'$CONDA_DEFAULT_ENV': env_loader}))
 
-    env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders))
+    env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders), undefined=jinja2.StrictUndefined)
     env.globals.update(ns_cfg())
     env.globals.update(context_processor())
 


### PR DESCRIPTION
For conda recipes, I think it is safer/desirable to use `jinja2` in "strict" mode, which raises an error if the template attempts to use a variable that isn't defined.

For instance, this recipe contains a typo in the `run` requirement:

```
requirements:
  build:
    - python {{PY_VER}}*
  run
    - python {{PY_VEER}}*
```

Without strict mode, the typo is ignored, and the template simply evaluates to nothing. (Not good.)

Here's another example:

```
requirements:
  build:
    - numpy {{NPY_VER}}*
```

No typos there, but if the user forgets to provide the `--numpy=` setting to `conda build`, then `NPY_VER` will be undefined.  Ideally, an error should be emitted in this case, but you won't see any error without strict mode.

This PR has the potential to break existing recipes, if they somehow rely template variables that might be undefined.  But my guess is that any such recipes were somehow broken anyway.

If anyone can think of a legitimate use-case for permitting undefined template variables in conda recipes, then don't accept this PR, obviously.

Edit: Here are the docs for jinja's strictness settings:
http://jinja.pocoo.org/docs/dev/api/#undefined-types