### PR TITLE
use memory map rather than read() to reduce memory usage.

### DIFF
--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -39,8 +39,8 @@ def rewrite_script(fn):
         fn = fn[:-10]
 
     # Check that it does have a #! python string, and skip it
-    m = SHEBANG_PAT.match(data)
-    if m and 'python' in m.group():
+    m = SHEBANG_PAT.match(data.encode('ascii'))
+    if m and b'python' in m.group():
         new_data = data[data.find('\n') + 1:]
     elif ISWIN:
         new_data = data

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -31,8 +31,7 @@ if sys.platform.startswith('linux'):
 elif sys.platform == 'darwin':
     from conda_build import macho
 
-SHEBANG_PAT = re.compile(r'^#!.+$', re.M)
-
+SHEBANG_PAT = re.compile(br'^#!.+$', re.M)
 
 def is_obj(path):
     assert sys.platform != 'win32'
@@ -58,7 +57,7 @@ def fix_shebang(f, osx_is_app=False):
         mm = mmap.mmap(fi.fileno(), 0)
         m = SHEBANG_PAT.match(mm)
 
-        if not (m and 'python' in m.group()):
+        if not (m and b'python' in m.group()):
             return
 
         data = mm[:]
@@ -66,7 +65,7 @@ def fix_shebang(f, osx_is_app=False):
     py_exec = ('/bin/bash ' + config.build_prefix + '/bin/python.app'
                if sys.platform == 'darwin' and osx_is_app else
                config.build_prefix + '/bin/' + basename(config.build_python))
-    new_data = SHEBANG_PAT.sub('#!' + py_exec, data, count=1)
+    new_data = SHEBANG_PAT.sub(b'#!' + py_exec.encode('ascii'), data, count=1)
     if new_data == data:
         return
     print("updating shebang:", f)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -15,6 +15,7 @@ except ImportError:
 import io
 from subprocess import call
 from collections import defaultdict
+import mmap
 
 from conda_build.config import config
 from conda_build import external
@@ -45,14 +46,22 @@ def fix_shebang(f, osx_is_app=False):
         return
     elif os.path.islink(path):
         return
-    with io.open(path, encoding=locale.getpreferredencoding()) as fi:
+
+    with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
         try:
-            data = fi.read()
-        except UnicodeDecodeError: # file is binary
+            data = fi.read(100)
+        except UnicodeDecodeError:  # file is binary
             return
-    m = SHEBANG_PAT.match(data)
-    if not (m and 'python' in m.group()):
-        return
+
+        # regexp on the memory mapped file so we only read it into
+        # memory if the regexp matches.
+        mm = mmap.mmap(fi.fileno(), 0)
+        m = SHEBANG_PAT.match(mm)
+
+        if not (m and 'python' in m.group()):
+            return
+
+        data = mm[:]
 
     py_exec = ('/bin/bash ' + config.build_prefix + '/bin/python.app'
                if sys.platform == 'darwin' and osx_is_app else
@@ -323,7 +332,6 @@ def post_build(m, files):
             mk_relative(m, f)
 
     check_symlinks(files)
-
 
 def check_symlinks(files):
     if readlink is False:


### PR DESCRIPTION
currently conda-build uses `data = fi.read()` on an entire file. It then uses `data = data.replace(a, b)`
even if `a` is never found in the file. The replace means that two copies of the entire data file are in memory at that point.

This uses a memory-map instead of fi.read() and only incurs the memory cost of the `.replace()` if the `a` is found in the file.