### PR TITLE
Update config.py to increase placeholder limit to 128

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -57,7 +57,7 @@ class Config(object):
         croot = abspath(expanduser('~/conda-bld'))
 
     short_build_prefix = join(cc.envs_dirs[0], '_build')
-    long_build_prefix = max(short_build_prefix, (short_build_prefix + 8 * '_placehold')[:80])
+    long_build_prefix = max(short_build_prefix, (short_build_prefix + 8 * '_placehold')[:128])
     # XXX: Make this None to be more rigorous about requiring the build_prefix
     # to be known before it is used.
     use_long_build_prefix = False

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -57,7 +57,7 @@ class Config(object):
         croot = abspath(expanduser('~/conda-bld'))
 
     short_build_prefix = join(cc.envs_dirs[0], '_build')
-    long_build_prefix = max(short_build_prefix, (short_build_prefix + 8 * '_placehold')[:128])
+    long_build_prefix = max(short_build_prefix, (short_build_prefix + 25 * '_placehold')[:255])
     # XXX: Make this None to be more rigorous about requiring the build_prefix
     # to be known before it is used.
     use_long_build_prefix = False


### PR DESCRIPTION
Recently hit this 80 character placeholder limit and was hoping to at least increase it to 128.  From this discussion, it sounds like >128 is not deemed useful on Linux systems.
https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/fgDBJ2YwETI