### PR TITLE
MNT: Remove git spam from conda build --output

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -92,11 +92,8 @@ def get_git_build_info(src_dir, git_url, expected_rev):
     if parts_length == 3:
         d.update(dict(zip(keys, parts)))
     # get the _full_ hash of the current HEAD
-    process = subprocess.Popen(["git", "rev-parse", "HEAD"],
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               env=env)
-    output = process.communicate()[0].strip()
-    output = output.decode('utf-8')
+    output = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], stderr=subprocess.STDOUT, env=env).decode()
     d['GIT_FULL_HASH'] = output
     # set up the build string
     if key_name('NUMBER') in d and key_name('HASH') in d:

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -46,20 +46,26 @@ def get_git_build_info(src_dir, git_url, expected_rev):
     env['GIT_DIR'] = git_dir
     try:
         # Verify current commit matches expected commit
-        current_commit = subprocess.check_output(["git", "log", "-n1", "--format=%H"], env=env)
+        current_commit = subprocess.check_output(
+            ["git", "log", "-n1", "--format=%H"], env=env,
+            stderr=subprocess.STDOUT)
         current_commit = current_commit.decode('utf-8')
-        expected_tag_commit = subprocess.check_output(["git", "log", "-n1", "--format=%H", expected_rev], env=env)
+        expected_tag_commit = subprocess.check_output(
+            ["git", "log", "-n1", "--format=%H", expected_rev], env=env,
+            stderr=subprocess.STDOUT)
         expected_tag_commit = expected_tag_commit.decode('utf-8')
 
         # Verify correct remote url.
         # (Need to find the git cache directory, and check the remote from there.)
-        cache_details = subprocess.check_output(["git", "remote", "-v"], env=env)
+        cache_details = subprocess.check_output(
+            ["git", "remote", "-v"], env=env, stderr=subprocess.STDOUT)
         cache_details = cache_details.decode('utf-8')
         cache_dir = cache_details.split('\n')[0].split()[1]
         assert "conda-bld/git_cache" in cache_dir
 
         env['GIT_DIR'] = cache_dir
-        remote_details = subprocess.check_output(["git", "remote", "-v"], env=env)
+        remote_details = subprocess.check_output(
+            ["git", "remote", "-v"], env=env, stderr=subprocess.STDOUT)
         remote_details = remote_details.decode('utf-8')
         remote_url = remote_details.split('\n')[0].split()[1]
 

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -185,10 +185,28 @@ different sets of packages."""
         metavar="R_VER",
         choices=RVersionsCompleter(),
     )
+    p.add_argument(
+        '-v',
+        '--verbose',
+        action='store_true',
+        help="Enable verbose mode. Turns on extra debug output"
+    )
     add_parser_channels(p)
     p.set_defaults(func=execute)
 
     args = p.parse_args()
+    # enable logging. Default to warning
+    import logging
+    stream = logging.StreamHandler()
+    from .utils import logger
+    if args.verbose:
+        loglevel = logging.DEBUG
+    else:
+        loglevel = logging.WARNING
+    stream.setLevel(loglevel)
+    logger.setLevel(loglevel)
+    logger.addHandler(stream)
+
     args_func(args, p)
 
 

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -197,7 +197,7 @@ different sets of packages."""
     args = p.parse_args()
     # enable logging. Default to warning
     import logging
-    stream = logging.StreamHandler()
+    stream = logging.StreamHandler(sys.stdout)
     from .utils import logger
     if args.verbose:
         loglevel = logging.DEBUG

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -409,7 +409,7 @@ def execute(args, parser):
                     # Something went wrong; possibly due to undefined GIT_ jinja variables.
                     # Maybe we need to actually download the source in order to resolve the build_id.
                     source.provide(m.path, m.get_section('source'))
