### PR TITLE
write env vars to bld.bat

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import shutil
-from os.path import dirname, isdir, isfile, join, exists
+from os.path import dirname, isdir, isfile, join
 
 import conda.config as cc
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -192,21 +192,22 @@ def build(m, bld_bat):
             os.makedirs(path)
 
     src_dir = source.get_dir()
-    with open(bld_bat) as fi:
-        data = fi.read()
-    with open(join(src_dir, 'bld.bat'), 'w') as fo:
-        fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
-        fo.write('\n')
-        # more debuggable with echo on
-        fo.write('@echo on\n')
-        for key, value in env.items():
-            fo.write('set "{key}={value}"\n'.format(key=key, value=value))
-        fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
-        fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
-        fo.write("REM ===== end generated header =====\n")
-        fo.write(data)
+    if os.path.isfile(bld_bat):
+        with open(bld_bat) as fi:
+            data = fi.read()
+        with open(join(src_dir, 'bld.bat'), 'w') as fo:
+            fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
+            fo.write('\n')
+            # more debuggable with echo on
+            fo.write('@echo on\n')
+            for key, value in env.items():
+                fo.write('set "{key}={value}"\n'.format(key=key, value=value))
+            fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
+            fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
+            fo.write("REM ===== end generated header =====\n")
+            fo.write(data)
 
-    cmd = [os.environ['COMSPEC'], '/c', 'call', 'bld.bat']
-    _check_call(cmd, cwd=src_dir)
-    kill_processes()
-    fix_staged_scripts()
+        cmd = [os.environ['COMSPEC'], '/c', 'call', 'bld.bat']
+        _check_call(cmd, cwd=src_dir)
+        kill_processes()
+        fix_staged_scripts()

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -192,20 +192,21 @@ def build(m, bld_bat):
             os.makedirs(path)
 
     src_dir = source.get_dir()
-    if exists(bld_bat):
-        with open(bld_bat) as fi:
-            data = fi.read()
-        with open(join(src_dir, 'bld.bat'), 'w') as fo:
-            fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
-            fo.write('\n')
-            # more debuggable with echo on
-            fo.write('@echo on\n')
-            fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
-            fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
-            fo.write("REM ===== end generated header =====\n")
-            fo.write(data)
+    with open(bld_bat) as fi:
+        data = fi.read()
+    with open(join(src_dir, 'bld.bat'), 'w') as fo:
+        fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
+        fo.write('\n')
+        # more debuggable with echo on
+        fo.write('@echo on\n')
+        for key, value in env.items():
+            fo.write('set "{key}={value}"\n'.format(key=key, value=value))
+        fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
+        fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
+        fo.write("REM ===== end generated header =====\n")
+        fo.write(data)
 
-        cmd = [os.environ['COMSPEC'], '/c', 'call', 'bld.bat']
-        _check_call(cmd, cwd=src_dir, env={str(k): str(v) for k, v in env.items()})
-        kill_processes()
-        fix_staged_scripts()
+    cmd = [os.environ['COMSPEC'], '/c', 'call', 'bld.bat']
+    _check_call(cmd, cwd=src_dir)
+    kill_processes()
+    fix_staged_scripts()


### PR DESCRIPTION
This also rolls back to an earlier behavior of writing the build env vars to the bld.bat script, rather than passing the env to the subprocess call.  This is simpler for debugging, but also (partially) fixes an issue observed in https://github.com/conda-forge/apptools-feedstock/pull/3 - there, with a Python 3.5 root install, the VS 2010 py 3.4 configuration was seeing the root environment rather than the build environment.  This PR changes that so at least the correct Python is on PATH - but the package is still broken somehow.

It should be said that this PR might actually somewhat mask some other issue - the issue being that the _build environment is not always being used, as it should be.