### PR TITLE
Fix Travis CI for Python 3.3 and conda 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,11 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes
-  - conda install --force --no-deps conda requests
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then
+      conda install --force --no-deps 'conda=3.*' requests;
+    else
+      conda install --force --no-deps conda requests;
+    fi
   - conda install pip pytest requests jinja2 patchelf pyflakes python=$TRAVIS_PYTHON_VERSION
   - pip install pytest-cov
   - python setup.py install

--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -31,9 +31,19 @@ echo "$OUTPUT" | grep "Error" | wc -l | grep 6
 ! OUTPUT=$(conda build --no-anaconda-upload conda-meta/ 2>&1)
 echo "$OUTPUT" | grep 'Error: Untracked file(s) ('\''conda-meta/nope'\'',)'
 
+# Get the version of conda as the error message changed in conda 4.
+set +e
+echo $(conda -V 2>&1) | grep "conda 3\..*"
+export IS_CONDA_3=$?
+set -e
+
 ! OUTPUT=$(conda build --no-anaconda-upload recursive-build/ 2>&1)
-echo "$OUTPUT" |  tail -n2 | head -n1 | grep 'Error:  Package missing in current .* channels: '
-echo "$OUTPUT" |  tail -n1 | grep '  - recursive-build2 2.0'
+if [[ $IS_CONDA_3 -eq 0 ]]; then
+    echo "$OUTPUT" | grep 'No packages found in current .* channels matching: recursive-build2 2\.0'
+else
+    echo "$OUTPUT" |  tail -n2 | head -n1 | grep 'Error:  Package missing in current .* channels: '
+    echo "$OUTPUT" |  tail -n1 | grep '  - recursive-build2 2.0'
+fi
 
 ! OUTPUT=$(conda build --no-anaconda-upload source_git_jinja2_oops/ 2>&1)
 echo "$OUTPUT" | grep '\''GIT_DSECRIBE_TAG'\'' is undefined'

--- a/tests/test-recipes/build_recipes.sh
+++ b/tests/test-recipes/build_recipes.sh
@@ -32,7 +32,8 @@ echo "$OUTPUT" | grep "Error" | wc -l | grep 6
 echo "$OUTPUT" | grep 'Error: Untracked file(s) ('\''conda-meta/nope'\'',)'
 
 ! OUTPUT=$(conda build --no-anaconda-upload recursive-build/ 2>&1)
-echo "$OUTPUT" | grep 'No packages found in current .* channels matching: recursive-build2 2\.0'
+echo "$OUTPUT" |  tail -n2 | head -n1 | grep 'Error:  Package missing in current .* channels: '
+echo "$OUTPUT" |  tail -n1 | grep '  - recursive-build2 2.0'
 
 ! OUTPUT=$(conda build --no-anaconda-upload source_git_jinja2_oops/ 2>&1)
 echo "$OUTPUT" | grep '\''GIT_DSECRIBE_TAG'\'' is undefined'


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/810
Includes https://github.com/conda/conda-build/pull/811
Includes https://github.com/conda/conda-build/pull/809

As of conda 4.0, Python 3.3 is not supported. However, testing continues to happen here for Python 3.3. We have added a workaround to handle installing a version of conda 3.x here for Python 3.3. Also, an error message changes in conda 4.0 so we have included a different check for that warning message. However, if conda 3.x is installed for the Python 3.3 case the old error message check is used instead.