### PR TITLE
support new environment variable CONDA_ACTIVE_ENV

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -298,13 +298,15 @@ def get_contents(meta_path):
                jinja2.FileSystemLoader(path)
                ]
 
+    # path to current conda environment (new and old variable name)
+    conda_env_path = os.environ.get('CONDA_ACTIVE_ENV') or \
+                     os.environ.get('CONDA_DEFAULT_ENV')
     # search relative to current conda environment directory
-    conda_env_path = os.environ.get('CONDA_DEFAULT_ENV')  # path to current conda environment
     if conda_env_path and os.path.isdir(conda_env_path):
         conda_env_path = os.path.abspath(conda_env_path)
         conda_env_path = conda_env_path.replace('\\', '/') # need unix-style path
         env_loader = jinja2.FileSystemLoader(conda_env_path)
-        loaders.append(jinja2.PrefixLoader({'$CONDA_DEFAULT_ENV': env_loader}))
+        loaders.append(jinja2.PrefixLoader({'$CONDA_ACTIVE_ENV': env_loader}))
 
     env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders), undefined=jinja2.StrictUndefined)
     env.globals.update(ns_cfg())


### PR DESCRIPTION
This is a follow-up on PR https://github.com/conda/conda-build/pull/578 to reflect the changes proposed in PR https://github.com/conda/conda/pull/1727. In particular, jinja now looks for configuration files both under `$CONDA_ACTIVE_ENV` and `$CONDA_DEFAULT_ENV`, but prefers the former if it exists.