### PR TITLE
fix svn url on Windows in checkout tool test

### DIFF
--- a/tests/test-recipes/metadata/_checkout_tool_as_dependency/meta.yaml
+++ b/tests/test-recipes/metadata/_checkout_tool_as_dependency/meta.yaml
@@ -1,9 +1,11 @@
+{% set recipe_dir = RECIPE_DIR if unix else "/" ~ RECIPE_DIR.replace("\\", "/") %}
+
 package:
   name: test-checkout-tool-as-dependency
   version: 1.0
 
 source:
-  svn_url: file://{{ RECIPE_DIR }}/_svn_repo/dummy
+  svn_url: file://{{ recipe_dir }}/_svn_repo/dummy
   svn_rev: 1
 
 requirements:


### PR DESCRIPTION
On Windows, SVN was unhappy that we were feeding it urls like

    file://c:\path\to\recipe

it wants

    file:///c:/path/to/recipe

ping @mjuric