### PR TITLE
metadata: Fixed selector regex to avoid confusion with jinja templates

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -69,7 +69,15 @@ def ns_cfg():
     return d
 
 
-sel_pat = re.compile(r'(.+?)\s*(#.*)?\[(.+)\](?(2).*)$')
+# Selectors must be either:
+# - at end of the line
+# - embedded (anywhere) within a comment
+#
+# Notes:
+# - [([^\[\]]+)\] means "find a pair of brackets containing any
+#                 NON-bracket chars, and capture the contents"
+# - (?(2).*)$ means "allow trailing characters iff group 2 (#.*) was found."
+sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 
 
 def select_lines(data, namespace):

--- a/tests/test-recipes/metadata/jinja_vars/meta.yaml
+++ b/tests/test-recipes/metadata/jinja_vars/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   number: 123
-  string: {{CONDA_TEST_VAR}}_{{PKG_BUILDNUM}}
+  string: {{CONDA_TEST_VAR[:]}}_{{PKG_BUILDNUM}} # [True]
 
   script_env:
     - CONDA_TEST_VAR

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,26 +9,40 @@ def test_select_lines():
     lines = """
 test
 test [abc] no
+test [abc] # no
 
 test [abc]
 test # [abc]
 test # [abc] yes
 test # stuff [abc] yes
+test {{ JINJA_VAR[:2] }}
+test {{ JINJA_VAR[:2] }} # stuff [abc] yes
+test {{ JINJA_VAR[:2] }} # stuff yes [abc]
+test {{ JINJA_VAR[:2] }} # [abc] stuff yes
+{{ environ["test"] }}  # [abc]
 """
 
     assert select_lines(lines, {'abc': True}) == """
 test
 test [abc] no
+test [abc] # no
 
 test
 test
 test
 test
+test {{ JINJA_VAR[:2] }}
+test {{ JINJA_VAR[:2] }}
+test {{ JINJA_VAR[:2] }}
+test {{ JINJA_VAR[:2] }}
+{{ environ["test"] }}
 """
     assert select_lines(lines, {'abc': False}) == """
 test
 test [abc] no
+test [abc] # no
 
+test {{ JINJA_VAR[:2] }}
 """
 
 


### PR DESCRIPTION
The fix here is to replace `(.+)` with `([^\[\]]+)`:

```diff
-sel_pat = re.compile(r'(.+?)\s*(#.*)?\[(.+)\](?(2).*)$')
+sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
```

That is, selectors don't contain "any character", they contain "any non-bracket character".

Fixes #955 