### PR TITLE
Stop setting values for undefined environment variables

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+2016-01-29   1.19.1:
+--------------------
+  * Environment variables defined in the 'script_env' build section of
+    the meta.yaml file were previously assigned the value '<UNDEFINED>'
+    if not found in the environment. Now they are left unset and a
+    warning is raised instead, #763.
+
 2016-01-29   1.19.0:
 --------------------
   * normalize unicode in conda skeleton cran, #681

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -5,6 +5,7 @@ import sys
 from os.path import join, normpath, isabs
 import subprocess
 import multiprocessing
+import warnings
 
 import conda.config as cc
 
@@ -134,8 +135,12 @@ def get_dict(m=None, prefix=None):
         for var_name in m.get_value('build/script_env', []):
             value = os.getenv(var_name)
             if value is None:
-                value = '<UNDEFINED>'
-            d[var_name] = value
+                warnings.warn(
+                    "The environment variable '%s' is undefined." % var_name,
+                    UserWarning
+                )
+            else:
+                d[var_name] = value
 
     if sys.platform == "darwin":
         # multiprocessing.cpu_count() is not reliable on OSX

--- a/tests/test-recipes/metadata/build_env/meta.yaml
+++ b/tests/test-recipes/metadata/build_env/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: conda-build-test-env
+  version: 1.0
+
+build:
+  script_env:
+    - UNDEF_VAR

--- a/tests/test-recipes/metadata/build_env/run_test.py
+++ b/tests/test-recipes/metadata/build_env/run_test.py
@@ -1,0 +1,9 @@
+import os
+
+def main():
+    undef_var = os.environ.get("UNDEF_VAR")
+
+    assert undef_var is None
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/612

In a recipe, a user can specify variables that can be defined externally to influence the recipe. The previous practice was to leave these undefined. However, a commit was added that began setting them to `<UNDEFINED>`. If a user intentionally left these variables undefined, they must now go back and unset them afterwards. The intent of this was likely to smoke out errors. This could initially be easily worked around in bash or batch. However, 2 pass jinja templating has forced us to handle this inside the `meta.yaml`, which is more challenging and unnecessarily ugly. Instead of continuing this trend of setting intentionally undefined variables, this breaks from that change and simply warns the user when they have an undefined environment variable.