### PR TITLE
Attempting to improve the logic for VS on Win

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -99,14 +99,14 @@ def msvc_env_cmd(bits, override=None):
         msvc_env_lines.append(vcvars_cmd)
     elif version == '9.0':
         # First, check for Microsoft Visual C++ Compiler for Python 2.7
-        localappdata = os.getenv('localappdata', program_files)
+        localappdata = os.getenv('localappdata', os.path.abspath(os.sep))
         vs_tools_py_local_path = os.path.join(
             localappdata, 'Programs', 'Common', 'Microsoft', 
             'Visual C++ for Python', '9.0', 'vcvarsall.bat')
         msvc_env_lines.append(build_vcvarsall_cmd(vs_tools_py_local_path))
         
         vs_tools_py_common_path = os.path.join(
-            localappdata, 'Common Files', 'Microsoft', 'Visual C++ for Python', 
+            program_files, 'Common Files', 'Microsoft', 'Visual C++ for Python', 
             '9.0', 'vcvarsall.bat')
         msvc_env_lines.append('if errorlevel 1 {}'.format(
             build_vcvarsall_cmd(vs_tools_py_common_path)))

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -83,7 +83,6 @@ def msvc_env_cmd(bits, override=None):
                       format(program_files=program_files))
         vcvars_cmd += '\nif errorlevel 1 {win_sdk_cmd}'.format(win_sdk_cmd=win_sdk_cmd)
         msvc_env_lines.append(vcvars_cmd)
-        not_vcvars = not isfile(vcvarsall)
     elif version == '9.0':
         # First, check for Microsoft Visual C++ Compiler for Python 2.7
         localappdata = os.getenv("localappdata", "C:\\")

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -99,7 +99,7 @@ def msvc_env_cmd(bits, override=None):
         msvc_env_lines.append(vcvars_cmd)
     elif version == '9.0':
         # First, check for Microsoft Visual C++ Compiler for Python 2.7
-        localappdata = os.getenv('localappdata', 'C:\\')
+        localappdata = os.getenv('localappdata', program_files)
         vs_tools_py_local_path = os.path.join(
             localappdata, 'Programs', 'Common', 'Microsoft', 
             'Visual C++ for Python', '9.0', 'vcvarsall.bat')

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -82,9 +82,9 @@ def msvc_env_cmd(bits, override=None):
         
         # Note that we explicitly want "Program Files" and not 
         # "Program Files (x86)"
-        win_sdk_bat_path = os.path.join(os.environ['ProgramFiles'], 
-                                        'Microsoft SDKs',  'Windows', 'v7.1', 
-                                        'Bin', 'SetEnv.cmd')
+        win_sdk_bat_path = os.path.join(os.path.abspath(os.sep),
+                                        'Program Files', 'Microsoft SDKs',
+                                        'Windows', 'v7.1', 'Bin', 'SetEnv.cmd')
         # Unfortunately, the Windows SDK takes a different command format for
         # the arch selector - debug is default so explicitly set 'Release'
         win_sdk_arch = '/x86 /Release' if bits == 32 else '/x64 /Release'

--- a/tests/test_win_vs_activate.py
+++ b/tests/test_win_vs_activate.py
@@ -24,12 +24,9 @@ if sys.platform == "win32":
     # VC9 compiler for python - common files
     vcvars_backup_files["python_system"] = [os.path.join(program_files, 'Common Files',
                     'Microsoft', 'Visual C++ for Python', "9.0", "vcvarsall.bat")]
-    # Windows SDK 7.1
-    vcvars_backup_files["win71sdk"] = ["{program_files}\\Microsoft SDKs\\Windows\\v7.1\\Bin\\SetEnv.cmd".\
-                                      format(program_files=program_files)]
 
     vs9  = {key:vcvars_backup_files[key] for key in ['vs9.0', 'python_local', 'python_system']}
-    vs10 = {key:vcvars_backup_files[key] for key in ['vs10.0', 'win71sdk']}
+    vs10 = {key:vcvars_backup_files[key] for key in ['vs10.0']}
     vs14 = {key:vcvars_backup_files[key] for key in ['vs14.0']}
 
     vcs = {"9.0": vs9, "10.0": vs10, "14.0": vs14}


### PR DESCRIPTION
Both VS9 and VS10 do not work out of the box for 64-bit builds.
This should try and remedy that. For VS9 it prefers the
Microsoft Visual C++ Compiler for Python 2.7 and when
falling back VS9 will call the correct bat file manually, rather
than relying on the broken logic in vcvarsall.bat.

For VS10, it will correctly call the Windows SDK rather than
relying on the also potentially incorrect vcvarsall.bat.

This was pretty difficult to test in my VM because I broke
it trying to test the different combinations. I need to create
a clean image and try each of the scenarios. 

What would be the best way to test this? I guess builds
need to be kicked off on Appveyor?