### PR TITLE
MatchSpec.strictness is no more

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -304,10 +304,10 @@ def handle_config_version(ms, ver):
     configuration, e.g. for ms.name == 'python', ver = 26 or None,
     return a (sometimes new) MatchSpec object
     """
-    if ms.strictness == 3:
+    if ms.is_exact():
         return ms
 
-    if ms.strictness == 2:
+    if not ms.is_simple() and not ms.is_exact():
         if ms.spec.split()[1] == 'x.x':
             if ver is None:
                 raise RuntimeError("'%s' requires external setting" % ms.spec)
@@ -315,7 +315,7 @@ def handle_config_version(ms, ver):
         else:  # regular version
             return ms
 
-    if ver is None or (ms.strictness == 1 and ms.name == 'numpy'):
+    if ver is None or (ms.is_simple() and ms.name == 'numpy'):
         return MatchSpec(ms.name)
 
     ver = text_type(ver)


### PR DESCRIPTION
It's been replaced with MatchSpec.is_simple() and
MatchSpec.is_exact():

https://github.com/conda/conda/commit/6ddc6d9845a49f25fa67ed6702c409168b2be1e8