### PR TITLE
Fix Python 3 incompatibility in cran.py

### DIFF
--- a/conda_build/cran.py
+++ b/conda_build/cran.py
@@ -571,7 +571,7 @@ def main(args, parser):
         name = d['packagename']
 
         #Normalize the metadata values
-        d = {k:unicodedata.normalize("NFKD", compat.text_type(v)).encode('ascii', 'ignore') for k, v in d.items()}
+        d = {k:unicodedata.normalize("NFKD", compat.text_type(v)).encode('ascii', 'ignore') for k, v in compat.iteritems(d)}
 
         makedirs(join(output_dir, name))
         print("Writing recipe for %s" % package.lower())

--- a/conda_build/cran.py
+++ b/conda_build/cran.py
@@ -571,7 +571,7 @@ def main(args, parser):
         name = d['packagename']
 
         #Normalize the metadata values
-        d = {k:unicodedata.normalize("NFKD", compat.text_type(v)).encode('ascii', 'ignore') for k, v in d.iteritems()}
+        d = {k:unicodedata.normalize("NFKD", compat.text_type(v)).encode('ascii', 'ignore') for k, v in d.items()}
 
         makedirs(join(output_dir, name))
         print("Writing recipe for %s" % package.lower())

--- a/conda_build/cran.py
+++ b/conda_build/cran.py
@@ -571,7 +571,7 @@ def main(args, parser):
         name = d['packagename']
 
         #Normalize the metadata values
-        d = {k:unicodedata.normalize("NFKD", compat.text_type(v)).encode('ascii', 'ignore') for k, v in compat.iteritems(d)}
+        d = {k:unicodedata.normalize("NFKD", compat.text_type(v)).encode('ascii', 'ignore').decode() for k, v in compat.iteritems(d)}
 
         makedirs(join(output_dir, name))
         print("Writing recipe for %s" % package.lower())


### PR DESCRIPTION
This PR fixes cran.py to use compat.iteritems instead of the old iteritems method of Python 2 dictionaries, which is no longer present in Python 3.