### PR TITLE
Make VS 2008 possible again

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -146,7 +146,7 @@ def msvc_env_cmd(bits, override=None):
                 msvc_env_lines.append(error1.format(
                     build_vcvarsall_cmd(VCVARS64_VS9_BAT_PATH)))
             else:
-                msvc_env_lines.appent(error1.format(
+                msvc_env_lines.append(error1.format(
                     build_vcvarsall_cmd(vcvarsall_vs_path)))
         else:
             msvc_env_lines.append(error1.format(

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -130,20 +130,26 @@ def msvc_env_cmd(bits, override=None):
         msvc_env_lines.append(win_sdk_cmd)
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
     elif version == '9.0':
+        error1 = 'if errorlevel 1 {}'
+
         # First, check for Microsoft Visual C++ Compiler for Python 2.7
         msvc_env_lines.append(build_vcvarsall_cmd(VS_TOOLS_PY_LOCAL_PATH))
         
-        msvc_env_lines.append('if errorlevel 1 {}'.format(
+        msvc_env_lines.append(error1.format(
             build_vcvarsall_cmd(VS_TOOLS_PY_COMMON_PATH)))
         # The Visual Studio 2008 Express edition does not properly contain
         # the amd64 build files, so we call the vcvars64.bat manually,
         # rather than using the vcvarsall.bat which would try and call the
         # missing bat file.
         if arch_selector == 'amd64':
-            msvc_env_lines.append('if errorlevel 1 {}'.format(
-                build_vcvarsall_cmd(VCVARS64_VS9_BAT_PATH)))
+            if exists(VCVARS64_VS9_BAT_PATH):
+                msvc_env_lines.append(error1.format(
+                    build_vcvarsall_cmd(VCVARS64_VS9_BAT_PATH)))
+            else:
+                msvc_env_lines.appent(error1.format(
+                    build_vcvarsall_cmd(vcvarsall_vs_path)))
         else:
-            msvc_env_lines.append('if errorlevel 1 {}'.format(
+            msvc_env_lines.append(error1.format(
                 build_vcvarsall_cmd(vcvarsall_vs_path)))
     else:
         # Visual Studio 14 or otherwise

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -142,12 +142,10 @@ def msvc_env_cmd(bits, override=None):
         # rather than using the vcvarsall.bat which would try and call the
         # missing bat file.
         if arch_selector == 'amd64':
-            if exists(VCVARS64_VS9_BAT_PATH):
-                msvc_env_lines.append(error1.format(
-                    build_vcvarsall_cmd(VCVARS64_VS9_BAT_PATH)))
-            else:
-                msvc_env_lines.append(error1.format(
-                    build_vcvarsall_cmd(vcvarsall_vs_path)))
+            msvc_env_lines.append(error1.format(
+                build_vcvarsall_cmd(VCVARS64_VS9_BAT_PATH)))
+            msvc_env_lines.append(error1.format(
+                build_vcvarsall_cmd(vcvarsall_vs_path)))
         else:
             msvc_env_lines.append(error1.format(
                 build_vcvarsall_cmd(vcvarsall_vs_path)))


### PR DESCRIPTION
The fallbacks for different versions variations of Visual C++ is great.  However, for Visual C++ 9.0, it was only possible to use VC for Python 2.7 or VS Express.  Conda-build would break if you had a full VS2008 install.

VS Express has vcvars64.bat in the VC\bin folder.  VS 2008 locates vcvars64.bat in VC\bin\amd64.  Checking to see if the file exists in VC\bin can distinguish between VS Express and VS 2008.