### PR TITLE
Fix handling of --perl and --R

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -299,7 +299,9 @@ def execute(args, parser):
                 setattr(args, lang, versions)
             return
         else:
-            version = int(versions[0].replace('.', ''))
+            version = versions[0]
+            if lang in ('python', 'numpy'):
+                version = int(version.replace('.', ''))
             setattr(config, conda_version[lang], version)
         if not len(str(version)) in (2, 3) and lang in ['python', 'numpy']:
             if all_versions[lang]:


### PR DESCRIPTION
Unlike the conventions for `config.CONDA_PY` and `config.CONDA_NPY`, which have values like `27` and `19`, respectively, the convention for  `CONDA_PERL` and `CONDA_R` [says][1] to keep the `.` characters in these variables, e.g. `CONDA_PERL=5.22.0`.

Fixes #696

[1]: https://github.com/conda/conda-build/blob/03c75c0597370c5ef1b0356c16f3beab1f417413/CHANGELOG.txt#L469-L472
