### PR TITLE
fix invalid option to gcc

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -309,8 +309,8 @@ def osx_vars(compiler_vars):
 def linux_vars(compiler_vars, prefix):
     compiler_vars['LD_RUN_PATH'] = prefix + '/lib'
     if cc.bits == 32:
-        compiler_vars['CFLAGS'] += ' -m 32'
-        compiler_vars['CXXFLAGS'] += ' -m 32'
+        compiler_vars['CFLAGS'] += ' -m32'
+        compiler_vars['CXXFLAGS'] += ' -m32'
     return {}
 
 


### PR DESCRIPTION
```
cc1: error: unrecognized command line option "-m"
```