### PR TITLE
Merge folders if they already exist when packaging a program

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -10,6 +10,7 @@ import operator
 import fnmatch
 from os.path import dirname, getmtime, getsize, isdir, join
 from collections import defaultdict
+import distutils.dir_util
 
 from conda.utils import md5_file
 from conda.compat import PY3, iteritems
@@ -32,7 +33,7 @@ def copy_into(src, dst):
         dstname = os.path.join(dst, afile)
 
         if os.path.isdir(srcname):
-            shutil.copytree(srcname, dstname)
+            distutils.dir_util.copy_tree(srcname, dstname)
         else:
             shutil.copy2(srcname, dstname)
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -8,7 +8,7 @@ import zipfile
 import subprocess
 import operator
 import fnmatch
-from os.path import dirname, getmtime, getsize, isdir, join, is_file
+from os.path import dirname, getmtime, getsize, isdir, join, isfile
 from collections import defaultdict
 import distutils.dir_util
 
@@ -35,7 +35,7 @@ def copy_into(src, dst):
         if os.path.isdir(srcname):
             # make sure we will not replace files while we merge folders
             files_to_be_copied = distutils.dir_util.copy_tree(srcname, dstname, dry_run=1)
-            existing_files = [path for path in files_to_be_copied if is_file(path)]
+            existing_files = [path for path in files_to_be_copied if isfile(path)]
             if existing_files:
                 raise Exception('The following files already exist:\n' +
                                 '\n'.join(existing_files))

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -8,7 +8,7 @@ import zipfile
 import subprocess
 import operator
 import fnmatch
-from os.path import dirname, getmtime, getsize, isdir, join
+from os.path import dirname, getmtime, getsize, isdir, join, exists
 from collections import defaultdict
 import distutils.dir_util
 
@@ -33,7 +33,14 @@ def copy_into(src, dst):
         dstname = os.path.join(dst, afile)
 
         if os.path.isdir(srcname):
-            distutils.dir_util.copy_tree(srcname, dstname)
+            # make sure we will not replace files while we merge folders
+            files_to_be_copied = distutils.dir_util.copy_tree(srcname, dstname, dry_run=1)
+            existing_files = [path for path in files_to_be_copied if exists(path)]
+            if existing_files:
+                raise Exception('The following files already exist:\n' + \
+                                '\n'.join(existing_files))
+            else:
+                distutils.dir_util.copy_tree(srcname, dstname)
         else:
             shutil.copy2(srcname, dstname)
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -8,7 +8,7 @@ import zipfile
 import subprocess
 import operator
 import fnmatch
-from os.path import dirname, getmtime, getsize, isdir, join, exists
+from os.path import dirname, getmtime, getsize, isdir, join, is_file
 from collections import defaultdict
 import distutils.dir_util
 
@@ -35,9 +35,9 @@ def copy_into(src, dst):
         if os.path.isdir(srcname):
             # make sure we will not replace files while we merge folders
             files_to_be_copied = distutils.dir_util.copy_tree(srcname, dstname, dry_run=1)
-            existing_files = [path for path in files_to_be_copied if exists(path)]
+            existing_files = [path for path in files_to_be_copied if is_file(path)]
             if existing_files:
