### PR TITLE
metadata: Allow selectors in imported jinja templates

### DIFF
--- a/tests/test-recipes/metadata/selectors_in_imported_templates/build.sh
+++ b/tests/test-recipes/metadata/selectors_in_imported_templates/build.sh
@@ -1,0 +1,2 @@
+# The selectors in variables.jinja make build_num == 2
+[ "${PKG_BUILDNUM}" == "2" ]

--- a/tests/test-recipes/metadata/selectors_in_imported_templates/meta.yaml
+++ b/tests/test-recipes/metadata/selectors_in_imported_templates/meta.yaml
@@ -1,0 +1,7 @@
+{% import 'variables.jinja' as variables %}
+package:
+  name: selectors-in-imported-templates
+  version: 1.0
+
+build:
+  number: {{ variables.build_num }}

--- a/tests/test-recipes/metadata/selectors_in_imported_templates/variables.jinja
+++ b/tests/test-recipes/metadata/selectors_in_imported_templates/variables.jinja
@@ -1,0 +1,4 @@
+
+{% set build_num = 1 %} # [False]
+{% set build_num = 2 %} # [True]
+{% set build_num = 3 %} # [False]


### PR DESCRIPTION
As tangentially mentioned in #728, it would be nice if selectors (e.g. `# [not win]`) were respected in not just `meta.yaml` itself, but also in any jinja templates that it happens to import.  This PR implements support for just that, with a simple test.