### PR TITLE
Display a nice error message for all yaml parsing errors, not just ParserError

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -97,7 +97,7 @@ Error: Invalid selector in meta.yaml line %d:
 def yamlize(data):
     try:
         return yaml.load(data, Loader=BaseLoader)
-    except yaml.parser.ParserError as e:
+    except yaml.error.YAMLError as e:
         if '{{' in data:
             try:
                 import jinja2


### PR DESCRIPTION
If `yamlize()` fails to parse `meta.yaml`, we'd like to show a nice error message.  But at the moment, `conda-build` only detects `yaml.parser.ParserError`.  Other errors from `yaml`, such as `ScannerError`, just trigger a normal traceback.

This one-line PR checks for `yaml.error.YAMLError` instead, which is the base class for all `yaml` errors.

Closes #860.