### PR TITLE
Add MSYS2 path translation exclusion for CL with MSVC builds

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -223,7 +223,6 @@ def execute(args, parser):
             if not isdir(d):
                 makedirs(d)
             update_index(d)
-        index = build.get_build_index(clear_cache=True)
 
     already_built = []
     to_build_recursive = []
@@ -258,6 +257,7 @@ def execute(args, parser):
             m = render_recipe(recipe_dir, no_download_source=False)
             if m.get_value('build/noarch_python'):
                 config.noarch = True
+
             if args.check and len(args.recipe) > 1:
                 print(m.path)
             m.check_fields()

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -111,17 +111,15 @@ def msvc_env_cmd(bits, override=None):
     def build_vcvarsall_cmd(cmd, arch=arch_selector):
         return 'call "{cmd}" {arch}'.format(cmd=cmd, arch=arch)
 
-    msvc_env_lines.append('set VS_VERSION="{}"'.format(version))
-    msvc_env_lines.append('set VS_MAJOR="{}"'.format(version.split('.')[0]))
-    msvc_env_lines.append('set VS_YEAR="{}"'.format(VS_VERSION_STRING[version][-4:]))
-    msvc_env_lines.append('set CMAKE_GENERATOR="{}"'.format(VS_VERSION_STRING[version] +
+    msvc_env_lines.append('set "VS_VERSION={}"'.format(version))
+    msvc_env_lines.append('set "VS_MAJOR={}"'.format(version.split('.')[0]))
+    msvc_env_lines.append('set "VS_YEAR={}"'.format(VS_VERSION_STRING[version][-4:]))
+    msvc_env_lines.append('set "CMAKE_GENERATOR={}"'.format(VS_VERSION_STRING[version] +
                                                             {64: ' Win64', 32: ''}[bits]))
     if version == '10.0':
-        # Unfortunately, the Windows SDK takes a different command format for
-        # the arch selector - debug is default so explicitly set 'Release'
-        win_sdk_arch = '/x86 /Release' if bits == 32 else '/x64 /Release'
+        win_sdk_arch = '/Release /x86' if bits == 32 else '/Release /x64'
         win_sdk_cmd = build_vcvarsall_cmd(WIN_SDK_BAT_PATH, arch=win_sdk_arch)
-        
+
         # Always call the Windows SDK first - if VS 2010 exists but was
         # installed using the broken installer then it will try and call the 
         # vcvars script, which will fail but NOT EXIT 1. To work around this,
@@ -134,7 +132,6 @@ def msvc_env_cmd(bits, override=None):
 
         # First, check for Microsoft Visual C++ Compiler for Python 2.7
         msvc_env_lines.append(build_vcvarsall_cmd(VS_TOOLS_PY_LOCAL_PATH))
-        
         msvc_env_lines.append(error1.format(
             build_vcvarsall_cmd(VS_TOOLS_PY_COMMON_PATH)))
         # The Visual Studio 2008 Express edition does not properly contain

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -115,6 +115,9 @@ def msvc_env_cmd(bits, override=None):
     msvc_env_lines.append('set "VS_YEAR={}"'.format(VS_VERSION_STRING[version][-4:]))
     msvc_env_lines.append('set "CMAKE_GENERATOR={}"'.format(VS_VERSION_STRING[version] +
                                                             {64: ' Win64', 32: ''}[bits]))
+    # tell msys2 to ignore path conversions for issue-causing windows-style flags in build
+    #   See https://github.com/conda-forge/icu-feedstock/pull/5
+    msvc_env_lines.append('set MSYS2_ARG_CONV_EXCL="/AI;/AL;/OUT;%MSYS2_ARG_CONV_EXCL%"')
     if version == '10.0':
         win_sdk_arch = '/Release /x86' if bits == 32 else '/Release /x64'
         win_sdk_cmd = build_vcvarsall_cmd(WIN_SDK_BAT_PATH, arch=win_sdk_arch)
@@ -150,10 +153,6 @@ def msvc_env_cmd(bits, override=None):
     else:
         # Visual Studio 14 or otherwise
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
-
-    # tell msys2 to ignore path conversions for issue-causing windows-style flags in build
-    #   See https://github.com/conda-forge/icu-feedstock/pull/5
-    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;%MSYS2_ARG_CONV_EXCL%"')
 
     return '\n'.join(msvc_env_lines)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -117,7 +117,8 @@ def msvc_env_cmd(bits, override=None):
                                                             {64: ' Win64', 32: ''}[bits]))
     # tell msys2 to ignore path conversions for issue-causing windows-style flags in build
     #   See https://github.com/conda-forge/icu-feedstock/pull/5
