### PR TITLE
Work-around System Integrity Protection on El Capitan.

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -191,7 +191,8 @@ def get_dict(m=None, prefix=None):
         d['OSX_ARCH'] = 'i386' if cc.bits == 32 else 'x86_64'
         d['CFLAGS'] = cflags + ' -arch %(OSX_ARCH)s' % d
         d['CXXFLAGS'] = cxxflags + ' -arch %(OSX_ARCH)s' % d
-        d['LDFLAGS'] = ldflags + ' -arch %(OSX_ARCH)s' % d
+        rpath = ' -rpath %(PREFIX)s/lib' % d # SIP workaround, DYLD_* no longer works.
+        d['LDFLAGS'] = ldflags + rpath + ' -arch %(OSX_ARCH)s' % d
         d['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
 
     elif sys.platform.startswith('linux'):      # -------- Linux

--- a/conda_build/macho.py
+++ b/conda_build/macho.py
@@ -63,6 +63,12 @@ def is_dylib_info(lines):
     return False
 
 
+def is_id_dylib(lines):
+    if len(lines) > 1 and lines[1].split()[1] == 'LC_ID_DYLIB':
+        return True
+    return False
+
+
 def is_load_dylib(lines):
     if len(lines) > 1 and lines[1].split()[1] == 'LC_LOAD_DYLIB':
         return True
@@ -153,6 +159,15 @@ def get_dylibs(path):
     """Return a list of the loaded dylib pathnames"""
     dylib_loads = otool(path, is_load_dylib)
     return [dylib_load['name'] for dylib_load in dylib_loads]
+
+
+def get_id(path):
+    """Returns the id name of the Mach-O file `path` or an empty string"""
+    dylib_loads = otool(path, is_id_dylib)
+    try:
+        return [dylib_load['name'] for dylib_load in dylib_loads][0]
+    except:
+        return ''
 
 
 def get_rpaths(path):

--- a/conda_build/macho.py
+++ b/conda_build/macho.py
@@ -182,6 +182,27 @@ def add_rpath(path, rpath, verbose = False):
         % p.returncode)
 
 
