### PR TITLE
fix extraneous output when outputting build path

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -16,7 +16,7 @@ from conda.lock import Locked
 import conda.config
 from conda.cli.common import spec_from_line
 from conda_build.metadata import MetaData
-from conda_build import build, pypi
+from conda_build import build, pypi, render
 from conda_build.config import config
 from conda_build.main_build import handle_binstar_upload
 
@@ -267,13 +267,13 @@ class bdist_conda(install):
             if self.binstar_upload:
                 class args:
                     binstar_upload = self.binstar_upload
-                handle_binstar_upload(build.bldpkg_path(m), args)
+                handle_binstar_upload(render.bldpkg_path(m), args)
             else:
                 no_upload_message = """\
 # If you want to upload this package to anaconda.org later, type:
 #
 # $ anaconda upload %s
-""" % build.bldpkg_path(m)
+""" % render.bldpkg_path(m)
                 print(no_upload_message)
 
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -183,6 +183,12 @@ def create_info_files(m, files, include_recipe=True):
                 shutil.copytree(src_path, dst_path)
             else:
                 shutil.copy(src_path, dst_path)
+        # move the potentially unrendered meta.yaml file
+        os.rename(join(recipe_dir, "meta.yaml"), join(recipe_dir, "meta.yaml.template"))
+        # store the rendered meta.yaml file, plus information about where it came from
+        #    and what version of conda-build created it
+        _render_recipe()
+
 
     license_file = m.get_value('about/license_file')
     if license_file:
@@ -368,7 +374,7 @@ def bldpkg_path(m):
     return join(config.bldpkgs_dir, '%s.tar.bz2' % m.dist())
 
 
-def build(m, post=None, include_recipe=True, keep_old_work=False, need_source_download=False):
+def build(m, post=None, include_recipe=True, keep_old_work=False, need_source_download=True):
     '''
     Build the package with the specified metadata.
 
@@ -436,7 +442,8 @@ def build(m, post=None, include_recipe=True, keep_old_work=False, need_source_do
                 try:
                     os.environ['PATH'] = prepend_bin_path({'PATH': _old_path},
                                                             config.build_prefix)['PATH']
-                    m, need_source_download = parse_or_try_download(m, no_download_source=False)
+                    m, need_source_download = parse_or_try_download(m, no_download_source=False,
+                                                                    hide_output=False)
                     assert not need_source_download, "Source download failed.  Please investigate."
                 finally:
                     os.environ['PATH'] = _old_path

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -27,9 +27,10 @@ from conda.lock import Locked
 from conda.utils import url_path
 from conda.resolve import Resolve, MatchSpec, NoPackagesFound
 
+from conda_build import __version__
 from conda_build import environ, source, tarcheck
 from conda_build.config import config
-from conda_build.render import parse_or_try_download
+from conda_build.render import parse_or_try_download, output_yaml, bldpkg_path
 from conda_build.scripts import create_entry_points, prepend_bin_path
 from conda_build.post import (post_process, post_build,
                               fix_permissions, get_build_metadata)
@@ -183,12 +184,17 @@ def create_info_files(m, files, include_recipe=True):
                 shutil.copytree(src_path, dst_path)
             else:
                 shutil.copy(src_path, dst_path)
-        # move the potentially unrendered meta.yaml file
         os.rename(join(recipe_dir, "meta.yaml"), join(recipe_dir, "meta.yaml.template"))
-        # store the rendered meta.yaml file, plus information about where it came from
-        #    and what version of conda-build created it
-        _render_recipe()
 
+    # store the rendered meta.yaml file, plus information about where it came from
+    #    and what version of conda-build created it
+    metayaml = output_yaml(m)
+    with open(join(config.info_dir, "meta.yaml"), 'w') as f:
+        f.write("# This file created by conda-build {}\n".format(__version__))
+        f.write("# meta.yaml template originally from:\n")
+        f.write("# " + source.get_repository_info(m.path) + "\n")
+        f.write("# ------------------------------------------------\n\n")
+        f.write(metayaml)
 
     license_file = m.get_value('about/license_file')
     if license_file:
@@ -235,7 +241,7 @@ def create_info_files(m, files, include_recipe=True):
 
     if sys.platform == 'win32':
         # make sure we use '/' path separators in metadata
-        files = [f.replace('\\', '/') for f in files]
+        files = [_f.replace('\\', '/') for _f in files]
 
     with open(join(config.info_dir, 'files'), 'w') as fo:
         if m.get_value('build/noarch_python'):
@@ -367,14 +373,8 @@ def rm_pkgs_cache(dist):
     plan.execute_plan(rmplan)
 
 
-def bldpkg_path(m):
-    '''
-    Returns path to built package's tarball given its ``Metadata``.
-    '''
-    return join(config.bldpkgs_dir, '%s.tar.bz2' % m.dist())
-
-
-def build(m, post=None, include_recipe=True, keep_old_work=False, need_source_download=True):
+def build(m, post=None, include_recipe=True, keep_old_work=False,
+          need_source_download=True, verbose=True):
     '''
     Build the package with the specified metadata.
 
@@ -442,8 +442,10 @@ def build(m, post=None, include_recipe=True, keep_old_work=False, need_source_do
                 try:
                     os.environ['PATH'] = prepend_bin_path({'PATH': _old_path},
                                                             config.build_prefix)['PATH']
-                    m, need_source_download = parse_or_try_download(m, no_download_source=False,
-                                                                    hide_output=False)
+                    m, need_source_download = parse_or_try_download(m,
+                                                                    no_download_source=False,
+                                                                    force_download=True,
+                                                                    verbose=verbose)
                     assert not need_source_download, "Source download failed.  Please investigate."
                 finally:
                     os.environ['PATH'] = _old_path

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -70,7 +70,9 @@ different sets of packages."""
     p.add_argument(
         '-t', "--test",
         action="store_true",
-        help="Test package (assumes package is already build).",
+        help="Test package (assumes package is already built).  RECIPE_DIR argument can be either "
+        "recipe directory, in which case source download may be necessary to resolve package"
+        "version, or path to built package .tar.bz2 file, in which case no source is necessary.",
     )
     p.add_argument(
         '--no-test',
@@ -271,7 +273,7 @@ def execute(args, parser):
 
         # this fully renders any jinja templating, throwing an error if any data is missing
         m, need_source_download = render_recipe(recipe_dir, no_download_source=False,
-                                                hide_download_output=args.output)
+                                                verbose=build.verbose)
         if m.get_value('build/noarch_python'):
             config.noarch = True
 

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -270,7 +270,8 @@ def execute(args, parser):
             sys.exit("Error: no such directory: %s" % recipe_dir)
 
         # this fully renders any jinja templating, throwing an error if any data is missing
