### PR TITLE
WIP: Add version control environmental variables for --output flag

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -361,6 +361,10 @@ def execute(args, parser):
                     print("%s is already built, skipping." % m.dist())
                     continue
             if args.output:
+                source.provide(m.path, m.get_section('source'))
+                # Parse our metadata again because we did not initialize the source
+                # information before.
+                m.parse_again()
                 print(build.bldpkg_path(m))
                 continue
             elif args.test:


### PR DESCRIPTION
**What problem does this solve?**

Gives `conda-build --output` a mechanism to correctly report the version string for a conda package 
that uses environmental variables from version control (e.g., GIT_DESCRIBE_NUMBER).

There is a lot of extra, unnecessary output in this (admittedly) hacky approach.  I copy/pasted two lines from elsewhere in the codebase that give conda-build the ability to use version control env vars to report output. Unfortunately, this resulted in the git clone and git checkout information to be dumped to the screen which breaks the ability to do:
```
$ anaconda upload -u user `conda build /path/to/recipe --output`
```
Is there any way to add this proposed functionality without breaking the aforementioned use case?

**Example of the output before and after this PR**

For example, trying to use `conda-build conda-build/conda-build.recipe --output` currently
returns the following build string:
```
$ conda build conda-build/conda_build.recipe/ --output
/home/edill/miniconda/conda-bld/linux-64/conda-build-1.10alpha.0-py35_GIT_STUB.tar.bz2
```

And with this change --output returns (along with a lot of extra output):
```
$ conda build conda-build/conda_build.recipe/ --output
Removing old work directory
remote: Counting objects: 4, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 2), reused 0 (delta 0)
Unpacking objects: 100% (4/4), done.
From /home/edill/dev/conda/conda-build/conda_build.recipe/..
   21ea84a..a37551a  master     -> master
   21ea84a..a37551a  origin/HEAD -> origin/HEAD
   21ea84a..a37551a  origin/master -> origin/master
 * [new tag]         1.19.0     -> 1.19.0
checkout: 'c7b0f5b8eb03b99c50198aa7d0e9104d0612061d'
Cloning into '/home/edill/miniconda/conda-bld/work'...
done.
Note: checking out 'c7b0f5b8eb03b99c50198aa7d0e9104d0612061d'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at c7b0f5b... MNT: Add GIT_* env vars for --output
==> git log -n1 <==

commit c7b0f5b8eb03b99c50198aa7d0e9104d0612061d
Author: Eric Dill <edill@bnl.gov>
Date:   Fri Jan 29 09:05:54 2016 -0500

    MNT: Add GIT_* env vars for --output
    
    Add the capability for `--output` to respect GIT_* environmental
    variables.  Without this modification the GIT_* vars are not set, so
    conda-build /path/to/recipe --output returns an incorrect build string.


==> git describe --tags --dirty <==

1.18.0-5-gc7b0f5b


==> git status <==

HEAD detached at c7b0f5b
nothing to commit, working directory clean


/home/edill/miniconda/conda-bld/linux-64/conda-build-1.10alpha.0-py35_5_gc7b0f5b.tar.bz2
```

where the important difference is:

before: `conda-build-1.10alpha.0-py35_GIT_STUB.tar.bz2`
after: `conda-build-1.10alpha.0-py35_5_gc7b0f5b.tar.bz2`