### PR TITLE
Reactivate skip-existing and two minor fixes.

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -225,7 +225,7 @@ def execute(args, parser):
             update_index(d)
         index = build.get_build_index(clear_cache=True)
 
-    already_built = {}
+    already_built = set()
     to_build_recursive = []
     with Locked(config.croot):
         recipes = deque(args.recipe)

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -203,7 +203,7 @@ def render_recipe(recipe_path, no_download_source=True):
     return m
 
 
-def get_package_build_string(metadata, no_download_source):
+def get_package_build_path(metadata, no_download_source):
     import conda_build.build as build
     metadata = parse_or_try_download(metadata, no_download_source=no_download_source)
     return build.bldpkg_path(metadata)
@@ -260,7 +260,7 @@ def main():
 
     metadata = render_recipe(find_recipe(args.recipe), no_download_source=args.no_source)
     if args.output:
-        print(get_package_build_string(metadata, args.no_source))
+        print(get_package_build_path(metadata, args.no_source))
     else:
         output = yaml.dump(MetaYaml(metadata.meta), Dumper=IndentDumper,
                             default_flow_style=False, indent=4)


### PR DESCRIPTION
@msarahan, your PR bioconda/conda-build#1 accidentally removed the entire skip-exisiting check. Since our fork was merged into upstream master afterwards, the master branch currently lacks skip-existing functionality. This PR reactivates it. 

Further, I have renamed `get_package_build_string` to `get_package_build_path`, because it returns a path and build string would be ambiguous with the build string from the meta.yaml.

Finally, I have changed `already_built` into a set, which is the better DS for adding and lookups.