-        m, need_source_download = render_recipe(recipe_dir, no_download_source=False)
+        m, need_source_download = render_recipe(recipe_dir, no_download_source=False,
+                                                hide_download_output=args.output)
         if m.get_value('build/noarch_python'):
             config.noarch = True
 

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -8,15 +8,11 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 
-import yaml
-
-from conda.compat import PY3
 from conda.cli.common import add_parser_channels
 from conda.cli.conda_argparse import ArgumentParser
 
 from conda_build import __version__
-from conda_build.build import bldpkg_path
-from conda_build.render import render_recipe, set_language_env_vars
+from conda_build.render import render_recipe, set_language_env_vars, bldpkg_path, output_yaml
 from conda_build.utils import find_recipe
 from conda_build.completers import (RecipeCompleter, PythonVersionCompleter, RVersionsCompleter,
                                     LuaVersionsCompleter, NumPyVersionCompleter)
@@ -116,16 +112,21 @@ def main():
         choices=RecipeCompleter(),
         help="Path to recipe directory.",
     )
-
+    # this is here because we have a different default than build
+    p.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Enable verbose output from download tools and progress updates',
+    )
     args = p.parse_args()
     set_language_env_vars(args, p)
 
-    metadata, _ = _render_recipe(find_recipe(args.recipe), no_download_source=args.no_source,
-                                 hide_download_output=args.output)
+    metadata, _ = render_recipe(find_recipe(args.recipe), no_download_source=args.no_source,
+                                 verbose=args.verbose)
     if args.output:
-        print(_get_output_path(metadata))
+        print(bldpkg_path(metadata))
     else:
