### PR TITLE
environ: Make CONDA_PY and CONDA_NPY available in build.sh

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -181,15 +181,20 @@ def conda_build_vars(prefix):
 
 
 def python_vars():
-    return {
+    vars = {
         'PYTHON': config.build_python,
         'PY3K': str(config.PY3K),
         'STDLIB_DIR': get_stdlib_dir(),
         'SP_DIR': get_sp_dir(),
         'PY_VER': get_py_ver(),
-        'NPY_VER': get_npy_ver(),
+        'CONDA_PY': str(config.CONDA_PY),
     }
-
+    # Only define these variables if '--numpy=X.Y' was provided,
+    # otherwise any attempt to use them should be an error.
+    if get_npy_ver():
+        vars['NPY_VER'] = get_npy_ver()
+        vars['CONDA_NPY'] = str(config.CONDA_NPY)
+    return vars
 
 def perl_vars():
     return {


### PR DESCRIPTION
**Update:** In addition to defining `CONDA_PY` and `CONDA_NPY`, this PR now fixes a bug (introduced via c43325f).  Please merge...

----

(This PR is tiny.)

Most of the [environment variables](http://conda.pydata.org/docs/building/environment-vars.html) listed in the conda build docs are available for use in `build.sh`, but `CONDA_PY` and `CONDA_NPY`are missing.  This PR adds them.

These variables can be useful when setting the build string from within `build.sh`, via [`__conda_buildstr__.txt`][1]

[1]: http://conda.pydata.org/docs/building/meta-yaml.html#package-version
