### PR TITLE
[WIP] Resolve dependencies before ```build_id``` can be computed

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -206,6 +206,9 @@ def create_info_files(m, files, include_recipe=True):
             info_index['depends'] = [' '.join(dist.rsplit('-', 2))
                                      for dist in dists]
 
+    dists = get_run_dists(m)
+    print(dists)
+
     # Deal with Python 2 and 3's different json module type reqs
     mode_dict = {'mode': 'w', 'encoding': 'utf-8'} if PY3 else {'mode': 'wb'}
     with open(join(config.info_dir, 'index.json'), **mode_dict) as fo:

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -250,7 +250,11 @@ def meta_vars(meta):
     d['PKG_NAME'] = meta.name()
     d['PKG_VERSION'] = meta.version()
     d['PKG_BUILDNUM'] = str(meta.build_number())
-    d['PKG_BUILD_STRING'] = str(meta.build_id())
+
+    # Passing the build string requires the build dependencies to be resolved.
+    # Added with https://github.com/conda/conda-build/pull/667/
+    # d['PKG_BUILD_STRING'] = str(meta.build_id())
+
     d['RECIPE_DIR'] = meta.path
     return d
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -261,7 +261,7 @@ FIELDS = {
               'always_include_files', 'skip', 'msvc_compiler',
               'pin_depends' # pin_depends is experimental still
              ],
