### PR TITLE
Fix skip-existing with custom build string.

### DIFF
--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -143,7 +143,7 @@ def set_language_env_vars(args, parser, execute=None):
             os.environ[var] = str(getattr(config, var))
 
 
-def parse_or_try_download(metadata, no_download_source):
+def parse_or_try_download(metadata, no_download_source=True):
     try:
         metadata.parse_again(permit_undefined_jinja=False)
     except SystemExit:
@@ -205,7 +205,7 @@ def render_recipe(recipe_path, no_download_source=True):
 
 def get_package_build_string(metadata):
     import conda_build.build as build
-    metadata = parse_or_try_download(metadata)
+    metadata = parse_or_try_download(metadata, no_download_source=True)
     return build.bldpkg_path(metadata)
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -139,7 +139,7 @@ def ensure_valid_fields(meta):
     if pin_depends not in ('', 'record', 'strict'):
         raise RuntimeError("build/pin_depends cannot be '%s'" % pin_depends)
 
-def parse(data):
+def parse(data, path=None):
     data = select_lines(data, ns_cfg())
     res = yamlize(data)
     # ensure the result is a dict
@@ -149,8 +149,8 @@ def parse(data):
         if field not in res:
             continue
         if not isinstance(res[field], dict):
-            raise RuntimeError("The %s field should be a dict, not %s" %
-                               (field, res[field].__class__.__name__))
+            raise RuntimeError("The %s field should be a dict, not %s in file %s." %
+                               (field, res[field].__class__.__name__, path))
 
 
 
@@ -325,7 +325,7 @@ class MetaData(object):
         # Start with bare-minimum contents so we can call environ.get_dict() with impunity
         # We'll immediately replace these contents in parse_again()
         self.meta = parse("package:\n"
-                          "  name: uninitialized")
+                          "  name: uninitialized", path=self.meta_path)
 
         # This is the 'first pass' parse of meta.yaml, so not all variables are defined yet
         # (e.g. GIT_FULL_HASH, etc. are undefined)
@@ -342,7 +342,7 @@ class MetaData(object):
         """
         if not self.meta_path:
             return
-        self.meta = parse(self._get_contents(permit_undefined_jinja))
+        self.meta = parse(self._get_contents(permit_undefined_jinja), path=self.meta_path)
 
         if (isfile(self.requirements_path) and
                    not self.meta['requirements']['run']):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -148,6 +148,9 @@ def parse(data, path=None):
     for field in FIELDS:
         if field not in res:
             continue
+        # ensure that empty fields are dicts (otherwise selectors can cause invalid fields)
+        if not res[field]:
+            res[field] = {}
         if not isinstance(res[field], dict):
             raise RuntimeError("The %s field should be a dict, not %s in file %s." %
                                (field, res[field].__class__.__name__, path))

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -23,10 +23,16 @@ rm_rf
 def find_recipe(path):
     """recurse through a folder, locating meta.yaml.  Raises error if more than one is found.
 
-    Returns folder containing meta.yaml, to be built."""
+    Returns folder containing meta.yaml, to be built.
+
+    If we have a base level meta.yaml and other supplemental ones, use that first"""
     results = rec_glob(path, ["meta.yaml", "conda.yaml"])
     if len(results) > 1:
-        raise IOError("More than one meta.yaml files found in %s" % path)
+        base_recipe = os.path.join(path, "meta.yaml")
+        if base_recipe in results:
+            return base_recipe
+        else:
+            raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:
         raise IOError("No meta.yaml files found in %s" % path)
     return os.path.dirname(results[0])

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -30,7 +30,7 @@ def find_recipe(path):
     if len(results) > 1:
         base_recipe = os.path.join(path, "meta.yaml")
         if base_recipe in results:
-            return base_recipe
+            return os.path.dirname(base_recipe)
         else:
             raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:


### PR DESCRIPTION
This PR fixes a bug in the skip-existing code: if a custom build string was used, it could happen that e.g. `PKG_BUILDNUM` was not initialized. Hence, skip-existing was assuming a wrong package name and errorneously assumed the package was either already present or vice versa. 

Thanks!
Johannes Köster

EDIT: The PR also includes a small improvement to an error message and a fix for a regression introduced in 1.20.1 (see the comments in the diff).