### PR TITLE
warn on IOError during rewrite_file_with_new_prefix

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1,4 +1,4 @@
-'''
+﻿'''
 Module that does most of the heavy lifting for the ``conda build`` command.
 '''
 from __future__ import absolute_import, division, print_function
@@ -152,9 +152,12 @@ def rewrite_file_with_new_prefix(path, data, old_prefix, new_prefix):
     st = os.stat(path)
     data = data.replace(old_prefix, new_prefix)
     # Save as
-    with open(path, 'wb') as fo:
-        fo.write(data)
-    os.chmod(path, stat.S_IMODE(st.st_mode) | stat.S_IWUSR)  # chmod u+w
+    try:
+        with open(path, 'wb') as fo:
+            fo.write(data)
+        os.chmod(path, stat.S_IMODE(st.st_mode) | stat.S_IWUSR) # chmod u+w
+    except IOError:
+        sys.stderr.write("Failed to rewrite file {} with new prefix.\n".format(path))
     return data
 
 


### PR DESCRIPTION
In creating a recipe for cygwin, there are certain files that give IOError based on permissions.  These are all SSL certificates and strange cache files.  They have no important path rewrite stuff in them.  File list and example output from this PR:

```
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/etc/pki/ca-trust/extracted/pem/email-ca-bundle.pem with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/etc/pki/ca-trust/extracted/pem/objsign-ca-bundle.pem with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/var/cache/rebase/rebase_dyn with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/var/cache/rebase/rebase_exe with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/var/cache/rebase/rebase_lst with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/var/cache/rebase/rebase_pkg with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/var/cache/rebase/rebase_user with new prefix.
Failed to rewrite file C:\Users\builder\Miniconda2_x64\envs\_build\Library/var/cache/rebase/rebase_user_exe with new prefix.
```

Alternatively to this PR, we could allow users to manually specify files to ignore from the path rewriting.