### PR TITLE
cran: Use MSYS2

### DIFF
--- a/conda_build/cran.py
+++ b/conda_build/cran.py
@@ -28,6 +28,9 @@ from conda import compat
 from conda_build import source, metadata
 
 CRAN_META = """\
+{{% set posix = 'm2-' if win else '' %}}
+{{% set native = 'm2w64-' if win else '' %}}
+
 package:
   name: {packagename}
   # Note that conda versions cannot contain -, so any -'s in the version have
@@ -552,41 +555,33 @@ def main(args, parser):
                     continue
                 if name == 'R':
                     # Put R first
-                    if d['cran_packagename'] in R_RECOMMENDED_PACKAGE_NAMES and dep_type == 'build':
-                        # On Linux and OS X, r is a metapackage depending on
-                        # r-base and r-recommended. Recommended packages cannot
-                        # build depend on r as they would then build depend on
-                        # themselves and the built package would end up being
-                        # empty (because conda would find no new files)
-                        r_name = 'r-base'
-                    else:
-                        r_name = 'r'
+                    # Regarless of build or run, and whether this is a recommended package or not,
+                    # it can only depend on 'r-base' since anything else can and will cause cycles
+                    # in the dependency graph. The cran metadata lists all dependencies anyway, even
+                    # those packages that are in the recommended group.
+                    r_name = 'r-base'
                     # We don't include any R version restrictions because we
                     # always build R packages against an exact R version
                     deps.insert(0, '{indent}{r_name}'.format(indent=INDENT, r_name=r_name))
                 else:
                     conda_name = 'r-' + name.lower()
 
-                    # The r package on Windows includes the recommended packages
-                    if name in R_RECOMMENDED_PACKAGE_NAMES:
-                        end = ' # [not win]'
-                    else:
-                        end = ''
                     if dep_dict[name]:
-                        deps.append('{indent}{name} {version}{end}'.format(name=conda_name,
-                            version=dep_dict[name], end=end, indent=INDENT))
+                        deps.append('{indent}{name} {version}'.format(name=conda_name,
+                            version=dep_dict[name], indent=INDENT))
                     else:
-                        deps.append('{indent}{name}{end}'.format(name=conda_name,
-                            indent=INDENT, end=end))
+                        deps.append('{indent}{name}'.format(name=conda_name,
+                            indent=INDENT))
                     if args.recursive:
                         if not exists(join(output_dir, conda_name)):
                             args.packages.append(name)
 
             if cran_package.get("NeedsCompilation", 'no') == 'yes':
                 if dep_type == 'build':
-                    deps.append('{indent}gcc # [not win]'.format(indent=INDENT))
-                else:
-                    deps.append('{indent}libgcc # [not win]'.format(indent=INDENT))
+                    deps.append('{indent}{{{{posix}}}}base       # [win]'.format(indent=INDENT))
+                    deps.append('{indent}{{{{posix}}}}zip        # [win]'.format(indent=INDENT))
+                    deps.append('{indent}{{{{native}}}}toolchain # [win]'.format(indent=INDENT))
+                    deps.append('{indent}gcc                 # [not win]'.format(indent=INDENT))
             d['%s_depends' % dep_type] = ''.join(deps)
 
     for package in package_dicts:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -437,7 +437,9 @@ class MetaData(object):
             ('numpy', config.CONDA_NPY),
             ('perl', config.CONDA_PERL),
             ('lua', config.CONDA_LUA),
+            # r is kept for legacy installations, r-base deprecates it.
             ('r', config.CONDA_R),
+            ('r-base', config.CONDA_R),
         ]
         for spec in self.get_value('requirements/' + typ, []):
             try:
@@ -476,7 +478,8 @@ class MetaData(object):
         res = []
         version_pat = re.compile(r'(?:==)?(\d+)\.(\d+)')
         for name, s in (('numpy', 'np'), ('python', 'py'),
-                        ('perl', 'pl'), ('lua', 'lua'), ('r', 'r')):
+                        ('perl', 'pl'), ('lua', 'lua'),
+                        ('r', 'r'), ('r-base', 'r')):
             for ms in self.ms_depends():
                 if ms.name == name:
                     try:
@@ -487,7 +490,7 @@ class MetaData(object):
                         break
                     if any(i in v for i in ',|>!<'):
                         break
-                    if name not in ['perl', 'r', 'lua']:
+                    if name not in ['perl', 'lua', 'r', 'r-base']:
                         match = version_pat.match(v)
                         if match:
                             res.append(s + match.group(1) + match.group(2))

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import sys
-from os.path import join, isdir, isfile, abspath, expanduser
+from os.path import join, isdir, isfile, abspath, expanduser, basename
 from shutil import copytree, copy2
 from subprocess import check_call, Popen, PIPE, CalledProcessError
 import locale
@@ -39,9 +39,8 @@ def download_to_cache(meta):
     if not isdir(SRC_CACHE):
         os.makedirs(SRC_CACHE)
 
-    fn = meta['fn']
+    fn = meta['fn'] if 'fn' in meta else basename(meta['url'])
     path = join(SRC_CACHE, fn)
-
     if isfile(path):
         print('Found source in cache: %s' % fn)
     else:
@@ -284,7 +283,7 @@ def provide(recipe_dir, meta, patch=True):
     """
     print("Removing old work directory")
     rm_rf(WORK_DIR)
-    if 'fn' in meta:
+    if any(k in meta for k in ('fn', 'url')):
         unpack(meta)
     elif 'git_url' in meta:
         git_source(meta, recipe_dir)


### PR DESCRIPTION
Unify Windows and Unix R dependencies:
 * Dependencies on packages in r-recommended are now explicitly listed
   on Windows just the same as for the other systems.
 * Add m2-base and m2w64-toolchain dependencies.
 * Use r-base as the build-string identifying dependency, as well as r
   (r is kept for legacy installations)