### PR TITLE
Fix git with local branches

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -38,7 +38,7 @@ def get_sp_dir():
     return join(get_stdlib_dir(), 'site-packages')
 
 def get_git_build_info(src_dir, git_url, expected_rev):
-    expected_rev = expected_rev or 'master'
+    expected_rev = expected_rev or 'HEAD'
     env = os.environ.copy()
     d = {}
     git_dir = join(src_dir, '.git')

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -116,7 +116,7 @@ def git_source(meta, recipe_dir):
     else:
         args = [git, 'clone', '--mirror']
         if git_depth > 0:
-            args += ['--depth', git_depth]
+            args += ['--depth', str(git_depth)]
 
         check_call(args + [git_url, cache_repo_arg],  cwd=recipe_dir)
         assert isdir(cache_repo)

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -112,7 +112,19 @@ def git_source(meta, recipe_dir):
 
     # update (or create) the cache repo
     if isdir(cache_repo):
-        check_call([git, 'fetch'], cwd=cache_repo)
+        if meta.get('git_rev', 'HEAD') != 'HEAD':
+            check_call([git, 'fetch'], cwd=cache_repo)
+        else:
+            # Unlike 'git clone', fetch doesn't automatically update the cache's HEAD,
+            # So here we explicitly store the remote HEAD in the cache's local refs/heads,
+            # and then explicitly set the cache's HEAD.
+            # This is important when the git repo is a local path like "git_url: ../",
+            # but the user is working with a branch other than 'master' without
+            # explicitly providing git_rev.
+            check_call([git, 'fetch', 'origin', '+HEAD:_conda_cache_origin_head'],
+                       cwd=cache_repo)
+            check_call([git, 'symbolic-ref', 'HEAD', 'refs/heads/_conda_cache_origin_head'],
+                       cwd=cache_repo)
     else:
         args = [git, 'clone', '--mirror']
         if git_depth > 0:


### PR DESCRIPTION
This PR addresses an issue that can occur when building a conda recipe from a local git repository. For example:

```yaml
source:
  git_url: ../
```

If the user *switches branches* and attempts to build a recipe, conda-build's `git_cache` will still point to the old `HEAD`, meaning that the user is not building the branch she thinks she's building.

For example:

```bash
cd my-git-repo
git checkout master

# This clones my-git-repo to the cache, and sets HEAD to 'master'
conda build my-conda-recipe

# Switch branches
git checkout develop

# This updates my-git-repo via 'git fetch', but HEAD is still 'master'.
# Oops! We're just re-building the 'master' recipe, not 'develop'.
conda build my-conda-recipe 
```

It's surprising that this hasn't been noticed before, but maybe most people use `source/path` instead of `source/git_url` for local repositories, so this problem doesn't affect them.

Aside from that issue, I'm fixing a few other git-related problems.  See the commit history for details.