### PR TITLE
Provide optional default environment variables

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,7 +3,8 @@
   * Environment variables defined in the 'script_env' build section of
     the meta.yaml file were previously assigned the value '<UNDEFINED>'
     if not found in the environment. Now they are left unset and a
-    warning is raised instead, #763.
+    warning is raised instead. However, it is possible to override
+    their default values by using a single element dictionary, #767.
 
 
 2016-01-29   1.19.0:

--- a/tests/test-recipes/metadata/build_env/meta.yaml
+++ b/tests/test-recipes/metadata/build_env/meta.yaml
@@ -4,4 +4,5 @@ package:
 
 build:
   script_env:
-    - UNDEF_VAR
+    - UNDEF_VAR1
+    - UNDEF_VAR2 : UNDEFINED

--- a/tests/test-recipes/metadata/build_env/run_test.py
+++ b/tests/test-recipes/metadata/build_env/run_test.py
@@ -1,9 +1,11 @@
 import os
 
 def main():
-    undef_var = os.environ.get("UNDEF_VAR")
+    undef_var1 = os.environ.get("UNDEF_VAR1")
+    undef_var2 = os.environ.get("UNDEF_VAR2")
 
-    assert undef_var is None
+    assert undef_var1 is None
+    assert undef_var2 == "UNDEFINED"
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Related: https://github.com/conda/conda-build/pull/763

Includes the change from this PR ( https://github.com/conda/conda-build/pull/763 ). Instead of simply leaving undefined environment values as such, this provide a mechanism for giving them a default value in `meta.yaml`. Users requiring or desiring to set the environment variables to some default value when not picked up externally can do so. However, this is better than the original strategy as this does it in a manner that is explicit.

Here is an example of the new syntax. All variables without a default value will be left undefined (if not defined in the external environment) during the build. All variables with a default value will be defined (if not defined in the external environment) using the default value.

```
build:
  script_env:
    - CC
    - CXX
    - CXX_FLAGS
    - CXX_LDFLAGS
    - USE_CYTHON: true
```

A test for this behavior is included in this PR.