### PR TITLE
environ: Removed invalid assertion.

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -74,7 +74,6 @@ def verify_git_repo(git_dir, git_url, expected_rev='HEAD'):
                                      stderr=STDOUT)
         cache_details = cache_details.decode('utf-8')
         cache_dir = cache_details.split('\n')[0].split()[1]
-        assert "conda-bld/git_cache" in cache_dir
 
         if not isinstance(cache_dir, str):
             # On Windows, subprocess env can't handle unicode.


### PR DESCRIPTION
This assertion in `environ.py` isn't correct because the conda-build root directory might not be `conda-bld` (it might be customized in `.condarc`).  The assertion didn't provide much value anyway, so I'm just removing it.

Fixes the error in conda-forge/nn-feedstock#3.