### PR TITLE
fixed race condition between removal and creation of tmp_dir on win

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -10,6 +10,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
 import tarfile
 import fnmatch
 from os.path import exists, isdir, isfile, islink, join
@@ -530,6 +531,8 @@ def test(m, move_broken=True):
 
     tmp_dir = join(config.croot, 'test-tmp_dir')
     rm_rf(tmp_dir)
+    if on_win:
+        time.sleep(1)  # wait for rm_rf(tmp_dir) to finish before recreating tmp_dir
     os.makedirs(tmp_dir)
     create_files(tmp_dir, m)
     # Make Perl or Python-specific test files


### PR DESCRIPTION
I already proposed this PR last fall, but Aaron wanted to implement a better fix. Now, as Aaron has left and the problem still exists, I'm trying again. 

The problem is that Windows removes the test dir asynchronously and can't recreate it before removal is finished, resulting in occasional test failures. I just avoid the problem pragmatically by waiting for a second between the two operations.