### PR TITLE
main: If user supplies --python, auto-set CONDA_PY environment variable.

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -12,6 +12,7 @@ from collections import deque
 from glob import glob
 from locale import getpreferredencoding
 from os import listdir
+from os import environ as os_environ
 from os.path import exists, isdir, isfile, join
 
 import conda.config as config
@@ -307,6 +308,13 @@ def execute(args, parser):
             else:
                 raise RuntimeError("%s must be major.minor, not %s" %
                     (conda_version[lang], version))
+
+    # Using --python, --numpy etc. is equivalent to using CONDA_PY, CONDA_NPY, etc.
+    # Auto-set those env variables
+    for var in conda_version.values():
+        if getattr(config, var):
+            # Set the env variable.
+            os_environ[var] = str(getattr(config, var))
 
     if args.skip_existing:
         if not isdir(config.bldpkgs_dir):


### PR DESCRIPTION
To build with a specific python version, the user can try two things:

1. The `CONDA_PY` environment variable, e.g. `CONDA_PY=27 conda build my-package`

    OR
2. The `--python` option on the command-line, e.g. `conda build --python=2.7 my-package`

Internally, both mechanisms set `CONDA_PY` within `conda_build.config`.  Additionally, `os.environ["CONDA_PY"]` can also be used, but **only** if the user used the first mechanism.  It would be nice if that also worked in the second case.  (For example, that would make the value consistently available to `jinja2` templates within `meta.yaml`, as well as the `build.sh` environment.)

This little PR just copies `config.CONDA_PY` (and `config.CONDA_NPY`, etc.) into `os.environ`, so the two modules are in sync for these variables.

It allows `meta.yaml` syntax like this, which doesn't always work in the current version of `conda-build`:

```
build:
  string: np{{CONDA_NPY}}py{{CONDA_PY}}_0_foo_bar
```
