### PR TITLE
Add a few options to skeleton pypi

### DIFF
--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -159,6 +159,15 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
         help="Creates recipe as noarch python"
     )
 
+    pypi.add_argument(
+        "--skeleton-setup-options",
+        action='append',
+        default=[],
+        help="Options to be passed to setup.py when generating recipe. "
+             "The characters '--' will be prepended to each option "
+             "automatically and should not be included."
+             "May be repeated to add several options.")
+
     cpan = repos.add_parser(
         "cpan",
         help="""

--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -168,6 +168,15 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
              "automatically and should not be included."
              "May be repeated to add several options.")
 
+    pypi.add_argument(
+        "--recipe-setup-options",
+        action='append',
+        default=[],
+        help="Options to be added to setup.py install in the recipe. "
+             "The characters '--' will be prepended to each option "
+             "automatically and should not be included."
+             "May be repeated to add several options.")
+
     cpan = repos.add_parser(
         "cpan",
         help="""

--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -177,6 +177,13 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
              "automatically and should not be included."
              "May be repeated to add several options.")
 
+    pypi.add_argument(
+        "--pin-numpy",
+        action='store_true',
+        help="Ensure that the generated recipe pins the version of numpy"
+             "to CONDA_NPY."
+    )
+
     cpan = repos.add_parser(
         "cpan",
         help="""

--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -160,22 +160,15 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
     )
 
     pypi.add_argument(
-        "--skeleton-setup-options",
+        "--setup-options",
         action='append',
         default=[],
-        help="Options to be passed to setup.py when generating recipe. "
-             "The characters '--' will be prepended to each option "
-             "automatically and should not be included."
-             "May be repeated to add several options.")
-
-    pypi.add_argument(
-        "--recipe-setup-options",
-        action='append',
-        default=[],
-        help="Options to be added to setup.py install in the recipe. "
-             "The characters '--' will be prepended to each option "
-             "automatically and should not be included."
-             "May be repeated to add several options.")
+        help='Options to be added to setup.py install in the recipe. '
+             'The same options are passed to setup.py install in both '
+             'the construction of the recipe and in the recipe itself.'
+             'For options that include a double-hypen or to pass multiple '
+             'options, use the syntax '
+             '--setup-options="--option1 --optin-with-arg arg"')
 
     pypi.add_argument(
         "--pin-numpy",

--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -168,7 +168,8 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
              'the construction of the recipe and in the recipe itself.'
              'For options that include a double-hypen or to pass multiple '
              'options, use the syntax '
-             '--setup-options="--option1 --optin-with-arg arg"')
+             '--setup-options="--option1 --option-with-arg arg"'
+    )
 
     pypi.add_argument(
         "--pin-numpy",

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -105,7 +105,7 @@ about:
 PYPI_BUILD_SH = """\
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install {recipe_setup_options}
 
 # Add more build steps here, if they are necessary.
 
@@ -115,7 +115,7 @@ $PYTHON setup.py install
 """
 
 PYPI_BLD_BAT = """\
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install {recipe_setup_options}
 if errorlevel 1 exit 1
 
 :: Add more build steps here, if they are necessary.
@@ -365,6 +365,9 @@ def main(args, parser):
 
         if d['entry_comment'] == d['import_comment'] == '# ':
             d['test_comment'] = '# '
+
+        recipe_setup_options = ['--' + o for o in args.recipe_setup_options]
+        d['recipe_setup_options'] = ' '.join(recipe_setup_options)
 
     for package in package_dicts:
         d = package_dicts[package]

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -366,8 +366,7 @@ def main(args, parser):
         if d['entry_comment'] == d['import_comment'] == '# ':
             d['test_comment'] = '# '
 
-        recipe_setup_options = ['--' + o for o in args.recipe_setup_options]
-        d['recipe_setup_options'] = ' '.join(recipe_setup_options)
+        d['recipe_setup_options'] = args.setup_options
 
         # Change requirements to use format that guarantees the numpy
         # version will be pinned when the recipe is built and that
@@ -496,13 +495,12 @@ def get_package_metadata(args, package, d, data):
 
     [output_dir] = args.output_dir
 
-    setup_options = ['--' + a for a in args.skeleton_setup_options]
     pkginfo = get_pkginfo(package,
                           filename=d['filename'],
                           pypiurl=d['pypiurl'],
                           md5=d['md5'],
                           python_version=args.python_version,
-                          setup_options=setup_options)
+                          setup_options=args.setup_options)
 
     setuptools_build = pkginfo['setuptools']
     setuptools_run = False

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -369,6 +369,20 @@ def main(args, parser):
         recipe_setup_options = ['--' + o for o in args.recipe_setup_options]
         d['recipe_setup_options'] = ' '.join(recipe_setup_options)
 
