### PR TITLE
metadata: Permit attribute access on undefined jinja values

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -595,7 +595,7 @@ class MetaData(object):
                 """
                 A class for Undefined jinja variables.
                 This is even less strict than the default jinja2.Undefined class,
-                because we permits things like {{ MY_UNDEFINED_VAR[:2] }} and {{ float(MY_UNDEFINED_VAR) }}.
+                because it permits things like {{ MY_UNDEFINED_VAR[:2] }} and {{ MY_UNDEFINED_VAR|int }}.
                 This can mask lots of errors in jinja templates, so it should only be used for a first-pass
                 parse, when you plan on running a 'strict' second pass later.
                 """
@@ -604,10 +604,22 @@ class MetaData(object):
                 __mod__ = __rmod__ = __pos__ = __neg__ = __call__ = \
                 __getitem__ = __lt__ = __le__ = __gt__ = __ge__ = \
                 __complex__ = __pow__ = __rpow__ = \
-                    lambda *args, **kwargs: ''
+                    lambda *args, **kwargs: UndefinedNeverFail()
+
+                __str__ = __repr__ = \
+                    lambda *args, **kwargs: u''
 
                 __int__ = lambda _: 0
                 __float__ = lambda _: 0.0
+
+                def __getattr__(self, k):
+                    try:
+                        return object.__getattr__(self, k)
+                    except AttributeError:
+                        return UndefinedNeverFail()
+
+                def __setattr__(self, k, v):
+                    pass
 
             undefined_type = UndefinedNeverFail
 

--- a/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
+++ b/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
@@ -1,12 +1,17 @@
+# This recipe exercises the use of GIT_ variables in jinja template strings,
+# including use cases involving expressions such as FOO[:7] or FOO.replace(...)
 package:
   name: conda-build-test-source-git-jinja2
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ GIT_DESCRIBE_TAG.replace('v', '') }}
 
 source:
   git_url: https://github.com/conda/conda-build
   git_tag: 1.8.1
 
+build:
+  number: {{ GIT_DESCRIBE_NUMBER|int }}
+  string: py{{ CONDA_PY }}_{{ GIT_DESCRIBE_NUMBER|int }}_g{{ GIT_FULL_HASH[:7] }}
+
 requirements:
   build:
-    # To test the conda_build version
-    - python
+    - python {{ PY_VER }}*


### PR DESCRIPTION
(This is an update to 03c75c0597370c5ef1b0356c16f3beab1f417413.  See also: #694.)

The `meta.yaml` file is parsed twice.  During the first parse, we permit undefined jinja variables without raising errors (but the final parse is strict).

So, this is allowed:

```yaml
build:
  string: {{ GIT_FULL_HASH }} # Not defined yet during the first pass, but that's okay.
```

We also avoid choking even if the undefined variable is used in an **expression** involving various operators:

```yaml
build:
  string: {{ GIT_FULL_HASH[:7] + "_hello" }}
```

But I forgot one operator: attribute access (`.`).  So, this will choke the jinja parser on the first pass:

```yaml
package:
    name: pandas
    version: {{ GIT_DESCRIBE_TAG.replace('.dev', 'dev') }}
```

This PR fixes that problem.

Update: I also made a few tiny clean-ups of this code while I was at it, and enhanced the `source_git_jinja2` test to cover this PR's fix.