### PR TITLE
Allow GIT_* variables in jinja templates

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -392,7 +392,7 @@ def build(m, get_src=True, verbose=True, post=None, channel_urls=(),
             source.provide(m.path, m.get_section('source'))
             # Parse our metadata again because we did not initialize the source
             # information before.
-            m.parse_again()
+            m.parse_again(provide_empty_git_variables=False)
 
         print("Package:", m.dist())
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -36,6 +36,13 @@ def get_stdlib_dir():
 def get_sp_dir():
     return join(get_stdlib_dir(), 'site-packages')
 
+def get_git_build_info_variable_names():
+    return ["GIT_DESCRIBE_TAG",
+            "GIT_DESCRIBE_NUMBER",
+            "GIT_DESCRIBE_HASH",
+            "GIT_BUILD_STR",
+            "GIT_FULL_HASH"]
+
 def get_git_build_info(src_dir):
     env = os.environ.copy()
     d = {}
@@ -70,6 +77,8 @@ def get_git_build_info(src_dir):
         d['GIT_BUILD_STR'] = '{}_{}'.format(d[key_name('NUMBER')],
                                             d[key_name('HASH')])
 
+    for key in get_git_build_info_variable_names():
+        assert key in d
     return d
 
 def get_dict(m=None, prefix=None):

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -10,6 +10,7 @@ import os
 
 from conda.compat import PY3
 from .environ import get_dict as get_environ
+from .environ import get_git_build_info_variable_names
 
 _setuptools_data = None
 
@@ -40,12 +41,18 @@ def load_npm():
     with open('package.json', **mode_dict) as pkg:
         return json.load(pkg)
 
-def context_processor():
-    ctx = get_environ()
-    environ = dict(os.environ)
-    environ.update(get_environ())
+def context_processor(provide_empty_git_variables=True):
+    conda_environ = get_environ()
 
+    if provide_empty_git_variables:
+        for var in get_git_build_info_variable_names():
+            conda_environ.setdefault(var, '')
+
+    os_environ = dict(os.environ)
+    os_environ.update(conda_environ)
+
+    ctx = conda_environ
     ctx.update(load_setuptools=load_setuptools,
                load_npm=load_npm,
-               environ=environ)
+               environ=os_environ)
     return ctx

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -275,7 +275,7 @@ def check_bad_chrs(s, field):
             sys.exit("Error: bad character '%s' in %s: %s" % (c, field, s))
 
 
-def get_contents(meta_path):
+def get_contents(meta_path, provide_empty_git_variables=True):
     '''
     Get the contents of the [meta.yaml|conda.yaml] file.
     If jinja is installed, then the template.render function is called
@@ -308,7 +308,7 @@ def get_contents(meta_path):
 
     env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders), undefined=jinja2.StrictUndefined)
     env.globals.update(ns_cfg())
-    env.globals.update(context_processor())
+    env.globals.update(context_processor(provide_empty_git_variables))
 
     try:
         template = env.get_or_select_template(filename)
@@ -360,13 +360,13 @@ class MetaData(object):
 
         self.parse_again()
 
-    def parse_again(self):
+    def parse_again(self, provide_empty_git_variables=True):
         """Redo parsing for key-value pairs that are not initialized in the
         first pass.
         """
         if not self.meta_path:
             return
-        self.meta = parse(get_contents(self.meta_path))
+        self.meta = parse(get_contents(self.meta_path, provide_empty_git_variables))
 
         if (isfile(self.requirements_path) and
                    not self.meta['requirements']['run']):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -310,12 +310,11 @@ def get_contents(meta_path):
     env.globals.update(ns_cfg())
     env.globals.update(context_processor())
 
-    template = env.get_or_select_template(filename)
-
     try:
+        template = env.get_or_select_template(filename)
         return template.render(environment=env)
     except jinja2.TemplateError as ex:
-        sys.exit("Error: Failed to parse jinja template in {}:\n{}".format(meta_path, ex.message))
+        sys.exit("Error: Failed to render jinja template in {}:\n{}".format(meta_path, ex.message))
 
 
 def handle_config_version(ms, ver):


### PR DESCRIPTION
(This fixes the issue I [mentioned](https://github.com/conda/conda-build/pull/661#issuecomment-153950535) in thread #661, after it was merged.)

Now that #661 is merged, templates in `meta.yaml` are not permitted to use undefined variables.  But I have discovered a special case that's now broken.

The problem is related to the fact that `conda-build` actually parses `meta.yaml` **twice**.  Before the first pass, variables like `GIT_DESCRIBE_HASH` are undefined.  Then, in the first pass, variables from the `source:` section are read, so they can be added to the `environ`.  So, by the time we run the [second pass](https://github.com/conda/conda-build/blob/84bb9a6d738ec3328be33c4d5442c25897155974/conda_build/build.py#L395),  `GIT_DESCRIBE_HASH` *might* have a definition (if the recipe actually uses git), so the recipe should be allowed to use it.

In case that wasn't clear, here's a summary of what conda-build does:

- run jinja on `meta.yaml`
- parse `meta.yaml` (first pass)
- now that we know `source/git_tag`, etc., Update `environ['GIT...']` 
- re-run jinja on `meta.yaml`, with updated `environ`
- parse `meta.yaml` again (second pass)

In earlier versions of `conda-build`, the `GIT_` variables were always initialized to `''`.  But that led to problems like #322.  It would also permit the user to accidentally use a `GIT_` variable in a recipe that doesn't even use git (not good).  Hence, the default values for these were removed in 417a0743853249aa261a7c792f0a5eb46d95286d.

This PR implements a workaround: We should provide 'fake' values (empty strings) for `GIT_` variables during the first pass (only), just so `jinja2` doesn't complain about them. But don't add them during the second pass -- they will already be defined in `environ`, and if they aren't, then the recipe shouldn't be using them.