### PR TITLE
Fix CYGWIN_PREFIX for other drive letters other than C:

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -173,8 +173,9 @@ def get_dict(m=None, prefix=None):
         d['LIBRARY_BIN'] = join(d['LIBRARY_PREFIX'], 'bin')
         d['LIBRARY_INC'] = join(d['LIBRARY_PREFIX'], 'include')
         d['LIBRARY_LIB'] = join(d['LIBRARY_PREFIX'], 'lib')
-        # This probably should be done more generally
-        d['CYGWIN_PREFIX'] = prefix.replace('\\', '/').replace('C:', '/cygdrive/c')
+
+        drive, tail = prefix.split(':')
+        d['CYGWIN_PREFIX'] = ''.join(['/cygdrive/', drive.lower(), tail.replace('\\', '/')])
 
         d['R'] = join(prefix, 'Scripts', 'R.exe')
     else:                               # -------- Unix


### PR DESCRIPTION
If the drive is on D: (for example), the CYGWIN_PREFIX environment variable will be wrong, which may cause it to miss paths to be replaced in text files.