### PR TITLE
Bugfix to restore functionality: building for multiple python versions on Windows

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -275,13 +275,13 @@ def execute(args, parser):
             # hard-linked by files in the trash. one of those is markupsafe, 
             # used by jinja2. see https://github.com/conda/conda-build/pull/520
             delete_trash(None)
-        except PermissionError:
+        except:
             # when we can't delete the trash, don't crash on AssertionError,
             # instead inform the user and try again next time.
             # see https://github.com/conda/conda-build/pull/744
-            warnings.warn("Cannot delete trash; some c extension has been " \
-                          "imported that is hard-linked by files in the " \
-                          "trash. Will try again on next run.")
+            warnings.warn("Cannot delete trash; some c extension has been "
+                          "imported that is hard-linked by files in the trash. "
+                          "Will try again on next run.")
 
     conda_version = {
         'python': 'CONDA_PY',

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -14,6 +14,7 @@ from locale import getpreferredencoding
 from os import listdir
 from os import environ as os_environ
 from os.path import exists, isdir, isfile, join
+import warnings
 
 import conda.config as config
 from conda.compat import PY3
@@ -269,11 +270,15 @@ def execute(args, parser):
     channel_urls = args.channel or ()
 
     if on_win:
-        # needs to happen before any c extensions are imported that might be
-        # hard-linked by files in the trash. one of those is markupsafe, used
-        # by jinja2. see https://github.com/conda/conda-build/pull/520
-        assert 'markupsafe' not in sys.modules
-        delete_trash(None)
+        try:
+            # needs to happen before any c extensions are imported that might be
+            # hard-linked by files in the trash. one of those is markupsafe, 
+            # used by jinja2. see https://github.com/conda/conda-build/pull/520
+            delete_trash(None)
+        except PermissionError:
+            warnings.warn("Cannot delete trash; some c extension has been "
+                          "imported that is hard-linked by files in the trash. "
+                          "Will try again on next run.")
 
     conda_version = {
         'python': 'CONDA_PY',

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -276,6 +276,9 @@ def execute(args, parser):
             # used by jinja2. see https://github.com/conda/conda-build/pull/520
             delete_trash(None)
         except PermissionError:
+            # when we can't delete the trash, don't crash on AssertionError,
+            # instead inform the user and try again next time.
+            # see https://github.com/conda/conda-build/pull/744
             warnings.warn("Cannot delete trash; some c extension has been "
                           "imported that is hard-linked by files in the trash. "
                           "Will try again on next run.")

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -279,9 +279,9 @@ def execute(args, parser):
             # when we can't delete the trash, don't crash on AssertionError,
             # instead inform the user and try again next time.
             # see https://github.com/conda/conda-build/pull/744
-            warnings.warn("Cannot delete trash; some c extension has been "
-                          "imported that is hard-linked by files in the trash. "
-                          "Will try again on next run.")
+            warnings.warn("Cannot delete trash; some c extension has been " \
+                          "imported that is hard-linked by files in the " \
+                          "trash. Will try again on next run.")
 
     conda_version = {
         'python': 'CONDA_PY',


### PR DESCRIPTION
There is a bug in conda-build that makes it impossible to build for multiple python versions in one line on Windows (e.g., `--py 35 --py 34 --py 27`), because of this assertion: https://github.com/conda/conda-build/blob/237e8fd2643863b6c1df6a4fd413dba8c24119b5/conda_build/main_build.py#L275 

Obviously that check will fail on any build after the first. The *real* solution for the issue that assert is trying to fix, would be to *not* delete the trash under such conditions, and to warn the user with a message that actually makes sense. This PR does so and restores the functionality.