### PR TITLE
Turn off compilation

### DIFF
--- a/conda_build.recipe/meta.yaml
+++ b/conda_build.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-build
-  version: 1.18.3
+  version: 1.10alpha.0
 
 source:
   git_url: ../

--- a/conda_build.recipe/meta.yaml
+++ b/conda_build.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-build
-  version: 1.10alpha.0
+  version: 1.18.3
 
 source:
   git_url: ../

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -517,7 +517,9 @@ def build(m, get_src=True, post=None, include_recipe=True, keep_old_work=False):
         assert not exists(config.info_dir)
         files2 = prefix_files()
 
-        post_process(sorted(files2 - files1), preserve_egg_dir=bool(m.get_value('build/preserve_egg_dir')))
+        post_process(sorted(files2 - files1), 
+            preserve_egg_dir=bool(m.get_value('build/preserve_egg_dir')), 
+            pyc_compilation=bool(m.get_value('build/pyc_compilation', True)))
 
         # The post processing may have deleted some files (like easy-install.pth)
         files2 = prefix_files()

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -151,7 +151,6 @@ def parse(data):
         if not isinstance(res[field], dict):
             raise RuntimeError("The %s field should be a dict, not %s" %
                                (field, res[field].__class__.__name__))
-                  'build/pyc_compilation',
 
 
 
@@ -261,7 +260,7 @@ FIELDS = {
               'detect_binary_files_with_prefix', 'rpaths',
               'always_include_files', 'skip', 'msvc_compiler',
               'pin_depends', # pin_depends is experimental still
-              'skip-pyc-compilation'
+              'pyc-compilation'
              ],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -151,6 +151,7 @@ def parse(data):
         if not isinstance(res[field], dict):
             raise RuntimeError("The %s field should be a dict, not %s" %
                                (field, res[field].__class__.__name__))
+                  'build/pyc_compilation',
 
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -259,7 +259,8 @@ FIELDS = {
               'has_prefix_files', 'binary_has_prefix_files', 'script_env',
               'detect_binary_files_with_prefix', 'rpaths',
               'always_include_files', 'skip', 'msvc_compiler',
-              'pin_depends' # pin_depends is experimental still
+              'pin_depends', # pin_depends is experimental still
+              'skip-pyc-compilation'
              ],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -157,11 +157,10 @@ def compile_missing_pyc():
                            '-q', '-x', 'port_v3', sp_dir])
 
 
-def post_process(files, preserve_egg_dir=False):
+def post_process(files, preserve_egg_dir=False, pyc_compilation=True):
     remove_easy_install_pth(files, preserve_egg_dir=preserve_egg_dir)
     rm_py_along_so()
-    skip_pyc_compilation = bool(m.get_value('build/skip_pyc_compilation', False))
-    if config.CONDA_PY < 30 and skip_pyc_compilation:
+    if config.CONDA_PY < 30 and pyc_compilation:
         compile_missing_pyc()
 
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -160,7 +160,8 @@ def compile_missing_pyc():
 def post_process(files, preserve_egg_dir=False):
     remove_easy_install_pth(files, preserve_egg_dir=preserve_egg_dir)
     rm_py_along_so()
-    if config.CONDA_PY < 30:
+    skip_pyc_compilation = bool(m.get_value('build/skip_pyc_compilation', False))
+    if config.CONDA_PY < 30 and skip_pyc_compilation:
         compile_missing_pyc()
 
 


### PR DESCRIPTION
I added an option to the build section where you can say:

`pyc_compilation: False`

and it will skip the pyc compilation step.

This should address #686 and #709. Hope I changed it correctly, though I verified that it works.