+        # Change requirements to use format that guarantees the numpy
+        # version will be pinned when the recipe is built and that
+        # the version is included in the build string.
+        if args.pin_numpy:
+            for depends in ['build_depends', 'run_depends']:
+                deps = d[depends].split(INDENT)
+                numpy_dep = [idx for idx, dep in enumerate(deps)
+                             if 'numpy' in dep]
+                if numpy_dep:
+                    # Turns out this needs to be inserted before the rest
+                    # of the numpy spec.
+                    deps.insert(numpy_dep[0], 'numpy x.x')
+                    d[depends] = INDENT.join(deps)
+
     for package in package_dicts:
         d = package_dicts[package]
         name = d['packagename']

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -366,7 +366,7 @@ def main(args, parser):
         if d['entry_comment'] == d['import_comment'] == '# ':
             d['test_comment'] = '# '
 
-        d['recipe_setup_options'] = args.setup_options
+        d['recipe_setup_options'] = ' '.join(args.setup_options)
 
         # Change requirements to use format that guarantees the numpy
         # version will be pinned when the recipe is built and that

--- a/tests/test-skeleton/test_skeleton.py
+++ b/tests/test-skeleton/test_skeleton.py
@@ -52,7 +52,7 @@ def test_skeleton_with_setup_options(tmpdir):
     # occurs by default.
 
     # Test that the setup option is used in constructing the skeleton.
