### PR TITLE
Fix --output command by downloading the source first if necessary

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -385,6 +385,17 @@ def execute(args, parser):
                       "configuration." % m.dist())
                 continue
             if args.output:
+                try:
+                    m.parse_again(permit_undefined_jinja=False)
+                except SystemExit:
+                    # Something went wrong; possibly due to undefined GIT_ jinja variables.
+                    # Maybe we need to actually download the source in order to resolve the build_id.
+                    source.provide(m.path, m.get_section('source'))
+                    
+                    # Parse our metadata again because we did not initialize the source
+                    # information before.
+                    m.parse_again(permit_undefined_jinja=False)
+
                 print(build.bldpkg_path(m))
                 continue
             elif args.test:


### PR DESCRIPTION
~~Do not merge yet.  This PR depends on #758, so review that first.~~

This PR builds on #750, but avoids downloading the source when it's not necessary.  Simply put, the `--output` flag doesn't produce the right answer if the `build_id` depends on downloading the source (so the git tag can be checked).  This PR downloads the source first, but only if necessary.