### PR TITLE
Add new option --keep-old-work

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -153,6 +153,12 @@ different sets of packages."""
         (locally or in the channels). """
         )
     p.add_argument(
+        '--keep-old-work',
+        action='store_true',
+        help="""Keep any existing, old work directory. Useful if debugging across
+        callstacks involving multiple packages/recipes. """
+    )
+    p.add_argument(
         '-q', "--quiet",
         action="store_true",
         help="do not display progress bar",
@@ -435,7 +441,8 @@ def execute(args, parser):
                     post = None
                 try:
                     build.build(m, post=post,
-                                include_recipe=args.include_recipe)
+                                include_recipe=args.include_recipe,
+                                keep_old_work=args.keep_old_work)
                 except (NoPackagesFound, Unsatisfiable) as e:
                     error_str = str(e)
                     # Typically if a conflict is with one of these


### PR DESCRIPTION
The point is to allow engineers to debug issues with callstacks spanning
multiple conda packages without having to hack conda-build or mess around
with multiple miniconda environments.

The contents of the old work directory are moved into a temporary dir
before the build commences and moved back after it has completed. It was
done this way because the source unpacking logic is fairly hostile to
this kind of change.