-    cmd = ("conda skeleton pypi --output-dir {} ccdproc "
+    cmd = ("conda skeleton pypi --output-dir {} --version=0.2.2 photutils "
            "--setup-options=--offline".format(tmpdir))
     subprocess.check_call(cmd.split())
 

--- a/tests/test-skeleton/test_skeleton.py
+++ b/tests/test-skeleton/test_skeleton.py
@@ -51,14 +51,15 @@ def test_skeleton_with_setup_options(tmpdir):
     # the flag --offline because of a bootstrapping a helper file that
     # occurs by default.
 
+    package_name = 'photutils'
     # Test that the setup option is used in constructing the skeleton.
-    cmd = ("conda skeleton pypi --output-dir {} --version=0.2.2 photutils "
-           "--setup-options=--offline".format(tmpdir))
+    cmd = ("conda skeleton pypi --output-dir {} --version=0.2.2 {} "
+           "--setup-options=--offline".format(tmpdir, package_name))
     subprocess.check_call(cmd.split())
 
     # Check that the setup option occurs in bld.bat and build.sh.
     for script in ['bld.bat', 'build.sh']:
-        with open('{}/ccdproc/{}'.format(tmpdir, script)) as f:
+        with open('{}/{}/{}'.format(tmpdir, package_name, script)) as f:
             content = f.read()
             assert '--offline' in content
 
@@ -66,10 +67,11 @@ def test_skeleton_with_setup_options(tmpdir):
 def test_skeleton_pin_numpy(tmpdir):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
-    cmd = "conda skeleton pypi --output-dir {} --version=0.9.0 --pin-numpy msumastro".format(tmpdir)
+    package_name = 'msumastro'
+    cmd = "conda skeleton pypi --output-dir {} --version=0.9.0 --pin-numpy {}".format(tmpdir, package_name)
     subprocess.check_call(cmd.split())
 
-    with open('{}/msumastro/meta.yaml'.format(tmpdir)) as f:
+    with open('{}/{}/meta.yaml'.format(tmpdir, package_name)) as f:
         actual = yaml.load(f)
 
     assert 'numpy x.x' in actual['requirements']['run']

--- a/tests/test-skeleton/test_skeleton.py
+++ b/tests/test-skeleton/test_skeleton.py
@@ -25,7 +25,6 @@ def test_skeleton_by_name(tmpdir):
 
 
 def test_name_with_version_specified(tmpdir):
-    tmpdir = tempfile.mkdtemp()
     cmd = "conda skeleton pypi --output-dir {} --version=0.7.5 sympy".format(tmpdir)
     subprocess.check_call(cmd.split())
     with open('{}/sympy-0.7.5/meta.yaml'.format(thisdir)) as f:
@@ -45,3 +44,33 @@ sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9".format(tmpdir)
     with open('{}/sympy/meta.yaml'.format(tmpdir)) as f:
         actual = yaml.load(f)
     assert expected == actual, (expected, actual)
+
+
+def test_skeleton_with_setup_options(tmpdir):
+    # Use package below because  skeleton will fail unless the setup.py is given
+    # the flag --offline because of a bootstrapping a helper file that
+    # occurs by default.
+
+    # Test that the setup option is used in constructing the skeleton.
+    cmd = ("conda skeleton pypi --output-dir {} ccdproc "
+           "--setup-options=--offline".format(tmpdir))
+    subprocess.check_call(cmd.split())
+
+    # Check that the setup option occurs in bld.bat and build.sh.
+    for script in ['bld.bat', 'build.sh']:
+        with open('{}/ccdproc/{}'.format(tmpdir, script)) as f:
+            content = f.read()
+            assert '--offline' in content
+
+
+def test_skeleton_pin_numpy(tmpdir):
+    # The package used here must have a numpy dependence for pin-numpy to have
+    # any effect.
+    cmd = "conda skeleton pypi --output-dir {} --version=0.9.0 --pin-numpy msumastro".format(tmpdir)
+    subprocess.check_call(cmd.split())
+
+    with open('{}/msumastro/meta.yaml'.format(tmpdir)) as f:
+        actual = yaml.load(f)
+
+    assert 'numpy x.x' in actual['requirements']['run']
+    assert 'numpy x.x' in actual['requirements']['build']


### PR DESCRIPTION
This adds a few new options to `conda skeleton pypi`:

+ `--skeleton-setup-options` to allow options to be passed to `python setup.py` when it is called to determine dependencies (motivation/use case below).
+ `--recipe-setup-options` to allow options to be added to `python setup.py install` in `build.sh` and `bld.bat` in the recipe generated by skeleton (motivation/use case below).
+ `--pin-numpy` to add the proper build/run requirements to ensure the version of numpy gets pinned when the recipe is built. Without this there is no way, currently, to use skeleton to generate a recipe that pins the numpy version without manually editing the recipe afterwards.

Use case/motivation for the first two options: I maintain builds for several astropy affiliated packages, most of which use a helpers package, astropy-helpers, for some functionality needed at install. Most are also configured to check for bugfix updates on pypi, and that attempt to download raises an error when skeleton tries to construct a recipe.

There is an option to `setup.py` to turn off that check, but no way to specify it currently without editing `conda-build`.

The same option needs to be included in the build scripts, and it makes sense to me to be able to add it while generating the recipe.

Taking a step back, I want to be able, in the builder-bot I'm maintaining, to generate recipes on the fly and then build from them. 

**Edit 2/14/16`:** The first two options have been combined into a single option, `--setup-options`.