-    msvc_env_lines.append('set MSYS2_ARG_CONV_EXCL="/AI;/AL;/OUT;%MSYS2_ARG_CONV_EXCL%"')
+    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out;%MSYS2_ARG_CONV_EXCL%"')
+    msvc_env_lines.append('set "MSYS2_ENV_CONV_EXCL=CL"')
     if version == '10.0':
         win_sdk_arch = '/Release /x86' if bits == 32 else '/Release /x64'
         win_sdk_cmd = build_vcvarsall_cmd(WIN_SDK_BAT_PATH, arch=win_sdk_arch)

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -119,10 +119,6 @@ def msvc_env_cmd(bits, override=None):
         win_sdk_arch = '/Release /x86' if bits == 32 else '/Release /x64'
         win_sdk_cmd = build_vcvarsall_cmd(WIN_SDK_BAT_PATH, arch=win_sdk_arch)
 
-        # win sdk activation adds stuff to CL that breaks builds (/AI)
-        #   See https://github.com/conda-forge/icu-feedstock/pull/5
-        msvc_env_lines.append('set "CONDA_CL_BACKUP=%CL%"')
-
         # Always call the Windows SDK first - if VS 2010 exists but was
         # installed using the broken installer then it will try and call the 
         # vcvars script, which will fail but NOT EXIT 1. To work around this,
@@ -130,10 +126,6 @@ def msvc_env_cmd(bits, override=None):
         # will overwrite any environemnt variables it needs, if necessary.
         msvc_env_lines.append(win_sdk_cmd)
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
-
-        # restore any user setting of CL prior to SDK activation
-        msvc_env_lines.append('set "CL=%CONDA_CL_BACKUP%"')
-        msvc_env_lines.append('set "CONDA_CL_BACKUP="')
 
     elif version == '9.0':
         error1 = 'if errorlevel 1 {}'
@@ -158,6 +150,10 @@ def msvc_env_cmd(bits, override=None):
     else:
         # Visual Studio 14 or otherwise
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
+
+    # convert slashes to dashes so that MSYS2 does not misinterpret them as paths.
+    #   See https://github.com/conda-forge/icu-feedstock/pull/5
+    msvc_env_lines.append('set "CL=%CL:/=-%"')
 
     return '\n'.join(msvc_env_lines)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -21,9 +21,8 @@ else:
     PROGRAM_FILES_PATH = os.environ['ProgramFiles']
 
 # Note that we explicitly want "Program Files" and not "Program Files (x86)"
-WIN_SDK_BAT_PATH = os.path.join(os.path.abspath(os.sep),
-                                'Program Files', 'Microsoft SDKs',
-                                'Windows', 'v7.1', 'Bin', 'SetEnv.cmd')
+WIN_SDK_BAT_PATH = os.path.join(PROGRAM_FILES_PATH.replace(" (x86)", ""),
+                                'Microsoft SDKs', 'Windows', 'v7.1', 'Bin', 'SetEnv.cmd')
 VS_TOOLS_PY_LOCAL_PATH = os.path.join(
     os.getenv('localappdata', os.path.abspath(os.sep)),
     'Programs', 'Common', 'Microsoft', 'Visual C++ for Python', '9.0',

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -151,9 +151,9 @@ def msvc_env_cmd(bits, override=None):
         # Visual Studio 14 or otherwise
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
 
-    # convert slashes to dashes so that MSYS2 does not misinterpret them as paths.
+    # tell msys2 to ignore path conversions for issue-causing windows-style flags in build
     #   See https://github.com/conda-forge/icu-feedstock/pull/5
-    msvc_env_lines.append('set "CL=%CL:/=-%"')
+    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=“/AI;/AL;/OUT;%MSYS2_ARG_CONV_EXCL%"')
 
     return '\n'.join(msvc_env_lines)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -153,7 +153,7 @@ def msvc_env_cmd(bits, override=None):
 
     # tell msys2 to ignore path conversions for issue-causing windows-style flags in build
     #   See https://github.com/conda-forge/icu-feedstock/pull/5
-    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=“/AI;/AL;/OUT;%MSYS2_ARG_CONV_EXCL%"')
+    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;%MSYS2_ARG_CONV_EXCL%"')
 
     return '\n'.join(msvc_env_lines)
 

--- a/tests/test-recipes/metadata/_cmake_generator/CMakeLists.txt
+++ b/tests/test-recipes/metadata/_cmake_generator/CMakeLists.txt
@@ -1,0 +1,5 @@
+PROJECT(HELLO)
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+
+add_executable(hello hello.c)

--- a/tests/test-recipes/metadata/_cmake_generator/bld.bat
+++ b/tests/test-recipes/metadata/_cmake_generator/bld.bat
@@ -1,0 +1,7 @@
+where cl.exe
+where link.exe
+:: maybe informative for MinGW?
+where gcc.exe
+
+cmake -G "%CMAKE_GENERATOR:"=%" "%RECIPE_DIR%"
+cmake --build . --config Release

--- a/tests/test-recipes/metadata/_cmake_generator/build.sh
+++ b/tests/test-recipes/metadata/_cmake_generator/build.sh
@@ -1,0 +1,2 @@
+cmake -G "$CMAKE_GENERATOR" $RECIPE_DIR
+cmake --build . --config Release

--- a/tests/test-recipes/metadata/_cmake_generator/hello.c
+++ b/tests/test-recipes/metadata/_cmake_generator/hello.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello world!\n");
+}

