### PR TITLE
Building noarch packages on Windows

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -441,17 +441,25 @@ def build(m, get_src=True, post=None, include_recipe=True):
             f.write(u'\n'.join(sorted(list(files1))))
             f.write(u'\n')
 
+        # Use script from recipe?
+        script = m.get_value('build/script', None)
+        if script:
+            if isinstance(script, list):
+                script = '\n'.join(script)
+
         if sys.platform == 'win32':
+            build_file = join(m.path, 'bld.bat')
+            if script:
+                build_file = join(source.get_dir(), 'bld.bat')
+                with open(join(source.get_dir(), 'bld.bat'), 'w') as bf:
+                    bf.write(script)
             import conda_build.windows as windows
-            windows.build(m)
+            windows.build(m, build_file)
         else:
             env = environ.get_dict(m)
             build_file = join(m.path, 'build.sh')
 
-            script = m.get_value('build/script', None)
             if script:
-                if isinstance(script, list):
-                    script = '\n'.join(script)
                 build_file = join(source.get_dir(), 'conda_build.sh')
                 with open(build_file, 'w') as bf:
                     bf.write(script)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -179,7 +179,7 @@ def parse(data):
     trues = {'y', 'on', 'true', 'yes'}
     falses = {'n', 'no', 'false', 'off'}
     for field in ('build/osx_is_app', 'build/preserve_egg_dir',
-                  'build/binary_relocation',
+                  'build/binary_relocation', 'build/noarch_python',
                   'build/detect_binary_files_with_prefix',
                   'build/skip', 'app/own_environment'):
         section, key = field.split('/')

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -106,6 +106,7 @@ def transform(m, files):
     _force_dir(bin_dir)
 
     # Create *nix prelink script
