### PR TITLE
metadata: Allow jinja templates to be imported from anywhere in the filesystem

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -577,6 +577,9 @@ class MetaData(object):
             env_loader = jinja2.FileSystemLoader(conda_env_path)
             loaders.append(jinja2.PrefixLoader({'$CONDA_DEFAULT_ENV': env_loader}))
 
+        loaders.append(jinja2.FileSystemLoader('/'))
+        loaders.append(jinja2.FileSystemLoader(os.getcwd()))
+
         undefined_type = jinja2.StrictUndefined
         if permit_undefined_jinja:
             class UndefinedNeverFail(jinja2.Undefined):


### PR DESCRIPTION
Currently, a recipe's `meta.yaml` file can be extended by importing a jinja template from another file, as long as that file resides [within the recipe directory or the `conda_build` package itself](https://github.com/conda/conda-build/blob/33135a88a103c566536a7fc40868df73d2795213/conda_build/metadata.py#L565-L569).

This PR would allow recipes to import templates from _anywhere_ in the filesystem, via either absolute or relative paths.  It adds a lot of flexibility, although maybe extra flexibility isn't always a good thing.  Comments welcome.