-                    
+
                     # Parse our metadata again because we did not initialize the source
                     # information before.
                     m.parse_again(permit_undefined_jinja=False)

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -135,7 +135,7 @@ def git_source(meta, recipe_dir):
     # assume the user wants the current HEAD
     if not checkout and git_url.startswith('.'):
         checkout = check_output(["git", "rev-parse", "HEAD"], cwd=git_url,
-                                stderr=STDOUT).decode()
+                                stderr=STDOUT).decode().strip()
     if checkout:
         logger.debug('checkout: %r' % checkout)
 

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -5,14 +5,13 @@ import sys
 from os.path import join, isdir, isfile, abspath, expanduser
 from shutil import copytree, copy2
 from subprocess import (check_call, CalledProcessError, check_output, STDOUT)
-import locale
 
 from conda.fetch import download
 from conda.utils import hashsum_file
 
 from conda_build import external
 from conda_build.config import config
-from conda_build.utils import rm_rf, tar_xf, unzip, safe_print_unicode, logger
+from conda_build.utils import rm_rf, tar_xf, unzip, logger
 
 SRC_CACHE = join(config.croot, 'src_cache')
 GIT_CACHE = join(config.croot, 'git_cache')

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -110,8 +110,15 @@ def git_source(meta, recipe_dir):
 
     # update (or create) the cache repo
     if isdir(cache_repo):
-        output = check_output([git, 'fetch'], cwd=cache_repo, stderr=STDOUT).decode()
-        logger.debug(output)
+        try:
+            output = check_output([git, 'fetch'], cwd=cache_repo,
+                                  stderr=STDOUT).decode()
+            logger.debug(output)
+        except CalledProcessError as cpe:
+            # output the actual git error message in case something goes wrong.
+            # then reraise the exception
+            print(cpe.output.decode())
+            raise
     else:
         args = [git, 'clone', '--mirror']
         if git_depth > 0:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -163,7 +163,7 @@ def git_info(fo=None):
         stdout = check_output(cmd.split(), cwd=WORK_DIR, env=env,
                               stderr=STDOUT).decode()
         if fo:
-            logger.debugfo.write(u'==> %s <==\n' % cmd)
+            logger.debug(u'==> %s <==\n' % cmd)
             logger.debug(stdout + u'\n')
         else:
             logger.debug(u'==> %s <==\n' % cmd)

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -144,9 +144,13 @@ def git_source(meta, recipe_dir):
         stderr=STDOUT).decode()
     logger.debug(output)
     if checkout:
-        output = check_output([git, 'checkout', checkout], cwd=WORK_DIR,
-                              stderr=STDOUT).decode()
-        logger.debug(output)
+        try:
+            output = check_output([git, 'checkout', checkout], cwd=WORK_DIR,
+                                  stderr=STDOUT).decode()
+            logger.debug(output)
+        except CalledProcessError as cpe:
+            print(cpe.output.decode())
+            raise
 
 
     git_info()

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -4,8 +4,7 @@ import os
 import sys
 from os.path import join, isdir, isfile, abspath, expanduser
 from shutil import copytree, copy2
-from subprocess import (check_call, Popen, PIPE, CalledProcessError,
-                        check_output, DEVNULL, STDOUT)
+from subprocess import (check_call, CalledProcessError, check_output, STDOUT)
 import locale
 
 from conda.fetch import download

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -15,6 +15,8 @@ from conda.compat import PY3, iteritems
 
 from conda_build import external
 
+import logging
+logger = logging.getLogger('conda-build')
 # Backwards compatibility import. Do not remove.
 from conda.install import rm_rf
 rm_rf


### PR DESCRIPTION
@stuarteberg Could you have a look at this to make sure that I am not introducing any unintended consequences?  

This PR silences the output from the git commands that get called with the `--output` flag and adds a `--verbose` flag to the conda build CLI.  This --verbose flag sets a logger to the debug level so that the output that was being directed to stderr by git and calls to print in source.py and are now sent to the console through the built in logging framework instead.

Deals with some discussion in #754. 
Retains backwards compatibility with certain use cases of `conda build /path --output` that #758 and #759 broke.