+    # Note: it's important to set newline to LF or it wont work if we build on Win
     with open(join(bin_dir, '.%s-pre-link.sh' % name), 'w', newline='\n') as fo:
         fo.write('''\
 #!/bin/bash

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -118,7 +118,7 @@ $PREFIX/bin/python $SOURCE_DIR/link.py
     _force_dir(scripts_dir)
 
     # Create windows prelink script (be nice and use Windows newlines)
-    with open(join(scripts_dir, '.%s-pre-link.bat' % name), 'w') as fo:
+    with open(join(scripts_dir, '.%s-pre-link.bat' % name), 'wb') as fo:
         fo.write('''\
 @echo off
 "%PREFIX%\\python.exe" "%SOURCE_DIR%\\link.py"

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -107,22 +107,22 @@ def transform(m, files):
     _force_dir(bin_dir)
 
     # Create *nix prelink script
-    # Note: it's important to set newline to LF or it wont work if we build on Win
-    with open(join(bin_dir, '.%s-pre-link.sh' % name), 'w', newline='\n') as fo:
+    # Note: it's important to use LF newlines or it wont work if we build on Win
+    with open(join(bin_dir, '.%s-pre-link.sh' % name), 'wb') as fo:
         fo.write('''\
 #!/bin/bash
 $PREFIX/bin/python $SOURCE_DIR/link.py
-''')
+'''.encode('utf-8'))
 
     scripts_dir = join(prefix, 'Scripts')
     _force_dir(scripts_dir)
 
     # Create windows prelink script (be nice and use Windows newlines)
-    with open(join(scripts_dir, '.%s-pre-link.bat' % name), 'w', newline='\r\n') as fo:
+    with open(join(scripts_dir, '.%s-pre-link.bat' % name), 'w') as fo:
         fo.write('''\
 @echo off
 "%PREFIX%\\python.exe" "%SOURCE_DIR%\\link.py"
-''')
+'''.replace('\n', '\r\n').encode('utf-8'))
 
     d = {'dist': m.dist(),
          'site-packages': [],

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -66,8 +66,9 @@ def handle_file(f, d):
 
     # The presence of .so indicated this is not a noarch package
     elif f.endswith(('.so', '.dll', '.pyd', '.exe', '.dylib')):
-        if f.endswith('.exe') and f.startswith('Scripts'):
-            os.unlink(path)  # we use the xx-script.py
+        if f.endswith('.exe') and (isfile(f[:-4] + '-script.py') or
+                                   basename(f[:-4]) in d['python-scripts']):
+            os.unlink(path)  # this is an entry point with a matching xx-script.py
             return
         _error_exit("Error: Binary library or executable found: %s" % f)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -110,7 +110,7 @@ def kill_processes(process_names=["msbuild.exe"]):
             continue
 
 
-def build(m):
+def build(m, bld_bat):
     env = dict(os.environ)
     env.update(environ.get_dict(m))
     env = environ.prepend_bin_path(env, config.build_prefix, True)
@@ -121,7 +121,6 @@ def build(m):
             os.makedirs(path)
 
     src_dir = source.get_dir()
-    bld_bat = join(m.path, 'bld.bat')
     if exists(bld_bat):
         with open(bld_bat) as fi:
             data = fi.read()

--- a/tests/test-recipes/metadata/noarch/meta.yaml
+++ b/tests/test-recipes/metadata/noarch/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: noarch_test_package
+  version: "1.0"
+
+source:
+  path: noarch_test_package
+
+build:
+  script: python setup.py install
+  noarch_python: True
+  entry_points:
+    - noarch_test_package_script = noarch_test_package:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - noarch_test_package
+  commands:
+    - noarch_test_package_script

--- a/tests/test-recipes/metadata/noarch/noarch_test_package/README
+++ b/tests/test-recipes/metadata/noarch/noarch_test_package/README
@@ -1,0 +1,1 @@
+Simple package to test noarch package building.

--- a/tests/test-recipes/metadata/noarch/noarch_test_package/noarch_test_package.py
+++ b/tests/test-recipes/metadata/noarch/noarch_test_package/noarch_test_package.py
@@ -1,0 +1,10 @@
+""" This functions as a module but also as entry point.
+"""
+
+answer = 142
+
+def main():
+    print(answer + 100)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/noarch/noarch_test_package/setup.py
+++ b/tests/test-recipes/metadata/noarch/noarch_test_package/setup.py
@@ -1,6 +1,8 @@
 import setuptools
 from distutils.core import setup
 
+setuptools  # fool pyflakes
+
 name = 'noarch_test_package'
 
 setup(

--- a/tests/test-recipes/metadata/noarch/noarch_test_package/setup.py
+++ b/tests/test-recipes/metadata/noarch/noarch_test_package/setup.py
@@ -1,0 +1,18 @@
+import setuptools
+from distutils.core import setup
+
+name = 'noarch_test_package'
+
+setup(
+    name=name,
+    version='1.0',
+    author='Almar',
+    author_email='almar@notmyemail.com',
+    url='http://continuum.io',
+    license='(new) BSD',
+    description='testing noarch package building',
+    platforms='any',
+    provides=[name],
+    py_modules=[name],
+    entry_points={'console_scripts': ['%s_script = %s:main' % (name, name)], },
+)

--- a/tests/test-recipes/metadata/noarch/run_test.py
+++ b/tests/test-recipes/metadata/noarch/run_test.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import subprocess
+
+pkgs_dir = os.path.abspath(os.path.join(sys.prefix, '..', '..', 'pkgs'))
+pkg_dir = os.path.join(pkgs_dir, 'noarch_test_package-1.0-py_0')
+
+assert os.path.isdir(pkg_dir)
+
+# Check newlines in prelink scripts
+# The one for the .sh is crucial, the one for the .bat is just good behavior
+
+fname_prelink_unix = os.path.join(pkg_dir, 'bin', '.noarch_test_package-pre-link.sh')
+fname_prelink_win = os.path.join(pkg_dir, 'Scripts', '.noarch_test_package-pre-link.bat')
+
+prelink_unix = open(fname_prelink_unix, 'rb').read().decode('utf-8')
+prelink_win = open(fname_prelink_win, 'rb').read().decode('utf-8')
+
+assert prelink_unix.count('\n') and not prelink_unix.count('\r') 
+assert prelink_win.count('\n') == prelink_win.count('\r') 
+
+# Check module
+
+import noarch_test_package
+assert noarch_test_package.answer == 142
+
+# Check entry point
+
+res = subprocess.check_output(['noarch_test_package_script']).decode('utf-8').strip()
+assert res == '242'


### PR DESCRIPTION
* Fixes that the `build/script` entry was ignored on Windows
* Fixes that setting `noarch_python` to `False` still builds it as a noarch package (#787)
* Enables making noarch packages on Windows (fixes #796)


