### PR TITLE
tests: Update failure message for recursive build

### DIFF
--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -32,7 +32,8 @@ echo "$OUTPUT" | grep "Error" | wc -l | grep 6
 echo "$OUTPUT" | grep 'Error: Untracked file(s) ('\''conda-meta/nope'\'',)'
 
 ! OUTPUT=$(conda build --no-anaconda-upload recursive-build/ 2>&1)
-echo "$OUTPUT" | grep 'No packages found in current .* channels matching: recursive-build2 2\.0'
+echo "$OUTPUT" |  tail -n2 | head -n1 | grep 'Error:  Package missing in current .* channels: '
+echo "$OUTPUT" |  tail -n1 | grep '  - recursive-build2 2.0'
 
 ! OUTPUT=$(conda build --no-anaconda-upload source_git_jinja2_oops/ 2>&1)
 echo "$OUTPUT" | grep '\''GIT_DSECRIBE_TAG'\'' is undefined'


### PR DESCRIPTION
The error message for a missing package has [changed]( https://github.com/conda/conda/blob/6a6409a6810cc1689de10e76a5d516814e197c47/conda/resolve.py#L100 ) for conda 4.0. Here we grep the two last lines to see if they match. We do so in a manner that works on OS X and hopefully will work on Linux too.