### PR TITLE
Revert "travis: Fix testing on Python 3.3."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.3" ]]; then
-      conda install --force --no-deps 'conda=3.*' requests;
-    else
-      conda install --force --no-deps conda requests;
-    fi
+  - conda install --force --no-deps conda requests
   - conda install pip pytest requests jinja2 patchelf pyflakes python=$TRAVIS_PYTHON_VERSION
   - pip install pytest-cov
   - python setup.py install


### PR DESCRIPTION
This reverts commit ( https://github.com/conda/conda-build/commit/f85dcdb1b511ffd059992133d1ad2adb35a9375a ).

As it appears Python 3.3 CI has been dropped, there is no longer a need for this check.