### PR TITLE
OpenBSD 5.x support

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -582,7 +582,7 @@ def test(m, verbose=True, channel_urls=(), override_channels=False):
         else:
             test_file = join(tmp_dir, 'run_test.sh')
             # TODO: Run the test/commands here instead of in run_test.py
-            cmd = ['/bin/bash', '-x', '-e', test_file]
+            cmd = ['/bin/sh', '-x', '-e', test_file]
             try:
                 subprocess.check_call(cmd, env=env, cwd=tmp_dir)
             except subprocess.CalledProcessError:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -439,7 +439,7 @@ def build(m, get_src=True, verbose=True, post=None, channel_urls=(),
                 os.chmod(build_file, 0o766)
 
             if isfile(build_file):
-                cmd = ['/bin/bash', '-x', '-e', build_file]
+                cmd = ['/bin/sh', '-x', '-e', build_file]
 
                 _check_call(cmd, env=env, cwd=src_dir)
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -320,7 +320,7 @@ def mk_relative(m, f):
     if not is_obj(path):
         return
 
-    if sys.platform.startswith('linux') or sys.platform.startswith('openbsd'):
+    if sys.platform.startswith('linux') or ('bsd' in sys.platform):
         mk_relative_linux(f, rpaths=m.get_value('build/rpaths', ['lib']))
     elif sys.platform == 'darwin':
         mk_relative_osx(path)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -320,7 +320,7 @@ def mk_relative(m, f):
     if not is_obj(path):
         return
 
-    if sys.platform.startswith('linux'):
+    if sys.platform.startswith('linux') or sys.platform.startswith('openbsd'):
         mk_relative_linux(f, rpaths=m.get_value('build/rpaths', ['lib']))
     elif sys.platform == 'darwin':
         mk_relative_osx(path)

--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -8,8 +8,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # Recipes that should fail and give some error
 
 for recipe in metadata/*/; do
-    if [[ $(ls -A "$recipe") ]]; then
-        if [[ $recipe =~ .*osx_is_app.* && $(uname) != "Darwin" ]]; then
+    # Only consider directories
+    if [ -d "$recipe" ]; then
+        # Disable test recipe "osx_is_app" if not on OSX
+        if [ "${recipe#*osx_is_app}" != "$recipe" ] && [ $(uname) != "Darwin" ]; then
             continue
         fi
         conda build --no-anaconda-upload $recipe

--- a/tests/test-recipes/metadata/jinja_vars/build.sh
+++ b/tests/test-recipes/metadata/jinja_vars/build.sh
@@ -1,11 +1,11 @@
 # CONDA_TEST_VAR was inherited via build/script_env
-[ "${CONDA_TEST_VAR}" == "conda_test" ]
+[ "${CONDA_TEST_VAR}" = "conda_test" ]
 
 # CONDA_TEST_VAR_2 was not inherited
-[ "${CONDA_TEST_VAR_2}" == "" ]
+[ "${CONDA_TEST_VAR_2}" = "" ]
 
 # Sanity check: Neither was LD_LIBRARY_PATH
-[ "$LD_LIBRARY_PATH" == "" ]
+[ "$LD_LIBRARY_PATH" = "" ]
 
 # Check the special value we gave the build string, which depends on build number
-[ "${PKG_BUILD_STRING}" == "${CONDA_TEST_VAR}_${PKG_BUILDNUM}" ]
+[ "${PKG_BUILD_STRING}" = "${CONDA_TEST_VAR}_${PKG_BUILDNUM}" ]


### PR DESCRIPTION
This is a followup on conda/conda#1891.

conda-build should use `/bin/sh` instead of `/bin/bash`, for reasons exposed in the above pull request. This allows the use of conda-build on *BSDs and some linux distributions which chose to distribute bash in e.g. `/usr/local/bin/bash`.