### PR TITLE
OS X: Revert SIP fix for now

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -216,8 +216,10 @@ def get_dict(m=None, prefix=None):
         d['OSX_ARCH'] = 'i386' if cc.bits == 32 else 'x86_64'
         d['CFLAGS'] = cflags + ' -arch %(OSX_ARCH)s' % d
         d['CXXFLAGS'] = cxxflags + ' -arch %(OSX_ARCH)s' % d
-        rpath = ' -Wl,-rpath,%(PREFIX)s/lib' % d # SIP workaround, DYLD_* no longer works.
-        d['LDFLAGS'] = ldflags + rpath + ' -arch %(OSX_ARCH)s' % d
+        # 10.7 install_name_tool -delete_rpath causes broken dylibs, I will revisit this ASAP.
+        #rpath = ' -Wl,-rpath,%(PREFIX)s/lib' % d # SIP workaround, DYLD_* no longer works.
+        #d['LDFLAGS'] = ldflags + rpath + ' -arch %(OSX_ARCH)s' % d
+        d['LDFLAGS'] = ldflags + ' -arch %(OSX_ARCH)s' % d
         d['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
 
     elif sys.platform.startswith('linux'):

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -256,9 +256,10 @@ def mk_relative_osx(path, build_prefix=None):
                              dirname(path)), '').replace('/./', '/')
         macho.add_rpath(path, rpath, verbose = True)
 
+        # 10.7 install_name_tool -delete_rpath causes broken dylibs, I will revisit this ASAP.
         # .. and remove config.build_prefix/lib which was added in-place of
         # DYLD_FALLBACK_LIBRARY_PATH since El Capitan's SIP.
-        macho.delete_rpath(path, config.build_prefix + '/lib', verbose = True)
+        #macho.delete_rpath(path, config.build_prefix + '/lib', verbose = True)
 
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be


### PR DESCRIPTION
@ilanschnell, @msharan, @kalefranz, @pelson, @groutr, @jakirkham, @stuarteberg 

It seems install_name_tool from OS X 10.7 is buggy regarding -delete_rpath. Another way forward will have to be found.

The proper fix (and even detection of the problem - I couldn't get a 10.7 VirtualBox image to work) is going to take a bit of time, I can't look at it for a while and there's no way I can leave things broken for that long. Unfortunately OS X 10.11 users of conda-build will face a minor regression, but that's less important.

I would appreciate it if everyone who's built binaries that have then failed to load could run:
strings $(install_name_tool 2>&1 | cut -d' ' -f2) | grep cctools
or:
strings $(which install_name_tool) | grep cctools
and also give me the md5sum of the real install_name_tool program (note that the first invocation above jumps through some hoops to get the right path since the install_name_tool in /usr/bin is just a stub - xcode-select probably? - to the real program).

Thanks all.