### PR TITLE
change pypi urls to pypi.io

### DIFF
--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -19,7 +19,7 @@ class PyPIPackagesCompleter(Completer):
     def _get_items(self):
         from conda_build.pypi import get_xmlrpc_client
         args = self.parsed_args
-        client = get_xmlrpc_client(getattr(args, 'pypi_url', 'https://pypi.python.org/pypi'))
+        client = get_xmlrpc_client(getattr(args, 'pypi_url'))
         return [i.lower() for i in client.list_packages()]
 
 class CRANPackagesCompleter(Completer):
@@ -105,7 +105,7 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
     pypi.add_argument(
         "--pypi-url",
         action="store",
-        default='https://pypi.python.org/pypi',
+        default='https://pypi.io/pypi',
         help="URL to use for PyPI (default: %(default)s).",
     )
     pypi.add_argument(

--- a/tests/test-skeleton/sympy-0.7.5-url/meta.yaml
+++ b/tests/test-skeleton/sympy-0.7.5-url/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: sympy-0.7.5.tar.gz
-  url: https://pypi.python.org/packages/source/s/sympy/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9
+  url: https://pypi.io/packages/source/s/sympy/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9
   md5: 7de1adb49972a15a3dd975e879a2bea9
 #  patches:
    # List any patch files here

--- a/tests/test-skeleton/sympy-0.7.5/meta.yaml
+++ b/tests/test-skeleton/sympy-0.7.5/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: sympy-0.7.5.tar.gz
-  url: https://pypi.python.org/packages/source/s/sympy/sympy-0.7.5.tar.gz
+  url: https://pypi.io/packages/source/s/sympy/sympy-0.7.5.tar.gz
   md5: 7de1adb49972a15a3dd975e879a2bea9
 #  patches:
    # List any patch files here

--- a/tests/test-skeleton/sympy-0.7.5/meta.yaml
+++ b/tests/test-skeleton/sympy-0.7.5/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: sympy-0.7.5.tar.gz
-  url: https://pypi.io/packages/source/s/sympy/sympy-0.7.5.tar.gz
+  url: https://pypi.io/packages/8c/a5/5fa8adee81837687f7315122769fc0b0e8b042c69e2fe5809c41191c7183/sympy-0.7.5.tar.gz
   md5: 7de1adb49972a15a3dd975e879a2bea9
 #  patches:
    # List any patch files here

--- a/tests/test-skeleton/test_skeleton.py
+++ b/tests/test-skeleton/test_skeleton.py
@@ -18,7 +18,7 @@ def tmpdir(request):
 
 
 def test_skeleton_by_name(tmpdir):
-    cmd = "conda skeleton pypi --output-dir {} sympy".format(tmpdir)
+    cmd = "conda skeleton pypi --output-dir {} conda".format(tmpdir)
     subprocess.check_call(cmd.split())
 
 
@@ -35,7 +35,7 @@ def test_name_with_version_specified(tmpdir):
 
 def test_url(tmpdir):
     cmd = "conda skeleton pypi --output-dir {} \
-https://pypi.python.org/packages/source/s/sympy/\
+https://pypi.io/packages/source/s/sympy/\
 sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9".format(tmpdir)
     subprocess.check_call(cmd.split())
     with open('{}/sympy-0.7.5-url/meta.yaml'.format(thisdir)) as f:


### PR DESCRIPTION
PyPI changed its URLs and broke tons of stuff.  Their fix is to go back to the old way on the new service: https://github.com/conda/conda-build/pull/900/files/2da794ddf79edceda68a6b33129628f2afb5a94a#r61319835