### PR TITLE
TEST: Adds a test using jinja2 environment variables

### DIFF
--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -30,4 +30,7 @@ echo "$OUTPUT" | grep 'Error: Untracked file(s) ('\''conda-meta/nope'\'',)'
 ! OUTPUT=$(conda build --no-anaconda-upload recursive-build/ 2>&1)
 echo "$OUTPUT" | grep 'No packages found in current .* channels matching: recursive-build2 2\.0'
 
+! OUTPUT=$(conda build --no-anaconda-upload source_git_jinja2_oops/ 2>&1)
+echo "$OUTPUT" | grep '\''GIT_DSECRIBE_TAG'\'' is undefined'
+
 echo "TESTS PASSED"

--- a/tests/test-recipes/fail/source_git_jinja2_oops/bld.bat
+++ b/tests/test-recipes/fail/source_git_jinja2_oops/bld.bat
@@ -1,0 +1,18 @@
+if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
+git describe --tags --dirty
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
+if errorlevel 1 exit 1
+echo "%gitdesc%"
+if not "%gitdesc%"=="1.8.1" exit 1
+echo "%PKG_VERSION%"
+if not "%PKG_VERSION%"="1.8.1" exit 1
+git status
+if errorlevel 1 exit 1
+git diff
+if errorlevel 1 exit 1
+set PYTHONPATH=.
+python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/fail/source_git_jinja2_oops/build.sh
+++ b/tests/test-recipes/fail/source_git_jinja2_oops/build.sh
@@ -1,0 +1,9 @@
+# We test the environment variables in a different recipe
+
+# Ensure we are in a git repo
+[ -d .git ]
+git describe
+[ "$(git describe)" = 1.8.1 ]
+echo "\$PKG_VERSION = $PKG_VERSION"
+[ "${PKG_VERSION}" = 1.8.1 ]
+PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"

--- a/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
+++ b/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: conda-build-test-source-git-jinja2
+  name: conda-build-test-source-git-jinja2-oops
   version: {{ GIT_DESCRIBE_TAG }}
 
 source:

--- a/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
+++ b/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-build-test-source-git-jinja2-oops
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ GIT_DSECRIBE_TAG }}
 
 source:
   git_url: https://github.com/conda/conda-build

--- a/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
+++ b/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: conda-build-test-source-git-jinja2
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  git_url: https://github.com/conda/conda-build
+  git_tag: 1.8.1
+
+requirements:
+  build:
+    # To test the conda_build version
+    - python

--- a/tests/test-recipes/metadata/source_git_jinja2/bld.bat
+++ b/tests/test-recipes/metadata/source_git_jinja2/bld.bat
@@ -1,0 +1,16 @@
+if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
+git describe --tags --dirty
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
+if errorlevel 1 exit 1
+echo "%gitdesc%"
+if not "%gitdesc%"=="1.8.1" exit 1
+git status
+if errorlevel 1 exit 1
+git diff
+if errorlevel 1 exit 1
+set PYTHONPATH=.
+python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/source_git_jinja2/bld.bat
+++ b/tests/test-recipes/metadata/source_git_jinja2/bld.bat
@@ -7,6 +7,8 @@ for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
 if errorlevel 1 exit 1
 echo "%gitdesc%"
 if not "%gitdesc%"=="1.8.1" exit 1
+echo "%PKG_VERSION%"
+if not "%PKG_VERSION%"="1.8.1" exit 1
 git status
 if errorlevel 1 exit 1
 git diff

--- a/tests/test-recipes/metadata/source_git_jinja2/build.sh
+++ b/tests/test-recipes/metadata/source_git_jinja2/build.sh
@@ -4,4 +4,6 @@
 [ -d .git ]
 git describe
 [ "$(git describe)" = 1.8.1 ]
+echo "\$PKG_VERSION = $PKG_VERSION"
+[ "${PKG_VERSION}" = 1.8.1 ]
 PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"

--- a/tests/test-recipes/metadata/source_git_jinja2/build.sh
+++ b/tests/test-recipes/metadata/source_git_jinja2/build.sh
@@ -1,0 +1,7 @@
+# We test the environment variables in a different recipe
+
+# Ensure we are in a git repo
+[ -d .git ]
+git describe
+[ "$(git describe)" = 1.8.1 ]
+PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"

--- a/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
+++ b/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: conda-build-test-source-git
+  version: 1.0
+
+source:
+  git_url: https://github.com/conda/conda-build
+  git_tag: 1.8.1
+
+requirements:
+  build:
+    # To test the conda_build version
+    - python

--- a/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
+++ b/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: conda-build-test-source-git
+  name: conda-build-test-source-git-jinja2
   version: {{ GIT_DESCRIBE_TAG }}
 
 source:

--- a/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
+++ b/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-build-test-source-git
-  version: 1.0
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   git_url: https://github.com/conda/conda-build


### PR DESCRIPTION
Requires https://github.com/conda/conda-build/pull/692

This provides a simple test using environment variables. This would have worked on `conda-build` 1.18.1 (did when tested locally). It is expected to fail on `conda-build` 1.18.2.