### PR TITLE
allow additional keys in "about" section

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -273,8 +273,10 @@ FIELDS = {
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
     'test': ['requires', 'commands', 'files', 'imports'],
-    'about': ['home', 'license', 'license_family', 'summary', 'description',
-              'readme', 'license_file', 'dev_url', 'doc_url'],
+    'about': ['home', 'dev_url', 'doc_url', 'license_url', # these are URLs
+              'license', 'summary', 'description', 'license_family', # text
+              'license_file', 'readme', # paths in source tree
+             ],
 }
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -273,8 +273,8 @@ FIELDS = {
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
     'test': ['requires', 'commands', 'files', 'imports'],
-    'about': ['home', 'license', 'license_family',
-              'summary', 'readme', 'license_file'],
+    'about': ['home', 'license', 'license_family', 'summary', 'description',
+              'readme', 'license_file', 'dev_url', 'doc_url'],
 }
 
 


### PR DESCRIPTION
In this PR, we add the following new (optional) keys to the `about` section in `meta.yaml`: `description`, `dev_url`, `doc_url` and `license_url`.  Here is an example of how they might be used:
```
about:
  license: Apache
  summary: N-D labeled arrays and datasets in Python
  description: |
    xarray (formerly xray) is an open source project and Python package that
    aims to bring the labeled data power of pandas to the physical sciences,
    by providing N-dimensional variants of the core pandas data structures.
  dev_url: https://github.com/pydata/xarray
  doc_url: http://xarray.pydata.org
```