-                raise Exception('The following files already exist:\n' + \
+                raise Exception('The following files already exist:\n' +
                                 '\n'.join(existing_files))
             else:
                 distutils.dir_util.copy_tree(srcname, dstname)

--- a/tests/test-recipes/metadata/conda_build_test.layer1.tier1/bld.bat
+++ b/tests/test-recipes/metadata/conda_build_test.layer1.tier1/bld.bat
@@ -1,0 +1,3 @@
+cd tests\test-recipes\test-3-tier-package_1
+python -B setup.py install
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/conda_build_test.layer1.tier1/build.sh
+++ b/tests/test-recipes/metadata/conda_build_test.layer1.tier1/build.sh
@@ -1,0 +1,3 @@
+cd tests/test-recipes/test-3-tier-package_1
+
+python -B setup.py install

--- a/tests/test-recipes/metadata/conda_build_test.layer1.tier1/meta.yaml
+++ b/tests/test-recipes/metadata/conda_build_test.layer1.tier1/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: conda_build_test.layer1.tier1
+  version: 1.0
+
+source:
+  git_url: ../../../../
+
+requirements:
+  build:
+    - python
+  run:
+    - python

--- a/tests/test-recipes/metadata/conda_build_test.layer1.tier2/bld.bat
+++ b/tests/test-recipes/metadata/conda_build_test.layer1.tier2/bld.bat
@@ -1,0 +1,3 @@
+cd tests\test-recipes\test-2-tier-package_2
+python -B setup.py install
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/conda_build_test.layer1.tier2/build.sh
+++ b/tests/test-recipes/metadata/conda_build_test.layer1.tier2/build.sh
@@ -1,0 +1,3 @@
+cd tests/test-recipes/test-3-tier-package_2
+
+python -B setup.py install

--- a/tests/test-recipes/metadata/conda_build_test.layer1.tier2/meta.yaml
+++ b/tests/test-recipes/metadata/conda_build_test.layer1.tier2/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: conda_build_test.layer1.tier2
+  version: 1.0
+
+source:
+  git_url: ../../../../
+
+requirements:
+  build:
+    - python
+    - conda_build_test.layer1.tier1
+  run:
+    - python

--- a/tests/test-recipes/test-3-tier-package_1/conda_build_test/__init__.py
+++ b/tests/test-recipes/test-3-tier-package_1/conda_build_test/__init__.py
@@ -1,0 +1,3 @@
+# see https://docs.python.org/3/library/pkgutil.html
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/test-recipes/test-3-tier-package_1/conda_build_test/layer1/__init__.py
+++ b/tests/test-recipes/test-3-tier-package_1/conda_build_test/layer1/__init__.py
@@ -1,0 +1,3 @@
+# see https://docs.python.org/3/library/pkgutil.html
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/test-recipes/test-3-tier-package_1/conda_build_test/layer1/tier1/__init__.py
+++ b/tests/test-recipes/test-3-tier-package_1/conda_build_test/layer1/tier1/__init__.py
@@ -1,0 +1,4 @@
+"""
+conda build test package
+"""
+print("conda_build_test.tier1 has been imported")

--- a/tests/test-recipes/test-3-tier-package_1/setup.py
+++ b/tests/test-recipes/test-3-tier-package_1/setup.py
@@ -1,0 +1,22 @@
+from distutils.core import setup
+from setuptools import find_packages
+setup(
+    name="conda_build_test.layer1.tier1",
+    version='1.0',
+    author="Continuum Analytics, Inc.",
+    url="https://github.com/conda/conda-build",
+    license="BSD",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+    ],
+    description="test package for testing conda-build",
+    packages=find_packages(),
+    zip_safe=False
+)

--- a/tests/test-recipes/test-3-tier-package_2/conda_build_test/__init__.py
+++ b/tests/test-recipes/test-3-tier-package_2/conda_build_test/__init__.py
@@ -1,0 +1,3 @@
+# see https://docs.python.org/3/library/pkgutil.html
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/test-recipes/test-3-tier-package_2/conda_build_test/layer1/__init__.py
+++ b/tests/test-recipes/test-3-tier-package_2/conda_build_test/layer1/__init__.py
@@ -1,0 +1,3 @@
+# see https://docs.python.org/3/library/pkgutil.html
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/test-recipes/test-3-tier-package_2/conda_build_test/layer1/tier2/__init__.py
+++ b/tests/test-recipes/test-3-tier-package_2/conda_build_test/layer1/tier2/__init__.py
@@ -1,0 +1,4 @@
+"""
+conda build test package
+"""
+print("conda_build_test.tier2 has been imported")

--- a/tests/test-recipes/test-3-tier-package_2/setup.py
+++ b/tests/test-recipes/test-3-tier-package_2/setup.py
@@ -1,0 +1,22 @@
+from distutils.core import setup
+from setuptools import find_packages
+setup(
+    name="conda_build_test.layer1.tier2",
+    version='1.0',
+    author="Continuum Analytics, Inc.",
+    url="https://github.com/conda/conda-build",
+    license="BSD",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+    ],
+    description="test package for testing conda-build",
+    packages=find_packages(),
+    zip_safe=False
+)


### PR DESCRIPTION
This patch prevents conda from complaining that a folder 
already exists when trying to package a program.
Fixes conda/conda-build#858