### PR TITLE
Do not move packages to broken directory when running tests only

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -488,7 +488,7 @@ can lead to packages that include their dependencies.""" %
         print("STOPPING BUILD BEFORE POST:", m.dist())
 
 
-def test(m, verbose=True, channel_urls=(), override_channels=False):
+def test(m, verbose=True, channel_urls=(), override_channels=False, move_broken=True):
     '''
     Execute any test scripts for the given package.
 
@@ -559,7 +559,7 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
                                    join(tmp_dir, 'run_test.py')],
                                   env=env, cwd=tmp_dir)
         except subprocess.CalledProcessError:
-            tests_failed(m)
+            tests_failed(m, move_broken=move_broken)
 
     if pl_files:
         try:
@@ -567,7 +567,7 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
                                    join(tmp_dir, 'run_test.pl')],
                                   env=env, cwd=tmp_dir)
         except subprocess.CalledProcessError:
-            tests_failed(m)
+            tests_failed(m, move_broken=move_broken)
 
     if shell_files:
         if sys.platform == 'win32':
@@ -576,7 +576,7 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
             try:
                 subprocess.check_call(cmd, env=env, cwd=tmp_dir)
             except subprocess.CalledProcessError:
-                tests_failed(m)
+                tests_failed(m, move_broken=move_broken)
         else:
             test_file = join(tmp_dir, 'run_test.sh')
             # TODO: Run the test/commands here instead of in run_test.py
@@ -584,11 +584,11 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
             try:
                 subprocess.check_call(cmd, env=env, cwd=tmp_dir)
             except subprocess.CalledProcessError:
-                tests_failed(m)
+                tests_failed(m, move_broken=move_broken)
 
     print("TEST END:", m.dist())
 
-def tests_failed(m):
+def tests_failed(m, move_broken):
     '''
     Causes conda to exit if any of the given package's tests failed.
 
@@ -598,5 +598,6 @@ def tests_failed(m):
     if not isdir(config.broken_dir):
         os.makedirs(config.broken_dir)
 
-    shutil.move(bldpkg_path(m), join(config.broken_dir, "%s.tar.bz2" % m.dist()))
+    if move_broken: 
+        shutil.move(bldpkg_path(m), join(config.broken_dir, "%s.tar.bz2" % m.dist()))
     sys.exit("TESTS FAILED: " + m.dist())

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -365,7 +365,7 @@ def execute(args, parser):
                 continue
             elif args.test:
                 build.test(m, verbose=not args.quiet,
-                    channel_urls=channel_urls, override_channels=args.override_channels)
+                    channel_urls=channel_urls, override_channels=args.override_channels, move_broken=False)
             elif args.source:
                 source.provide(m.path, m.get_section('source'))
                 print('Source tree in:', source.get_dir())


### PR DESCRIPTION
Packages should be left wherever they were loaded from when running with conda build --test. 

#678 