### PR TITLE
Support x.x for all dependencies.

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -27,6 +27,7 @@ class Config(object):
     else:
         CONDA_NPY = int(CONDA_NPY.replace('.', '')) or None
     CONDA_R = os.getenv("CONDA_R", "3.2.2")
+    versions = {}
 
     @property
     def PY3K(self):

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -382,10 +382,6 @@ def execute(args, parser):
                 if m.pkg_fn() in index or m.pkg_fn() in already_built:
                     print("%s is already built, skipping." % m.dist())
                     continue
-            if m.skip():
-                print("Skipped: The %s recipe defines build/skip for this "
-                      "configuration." % m.dist())
-                continue
             if args.output:
                 print(build.bldpkg_path(m))
                 continue
@@ -408,6 +404,10 @@ def execute(args, parser):
                 else:
                     post = None
                 try:
+                    if m.skip():
+                        print("Skipped: The %s recipe defines build/skip for this "
+                              "configuration." % m.dist())
+                        continue
                     build.build(m, verbose=not args.quiet, post=post,
                         channel_urls=channel_urls,
                         override_channels=args.override_channels, include_recipe=args.include_recipe)

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -184,6 +184,13 @@ different sets of packages."""
         metavar="R_VER",
         choices=RVersionsCompleter(),
     )
+    p.add_argument(
+        '--versions',
+        nargs='+',
+        metavar='PACKAGE=VERSION',
+        help='Set the version of of any number of packages. The resulting build '
+             'will strictly depend on this version.'
+    )
     add_parser_channels(p)
     p.set_defaults(func=execute)
 
@@ -310,6 +317,11 @@ def execute(args, parser):
             else:
                 raise RuntimeError("%s must be major.minor, not %s" %
                     (conda_version[lang], version))
+
+    if args.versions:
+        for spec in args.versions:
+            name, version = spec.split('=')
+            config.versions[name] = version
 
     # Using --python, --numpy etc. is equivalent to using CONDA_PY, CONDA_NPY, etc.
     # Auto-set those env variables

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -370,6 +370,10 @@ def execute(args, parser):
                 if m.pkg_fn() in index or m.pkg_fn() in already_built:
                     print("%s is already built, skipping." % m.dist())
                     continue
+            if m.skip():
+                print("Skipped: The %s recipe defines build/skip for this "
+                      "configuration." % m.dist())
+                continue
             if args.output:
                 print(build.bldpkg_path(m))
                 continue
@@ -392,10 +396,6 @@ def execute(args, parser):
                 else:
                     post = None
                 try:
-                    if m.skip():
-                        print("Skipped: The %s recipe defines build/skip for this "
-                              "configuration." % m.dist())
-                        continue
                     build.build(m, verbose=not args.quiet, post=post,
                         channel_urls=channel_urls,
                         override_channels=args.override_channels, include_recipe=args.include_recipe)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -286,12 +286,9 @@ def handle_config_version(ms, ver):
         return ms
 
     if ms.strictness == 2:
-        v = ms.spec.split()[1].split(',')
-        if 'x.x' in v or (ms.name in ('python', 'perl', 'R')):
+        if ms.spec.split()[1] == 'x.x':
             if ver is None:
                 raise RuntimeError("'%s' requires external setting" % ms.spec)
-            if v != ['x.x'] and not any(vs.match(text_type(ver)) for vs in ms.vspecs):
-                raise RuntimeError("External setting of '%s' violates constraints (%s)." % (ver, ms.spec))
             # (no return here - proceeds below)
         else: # regular version
             return ms

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -281,7 +281,6 @@ def handle_config_version(ms, ver):
     configuration, e.g. for ms.name == 'python', ver = 26 or None,
     return a (sometimes new) MatchSpec object
     """
-    ver = text_type(ver)
 
     if ms.strictness == 3:
         return ms
@@ -291,8 +290,8 @@ def handle_config_version(ms, ver):
         if 'x.x' in v or (ms.name in ('python', 'perl', 'R')):
             if ver is None:
                 raise RuntimeError("'%s' requires external setting" % ms.spec)
-            if v != ['x.x'] and not any(vs.match(ver) for vs in ms.vspecs):
-                raise RuntimeError("External setting of '%s' violates constraints." % ms.spec)
+            if v != ['x.x'] and not any(vs.match(text_type(ver)) for vs in ms.vspecs):
+                raise RuntimeError("External setting of '%s' violates constraints (%s)." % (ver, ms.spec))
             # (no return here - proceeds below)
         else: # regular version
             return ms
@@ -300,6 +299,7 @@ def handle_config_version(ms, ver):
     if ver is None or (ms.strictness == 1 and ms.name not in ('python', 'perl', 'R')):
         return MatchSpec(ms.name)
 
+    ver = text_type(ver)
     if '.' not in ver:
         if ms.name == 'numpy':
             ver = '%s.%s' % (ver[0], ver[1:])


### PR DESCRIPTION
# Motivation

Currently, using x.x to allow pinning of dependencies to externally provided versions works for Python, Perl, R and numpy.
However, the functionality is critical in order to be able to pin dependencies in case of ABI incompatibilities. E.g., this mechanism can be used to build for particular boost versions.
This PR modifies conda-build to support this mechanism for all dependencies.

# Changes
1. The CLI is changed to provide an additional argument --versions which allows to pin the versions for arbitrary packages, e.g. ``--versions boost=1.57``.
2. The config object is changed to allow storage of these versions.
3. The function ms_depends is changed to generalize the current pinning mechanism.

# Outlook
The new implementation could be used as well to handle the previous mechanism that was specific for Python, Perl, R and numpy. However, I left the old code for backwards compatibility.

Johannes Köster on behalf of the Bioconda team.