+def delete_rpath(path, rpath, verbose = False):
+    """Delete an `rpath` from the Mach-O file at `path`"""
+    args = ['install_name_tool', '-delete_rpath', rpath, path]
+    if verbose:
+        print(' '.join(args))
+    p = Popen(args, stderr=PIPE)
+    stdout, stderr = p.communicate()
+    stderr = stderr.decode('utf-8')
+    if "Mach-O dynamic shared library stub file" in stderr:
+        print("Skipping Mach-O dynamic shared library stub file %s\n" % path)
+        return
+    elif "no LC_RPATH load command with path:" in stderr:
+        print("Skipping -delete_rpath, file doesn't contain that LC_RPATH")
+        return
+    else:
+        print(stderr, file=sys.stderr)
+        if p.returncode:
+            raise RuntimeError("install_name_tool failed with exit status %d"
+        % p.returncode)
+
+
 def install_name_change(path, cb_func, verbose = False):
     """Change dynamic shared library load name or id name of Mach-O Binary `path`.
 

--- a/conda_build/macho.py
+++ b/conda_build/macho.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
-import subprocess
+from subprocess import Popen, check_output, PIPE
 from os.path import islink, isfile
+from itertools import islice
 
 NO_EXT = (
     '.py', '.pyc', '.pyo', '.h', '.a', '.c', '.txt', '.html',
@@ -43,8 +44,9 @@ def is_macho(path):
 def is_dylib(path):
     return human_filetype(path) == 'DYLIB'
 
+
 def human_filetype(path):
-    lines = subprocess.check_output(['otool', '-h', path]).decode('utf-8').splitlines()
+    lines = check_output(['otool', '-h', path]).decode('utf-8').splitlines()
     assert lines[0].startswith(path), path
 
     for line in lines:
@@ -53,51 +55,160 @@ def human_filetype(path):
             filetype = int(header[4])
             return FILETYPE[filetype][3:]
 
-def otool(path):
-    "thin wrapper around otool -L"
-    lines = subprocess.check_output(['otool', '-L', path]).decode('utf-8').splitlines()
-    assert lines[0].startswith(path), path
-    res = []
-    for line in lines[1:]:
-        assert line[0] == '\t', path
-        res.append(line.split()[0])
-    return res
+
+def is_dylib_info(lines):
+    dylib_info = ('LC_ID_DYLIB', 'LC_LOAD_DYLIB')
+    if len(lines) > 1 and lines[1].split()[1] in dylib_info:
+        return True
+    return False
+
+
+def is_load_dylib(lines):
+    if len(lines) > 1 and lines[1].split()[1] == 'LC_LOAD_DYLIB':
+        return True
+    return False
+
+
+def is_rpath(lines):
+    if len(lines) > 1 and lines[1].split()[1] == 'LC_RPATH':
+        return True
+    return False
+
+
+def _get_load_commands(lines):
+    """yields each load command from the output of otool -l"""
+    a = 1 # first line is the filename.
+    for ln, line in enumerate(lines):
+        if line.startswith("Load command"):
+            if a < ln:
+                yield lines[a:ln]
+            a = ln
+    yield lines[a:]
+
+
+def _get_matching_load_commands(lines, cb_filter):
+    """Workhorse function for otool
+
+    Does the work of filtering load commands and making a list
+    of dicts. The logic for splitting the free-form lines into
+    keys and values in entirely encoded here. Values that can
+    be converted to ints are converted to ints.
+    """
+    result = []
+    for lcmds in _get_load_commands(lines):
+        if cb_filter(lcmds):
+            lcdict = {}
+            for line in islice(lcmds, 1, len(lcmds)):
+                listy = line.split()
+                # This could be prettier, but what we need it to handle
+                # is fairly simple so let's just hardcode it for speed.
+                if len(listy) == 2:
+                    key, value = listy
+                elif listy[0] == 'name' or listy[0] == 'path':
+                    # Create an entry for 'name offset' if there is one
+                    # as that can be useful if we need to know if there
+                    # is space to patch it for relocation purposes.
+                    if listy[2] == '(offset':
+                        key = listy[0] + ' offset'
+                        value = int(listy[3][:-1])
+                        lcdict[key] = value
+                    key, value = listy[0:2]
+                elif listy[0] == 'time':
+                    key = ' '.join(listy[0:3])
+                    value = ' '.join(listy[3:])
+                elif listy[0] in ('current', 'compatibility'):
+                    key = ' '.join(listy[0:2])
+                    value = listy[2]
+                try:
+                    value = int(value)
+                except:
+                    pass
+                lcdict[key] = value
+            result.append(lcdict)
+    return result
+
+
+def otool(path, cb_filter=is_dylib_info):
+    """A wrapper around otool -l
+
+    Parse the output of the otool -l 'load commands', filtered by
+    cb_filter, returning a list of dictionairies for the records.
+
+    cb_filter receives the whole load command record, including the
+    first line, the 'Load Command N' one. All the records have been
+    pre-stripped of white space.
+
+    The output of otool -l is entirely freeform; delineation between
+    key and value doesn't formally exist, so that is hard coded. I
+    didn't want to use regexes to parse it for speed purposes.
+
+    Any key values that can be converted to integers are converted
+    to integers, the rest are strings.
+    """
+    lines = check_output(['otool', '-l', path]).decode('utf-8').splitlines()
+    return _get_matching_load_commands(lines, cb_filter)
+
+
+def get_dylibs(path):
+    """Return a list of the loaded dylib pathnames"""
+    dylib_loads = otool(path, is_load_dylib)
+    return [dylib_load['name'] for dylib_load in dylib_loads]
+
 
 def get_rpaths(path):
-    lines = subprocess.check_output(['otool', '-l',
-        path]).decode('utf-8').splitlines()
-    check_for_rpath = False
-    rpaths = []
-    for line in lines:
-        if 'cmd LC_RPATH' in line:
-            check_for_rpath = True
-        if check_for_rpath and 'path' in line:
-            _, rpath, _ = line.split(None, 2)
-            rpaths.append(rpath)
-    return rpaths
+    """Return a list of the dylib rpaths"""
+    rpaths = otool(path, is_rpath)
+    return [rpath['path'] for rpath in rpaths]
 
-def install_name_change(path, cb_func):
-    """
-    change dynamic shared library install names of Mach-O binary `path`.
 
