### PR TITLE
make no-arch exmaple really simple

### DIFF
--- a/example_packages/noarch_python/README.txt
+++ b/example_packages/noarch_python/README.txt
@@ -1,0 +1,4 @@
+This is probably the most simple noarch Python recipe.
+You build the package (as always) using:
+
+$ conda build .

--- a/example_packages/noarch_python/build.sh
+++ b/example_packages/noarch_python/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+cp $RECIPE_DIR/foo.py $SRC_DIR
+cp $RECIPE_DIR/setup.py $SRC_DIR
 
-EXAMPLES=$PREFIX/Examples
-mkdir $EXAMPLES
-mv examples $EXAMPLES/bokeh
+$PYTHON setup.py install

--- a/example_packages/noarch_python/foo.py
+++ b/example_packages/noarch_python/foo.py
@@ -1,0 +1,5 @@
+__version__ = '1.2.3'
+
+
+def main():
+    print("foo version: %s" % __version__)

--- a/example_packages/noarch_python/meta.yaml
+++ b/example_packages/noarch_python/meta.yaml
@@ -1,46 +1,20 @@
 package:
-  name: bokeh
-  version: 0.7.1
-
-source:
-  fn: bokeh-0.7.1.tar.gz
-  url: https://pypi.python.org/packages/source/b/bokeh/bokeh-0.7.1.tar.gz
-  md5: 426f2b0850018fab1407f2e7ed129544
+  name: foo
+  version: 1.2.3
 
 build:
   noarch_python: True
-  number: 1
+  entry_points:
+    - foo = foo:main
 
 requirements:
   build:
     - python
   run:
     - python
-    - numpy
-    - pandas
-    - flask
-    - jinja2
-    - markupsafe
-    - werkzeug
-    - greenlet
-    - dateutil
-    - pytz
-    - requests
-    - six
-    - pygments
-    - pyyaml
-    - pyzmq
-    - tornado
 
 test:
-  requires:
-    - nose
-    - mock
   commands:
-    - bokeh-server -h
+    - foo
   imports:
-    - bokeh
-
-about:
-  home: https://github.com/ContinuumIO/Bokeh
-  license: New BSD
+    - foo

--- a/example_packages/noarch_python/run_test.py
+++ b/example_packages/noarch_python/run_test.py
@@ -1,8 +1,3 @@
-import sys
-import bokeh
+import foo
 
-if sys.platform != 'win32':
-    bokeh.test(verbosity=2, exit=False)
-
-print('bokeh.__version__: %s' % bokeh.__version__)
-#assert bokeh.__version__ == '0.7.1'
+assert foo.__version__ == '1.2.3'

--- a/example_packages/noarch_python/setup.py
+++ b/example_packages/noarch_python/setup.py
@@ -1,0 +1,11 @@
+from distutils.core import setup
+
+setup(
+    name = "foo",
+    version = '1.2.3',
+    author = "Ilan Schnell",
+    py_modules = ["foo"],
+    entry_points = {
+        'console_scripts': ['foo = foo:main'],
+    },
+)


### PR DESCRIPTION
Previously `bokeh` was the noarch example package, which is actually not a good example because it is quite large and has many dependencies.  The new example is simple, *really simple*.