### PR TITLE
remove upload always true, fix some args in download functions

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -277,7 +277,7 @@ def execute(args, parser):
                       "configuration." % m.dist())
                 continue
             if args.output:
-                print(get_package_build_string(m))
+                print(get_package_build_string(m, no_download_source=False))
                 continue
             elif args.test:
                 build.test(m, move_broken=False)
@@ -341,12 +341,10 @@ def execute(args, parser):
                 if not args.notest:
                     build.test(m)
 
-                binstar_upload = True
-
             if need_cleanup:
                 shutil.rmtree(recipe_dir)
 
-            if binstar_upload:
+            if args.binstar_upload:
                 handle_binstar_upload(build.bldpkg_path(m), args)
 
             already_built.append(m.pkg_fn())

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -203,9 +203,9 @@ def render_recipe(recipe_path, no_download_source=True):
     return m
 
 
-def get_package_build_string(metadata):
+def get_package_build_string(metadata, no_download_source):
     import conda_build.build as build
-    metadata = parse_or_try_download(metadata)
+    metadata = parse_or_try_download(metadata, no_download_source=no_download_source)
     return build.bldpkg_path(metadata)
 
 
@@ -260,7 +260,7 @@ def main():
 
     metadata = render_recipe(find_recipe(args.recipe), no_download_source=args.no_source)
     if args.output:
-        print(get_package_build_string(metadata))
+        print(get_package_build_string(metadata, args.no_source))
     else:
         output = yaml.dump(MetaYaml(metadata.meta), Dumper=IndentDumper,
                             default_flow_style=False, indent=4)


### PR DESCRIPTION
This makes the --output argument of conda render respect the --no-source argument.  It also tries to fix some logic regarding anaconda.org uploading that looked broken.