-    `cb_func` is a callback function which called for each shared library name.
-    It is called with `path` and the current shared library install name,
-    and return the new name (or None if the name should be unchanged).
+def add_rpath(path, rpath, verbose = False):
+    """Add an `rpath` to the Mach-O file at `path`"""
+    args = ['install_name_tool', '-add_rpath', rpath, path]
+    if verbose:
+        print(' '.join(args))
+    p = Popen(args, stderr=PIPE)
+    stdout, stderr = p.communicate()
+    stderr = stderr.decode('utf-8')
+    if "Mach-O dynamic shared library stub file" in stderr:
+        print("Skipping Mach-O dynamic shared library stub file %s\n" % path)
+        return
+    elif "would duplicate path, file already has LC_RPATH for:" in stderr:
+        print("Skipping -add_rpath, file already has LC_RPATH set")
+        return
+    else:
+        print(stderr, file=sys.stderr)
+        if p.returncode:
+            raise RuntimeError("install_name_tool failed with exit status %d"
+        % p.returncode)
+
+
+def install_name_change(path, cb_func, verbose = False):
+    """Change dynamic shared library load name or id name of Mach-O Binary `path`.
+
+    `cb_func` is called for each shared library load command. The dictionary of
+    the load command is passed in and the callback returns the new name or None
+    if the name should be unchanged.
+
+    When dealing with id load commands, `install_name_tool -id` is used.
+    When dealing with dylib load commands `install_name_tool -change` is used.
     """
+    dylibs = otool(path)
     changes = []
-    for link in otool(path):
-        # The first link may be the install name of the library itself, but
-        # this isn't a big deal because install_name_tool -change is a no-op
-        # if given a dependent install name that doesn't exist.
-        new_link = cb_func(path, link)
-        if new_link:
-            changes.append((link, new_link))
+    for index, dylib in enumerate(dylibs):
+        new_name = cb_func(path, dylib)
+        if new_name:
+            changes.append((index, new_name))
 
     ret = True
-    for old, new in changes:
-        args = ['install_name_tool', '-change', old, new, path]
-        print(' '.join(args))
-        p = subprocess.Popen(args, stderr=subprocess.PIPE)
+    for index, new_name in changes:
+        args = ['install_name_tool']
+        if dylibs[index]['cmd'] == 'LC_ID_DYLIB':
+            args.extend(('-id', new_name, path))
+        else:
+            args.extend(('-change', dylib['name'], new_name, path))
+        if verbose:
+            print(' '.join(args))
+        p = Popen(args, stderr=PIPE)
         stdout, stderr = p.communicate()
         stderr = stderr.decode('utf-8')
         if "Mach-O dynamic shared library stub file" in stderr:
@@ -110,6 +221,7 @@ def install_name_change(path, cb_func):
             raise RuntimeError("install_name_tool failed with exit status %d"
                 % p.returncode)
     return ret
+
 
 if __name__ == '__main__':
     if sys.platform == 'darwin':

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -8,15 +8,13 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 from os.path import join, isdir, abspath, expanduser, exists
-from os import walk
-import fnmatch
 import shutil
 
 from conda.cli.common import add_parser_prefix, get_prefix
 from conda.cli.conda_argparse import ArgumentParser
 from conda_build.main_build import args_func
 from conda_build.post import mk_relative_osx
-from conda_build.utils import _check_call
+from conda_build.utils import _check_call, rec_glob
 
 from conda.install import linked
 
