### PR TITLE
Fix issue with cpan skeleton generating invalid recipes for core modules.

### DIFF
--- a/conda_build/cpan.py
+++ b/conda_build/cpan.py
@@ -27,7 +27,7 @@ package:
   name: {packagename}
   version: "{version}"
 
-source:
+{source_comment}source:
   {useurl}fn: {filename}
   {useurl}url: {cpanurl}
   {usemd5}md5: {md5}
@@ -47,7 +47,7 @@ requirements:
   run:
     - perl{run_depends}
 
-test:
+{import_comment}test:
   # Perl 'use' tests
   {import_comment}imports:{import_tests}
 
@@ -192,6 +192,7 @@ def main(args, parser):
                                                'test_commands': '',
                                                'usemd5': '',
                                                'useurl': '',
+                                               'source_comment': '',
                                                'summary': "''",
                                                'import_tests': ''})
 
@@ -217,6 +218,7 @@ def main(args, parser):
         else:
             d['useurl'] = '#'
             d['usemd5'] = '#'
+            d['source_comment'] = '#'
             d['cpanurl'] = ''
             d['filename'] = ''
             d['md5'] = ''
@@ -241,6 +243,7 @@ def main(args, parser):
                                           LooseVersion(args.version))):
             d['useurl'] = '#'
             d['usemd5'] = '#'
+            d['source_comment'] = '#'
             empty_recipe = True
         # Add dependencies to d if not in core, or newer than what's in core
         else:


### PR DESCRIPTION
Since the conda skeleton was written `source` and `test` are now required to be dicts if present instead of allowing empty strings.  This fix comments `source` and `test` out if they would have been empty.