### PR TITLE
Provide parsed metadata from first pass as context to second pass

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -144,6 +144,7 @@ def get_dict(m=None, prefix=None):
         d['PKG_NAME'] = m.name()
         d['PKG_VERSION'] = m.version()
         d['PKG_BUILDNUM'] = str(m.build_number())
+        d['PKG_BUILD_STRING'] = str(m.build_id())
         d['RECIPE_DIR'] = m.path
 
     return d

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -40,10 +40,16 @@ def load_npm():
     with open('package.json', **mode_dict) as pkg:
         return json.load(pkg)
 
-def context_processor():
-    ctx = get_environ()
+def context_processor(initial_metadata=None):
+    """
+    Return a dictionary to use as context for jinja templates.
+
+    initial_metadata: Augment the context with values from this MetaData object.
+                      Used to bootstrap metadata contents via multiple parsing passes.
+    """
+    ctx = get_environ(m=initial_metadata)
     environ = dict(os.environ)
-    environ.update(get_environ())
+    environ.update(get_environ(m=initial_metadata))
 
     ctx.update(load_setuptools=load_setuptools,
                load_npm=load_npm,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -316,6 +316,11 @@ class MetaData(object):
             if not isfile(self.meta_path):
                 sys.exit("Error: meta.yaml or conda.yaml not found in %s" % path)
 
+        # Start with bare-minimum contents so we can call environ.get_dict() with impunity
+        # We'll immediately replace these contents in parse_again()
+        self.meta = parse("package:\n"
+                          "  name: uninitialized")
+
         # This is the 'first pass' parse of meta.yaml, so not all variables are defined yet
         # (e.g. GIT_FULL_HASH, etc. are undefined)
         # Therefore, undefined jinja variables are permitted here
@@ -596,7 +601,7 @@ class MetaData(object):
     
         env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders), undefined=undefined_type)
         env.globals.update(ns_cfg())
-        env.globals.update(context_processor())
+        env.globals.update(context_processor(self))
     
         try:
             template = env.get_or_select_template(filename)

--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -5,7 +5,10 @@ set -x
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Recipes that should fail and give some error
+# These variables are defined solely for testing purposes,
+# so they can be checked within build scripts
+export CONDA_TEST_VAR="conda_test"
+export CONDA_TEST_VAR_2="conda_test_2"
 
 for recipe in metadata/*/; do
     if [[ $(ls -A "$recipe") ]]; then
@@ -16,6 +19,7 @@ for recipe in metadata/*/; do
     fi
 done
 
+# Recipes that should fail and give some error
 cd fail
 
 # We use 2>&1 as the error is printed to stderr. We could do >/dev/null to

--- a/tests/test-recipes/metadata/jinja_vars/build.sh
+++ b/tests/test-recipes/metadata/jinja_vars/build.sh
@@ -1,0 +1,11 @@
+# CONDA_TEST_VAR was inherited via build/script_env
+[ "${CONDA_TEST_VAR}" == "conda_test" ]
+
+# CONDA_TEST_VAR_2 was not inherited
+[ "${CONDA_TEST_VAR_2}" == "" ]
+
+# Sanity check: Neither was LD_LIBRARY_PATH
+[ "$LD_LIBRARY_PATH" == "" ]
+
+# Check the special value we gave the build string, which depends on build number
+[ "${PKG_BUILD_STRING}" == "${CONDA_TEST_VAR}_${PKG_BUILDNUM}" ]

--- a/tests/test-recipes/metadata/jinja_vars/meta.yaml
+++ b/tests/test-recipes/metadata/jinja_vars/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-jinja-vars
+  version: 1.0
+
+build:
+  number: 123
+  string: {{CONDA_TEST_VAR}}_{{PKG_BUILDNUM}}
+
+  script_env:
+    - CONDA_TEST_VAR
+  


### PR DESCRIPTION
**Note:** The "Files changed" tab here on github makes this PR seem bigger than it really is.  If you review these commits individually, you'll see that each one is small.

---

conda-build defines a number of [environment variables][1] that can be used within `build.sh`.  Using jinja templates, you can also use *most* these variables within `meta.yaml`.  I say *most* because some of those variables come from `meta.yaml` itself, such as `PKG_BUILDNUM`.

For instance, this recipe attempts to include the build number as part of the build string, but it won't work:

```
build:
  number: 99
  string: special_build_n{{PKG_BUILDNUM}}
```

We can fix this.  Since conda-build parses `meta.yaml` in *two passes*, there's no reason we can't make those variables available in the second pass.  That way, there is no longer a discrepancy between the set of variables available in `meta.yaml` and those available in `build.sh`.

It's a pretty easy fix: Just provide the `MetaData` contents (after the first pass) to the jinja context of the second pass.

[1]: http://conda.pydata.org/docs/building/environment-vars.html

--
**Edit:**

I can think of another potential use for this feature.  In `meta.yaml` the [`build: script_env:` section][2] allows the user to provide a list of "inherited" environment variables, which can be used in `build.sh`.  With this PR, those same variables can also be used within `meta.yaml` itself!  For example:

[2]: http://conda.pydata.org/docs/building/environment-vars.html#inherited-environment-variables

```
build:
  script_env:
   - USER
  string: {{USER}}_{{PKG_BUILDNUM}}
```

...ok, I'm not sure how useful that is; it just seemed worth mentioning.  The main thing I'm interested in is still the `PKG_BUILDNUM` syntax shown above.

