### PR TITLE
Add git precommit hook to run flake8; add script to "install" it

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This file is not automatically enabled on your clone.  To enable it,
+#   you need to:
+#
+# cd <root of conda-build clone>
+# ln -s $(pwd)/git_hooks/pre-commit .git/hooks/pre-commit
+
+# Run flake8
+flake8 .

--- a/install_pre_commit_hook.sh
+++ b/install_pre_commit_hook.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "${0%/*}"
+ln -s $(pwd)/git_hooks/pre-commit .git/hooks/pre-commit


### PR DESCRIPTION
This does not install itself - it must be a user choice.  The install script provided here is one simple way, if people don't already have their pre-commit hook set.

Should anything else be added here?  I know I'll use this - would this be useful to anyone else?