### PR TITLE
split off recipe render from build; recurse to find meta.yaml

### DIFF
--- a/bin/conda-render
+++ b/bin/conda-render
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+import sys
+from conda_build.main_render import main
+
+sys.exit(main())

--- a/conda_build/completers.py
+++ b/conda_build/completers.py
@@ -1,0 +1,49 @@
+from os.path import isdir, isfile
+from conda.cli.common import Completer
+
+
+all_versions = {
+    'python': [26, 27, 33, 34, 35],
+    'numpy': [16, 17, 18, 19, 110],
+    'perl': None,
+    'R': None,
+    'lua': ["2.0", "5.1", "5.2", "5.3"]
+}
+
+conda_version = {
+    'python': 'CONDA_PY',
+    'numpy': 'CONDA_NPY',
+    'perl': 'CONDA_PERL',
+    'R': 'CONDA_R',
+    'lua': 'CONDA_LUA',
+}
+
+class RecipeCompleter(Completer):
+    def _get_items(self):
+        completions = []
+        for path in listdir('.'):
+            if isdir(path) and isfile(join(path, 'meta.yaml')):
+                completions.append(path)
+        if isfile('meta.yaml'):
+            completions.append('.')
+        return completions
+
+# These don't represent all supported versions. It's just for tab completion.
+
+class PythonVersionCompleter(Completer):
+    def _get_items(self):
+        return ['all'] + [str(i/10) for i in all_versions['python']]
+
+class NumPyVersionCompleter(Completer):
+    def _get_items(self):
+        versions = [str(i) for i in all_versions['numpy']]
+        return ['all'] + ['%s.%s' % (ver[0], ver[1:]) for ver in versions]
+
+class RVersionsCompleter(Completer):
+    def _get_items(self):
+        return ['3.1.2', '3.1.3', '3.2.0', '3.2.1', '3.2.2']
+
+class LuaVersionsCompleter(Completer):
+    def _get_items(self):
+        return ['all'] + [i for i in all_versions['lua']]
+

--- a/conda_build/completers.py
+++ b/conda_build/completers.py
@@ -1,4 +1,5 @@
-from os.path import isdir, isfile
+import os
+from os.path import isdir, isfile, join
 from conda.cli.common import Completer
 
 
@@ -21,7 +22,7 @@ conda_version = {
 class RecipeCompleter(Completer):
     def _get_items(self):
         completions = []
-        for path in listdir('.'):
+        for path in os.listdir('.'):
             if isdir(path) and isfile(join(path, 'meta.yaml')):
                 completions.append(path)
         if isfile('meta.yaml'):

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -7,29 +7,24 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
+import os
 import sys
 from collections import deque
 from glob import glob
 from locale import getpreferredencoding
-from os import listdir
-from os import environ as os_environ
-from os.path import exists, isdir, isfile, join
 import warnings
 
 import conda.config as config
 from conda.compat import PY3
-from conda.cli.common import add_parser_channels, Completer
-from conda.cli.conda_argparse import ArgumentParser
+from conda.cli.common import add_parser_channels
 from conda.install import delete_trash
 from conda.resolve import NoPackagesFound, Unsatisfiable
 
-from conda_build import __version__, exceptions
+from conda_build import exceptions
 from conda_build.index import update_index
 from conda_build.main_render import get_render_parser
-from conda_build.completers import (all_versions, conda_version, RecipeCompleter, PythonVersionCompleter,
-                                  RVersionsCompleter, LuaVersionsCompleter, NumPyVersionCompleter)
 from conda_build.utils import find_recipe
-from conda_build.main_render import render_recipe, get_package_build_string, set_language_env_vars
+from conda_build.main_render import get_package_build_string, set_language_env_vars, RecipeCompleter
 on_win = (sys.platform == 'win32')
 
 
@@ -216,7 +211,7 @@ def execute(args, parser):
                           "imported that is hard-linked by files in the trash. "
                           "Will try again on next run.")
 
-    set_language_env_vars(args)
+    set_language_env_vars(args, parser, execute=execute)
 
     if args.skip_existing:
         for d in config.bldpkgs_dirs:
@@ -315,7 +310,7 @@ def execute(args, parser):
                         if pkg in skip_names:
                             continue
                         recipe_glob = glob(pkg + '-[v0-9][0-9.]*')
