### PR TITLE
Add git_recursive option (defaults to true)

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -181,7 +181,8 @@ def parse(data):
     for field in ('build/osx_is_app', 'build/preserve_egg_dir',
                   'build/binary_relocation',
                   'build/detect_binary_files_with_prefix',
-                  'build/skip', 'app/own_environment'):
+                  'build/skip', 'app/own_environment',
+                  'source/git_recursive'):
         section, key = field.split('/')
         if res.get(section) is None:
             res[section] = {}
@@ -258,6 +259,7 @@ FIELDS = {
     'package': ['name', 'version'],
     'source': ['fn', 'url', 'md5', 'sha1', 'sha256', 'path',
                'git_url', 'git_tag', 'git_branch', 'git_rev', 'git_depth',
+               'git_recursive',
                'hg_url', 'hg_tag',
                'svn_url', 'svn_rev', 'svn_ignore_externals',
                'patches'],

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -134,7 +134,11 @@ def git_source(meta, recipe_dir):
     if checkout:
         print('checkout: %r' % checkout)
 
-    check_call([git, 'clone', '--recursive', cache_repo_arg, WORK_DIR])
+    git_clone = [git, 'clone']
+    if meta.get('git_recursive', True):
+        git_clone.append('--recursive')
+
+    check_call(git_clone + [cache_repo_arg, WORK_DIR])
     if checkout:
         check_call([git, 'checkout', checkout], cwd=WORK_DIR)
 


### PR DESCRIPTION
Since the change in #745, the requirement to use `git_url` instead of `path` even for local git repositories forces a clone of any submodules every time a conda build is run (the `--mirror` option used to create the local cache does not mirror submodules). This can be a problem if the submodules are large (e.g. several hundreds of MB is not uncommon) and especially if they are not actually required for the build.

This commit adds a `git_recursive` option, which defaults to `true`. When `true`, the git clone that conda build makes is recursive, and submodules are included; when `false`, the clone is not recursive and submodules are not cloned.

This is one way that I could see around the issue, so I've had a go at the implementation of it here - I thought about adding a test recipe for this too, but I am not really sure how to effectively test this change, though I have tested it locally with a recipe inside a repository that used submodules.

Any feedback is appreciated!
