### PR TITLE
conda_build/source.py: give symlinks=True to copytree()

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -221,7 +221,7 @@ def svn_source(meta):
         assert isdir(cache_repo)
 
     # now copy into work directory
-    copytree(cache_repo, WORK_DIR)
+    copytree(cache_repo, WORK_DIR, symlinks=True)
     return WORK_DIR
 
 


### PR DESCRIPTION
This copies symbolic links as links. This should be more efficient, and I have
one pathological example of a SVN repository that contains a symlink to '.'
that results in a endlessly recursive copy that eventually throws an exception
from the path getting too long.