### PR TITLE
Fix --skip-existing since channel prefixes

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -267,7 +267,8 @@ def execute(args, parser):
                     "configuration." % m.dist())
             continue
         if args.skip_existing:
-            if m.pkg_fn() in index or m.pkg_fn() in already_built:
+            # 'or m.pkg_fn() in index' is for conda <4.1 and could be removed in the future.
+            if 'local::' + m.pkg_fn() in index or m.pkg_fn() in index or m.pkg_fn() in already_built:
                 print(m.dist(), "is already built, skipping.")
                 continue
         if args.output:

--- a/tests/test-recipes/metadata/build_number/run_test.sh
+++ b/tests/test-recipes/metadata/build_number/run_test.sh
@@ -1,6 +1,8 @@
 conda list -p $PREFIX --canonical
-# This is actually the build string. We test the build number below
-[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-build-number-1.0-1" ]
+# This is actually the build string. We test the build number below, the variant without
+# 'local::' is for conda <4.1 and could be removed in the future.
+[ "$(conda list -p $PREFIX --canonical)" = "conda-build-test-build-number-1.0-1" ] || \
+[ "$(conda list -p $PREFIX --canonical)" = "local::conda-build-test-build-number-1.0-1" ]
 
 cat $PREFIX/conda-meta/conda-build-test-build-number-1.0-1.json
 cat $PREFIX/conda-meta/conda-build-test-build-number-1.0-1.json | grep '"build_number": 1'


### PR DESCRIPTION
Now, local packages have a 'local::' prefix so we must add
that when checking for a package in the index.