### PR TITLE
Fix --skip-existing since channel prefixes

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -395,7 +395,7 @@ def execute(args, parser):
             if args.check:
                 continue
             if args.skip_existing:
-                if m.pkg_fn() in index or m.pkg_fn() in already_built:
+                if 'local::'+m.pkg_fn() in index or m.pkg_fn() in already_built:
                     print("%s is already built, skipping." % m.dist())
                     continue
             if m.skip():


### PR DESCRIPTION
@mcg1969, @kalefranz, please review.

Now, local packages have a 'local::' prefix so we must add
that when checking for a package in the index.
