### PR TITLE
handle empty files. closes #868

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -107,6 +107,10 @@ def have_prefix_files(files):
             # skip symbolic links (as we can on Linux)
             continue
 
+        # dont try to mmap an empty file
+        if os.stat(path).st_size == 0:
+            continue
+
         fi = open(path, 'rb+')
         mm = mmap.mmap(fi.fileno(), 0)
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -46,6 +46,9 @@ def fix_shebang(f, osx_is_app=False):
     elif os.path.islink(path):
         return
 
+    if os.stat(path).st_size == 0:
+        return
+
     with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
         try:
             data = fi.read(100)


### PR DESCRIPTION
This adds an empty file to one of the recipes. Without this fix, the error reported in #868 manifests in tests/test_build_recipes.py

Any suggestions on how to test better? How/where to check if `empty.py` appears in the .bz2