### PR TITLE
VS_YEAR, VS_VERSION, VS_MAJOR and CMAKE_GENERATOR Env Variables

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -287,6 +287,7 @@ def unix_vars(prefix):
     return {
         'HOME': os.getenv('HOME', 'UNKNOWN'),
         'PKG_CONFIG_PATH': join(prefix, 'lib', 'pkgconfig'),
+        'CMAKE_GENERATOR': 'Unix Makefiles',
         'R': join(prefix, 'bin', 'R'),
     }
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -34,6 +34,14 @@ VS_TOOLS_PY_COMMON_PATH = os.path.join(PROGRAM_FILES_PATH, 'Common Files',
 VCVARS64_VS9_BAT_PATH = os.path.join(PROGRAM_FILES_PATH,
                                      'Microsoft Visual Studio 9.0', 'VC', 'bin',
                                      'vcvars64.bat')
+VS_VERSION_STRING = {
+    '8.0': 'Visual Studio 8 2005',
+    '9.0': 'Visual Studio 9 2008',
+    '10.0': 'Visual Studio 10 2010',
+    '11.0': 'Visual Studio 11 2012',
+    '12.0': 'Visual Studio 12 2013',
+    '14.0': 'Visual Studio 14 2015'
+}
 
 
 def build_vcvarsall_vs_path(version):
@@ -104,6 +112,10 @@ def msvc_env_cmd(bits, override=None):
         return 'call "{cmd}" {arch}'.format(cmd=cmd, arch=arch)
 
     msvc_env_lines.append('set VS_VERSION="{}"'.format(version))
+    msvc_env_lines.append('set VS_MAJOR="{}"'.format(version.split('.')[0]))
+    msvc_env_lines.append('set VS_YEAR="{}"'.format(VS_VERSION_STRING[version][-4:]))
+    msvc_env_lines.append('set CMAKE_GENERATOR="{}"'.format(VS_VERSION_STRING[version] +
+                                                            {64: ' Win64', 32: ''}[bits]))
     if version == '10.0':
         # Unfortunately, the Windows SDK takes a different command format for
         # the arch selector - debug is default so explicitly set 'Release'

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -103,6 +103,7 @@ def msvc_env_cmd(bits, override=None):
     def build_vcvarsall_cmd(cmd, arch=arch_selector):
         return 'call "{cmd}" {arch}'.format(cmd=cmd, arch=arch)
 
+    msvc_env_lines.append('set VS_VERSION="{}"'.format(version))
     if version == '10.0':
         # Unfortunately, the Windows SDK takes a different command format for
         # the arch selector - debug is default so explicitly set 'Release'

--- a/tests/test_win_vs_activate.py
+++ b/tests/test_win_vs_activate.py
@@ -6,24 +6,20 @@ import sys
 
 import pytest
 
-vcvars_backup_files={}
+vcvars_backup_files = {}
 if sys.platform == "win32":
-    if 'ProgramFiles(x86)' in os.environ:
-        program_files = os.environ['ProgramFiles(x86)']
-    else:
-        program_files = os.environ['ProgramFiles']
+    from conda_build.windows import (build_vcvarsall_vs_path,
+                                     VCVARS64_VS9_BAT_PATH,
+                                     VS_TOOLS_PY_LOCAL_PATH,
+                                     VS_TOOLS_PY_COMMON_PATH)
 
-    vcvars_backup_files = {"vs{}".format(version): [os.path.join(program_files,
-                                  'Microsoft Visual Studio {version}'.format(version=version),
-                                  'VC', 'vcvarsall.bat')] for version in ["9.0", "10.0", "14.0"]}
-    vcvars_backup_files['vs9.0'].append(os.path.dirname(vcvars_backup_files['vs9.0'][0])+"\\bin\\vcvars64.bat")
+    vcvars_backup_files = {"vs{}".format(version): [build_vcvarsall_vs_path(version)]
+                           for version in ["9.0", "10.0", "14.0"]}
+    vcvars_backup_files['vs9.0'].append(VCVARS64_VS9_BAT_PATH)
     # VC9 compiler for python - local user install
-    localappdata = os.environ.get("localappdata")
-    vcvars_backup_files["python_local"] = [os.path.join(localappdata, 'Programs', 'Common',
-                    'Microsoft', 'Visual C++ for Python', "9.0", "vcvarsall.bat")]
+    vcvars_backup_files["python_local"] = [VS_TOOLS_PY_LOCAL_PATH]
     # VC9 compiler for python - common files
-    vcvars_backup_files["python_system"] = [os.path.join(program_files, 'Common Files',
-                    'Microsoft', 'Visual C++ for Python', "9.0", "vcvarsall.bat")]
+    vcvars_backup_files["python_system"] = [VS_TOOLS_PY_COMMON_PATH]
 
     vs9  = {key:vcvars_backup_files[key] for key in ['vs9.0', 'python_local', 'python_system']}
     vs10 = {key:vcvars_backup_files[key] for key in ['vs10.0']}

--- a/tests/test_win_vs_activate.py
+++ b/tests/test_win_vs_activate.py
@@ -96,6 +96,7 @@ def test_activation(bits, compiler):
     #     this is effectively the test condition for all below tests.
     with open('tmp_call.bat', "w") as f:
         f.write(msvc_env_cmd(bits, compiler_version))
+        f.write('\nif not %VS_VERSION% == "{}" exit /b 1'.format(compiler_version))
 
     try:
         subprocess.check_call(['cmd.exe', '/C', 'tmp_call.bat'], shell=True)


### PR DESCRIPTION
Following up from my work in #861, this does two things:

  1. Refactor the path logic so that the paths are defined once at the top of the `windows.py` file. This should reduce the risk of the tests going out of sync with the file.
  2. Add a new ENV variable `VS_VERSION` that supplies the visual studio version (9.0, 10.0, 12.0, 14.0 etc). This should remove the need for the 'black magic' from the Wiki as the user is supplied with whatever VS version command was run.

If everyone is happy with this then I will also add it to the documentation.