### PR TITLE
use conda_build.metadata for checking metadata

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -307,7 +307,7 @@ def handle_config_version(ms, ver):
 class MetaData(object):
 
     def __init__(self, path):
-        assert isdir(path)
+        assert isdir(path), "Not a directory: %s" % path
         self.path = path
         self.meta_path = join(path, 'meta.yaml')
         self.requirements_path = join(path, 'requirements.txt')
@@ -630,13 +630,13 @@ class MetaData(object):
 
 if __name__ == '__main__':
     from pprint import pprint
-    from os.path import expanduser
 
-    recipes = sys.argv[1:] or [expanduser('~/conda-recipes/pycosat')]
-    for recipe in recipes:
+    print('Quick check of meta.yaml files. Args: recipe directories.\n'
+          'Stdout: index info after FIRST-PASS parse. Stderr: parsing errors.')
+    for recipe in sys.argv[1:]:
         try:
-            m = MetaData(recipe)
-            pprint(m.info_index())
-            m.check_fields()
+            met = MetaData(recipe)
+            pprint(met.info_index())
+            met.check_fields()
         except (Exception, SystemExit) as e:
-            sys.stderr.write('***** Error in %s:\n  %s\n' % (recipe, e))
+            print('***** Error in %s:\n  %s' % (recipe, e), file=sys.stderr)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -632,5 +632,11 @@ if __name__ == '__main__':
     from pprint import pprint
     from os.path import expanduser
 
-    m = MetaData(expanduser('~/conda-recipes/pycosat'))
-    pprint(m.info_index())
+    recipes = sys.argv[1:] or [expanduser('~/conda-recipes/pycosat')]
+    for recipe in recipes:
+        try:
+            m = MetaData(recipe)
+            pprint(m.info_index())
+            m.check_fields()
+        except (Exception, SystemExit) as e:
+            sys.stderr.write('***** Error in %s:\n  %s\n' % (recipe, e))


### PR DESCRIPTION
A simple generalization of the `__main__` section in metadata.py
to (ab)use it for quick checking of meta.yaml files.

I just came across a syntax error in conda-recipes/test-noarch/meta.yaml
https://github.com/conda/conda-recipes/issues/554
and I was curious if there are more errors. This PR is a quick hack that I used to check all recipes in conda-recipes:

```
$ PYTHONPATH=$PWD/../conda-build ~/anaconda/bin/python -m conda_build.metadata * >/dev/null
***** Error in aubio:
  'numpy x.x' requires external setting
***** Error in binstar_client:
  
***** Error in cyrus-sasl:
  Error: meta.yaml or conda.yaml not found in cyrus-sasl
***** Error in LICENSE.txt:
  
***** Error in matplotlib-tests:
  Error: in section u'requirements': unknown key u'imports'
***** Error in README.md:
  
***** Error in r-not-working:
  Error: meta.yaml or conda.yaml not found in r-not-working
***** Error in r-packages:
  Error: meta.yaml or conda.yaml not found in r-packages
***** Error in test-noarch:
  Error: in section u'build': unknown key u'noarch'
```

It would be more verbose without `>/dev/null`.
 It's not perfect, but it doesn't add much complexity so perhaps can be merged.