-        print(_output_yaml(metadata, args.file)
+        print(output_yaml(metadata, args.file))
 
 if __name__ == '__main__':
     main()

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -41,7 +41,7 @@ platform specifics, making it simple to create working environments from
         version='conda-build %s' % __version__,
     )
     p.add_argument(
-        '-n', "--no_source",
+        '-n', "--no-source",
         action="store_true",
         help="When templating can't be completed, do not obtain the \
 source to try fill in related template variables.",
@@ -100,37 +100,6 @@ source to try fill in related template variables.",
     return p
 
 
-# Next bit of stuff is to support YAML output in the order we expect.
-# http://stackoverflow.com/a/17310199/1170370
-class MetaYaml(dict):
-    fields = ["package", "source", "build", "requirements", "test", "about", "extra"]
-
-    def to_omap(self):
-        return [(field, self[field]) for field in MetaYaml.fields if field in self]
-
-
-def represent_omap(dumper, data):
-    return dumper.represent_mapping(u'tag:yaml.org,2002:map', data.to_omap())
-
-
-def unicode_representer(dumper, uni):
-    node = yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=uni)
-    return node
-
-
-class IndentDumper(yaml.Dumper):
-    def increase_indent(self, flow=False, indentless=False):
-        return super(IndentDumper, self).increase_indent(flow, False)
-
-
-yaml.add_representer(MetaYaml, represent_omap)
-if PY3:
-    yaml.add_representer(str, unicode_representer)
-    unicode = None  # silence pyflakes about unicode not existing in py3
-else:
-    yaml.add_representer(unicode, unicode_representer)
-
-
 def main():
     p = get_render_parser()
     p.add_argument(
@@ -151,18 +120,12 @@ def main():
     args = p.parse_args()
     set_language_env_vars(args, p)
 
-    metadata = render_recipe(find_recipe(args.recipe), no_download_source=args.no_source)
+    metadata, _ = _render_recipe(find_recipe(args.recipe), no_download_source=args.no_source,
+                                 hide_download_output=args.output)
     if args.output:
-        print(bldpkg_path(metadata))
+        print(_get_output_path(metadata))
     else:
-        output = yaml.dump(MetaYaml(metadata.meta), Dumper=IndentDumper,
-                            default_flow_style=False, indent=4)
-        if args.file:
-            with open(args.file, "w") as f:
-                f.write(output)
-        else:
-            print(output)
-
+        print(_output_yaml(metadata, args.file)
 
 if __name__ == '__main__':
     main()

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -376,26 +376,26 @@ def check_symlinks(files):
 def get_build_metadata(m):
     src_dir = source.get_dir()
     if exists(join(src_dir, '__conda_version__.txt')):
-        print("Deprecation warning: support for __conda_version__ will be removed in Conda build 2.0."
+        print("Deprecation warning: support for __conda_version__ will be removed in Conda build 2.0."  # noqa
               "Try Jinja templates instead: "
-              "http://conda.pydata.org/docs/building/environment-vars.html#git-environment-variables")
+              "http://conda.pydata.org/docs/building/environment-vars.html#git-environment-variables")  # noqa
         with open(join(src_dir, '__conda_version__.txt')) as f:
             version = f.read().strip()
             print("Setting version from __conda_version__.txt: %s" % version)
             m.meta['package']['version'] = version
     if exists(join(src_dir, '__conda_buildnum__.txt')):
-        print("Deprecation warning: support for __conda_buildnum__ will be removed in Conda build 2.0."
+        print("Deprecation warning: support for __conda_buildnum__ will be removed in Conda build 2.0."  # noqa
               "Try Jinja templates instead: "
-              "http://conda.pydata.org/docs/building/environment-vars.html#git-environment-variables")
+              "http://conda.pydata.org/docs/building/environment-vars.html#git-environment-variables")  # noqa
         with open(join(src_dir, '__conda_buildnum__.txt')) as f:
             build_number = f.read().strip()
             print("Setting build number from __conda_buildnum__.txt: %s" %
                   build_number)
             m.meta['build']['number'] = build_number
     if exists(join(src_dir, '__conda_buildstr__.txt')):
-        print("Deprecation warning: support for __conda_buildstr__ will be removed in Conda build 2.0."
+        print("Deprecation warning: support for __conda_buildstr__ will be removed in Conda build 2.0."  # noqa
               "Try Jinja templates instead: "
-              "http://conda.pydata.org/docs/building/environment-vars.html#git-environment-variables")
+              "http://conda.pydata.org/docs/building/environment-vars.html#git-environment-variables")  # noqa
         with open(join(src_dir, '__conda_buildstr__.txt')) as f:
             buildstr = f.read().strip()
             print("Setting version from __conda_buildstr__.txt: %s" % buildstr)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+
+from conda.compat import PY3
+from conda.config import subdir
+
+thisdir = os.path.dirname(os.path.realpath(__file__))
+metadata_dir = os.path.join(thisdir, "test-recipes/metadata")
+
+
+def test_output_build_path():
+    cmd = 'conda render --output {}'.format(os.path.join(metadata_dir, "python_run"))
+    process = subprocess.Popen(cmd.split(),
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = process.communicate()
+    test_path = os.path.join(sys.prefix, "conda-bld", subdir,
+                                  "conda-build-test-python-run-1.0-py{}{}_0.tar.bz2".format(
+                                      sys.version_info.major, sys.version_info.minor))
+    if PY3:
+        output = output.decode("UTF-8")
+    assert output.rstrip() == test_path


### PR DESCRIPTION
conda build --output was outputting other stuff, when external tools required strictly the package output path.  This fixes it, and adds tests for the behavior.

Closes #949 (sorry everyone)