### PR TITLE
Find uncompress in old Linux

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -62,8 +62,10 @@ def tar_xf(tarball, dir_path, mode='r:*'):
     if tarball.lower().endswith('.tar.z'):
         uncompress = external.find_executable('uncompress')
         if not uncompress:
+            uncompress = external.find_executable('gunzip')
+        if not uncompress:
             sys.exit("""\
-uncompress is required to unarchive .z source files.
+uncompress (or gunzip) is required to unarchive .z source files.
 """)
         subprocess.check_call([uncompress, '-f', tarball])
         tarball = tarball[:-2]


### PR DESCRIPTION
This PR changes `uncompress` to `gunzip`.

`uncompress` is an alias for `gunzip` and that alias is not always defined in old Linux systems (like CentOS 6).  (See the failures [here](https://circleci.com/gh/ioos/conda-recipes/929) for an example.)

For more information see the discussion in https://github.com/conda/conda-build/issues/362#issuecomment-101066000.