### PR TITLE
fix more source checkout outputs showing up without --verbose

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -273,7 +273,7 @@ def execute(args, parser):
 
         # this fully renders any jinja templating, throwing an error if any data is missing
         m, need_source_download = render_recipe(recipe_dir, no_download_source=False,
-                                                verbose=build.verbose)
+                                                verbose=False)
         if m.get_value('build/noarch_python'):
             config.noarch = True
 
@@ -299,7 +299,7 @@ def execute(args, parser):
         elif args.test:
             build.test(m, move_broken=False)
         elif args.source:
-            source.provide(m.path, m.get_section('source'))
+            source.provide(m.path, m.get_section('source'), verbose=build.verbose)
             print('Source tree in:', source.get_dir())
         else:
             # This loop recursively builds dependencies if recipes exist

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -23,13 +23,13 @@ def is_valid_dir(parent_dir, dirname):
 
 
 # TODO: this does not currently take into account post-build versioning changes with __conda_? files
-def test_output_build_path():
-    cmd = 'conda build --output {}'.format(os.path.join(metadata_dir, "python_run"))
+def test_output_build_path_git_source():
+    cmd = 'conda build --output {}'.format(os.path.join(metadata_dir, "source_git_jinja2"))
     process = subprocess.Popen(cmd.split(),
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output, error = process.communicate()
     test_path = os.path.join(sys.prefix, "conda-bld", subdir,
-                                  "conda-build-test-python-run-1.0-py{}{}_0.tar.bz2".format(
+                        "conda-build-test-source-git-jinja2-1.8.1-py{}{}_0_gf3d51ae.tar.bz2".format(
                                       sys.version_info.major, sys.version_info.minor))
     if PY3:
         output = output.decode("UTF-8")


### PR DESCRIPTION
Extra output was showing up with git sources that the test was not catching.  We need tests for svn and hg, as well as file copying.  Filing issues for those separately.

cc @stefanseefeld