### PR TITLE
WIP: Build customization

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -411,6 +411,9 @@ def build(m, get_src=True, post=None, include_recipe=True):
         if get_src:
             source.provide(m.path, m.get_section('source'))
 
+        # set CONDA_DEFAULT_ENV to the build dir, so that jinja2 see the right path
+        os.environ['CONDA_DEFAULT_ENV'] = config.build_prefix
+
         # Parse our metadata again because we did not initialize the source
         # information before.
         # By now, all jinja variables should be defined, so don't permit undefined vars.


### PR DESCRIPTION
# Conda-build Customization

This PR implements a number of enhancements that greatly simplify customization of the build and run requirements of a recipe. The general idea is this:

* the recipe's build requirements should state source compatibility constraints
* constraints on build dependency *binaries* are added at build time via customization
* constraints on run requirements are computed at build time

The PR is not necessarily meant to be merged as-is, but should primarily serve as a solid basis for discussion of customization ideas.

Note: This PR intentionally omits the problems of features, which will be the subject of another proposal.

## Option `--build-config`

This option allows the user to pass a build config file to conda-build via
```
conda build --build-config /path/to/config.yaml   foo
```
`config.yaml` is similar to `meta.yaml`, but only contains the section `requirements/build` (everything else is currently ignored). The contents of this file are simply concatenated to the recipe's build requirements. If this results in multiple lines referring to the same package, all corresponding constraints are joined and must be valid simultaneously. This behavior is already realized in conda's version resolution algorithm, and there is no need for any additional logic to be implemented. Semantically, recipes state the specific requirements of particular packages, whereas config files state requirements to be shared by a family of builds (e.g. (meta)packages that activate desired `track_features` declarations). In an automated deployment system, config files can be auto-generated from a build matrix.

## Option `--bootstrap`

This option allows the user to pass a bootstrap environment to conda-build via
```
conda build --bootstrap some_env_name   foo
```
This behaves like `--build-config`, but the config file is automatically constructed from the given environment: All packages currently installed in `some_env_name` are considered as build requirements of the package to be built, in precisely the version found in the environment. This approach leverages the full power of conda's version resolution logic to free the user from the tedious and error-prone task of maintaining config files manually.

## Jinja2 variable `{{ installed }}`

This variable is a dictionary whose keys are the package names found in the current `_build` environment, and the corresponding values contain the complete metadata from `_build/conda-meta/package_name.json`. This information can be used to configure run requirements in `meta.yaml` at build time with up-to-date information from the build itself:
```yaml
requirements:
  build:
    - zlib
    - jpeg 

  run:
    - zlib  {{ installed['zlib']['version'] }}
    - jpeg  {{ installed['jpeg']['version'] }}
```
This pins the run requirements to the exact dependency versions present during the build. Of course, strict run requirements like this are a bit too pessimistic to be practical, so it is desirable to suitably relax the constraints. A solution using jinja filters is described in the next section. Another good idea would be to adapt the "compatible release" operator `~=` from [PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release) to conda-build, so that one could write
```yaml
  run:
    - zlib  ~={{ installed['zlib']['version'] }}
    - jpeg  ~={{ installed['jpeg']['version'] }}
```
to permit all versions that are considered compatible with the build dependency.

## Jinja2 configuration callback

If the recipe directory contains a file `jinja_config.py` that defines a function `jinja_config(jinja_env)`, this function is called by conda-build just before asking jinja to parse `meta.yaml`. This allows the user to add additional variables and filters to the jinja namespace. A useful application of this capability is a filter that approximates the behavior of the compatible release operator `~=` by transforming a version number like `1.2.3` into a version constraint like `1.2*,>=1.2.3`. A simple implementation of the callback function might look like this:
```python
def jinja_config(jinja_env):

    def compatible_versions(version):
        v = version.split('.')
        if len(v) > 1:
            return v[0]+'.'+v[1]+'*,>='+version
        else:
            return version

    jinja_env.filters['compatible'] = compatible_versions
```
and could be used in `meta.yaml` via the pipe operator `|`
```yaml
  run:
    - zlib  {{ installed['zlib']['version'] | compatible }}
    - jpeg   {{ installed['jpeg']['version'] | compatible }}
```
The callbeck mechanism would provide recipe designers a very useful tool for experimentation with jinja magic. Eventually, the best ideas will be implemented natively within conda-build to make them conveniently accessible to everyone. (Then, the configuration callback will mainly serve as a last resort.)