--- a/tests/test-recipes/metadata/_cmake_generator/meta.yaml
+++ b/tests/test-recipes/metadata/_cmake_generator/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: conda-build-test-cmake-generator
+  version: 1.0
+
+requirements:
+  build:
+    - cmake

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -78,6 +78,20 @@ exit -1
         shutil.rmtree(tmpdir)
 
 
+platforms = ["64" if sys.maxsize > 2**32 else "32"]
+if sys.platform=="win32":
+    platforms = set(["32",] + platforms)
+    compilers = ["2.7", "3.4", "3.5"]
+else:
+    compilers = [".".join([str(sys.version_info.major), str(sys.version_info.minor)])]
+
+@pytest.mark.parametrize("platform", platforms)
+@pytest.mark.parametrize("target_compiler", compilers)
+def test_cmake_generator(platform, target_compiler):
+    # TODO: need a better way to specify compiler more directly on win
+    cmd = 'conda build --no-anaconda-upload {}/_cmake_generator --python={}'.format(metadata_dir, target_compiler)
+    subprocess.check_call(cmd.split())
+
 
 @pytest.mark.skipif(sys.platform=="win32",
                     reason="No windows symlinks")
@@ -88,6 +102,7 @@ def test_symlink_fail():
     output, error = process.communicate()
     error = error.decode('utf-8')
     assert error.count("Error") == 6
+
 
 @pytest.mark.skipif(sys.platform=="win32",
                     reason="Windows doesn't show this error")

--- a/tests/test_win_vs_activate.py
+++ b/tests/test_win_vs_activate.py
@@ -96,10 +96,10 @@ def test_activation(bits, compiler):
     #     this is effectively the test condition for all below tests.
     with open('tmp_call.bat', "w") as f:
         f.write(msvc_env_cmd(bits, compiler_version))
-        f.write('\nif not %VS_VERSION% == "{}" exit /b 1'.format(compiler_version))
-        f.write('\nif not %VS_MAJOR% == "{}" exit /b 1'.format(compiler_version.split('.')[0]))
-        f.write('\nif not %VS_YEAR% == "{}" exit /b 1'.format(VS_VERSION_STRING[compiler_version][-4:]))
-        f.write('\nif not %CMAKE_GENERATOR% == "{}" exit /b 1'.format(VS_VERSION_STRING[compiler_version] +
+        f.write('\nif not "%VS_VERSION%" == "{}" exit /b 1'.format(compiler_version))
+        f.write('\nif not "%VS_MAJOR%" == "{}" exit /b 1'.format(compiler_version.split('.')[0]))
+        f.write('\nif not "%VS_YEAR%" == "{}" exit /b 1'.format(VS_VERSION_STRING[compiler_version][-4:]))
+        f.write('\nif not "%CMAKE_GENERATOR%" == "{}" exit /b 1'.format(VS_VERSION_STRING[compiler_version] +
                                                                       {64: ' Win64', 32: ''}[bits]))
     try:
         subprocess.check_call(['cmd.exe', '/C', 'tmp_call.bat'], shell=True)


### PR DESCRIPTION
This might work - needs testing.  If it doesn't, I think we might need to remove the /Release flag (but this really should work: https://msdn.microsoft.com/en-us/library/ff660764(v=vs.100).aspx)

ping @patricksnape @jakirkham - is there a good way for us to test this with conda-forge?