-    'requirements': ['build', 'run', 'conflicts'],
+    'requirements': ['build', 'run', 'conflicts', 'pin_from_build'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
     'test': ['requires', 'commands', 'files', 'imports'],
@@ -332,6 +332,9 @@ class MetaData(object):
         # Therefore, undefined jinja variables are permitted here
         # In the second pass, we'll be more strict. See build.build()
         self.parse_again(permit_undefined_jinja=True)
+
+        self._index = None
+        self._resolved_build_pkgs = None
 
     def parse_again(self, permit_undefined_jinja=False):
         """Redo parsing for key-value pairs that are not initialized in the
@@ -421,6 +424,27 @@ class MetaData(object):
     def build_number(self):
         return int(self.get_value('build/number', 0))
 
+    def config_deps(self):
+        # Return the specs needed to adhere to the desired environment variables.
+        name_ver_list = [
+            ('python', config.CONDA_PY),
+            ('numpy', config.CONDA_NPY),
+            ('perl', config.CONDA_PERL),
+            ('r', config.CONDA_R),
+        ]
+        specs = []
+        for spec in self.get_value('requirements/build', []):
+            try:
+                ms = MatchSpec(spec)
+            except AssertionError:
+                raise RuntimeError("Invalid package specification: %r" % spec)
+            if ms.name == self.name():
+                raise RuntimeError("%s cannot depend on itself" % self.name())
+            for name, ver in name_ver_list:
+                if ms.name == name:
+                    specs.append(handle_config_version(ms, ver).spec)
+        return specs
+
     def ms_depends(self, typ='run'):
         res = []
         name_ver_list = [
@@ -459,47 +483,70 @@ class MetaData(object):
             res.append(ms)
         return res
 
-    def resolve_depends(self, typ='run', index=None):
+    def resolve_build_deps(self, index=None):
+        """
+        Turn the version specifications of this meta into concrete versions.
+
+        """
         import conda.resolve
-        import conda.api
+        if index:
+            self._index = index
+        if self._index is None:
+            raise RuntimeError('Please supply an index from which to resolve.')
 
-        if index is None:
-            index = conda.api.get_index()
+        specs = [ms.spec for ms in self.ms_depends('build')]
+        config_specs = self.config_deps()
+        r = conda.resolve.Resolve(self._index)
+        result = r.solve(specs + config_specs)
+        # Clear to a newline after the solve stage.
+        print('\n')
+        self._resolved_build_pkgs = {pkg: self._index[pkg] for pkg in result}
+        return self._resolved_build_pkgs
 
-        specs = [ms.spec for ms in self.ms_depends(typ)]
-        r = conda.resolve.Resolve(index)
-        # TODO: What should features be? Do we build with features on? e.g. scipy mkl?
-        result = r.solve2(specs, features=set())
-        return {pkg: index[pkg] for pkg in result}
-
-    def pinned_specs(self, index=None):
+    def pinned_specs(self):
         def extract_version(version, match_pattern, build_string=''):
             """
             Given a pattern such as 'x.*', return '1.*' from '1.2.3'.
 
             """
-            if match_pattern == 'x.*':
+            if match_pattern == '*':
+                return '*'
+            elif match_pattern == 'x.*':
                 return '{}.*'.format(version.split('.')[0])
             elif match_pattern == 'x.x.*':
                 return '{}.{}.*'.format(*version.split('.')[:2])
             else:
-                raise NotYetImplemented('General form not yet implemented.')
+                # TODO
+                raise NotYetImplemented('General form for pin_from_build not '
+                                        'yet implemented.')
+
+        if self._resolved_build_pkgs is None:
+            self.resolve_build_deps()
+        build_deps = self._resolved_build_pkgs
 
         build_dep_names = [spec.name
                            for spec in self.ms_depends('build')]
-        build_deps = self.resolve_depends('build', index=index)
         build_deps_by_name = {pkg['name']: pkg for pkg in build_deps.values()}
         pinned = self.get_value('requirements/pin_from_build', [])
         unresolved_pinned_specs = {MatchSpec(spec).name: MatchSpec(spec)
                                    for spec in pinned}
-        print(unresolved_pinned_specs, build_dep_names)
-        unexpected_pinned = set(unresolved_pinned_specs) - set(build_dep_names)
+        unexpected_pinned = (set(unresolved_pinned_specs) -
+                             set(build_dep_names))
         if unexpected_pinned:
-            msg = "Found requirements/pin_from_build which aren't part of the requirements/build ({}).".format(', '.join(sorted(unexpected_pinned)))
+            msg = ("Found requirements/pin_from_build which aren't part of "
+                   "the requirements/build ({})."
+                   "".format(', '.join(sorted(unexpected_pinned))))
             raise ValueError(msg)
+
         pinned_specs = []
-        if 'python' not in unresolved_pinned_specs:
+        # Put python in there as a special case. This has been the behaviour
+        # of conda-build since immemorial, and can be overridden by adding
+        # "python *" as a pinned spec.
+        if ('python' not in unresolved_pinned_specs and
+                'python' in build_deps_by_name):
             unresolved_pinned_specs['python'] = MatchSpec('python x.x.*')
+
+        # Compute the appropriate specs based on the resolved dependencies.
         for ms in unresolved_pinned_specs.values():
             pkg_info = build_deps_by_name[ms.name]
             assert ms.strictness == 2
@@ -509,39 +556,28 @@ class MetaData(object):
         return pinned_specs
 
     def build_id(self):
-        ret = self.get_value('build/string')
-        if ret:
-            check_bad_chrs(ret, 'build/string')
-            return ret
-        res = []
-        version_pat = re.compile(r'(?:==)?(\d+)\.(\d+)')
-        for name, s in (('numpy', 'np'), ('python', 'py'),
-                        ('perl', 'pl'), ('lua', 'lua'), ('r', 'r')):
-            for ms in self.ms_depends():
-                if ms.name == name:
-                    try:
-                        v = ms.spec.split()[1]
-                    except IndexError:
-                        if name not in ['numpy']:
-                            res.append(s)
-                        break
-                    if any(i in v for i in ',|>!<'):
-                        break
-                    if name not in ['perl', 'r', 'lua']:
-                        match = version_pat.match(v)
-                        if match:
-                            res.append(s + match.group(1) + match.group(2))
-                    else:
-                        res.append(s + v.strip('*'))
-                    break
+        if self._resolved_build_pkgs is None:
+            self.resolve_build_deps()
+        build_deps = self._resolved_build_pkgs
+
+        template = self.get_value('build/string')
+        if not template:
+            template = '{extras}'
+        
+        tidy_names = {'python': 'py', 'numpy': 'np', 'perl': 'pl'}
+        pinned = ''
+        for pinned_spec in self.pinned_specs():
+            name, spec = pinned_spec.split(' ', 1)
+            nicer_vn = spec.replace('*', '').replace('.', '')
+            pinned += '{}{}'.format(tidy_names.get(name, name),
+                                    nicer_vn)
 
         features = self.get_value('build/features', [])
-        if res:
-            res.append('_')
-        if features:
-            res.extend(('_'.join(features), '_'))
-        res.append('%d' % self.build_number())
-        return ''.join(res)
+
+        extras = [pinned, '_'.join(features), unicode(self.build_number())]
+        result = template.format(extras='_'.join(extra for extra in extras if extra))
+        check_bad_chrs(result, 'build/string')
+        return result
 
     def dist(self):
         return '%s-%s-%s' % (self.name(), self.version(), self.build_id())

--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -31,7 +31,7 @@ from conda.config import get_proxy_servers
 from conda.cli.common import spec_from_line
 from conda_build.utils import tar_xf, unzip
 from conda_build.source import SRC_CACHE, apply_patch
-from conda_build.build import create_env
+from conda_build.build import create_env, get_build_index
 from conda_build.config import config
 
 from requests.packages.urllib3.util.url import parse_url
@@ -761,7 +761,7 @@ def run_setuppy(src_dir, temp_dir, python_version):
     # TODO: Try with another version of Python if this one fails. Some
     # packages are Python 2 or Python 3 only.
     create_env(config.build_prefix, ['python %s*' % python_version, 'pyyaml',
-        'setuptools', 'numpy'], clear_cache=False)
+        'setuptools', 'numpy'], index=get_build_index(clear_cache=False))
     stdlib_dir = join(config.build_prefix,
                       'Lib' if sys.platform == 'win32'
                       else 'lib/python%s' % python_version)

--- a/tests/dummy_index.py
+++ b/tests/dummy_index.py
@@ -1,0 +1,65 @@
+import collections
+import os
+
+from conda_build.index import write_repodata
+import conda.config
+
+
+_DummyPackage = collections.namedtuple('_DummyPackage',
+                                       ['pkg_name', 'build_deps', 'run_deps'])
+
+
+class DummyPackage(_DummyPackage):
+    def __new__(cls, name, build_deps=None, run_deps=None):
+        return super(DummyPackage, cls).__new__(cls, name, build_deps or (),
+                                                run_deps or ())
+
+    def name(self):
+        return self.pkg_name
+
+    def dist(self):
+        return '{}-{}-{}'.format(self.name(), '0.0', '0')
+
+    def get_value(self, item, default):
+        if item == 'requirements/run':
+            return self.run_deps
+        elif item == 'requirements/build':
+            return self.build_deps
+        else:
+            raise AttributeError(item)
+
+    def __repr__(self):
+        # For testing purposes, this is particularly convenient.
+        return self.name()
+
+
+class DummyIndex(dict):
+    def add_pkg(self, name, version, build_string='',
+                depends=(), build_number='0',
+                **extra_items):
+        if build_string:
+            build_string = '{}_{}'.format(build_string, build_number)
+        else:
+            build_string = build_number
+        pkg_info = dict(name=name, version=version, build_number=build_number,
+                        build=build_string, subdir=conda.config.subdir,
+                        depends=tuple(depends), **extra_items)
+        self['{}-{}-{}.tar.bz2'.format(name, version, build_string)] = pkg_info
+
+    def add_pkg_meta(self, meta):
+        # Add a package given its MetaData instance. This may include a DummyPackage
+        # instance in the future.
+        if isinstance(meta, DummyPackage):
+            raise NotImplementedError('')
+        self['{}.tar.bz2'.format(meta.dist())] = meta.info_index()
+
+    def write_to_channel(self, dest):
+        # Write the index to a channel. Useful to get conda to read it back in again
+        # using conda.api.get_index().
+        channel_subdir = os.path.join(dest, conda.config.subdir)
+        if not os.path.exists(channel_subdir):
+            os.mkdir(channel_subdir)
+        write_repodata({'packages': self, 'info': {}}, channel_subdir)
+
+        return channel_subdir
+

--- a/tests/test-recipes/metadata/jinja_vars/build.sh
+++ b/tests/test-recipes/metadata/jinja_vars/build.sh
@@ -6,6 +6,3 @@
 
 # Sanity check: Neither was LD_LIBRARY_PATH
 [ "$LD_LIBRARY_PATH" == "" ]
-
-# Check the special value we gave the build string, which depends on build number
-[ "${PKG_BUILD_STRING}" == "${CONDA_TEST_VAR}_${PKG_BUILDNUM}" ]

--- a/tests/test-recipes/metadata/pinned_build_dep/meta.yaml
+++ b/tests/test-recipes/metadata/pinned_build_dep/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: conda-build-test-pinned-specs
+  version: 1.0
+
+requirements:
+  build:
+    - python 3.5.*
+    - numpy 1.10.1*
+  run:
+    - python
+  pin_from_build:
+    - numpy x.x.*

--- a/tests/test-recipes/metadata/pinned_build_dep/run_test.py
+++ b/tests/test-recipes/metadata/pinned_build_dep/run_test.py
@@ -1,0 +1,20 @@
+import os
+import json
+import glob
+
+
+def main():
+    fname = os.path.join(prefix, 'conda-meta',
+                         '{env[PKG_NAME]}.json'.format(env=os.environ))
+    print('Info from {}'.format(fname))
+    prefix = os.environ['PREFIX']
+    with open(fname, 'r') as fh:
+        info = json.load(fh)
+
+    print('Depends:', info['depends'])
+    assert set(info['depends']) == set(["python", "python 3.5.*",
+                                        "numpy 1.10.*"])
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/pinned_build_dep/run_test.py
+++ b/tests/test-recipes/metadata/pinned_build_dep/run_test.py
@@ -1,13 +1,13 @@
 import os
 import json
-import glob
 
 
 def main():
+    prefix = os.environ['PREFIX']
     fname = os.path.join(prefix, 'conda-meta',
                          '{env[PKG_NAME]}.json'.format(env=os.environ))
     print('Info from {}'.format(fname))
-    prefix = os.environ['PREFIX']
+
     with open(fname, 'r') as fh:
         info = json.load(fh)
 


### PR DESCRIPTION
This looks like a long PR, but the majority is really the addition of tests and test-infrastructure.

My aim in this PR is to facilitate a more natural pinning scheme \*. Exactly *how* the pinning looks is academic to this PR (though I had to get off the fence and implemented *something*) - to be able to support pinning without users pre-defining the versions in (environment) variables before calling ```conda-build``` it is necessary to resolve *which* distributions are available to build against. The existing environment variables have been preserved as hints to the solver to determine *which* distributions are wanted, but they do not directly feed into the pinned down version in the resulting built distribution.

The main implication of this change is that one cannot compute the ```build_id``` of a distribution until *after* the build dependencies have been resolved.

With the resolved information so readily available, it would have been much easier for @ilanschnell to implement the usecase targeted with #741.

This PR is still a work in progress, but I'd really value some input from @ilanschnell / @msarahan / @stuarteberg + others as to whether this is going in the right direction, or whether you want to apply the brakes. @kalefranz may be particularly interested in the test strategy involved.

The pinning mechanism invoked in this PR is done at build-time, rather than parse time. There are implications for doing the pinning at parse time, but the changes here do not preclude that being chosen at a future point. Essentially, I've implemented a pretty rudimentary scheme which looks like:

```
requirements:
  build:
    - python
    - proj4
  run:
    - python
    - proj4
  pin_from_build:
     - python x.x.*
     - proj4 x.x.x.*
```

I'm not especially tied to this solution, and it is completely possible to re-use the ``x.x`` scheme already implemented - it just made sense to separate the concerns when I was doing it (explicit is better than implicit).

\* There has been plenty of discussion about *how* pinning should take place. Those conversations have value and should continue in #728 and #650.