### PR TITLE
Fix parsing git metadata while metadata is None

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -153,7 +153,7 @@ def get_dict(m=None, prefix=None):
         except NotImplementedError:
             d['CPU_COUNT'] = "1"
 
-    if m.get_value('source/git_url'):
+    if m and m.get_value('source/git_url'):
         git_url = m.get_value('source/git_url')
         if '://' not in git_url:
             # If git_url is a relative path instead of a url, convert it to an abspath


### PR DESCRIPTION
Inside of `conda_build.environ.get_dict()`:

The initial value of `m` is `None`. An erroneous call to `m.get_value('source/git_url')` without first checking the status of `m` raises a `NoneType` exception if `get_dict()` is referenced outside of a real build environment.

See also, #751 