### PR TITLE
Remove cygwin from conda build's search path

### DIFF
--- a/conda_build/external.py
+++ b/conda_build/external.py
@@ -16,7 +16,7 @@ def find_executable(executable):
                      join(config.build_prefix, 'Library\\bin'),
                      join(cc.root_dir, 'Scripts'),
                      join(cc.root_dir, 'Library\\bin'),
-                     'C:\\cygwin\\bin']
+                    ]
     else:
         dir_paths = [join(config.build_prefix, 'bin'),
                      join(cc.root_dir, 'bin'),]


### PR DESCRIPTION
This can cause crashes with some programs, e.g. git.  We should not do this - we should only put our own environment on PATH.  If anyone wants cygwin, they can add it themselves.

Closes https://github.com/conda/conda-build/issues/902