### PR TITLE
Restore old conda-build behavior for empty sections

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -148,6 +148,8 @@ def parse(data):
     for field in FIELDS:
         if field not in res:
             continue
+        if not res[field]:
+            res[field] = {}
         if not isinstance(res[field], dict):
             raise RuntimeError("The %s field should be a dict, not %s" %
                                (field, res[field].__class__.__name__))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -162,7 +162,7 @@ def parse(data):
 trues = {'y', 'on', 'true', 'yes'}
 falses = {'n', 'no', 'false', 'off'}
 
-default_stucts = {
+default_structs = {
     'source/patches': list,
     'build/entry_points': list,
     'build/script_env': list,
@@ -376,8 +376,8 @@ class MetaData(object):
         section, key = field.split('/')
 
         # get correct default
-        if autotype and default is None and field in default_stucts:
-            default = default_stucts[field]()
+        if autotype and default is None and field in default_structs:
+            default = default_structs[field]()
 
         value = self.get_section(section).get(key, default)
 

--- a/tests/test-recipes/metadata/empty_sections/meta.yaml
+++ b/tests/test-recipes/metadata/empty_sections/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: empty_sections
+  version: 0.0
+
+
+build:
+
+requirements:
+  build:
+


### PR DESCRIPTION
This is something that I inadvertently broke in #801.  This restores the old behavior until #874 is finished. 