@@ -67,27 +65,6 @@ This works by creating a conda.pth file in site-packages."""
     args_func(args, p)
 
 
-def sharedobjects_list(pkg_path):
-    '''
-    return list of shared objects (*.so) found in pkg_path.
-
-    :param pkg_path: look for shared objects to relink in pkg_path
-    '''
-    bin_files = []
-
-    # only relevant for mac/linux
-    pattern = '*.so'
-
-    for d_f in walk(pkg_path):
-        m = fnmatch.filter(d_f[2], pattern)
-        if m:
-            # list is not empty, append full path to binary, then add it
-            # to bin_files list
-            bin_files.extend([join(d_f[0], f) for f in m])
-
-    return bin_files
-
-
 def relink_sharedobjects(pkg_path, build_prefix):
     '''
     invokes functions in post module to relink to libraries in conda env
@@ -101,7 +78,7 @@ def relink_sharedobjects(pkg_path, build_prefix):
         since runtime libraries should be loaded from environment's lib/. first
     '''
     # find binaries in package dir and make them relocatable
-    bin_files = sharedobjects_list(pkg_path)
+    bin_files = rec_glob(pkg_path, ['.so'])
     for b_file in bin_files:
         if sys.platform == 'darwin':
             mk_relative_osx(b_file, build_prefix)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -256,6 +256,9 @@ def mk_relative_osx(path, build_prefix=None):
                              dirname(path)), '').replace('/./', '/')
         macho.add_rpath(path, rpath, verbose = True)
 
+        # .. and remove config.build_prefix/lib which was added in-place of
+        # DYLD_FALLBACK_LIBRARY_PATH since El Capitan's SIP.
+        macho.delete_rpath(path, config.build_prefix + '/lib', verbose = True)
 
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     readlink = False
 import io
-from subprocess import call, Popen, PIPE
+from subprocess import call
 from collections import defaultdict
 
 from conda_build.config import config
@@ -190,7 +190,9 @@ def find_lib(link, path=None):
         return file_names[link][0]
     print("Don't know how to find %s, skipping" % link)
 
-def osx_ch_link(path, link):
+
+def osx_ch_link(path, link_dict):
+    link = link_dict['name']
     print("Fixing linking of %s in %s" % (link, path))
     link_loc = find_lib(link, path)
     if not link_loc:
@@ -216,7 +218,7 @@ def osx_ch_link(path, link):
     # @loader_path/path_to_lib/lib_to_link/basename(link), like
     # @loader_path/../../things/libthings.dylib.
 
-    ret =  '@rpath/%s/%s' % (lib_to_link, basename(link))
+    ret = '@rpath/%s/%s' % (lib_to_link, basename(link))
 
     # XXX: IF the above fails for whatever reason, the below can be used
     # TODO: This might contain redundant ..'s if link and path are both in
@@ -224,7 +226,9 @@ def osx_ch_link(path, link):
     # ret = '@loader_path/%s/%s/%s' % (path_to_lib, lib_to_link, basename(link))
 
     ret = ret.replace('/./', '/')
+
     return ret
+
 
 def mk_relative_osx(path, build_prefix=None):
     '''
@@ -245,57 +249,13 @@ def mk_relative_osx(path, build_prefix=None):
 
     names = macho.otool(path)
     if names:
-        # Strictly speaking, not all object files have install names (e.g.,
-        # bundles and executables do not). In that case, the first name here
-        # will not be the install name (i.e., the id), but it isn't a problem,
-        # because in that case it will be a no-op (with the exception of stub
-        # files, which give an error, which is handled below).
-        args = [
-            'install_name_tool',
-            '-id',
-            join('@rpath', relpath(dirname(path),
-                                   join(config.build_prefix, 'lib')),
-                 basename(names[0])),
-            path,
-        ]
-        print(' '.join(args))
-        p = Popen(args, stderr=PIPE)
-        stdout, stderr = p.communicate()
-        stderr = stderr.decode('utf-8')
-        if "Mach-O dynamic shared library stub file" in stderr:
-            print("Skipping Mach-O dynamic shared library stub file %s" % path)
-            return
-        else:
-            print(stderr, file=sys.stderr)
-            if p.returncode:
-                raise RuntimeError("install_name_tool failed with exit status %d"
-            % p.returncode)
-
         # Add an rpath to every executable to increase the chances of it
         # being found.
-        args = [
-            'install_name_tool',
-            '-add_rpath',
-            join('@loader_path',
-                 relpath(join(config.build_prefix, 'lib'),
-                         dirname(path)), '').replace('/./', '/'),
-            path,
-            ]
-        print(' '.join(args))
-        p = Popen(args, stderr=PIPE)
-        stdout, stderr = p.communicate()
-        stderr = stderr.decode('utf-8')
-        if "Mach-O dynamic shared library stub file" in stderr:
-            print("Skipping Mach-O dynamic shared library stub file %s\n" % path)
-            return
-        elif "would duplicate path, file already has LC_RPATH for:" in stderr:
-            print("Skipping -add_rpath, file already has LC_RPATH set")
-            return
-        else:
-            print(stderr, file=sys.stderr)
-            if p.returncode:
-                raise RuntimeError("install_name_tool failed with exit status %d"
-            % p.returncode)
+        rpath = join('@loader_path',
+                     relpath(join(config.build_prefix, 'lib'),
+                             dirname(path)), '').replace('/./', '/')
+        macho.add_rpath(path, rpath, verbose = True)
+
 
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be
@@ -310,9 +270,11 @@ def mk_relative_linux(f, rpaths=('lib',)):
     print('patchelf: file: %s\n    setting rpath to: %s' % (path, rpath))
     call([patchelf, '--force-rpath', '--set-rpath', rpath, path])
 
+
 def assert_relative_osx(path):
-    for name in macho.otool(path):
+    for name in macho.get_dylibs(path):
         assert not name.startswith(config.build_prefix), path
+
 
 def mk_relative(m, f):
     assert sys.platform != 'win32'
@@ -390,6 +352,7 @@ def check_symlinks(files):
         for msg in msgs:
             print("Error: %s" % msg, file=sys.stderr)
         sys.exit(1)
+
 
 def get_build_metadata(m):
     src_dir = source.get_dir()

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -7,6 +7,7 @@ import tarfile
 import zipfile
 import subprocess
 import operator
+import fnmatch
 from os.path import dirname, getmtime, getsize, isdir, join
 from collections import defaultdict
 
@@ -180,3 +181,14 @@ def safe_print_unicode(*args, **kwargs):
     line = sep.join(args) + end
     encoding = sys.stdout.encoding or 'utf8'
     func(line.encode(encoding, errors))
+
+
+def rec_glob(path, patterns):
+    result = []
+    for d_f in os.walk(path):
+        m = []
+        for pattern in patterns:
+            m.extend(fnmatch.filter(d_f[2], pattern))
+        if m:
+            result.extend([os.path.join(d_f[0], f) for f in m])
+    return result


### PR DESCRIPTION
The first commit is about making otool more useful / informative, then removing a hack and a bit of refactoring.

The 2nd commit builds on it and is important. Any package that depends on DYLD_FALLBACK_LIBRARY_PATH on OS X can't be built currently on 10.11 and this change addresses that. My approach is to add an -rpath to LDFLAGS during the build and then remove it from the executables at the end.

I went down a different path for fixing this initially (modifying the LC_ID_DYLIB load command names in the dylib files in the build environment) but backed it out when I realized it would've required copying instead of hard-linking when installing packages into the build environment. Also doing it as-per this PR involves less code (but it does rely on people not overriding LDFLAGS in build.sh)

We could mark packages that need this work-around explicitly, but I feel that it needs to work in every case anyway.

Finally, some packages that have dylibs with incorrect LC_ID_DYLIB load command names (they are missing '@rpath/') and they need to be rebuilt. I'm going to get a list together.