### PR TITLE
macho.py: Change the right dylib name

### DIFF
--- a/conda_build/macho.py
+++ b/conda_build/macho.py
@@ -241,7 +241,7 @@ def install_name_change(path, cb_func, verbose = False):
         if dylibs[index]['cmd'] == 'LC_ID_DYLIB':
             args.extend(('-id', new_name, path))
         else:
-            args.extend(('-change', dylib['name'], new_name, path))
+            args.extend(('-change', dylibs[index]['name'], new_name, path))
         if verbose:
             print(' '.join(args))
         p = Popen(args, stderr=PIPE)


### PR DESCRIPTION
Fixes a bug I introduced in 38f333 where
install_name_tool -change was being called
on the last LC_LOAD_DYLIB instead of the
one that was meant to be changed.