### PR TITLE
Include the run specs in the test environment

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -591,8 +591,9 @@ def test(m, move_broken=True):
     get_build_metadata(m)
     specs = ['%s %s %s' % (m.name(), m.version(), m.build_id())]
 
-    # add packages listed in test/requires
+    # add packages listed in the run environment and test/requires
     specs.extend(ms.spec for ms in m.ms_depends('run'))
+    specs += m.get_value('test/requires', [])
 
     if py_files:
         # as the tests are run by python, ensure that python is installed.

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -592,7 +592,7 @@ def test(m, move_broken=True):
     specs = ['%s %s %s' % (m.name(), m.version(), m.build_id())]
 
     # add packages listed in test/requires
-    specs += m.get_value('test/requires', [])
+    specs.extend(ms.spec for ms in m.ms_depends('run'))
 
     if py_files:
         # as the tests are run by python, ensure that python is installed.


### PR DESCRIPTION
The command that creates the test environment does not explicitly request the packages listed in the `requirements/run` of the `meta.yaml` file in the environment creation. 

Of course, because they are included in the newly-built package's metadata, you would think this doesn't matter---they're going to get picked up due to that package's dependencies.

The problem is that conda priorities maximizing the versions of the packages that are explicitly requested *first*, and then maximizes the versions of any packages included by dependency *second*. During the *build* stage, then, the build dependencies are given high version-maximation priority; and during the *test* stage, they were given lower version-maximization priority.

This sometimes caused `conda` to select different version of the packages between `build` and `test` environments, even in situations where common sense suggested they should be identical (e.g., identical dependencies for both `build` and `test`; no `test/requires` section). Technically, if this causes functional differences, those differences should be investigated, and tighter requirements for *both* build and run should be considered. Still, it causes confusion and should be fixed.

See, for example, the comment thread in this conda-forge PR: https://github.com/conda-forge/staged-recipes/pull/444