### PR TITLE
"replace" unicode errors in git_info (hopefully fixing #349)

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -12,7 +12,7 @@ from conda.utils import hashsum_file
 
 from conda_build import external
 from conda_build.config import config
-from conda_build.utils import rm_rf, tar_xf, unzip
+from conda_build.utils import rm_rf, tar_xf, unzip, safe_print_unicode
 
 
 SRC_CACHE = join(config.croot, 'src_cache')
@@ -165,7 +165,7 @@ def git_info(fo=None):
             fo.write(stdout + u'\n')
         else:
             print(u'==> %s <==\n' % cmd)
-            print(stdout + u'\n')
+            safe_print_unicode(stdout + u'\n')
 
 
 def hg_source(meta):

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -156,3 +156,25 @@ def comma_join(items):
     'a, b, and c'
     """
     return ' and '.join(items) if len(items) <= 2 else ', '.join(items[:-1]) + ', and ' + items[-1]
+
+
+def safe_print_unicode(*args, **kwargs):
+    """
+    prints unicode strings to stdout using configurable `errors` handler for
+    encoding errors
+
+    :param args: unicode strings to print to stdout
+    :param sep: separator (defaults to ' ')
+    :param end: ending character (defaults to '\n')
+    :param errors: error handler for encoding errors (defaults to 'replace')
+    """
+    sep = kwargs.pop('sep', u' ')
+    end = kwargs.pop('end', u'\n')
+    errors = kwargs.pop('errors', 'replace')
+    if PY3:
+        func = sys.stdout.buffer.write
+    else:
+        func = sys.stdout.write
+    line = sep.join(args) + end
+    encoding = sys.stdout.encoding or 'utf8'
+    func(line.encode(encoding, errors))


### PR DESCRIPTION
Trying to fix issue #349.

With this patch, I can successfully build on Windows using Python3 (it's broken otherwise). I tested the helper function using python2 but not a whole build.