-                        if exists(pkg):
+                        if os.path.exists(pkg):
                             recipe_glob.append(pkg)
                         if recipe_glob:
                             try_again = True

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -52,13 +52,6 @@ platform specifics, making it simple to create working environments from
         help="Obtain the source and fill in related template variables.",
     )
     p.add_argument(
-        'recipe',
-        action="store",
-        metavar='RECIPE_PATH',
-        choices=RecipeCompleter(),
-        help="Path to recipe directory.",
-    )
-    p.add_argument(
         '--python',
         action="append",
         help="""Set the Python version used by conda build. Can be passed
@@ -239,6 +232,14 @@ def main():
         '-y', '--yaml',
         action="store_true",
         help="print YAML, as opposed to printing the metadata as a dictionary"
+    )
+    # we do this one separately because we only allow one entry to conda render
+    p.add_argument(
+        'recipe',
+        action="store",
+        metavar='RECIPE_PATH',
+        choices=RecipeCompleter(),
+        help="Path to recipe directory.",
     )
 
     args = p.parse_args()

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -239,7 +239,6 @@ else:
 
 
 def main():
-    import pprint
     p = get_render_parser()
     p.add_argument(
         '-f', '--file',

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -1,0 +1,218 @@
+# (c) Continuum Analytics, Inc. / http://continuum.io
+# All Rights Reserved
+#
+# conda is distributed under the terms of the BSD 3-clause license.
+# Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+from collections import deque
+from glob import glob
+from locale import getpreferredencoding
+import os
+from os.path import exists, isdir, isfile, join, abspath
+
+# import conda.config as config
+from conda_build.config import config
+from conda.compat import PY3
+from conda.cli.common import add_parser_channels
+from conda.cli.conda_argparse import ArgumentParser
+
+from conda_build import __version__, exceptions
+from conda_build.metadata import MetaData
+import conda_build.source as source
+from conda_build.completers import (all_versions, conda_version, RecipeCompleter, PythonVersionCompleter,
+                                  RVersionsCompleter, LuaVersionsCompleter, NumPyVersionCompleter)
+from conda_build.utils import find_recipe
+
+on_win = (sys.platform == 'win32')
+
+
+def get_render_parser():
+    p = ArgumentParser(
+        description="""
+Tool for building conda packages. A conda package is a binary tarball
+containing system-level libraries, Python modules, executable programs, or
+other components. conda keeps track of dependencies between packages and
+platform specifics, making it simple to create working environments from
+        different sets of packages.""",
+        conflict_handler='resolve'
+    )
+    p.add_argument(
+        '-V', '--version',
+        action='version',
+        help='Show the conda-build version number and exit.',
+        version = 'conda-build %s' % __version__,
+    )
+    p.add_argument(
+        '-s', "--source",
+        action="store_true",
+        help="Obtain the source and fill in related template variables.",
+    )
+    p.add_argument(
+        'recipe',
+        action="store",
+        metavar='RECIPE_PATH',
+        choices=RecipeCompleter(),
+        help="Path to recipe directory.",
+    )
+    p.add_argument(
+        '--python',
+        action="append",
+        help="""Set the Python version used by conda build. Can be passed
+        multiple times to build against multiple versions. Can be 'all' to
+    build against all known versions (%r)""" % [i for i in
+    PythonVersionCompleter() if '.' in i],
+        metavar="PYTHON_VER",
+        choices=PythonVersionCompleter(),
+    )
+    p.add_argument(
+        '--perl',
+        action="append",
+        help="""Set the Perl version used by conda build. Can be passed
+        multiple times to build against multiple versions.""",
+        metavar="PERL_VER",
+    )
+    p.add_argument(
+        '--numpy',
+        action="append",
+        help="""Set the NumPy version used by conda build. Can be passed
+        multiple times to build against multiple versions. Can be 'all' to
+    build against all known versions (%r)""" % [i for i in
+    NumPyVersionCompleter() if '.' in i],
+        metavar="NUMPY_VER",
+        choices=NumPyVersionCompleter(),
+    )
+    p.add_argument(
+        '--R',
+        action="append",
+        help="""Set the R version used by conda build. Can be passed
+        multiple times to build against multiple versions.""",
+        metavar="R_VER",
+        choices=RVersionsCompleter(),
+    )
+    p.add_argument(
+        '--lua',
+        action="append",
+        help="""Set the Lua version used by conda build. Can be passed
+        multiple times to build against multiple versions (%r).""" % [i for i in LuaVersionsCompleter()],
+        metavar="LUA_VER",
+        choices=LuaVersionsCompleter(),
+    )
+    add_parser_channels(p)
+    return p
+
+
+def set_language_env_vars(args):
+    """Given args passed into conda command, set language env vars"""
+    for lang in all_versions:
+        versions = getattr(args, lang)
+        if not versions:
+            continue
+        if versions == ['all']:
+            if all_versions[lang]:
+                versions = all_versions[lang]
+            else:
+                parser.error("'all' is not supported for --%s" % lang)
+        if len(versions) > 1:
+            for ver in versions[:]:
+                setattr(args, lang, [str(ver)])
+                execute(args, parser)
+                # This is necessary to make all combinations build.
+                setattr(args, lang, versions)
+            return
+        else:
+            version = versions[0]
+            if lang in ('python', 'numpy'):
+                version = int(version.replace('.', ''))
+            setattr(config, conda_version[lang], version)
+        if not len(str(version)) in (2, 3) and lang in ['python', 'numpy']:
+            if all_versions[lang]:
+                raise RuntimeError("%s must be major.minor, like %s, not %s" %
+                    (conda_version[lang], all_versions[lang][-1]/10, version))
+            else:
+                raise RuntimeError("%s must be major.minor, not %s" %
+                    (conda_version[lang], version))
+
+    # Using --python, --numpy etc. is equivalent to using CONDA_PY, CONDA_NPY, etc.
+    # Auto-set those env variables
+    for var in conda_version.values():
+        if hasattr(config, var):
+            # Set the env variable.
+            os.environ[var] = str(getattr(config, var))
+
+
+def render_recipe(recipe_path, download_source=False):
+    import shutil
+    import tarfile
+    import tempfile
+
+    from conda.lock import Locked
+
+    with Locked(config.croot):
+        arg = recipe_path
+        try_again = False
+        # Don't use byte literals for paths in Python 2
+        if not PY3:
+            arg = arg.decode(getpreferredencoding() or 'utf-8')
+        if isfile(arg):
+            if arg.endswith(('.tar', '.tar.gz', '.tgz', '.tar.bz2')):
+                recipe_dir = tempfile.mkdtemp()
+                t = tarfile.open(arg, 'r:*')
+                t.extractall(path=recipe_dir)
+                t.close()
+                need_cleanup = True
+            else:
+                print("Ignoring non-recipe: %s" % arg)
+                return
+        else:
+            recipe_dir = abspath(arg)
+            need_cleanup = False
+
+        if not isdir(recipe_dir):
+            sys.exit("Error: no such directory: %s" % recipe_dir)
+
+        try:
+            m = MetaData(recipe_dir)
+        except exceptions.YamlParsingError as e:
+            sys.stderr.write(e.error_msg())
+            sys.exit(1)
+
+        if download_source:
+            source.provide(m.path, m.get_section('source'), patch=False)
+            print('Source tree in:', source.get_dir())
+
+        try:
+            m.parse_again(permit_undefined_jinja=False)
+        except SystemExit:
+            # Something went wrong; possibly due to undefined GIT_ jinja variables.
+            # Maybe we need to actually download the source in order to resolve the build_id.
+            source.provide(m.path, m.get_section('source'))
+
+            # Parse our metadata again because we did not initialize the source
+            # information before.
+            m.parse_again(permit_undefined_jinja=False)
+
+            print(build.bldpkg_path(m))
+            raise
+
+        if need_cleanup:
+            shutil.rmtree(recipe_dir)
+
+    return m
+
+
+def main():
+    import pprint
+    p = get_render_parser()
+
+    args = p.parse_args()
+    set_language_env_vars(args)
+
+    metadata = render_recipe(find_recipe(args.recipe), download_source=args.source)
+    pprint.pprint(metadata.meta)
+
+
+if __name__ == '__main__':
+    main()

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -212,7 +212,7 @@ def get_package_build_string(metadata):
 # Next bit of stuff is to support YAML output in the order we expect.
 # http://stackoverflow.com/a/17310199/1170370
 class MetaYaml(dict):
-    fields = ["package", "source", "build", "requirements", "test", "extra"]
+    fields = ["package", "source", "build", "requirements", "test", "about", "extra"]
     def to_omap(self):
         return [(field, self[field]) for field in MetaYaml.fields if field in self]
 

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -228,6 +228,7 @@ class IndentDumper(yaml.Dumper):
 yaml.add_representer(MetaYaml, represent_omap)
 if PY3:
     yaml.add_representer(str, unicode_representer)
+    unicode = None  # silence pyflakes about unicode not existing in py3
 else:
     yaml.add_representer(unicode, unicode_representer)
 

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -190,7 +190,7 @@ def render_recipe(recipe_path, no_download_source=True):
             sys.exit("Error: no such directory: %s" % recipe_dir)
 
         try:
-            m = MetaData(recipe_dir, permit_undefined_jinja=False)
+            m = MetaData(recipe_dir)
         except exceptions.YamlParsingError as e:
             sys.stderr.write(e.error_msg())
             sys.exit(1)
@@ -214,7 +214,7 @@ def get_package_build_string(metadata):
 class MetaYaml(dict):
     fields = ["package", "source", "build", "requirements", "test", "extra"]
     def to_omap(self):
-        return [(field, self[field]) for field in MetaYaml.fields]
+        return [(field, self[field]) for field in MetaYaml.fields if field in self]
 
 
 def represent_omap(dumper, data):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -312,7 +312,7 @@ def handle_config_version(ms, ver):
 
 class MetaData(object):
 
-    def __init__(self, path):
+    def __init__(self, path, permit_undefined_jinja=True):
         assert isdir(path)
         self.path = path
         self.meta_path = join(path, 'meta.yaml')
@@ -331,7 +331,7 @@ class MetaData(object):
         # (e.g. GIT_FULL_HASH, etc. are undefined)
         # Therefore, undefined jinja variables are permitted here
         # In the second pass, we'll be more strict. See build.build()
-        self.parse_again(permit_undefined_jinja=True)
+        self.parse_again(permit_undefined_jinja=permit_undefined_jinja)
 
     def parse_again(self, permit_undefined_jinja=False):
         """Redo parsing for key-value pairs that are not initialized in the

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -312,7 +312,7 @@ def handle_config_version(ms, ver):
 
 class MetaData(object):
 
-    def __init__(self, path, permit_undefined_jinja=True):
+    def __init__(self, path):
         assert isdir(path)
         self.path = path
         self.meta_path = join(path, 'meta.yaml')
@@ -331,7 +331,7 @@ class MetaData(object):
         # (e.g. GIT_FULL_HASH, etc. are undefined)
         # Therefore, undefined jinja variables are permitted here
         # In the second pass, we'll be more strict. See build.build()
-        self.parse_again(permit_undefined_jinja=permit_undefined_jinja)
+        self.parse_again(permit_undefined_jinja=True)
 
     def parse_again(self, permit_undefined_jinja=False):
         """Redo parsing for key-value pairs that are not initialized in the

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import fnmatch
 import sys
 import shutil
 import tarfile
@@ -19,6 +20,27 @@ from conda_build import external
 # Backwards compatibility import. Do not remove.
 from conda.install import rm_rf
 rm_rf
+
+
+def _recursive_glob(treeroot, pattern):
+    results = []
+    for base, dirs, files in os.walk(treeroot):
+        goodfiles = fnmatch.filter(files, pattern)
+        results.extend(os.path.join(base, f) for f in goodfiles)
+    return results
+
+
+def find_recipe(path):
+    """recurse through a folder, locating meta.yaml.  Raises error if more than one is found.
+
+    Returns folder containing meta.yaml, to be built."""
+    results = _recursive_glob(path, "meta.yaml")
+    if len(results) > 1:
+        raise IOError("More than one meta.yaml files found in %s" % path)
+    elif not results:
+        raise IOError("No meta.yaml files found in %s" % path)
+    return os.path.dirname(results[0])
+
 
 def copy_into(src, dst):
     "Copy all the files and directories in src to the directory dst"

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-import os
 import fnmatch
+import os
 import sys
 import shutil
 import tarfile
 import zipfile
 import subprocess
 import operator
-import fnmatch
 from os.path import dirname, getmtime, getsize, isdir, join
 from collections import defaultdict
 
@@ -21,20 +20,11 @@ from conda_build import external
 from conda.install import rm_rf
 rm_rf
 
-
-def _recursive_glob(treeroot, pattern):
-    results = []
-    for base, dirs, files in os.walk(treeroot):
-        goodfiles = fnmatch.filter(files, pattern)
-        results.extend(os.path.join(base, f) for f in goodfiles)
-    return results
-
-
 def find_recipe(path):
     """recurse through a folder, locating meta.yaml.  Raises error if more than one is found.
 
     Returns folder containing meta.yaml, to be built."""
-    results = _recursive_glob(path, "meta.yaml")
+    results = rec_glob(path, ["meta.yaml"])
     if len(results) > 1:
         raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -24,7 +24,7 @@ def find_recipe(path):
     """recurse through a folder, locating meta.yaml.  Raises error if more than one is found.
 
     Returns folder containing meta.yaml, to be built."""
-    results = rec_glob(path, ["meta.yaml"])
+    results = rec_glob(path, ["meta.yaml", "conda.yaml"])
     if len(results) > 1:
         raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:

--- a/tests/test-recipes/metadata/nested_recipe/build_number/meta.yaml
+++ b/tests/test-recipes/metadata/nested_recipe/build_number/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: conda-build-test-build-number
+  version: 1.0
+
+build:
+  number: 1

--- a/tests/test-recipes/metadata/nested_recipe/build_number/run_test.bat
+++ b/tests/test-recipes/metadata/nested_recipe/build_number/run_test.bat
@@ -1,0 +1,10 @@
+conda list -p "%PREFIX%" --canonical
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('conda list -p "%PREFIX%" --canonical') do set condalist=%%i
+if errorlevel 1 exit 1
+echo "%condalist%"
+if not "%condalist%"=="conda-build-test-build-number-1.0-1" exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-build-number-1.0-1.json"
+if errorlevel 1 exit 1
+cat "%PREFIX%\conda-meta\conda-build-test-build-number-1.0-1.json" | grep '"build_number": 1'
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/nested_recipe/build_number/run_test.sh
+++ b/tests/test-recipes/metadata/nested_recipe/build_number/run_test.sh
@@ -1,0 +1,6 @@
+conda list -p $PREFIX --canonical
+# This is actually the build string. We test the build number below
+[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-build-number-1.0-1" ]
+
+cat $PREFIX/conda-meta/conda-build-test-build-number-1.0-1.json
+cat $PREFIX/conda-meta/conda-build-test-build-number-1.0-1.json | grep '"build_number": 1'


### PR DESCRIPTION
Closes #887 

This is the start of splitting off recipe rendering from building.  I am trying to avoid duplicating code, so I'm splitting the existing code off into other modules.

Right now, it only prints the processed metadata, not a yaml file.  That's easy enough to write as an addon option later - I'm expecting that the raw dictionary will be the most useful thing to people, rather than going back to some file on disk.  My idea is that the build module will just call functions from this file to render each recipe's meta.yaml.

This works right now, with a trivial test of a recipe from conda-forge (zlib).  Original recipe at https://github.com/conda-forge/zlib-feedstock, which I have cloned as a submodule into the packages/zlib folder:

```
$ conda render packages/zlib
{u'about': {u'home': u'http://zlib.net/',
            u'license': u'zlib (http://zlib.net/zlib_license.html)',
            u'license_family': u'Other',
            u'license_file': u'license.txt',
            u'summary': u'Massively spiffy yet delicately unobtrusive compression library'},
 u'build': {u'features': u''},
 u'extra': {u'recipe-maintainers': [u'groutr', u'msarahan', u'ocefpaf']},
 u'package': {u'name': u'zlib', u'version': u'1.2.8'},
 u'requirements': {u'build': [u'cmake']},
 u'source': {u'fn': u'zlib-1.2.8.tar.gz',
             u'sha256': u'36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d',
             u'url': u'http://zlib.net/zlib-1.2.8.tar.gz'},
 u'test': {u'commands': [u'test -f ${PREFIX}/lib/libz.a']}}
```

This change also makes conda-build recursively search for meta.yaml in any folder you provide, so it should make conda build more directly compatible with the conda-forge layout of having the recipe one level deeper.

I'll be cleaning this up and coming up with test cases - please kick the tires and point out any details I should pay special attention to.

CC @jakirkham @stuarteberg @kalefranz @pelson @groutr 