### PR TITLE
Add #!python_d to scripts when package is debug

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -65,7 +65,13 @@ class Config(object):
 
     def _get_python(self, prefix):
         if sys.platform == 'win32':
-            res = join(prefix, 'python.exe')
+            import conda.install
+            packages = conda.install.linked(prefix)
+            packages_names = (pkg.split('-')[0] for pkg in packages)
+            if 'debug' in packages_names:
+                res = join(prefix, 'python_d.exe')
+            else:
+                res = join(prefix, 'python.exe')
         else:
             res = join(prefix, 'bin/python')
         return res

--- a/conda_build/scripts.py
+++ b/conda_build/scripts.py
@@ -10,6 +10,7 @@ import sys
 import shutil
 from os.path import dirname, isdir, join
 
+import conda.install
 import conda.config as cc
 
 from conda_build.config import config
@@ -40,6 +41,10 @@ def create_entry_point(path, module, func):
     pyscript = PY_TMPL % {'module': module, 'func': func}
     if sys.platform == 'win32':
         with open(path + '-script.py', 'w') as fo:
+            packages = conda.install.linked(config.build_prefix)
+            packages_names = (pkg.split('-')[0] for pkg in packages)
+            if 'debug' in packages_names:
+                fo.write('#!python_d\n')
             fo.write(pyscript)
         shutil.copyfile(join(dirname(__file__), 'cli-%d.exe' % cc.bits),
                         path + '.exe')


### PR DESCRIPTION
This fixes a problem when the `debug` feature is enabled (via `debug` metapackage): the interpreter that runs scripts should be `python_d`, otherwise it won't find compiled dependencies.