### PR TITLE
Moved m.skip() above the code for --output, such that --output does not provide misleading information.

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -370,6 +370,10 @@ def execute(args, parser):
                 if m.pkg_fn() in index or m.pkg_fn() in already_built:
                     print("%s is already built, skipping." % m.dist())
                     continue
+            if m.skip():
+                print("Skipped: The %s recipe defines build/skip for this "
+                      "configuration." % m.dist())
+                continue
             if args.output:
                 print(build.bldpkg_path(m))
                 continue
@@ -392,10 +396,6 @@ def execute(args, parser):
                 else:
                     post = None
                 try:
-                    if m.skip():
-                        print("Skipped: The %s recipe defines build/skip for this "
-                              "configuration." % m.dist())
-                        continue
                     build.build(m, verbose=not args.quiet, post=post,
                         channel_urls=channel_urls,
                         override_channels=args.override_channels, include_recipe=args.include_recipe)


### PR DESCRIPTION
Currently, a recipe that skips a certain configuration would still cause --output to print a file path. This is misleading, because if that configuration is skipped in the meta.yaml, no file path should be provided. This PR fixes the issue by moving the code for skipping a configuration above the handling of --output.

A quick merge and bugfix release of conda build would be much appreciated.

Thanks!
The Bioconda team.