### PR TITLE
Enhancements for module exec in load_setuptools

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -34,7 +34,8 @@ def load_setuptools(setup_file='setup.py'):
             '__doc__': None,
             '__file__': setup_file,
         }
-        code = compile(open(setup_file).read(), setup_file, 'exec')
+        code = compile(open(setup_file).read(), setup_file, 'exec',
+                       dont_inherit=1)
         exec(code, ns, ns)
         setuptools.setup = setuptools_setup
         del sys.path[-1]

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -29,7 +29,12 @@ def load_setuptools(setup_file='setup.py'):
         #Patch setuptools
         setuptools_setup = setuptools.setup
         setuptools.setup = setup
-        exec(open(setup_file).read())
+        ns = {
+            '__name__': os.path.splitext(os.path.basename(setup_file))[0],
+            '__doc__': None,
+            '__file__': setup_file,
+        }
+        exec(open(setup_file).read(), ns, ns)
         setuptools.setup = setuptools_setup
         del sys.path[-1]
     return _setuptools_data

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -34,7 +34,8 @@ def load_setuptools(setup_file='setup.py'):
             '__doc__': None,
             '__file__': setup_file,
         }
-        exec(open(setup_file).read(), ns, ns)
+        code = compile(open(setup_file).read(), setup_file, 'exec')
+        exec(code, ns, ns)
         setuptools.setup = setuptools_setup
         del sys.path[-1]
     return _setuptools_data

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -22,13 +22,15 @@ def load_setuptools(setup_file='setup.py'):
             _setuptools_data.update(kw)
 
         import setuptools
+        import distutils.core
         #Add current directory to path
         import sys
         sys.path.append('.')
 
-        #Patch setuptools
+        #Patch setuptools, distutils
         setuptools_setup = setuptools.setup
-        setuptools.setup = setup
+        distutils_setup = distutils.core.setup
+        setuptools.setup = distutils.core.setup = setup
         ns = {
             '__name__': os.path.splitext(os.path.basename(setup_file))[0],
             '__doc__': None,
@@ -37,6 +39,7 @@ def load_setuptools(setup_file='setup.py'):
         code = compile(open(setup_file).read(), setup_file, 'exec',
                        dont_inherit=1)
         exec(code, ns, ns)
+        distutils.core.setup = distutils_setup
         setuptools.setup = setuptools_setup
         del sys.path[-1]
     return _setuptools_data

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -37,7 +37,7 @@ def load_setuptools(setup_file='setup.py', from_recipe_dir=False,
         distutils_setup = distutils.core.setup
         setuptools.setup = distutils.core.setup = setup
         ns = {
-            '__name__': os.path.splitext(os.path.basename(setup_file))[0],
+            '__name__': '__main__',
             '__doc__': None,
             '__file__': setup_file,
         }

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -601,7 +601,7 @@ class MetaData(object):
 
         env = jinja2.Environment(loader=jinja2.ChoiceLoader(loaders), undefined=undefined_type)
         env.globals.update(ns_cfg())
-        env.globals.update(context_processor(self))
+        env.globals.update(context_processor(self, path))
 
         try:
             template = env.get_or_select_template(filename)

--- a/tests/test-recipes/metadata/jinja_load_setuptools/build.sh
+++ b/tests/test-recipes/metadata/jinja_load_setuptools/build.sh
@@ -1,0 +1,1 @@
+python setup.py install

--- a/tests/test-recipes/metadata/jinja_load_setuptools/meta.yaml
+++ b/tests/test-recipes/metadata/jinja_load_setuptools/meta.yaml
@@ -1,0 +1,15 @@
+{% set data = load_setuptools(from_recipe_dir=True) %}
+
+package:
+  name: test-jinja-setuptools
+  version: {{ data.get('test_attr') }}
+
+source:
+  path: ../../test-package
+
+requirements:
+  build:
+    - python
+    {% for req in data.get('install_requires', []) -%}
+    - {{req}}
+    {% endfor %}

--- a/tests/test-recipes/metadata/jinja_load_setuptools/setup.py
+++ b/tests/test-recipes/metadata/jinja_load_setuptools/setup.py
@@ -1,0 +1,33 @@
+from distutils.core import setup
+
+VERSION = '1.test'
+
+
+def version_func():
+    # ensure we can look up globals from function scope
+    return VERSION
+
+
+setup(
+    name="conda-build-load_setuptools",
+    version=version_func(),
+    author="Continuum Analytics, Inc.",
+    url="https://github.com/conda/conda-build",
+    license="BSD",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+    ],
+    description="test package for testing conda-build",
+    packages=['../../test-package/conda_build_test'],
+    scripts=[
+        '../../test-package/bin/test-script-setup.py',
+    ],
+    test_attr=version_func(),
+)


### PR DESCRIPTION
Our setup.py relies on `__file__`, so I've added that, as well as `__name__` and `__doc__`, to the namespace used when exec'ing the file.