### PR TITLE
Metadata: Track undefined jinja names and decide whether to download source

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -9,10 +9,61 @@ import json
 import os
 from functools import partial
 
+import jinja2
+
 from conda.compat import PY3
 from .environ import get_dict as get_environ
+from .metadata import select_lines, ns_cfg
 
 _setuptools_data = None
+
+
+class UndefinedNeverFail(jinja2.Undefined):
+    """
+    A class for Undefined jinja variables.
+    This is even less strict than the default jinja2.Undefined class,
+    because it permits things like {{ MY_UNDEFINED_VAR[:2] }} and
+    {{ MY_UNDEFINED_VAR|int }}. This can mask lots of errors in jinja templates, so it
+    should only be used for a first-pass parse, when you plan on running a 'strict'
+    second pass later.
+    """
+    __add__ = __radd__ = __mul__ = __rmul__ = __div__ = __rdiv__ = \
+    __truediv__ = __rtruediv__ = __floordiv__ = __rfloordiv__ = \
+    __mod__ = __rmod__ = __pos__ = __neg__ = __call__ = \
+    __getitem__ = __lt__ = __le__ = __gt__ = __ge__ = \
+    __complex__ = __pow__ = __rpow__ = \
+        lambda *args, **kwargs: UndefinedNeverFail()
+
+    __str__ = __repr__ = \
+        lambda *args, **kwargs: u''
+
+    __int__ = lambda _: 0
+    __float__ = lambda _: 0.0
+
+    def __getattr__(self, k):
+        try:
+            return object.__getattr__(self, k)
+        except AttributeError:
+            return UndefinedNeverFail()
+
+    def __setattr__(self, k, v):
+        pass
+
+
+class FilteredLoader(jinja2.BaseLoader):
+    """
+    A pass-through for the given loader, except that the loaded source is
+    filtered according to any metadata selectors in the source text.
+    """
+
+    def __init__(self, unfiltered_loader):
+        self._unfiltered_loader = unfiltered_loader
+        self.list_templates = unfiltered_loader.list_templates
+
+    def get_source(self, environment, template):
+        contents, filename, uptodate = self._unfiltered_loader.get_source(environment,
+                                                                          template)
+        return select_lines(contents, ns_cfg()), filename, uptodate
 
 
 def load_setuptools(setup_file='setup.py', from_recipe_dir=False,

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -27,6 +27,13 @@ class UndefinedNeverFail(jinja2.Undefined):
     should only be used for a first-pass parse, when you plan on running a 'strict'
     second pass later.
     """
+    all_undefined_names = []
+
+    def __init__(self, hint=None, obj=jinja2.runtime.missing, name=None,
+                 exc=jinja2.exceptions.UndefinedError):
+        UndefinedNeverFail.all_undefined_names.append(name)
+        jinja2.Undefined.__init__(self, hint, obj, name, exc)
+
     __add__ = __radd__ = __mul__ = __rmul__ = __div__ = __rdiv__ = \
     __truediv__ = __rtruediv__ = __floordiv__ = __rfloordiv__ = \
     __mod__ = __rmod__ = __pos__ = __neg__ = __call__ = \

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -610,7 +610,7 @@ class MetaData(object):
             with open(self.meta_path) as fd:
                 return fd.read()
 
-        from conda_build.jinja_context import context_processor
+        from conda_build.jinja_context import context_processor, UndefinedNeverFail, FilteredLoader
 
         path, filename = os.path.split(self.meta_path)
         loaders = [  # search relative to '<conda_root>/Lib/site-packages/conda_build/templates'
@@ -627,54 +627,8 @@ class MetaData(object):
             env_loader = jinja2.FileSystemLoader(conda_env_path)
             loaders.append(jinja2.PrefixLoader({'$CONDA_DEFAULT_ENV': env_loader}))
 
-        class FilteredLoader(jinja2.BaseLoader):
-            """
-            A pass-through for the given loader, except that the loaded source is
-            filtered according to any metadata selectors in the source text.
-            """
-
-            def __init__(self, unfiltered_loader):
-                self._unfiltered_loader = unfiltered_loader
-                self.list_templates = unfiltered_loader.list_templates
-
-            def get_source(self, environment, template):
-                contents, filename, uptodate = self._unfiltered_loader.get_source(environment,
-                                                                                  template)
-                return select_lines(contents, ns_cfg()), filename, uptodate
-
         undefined_type = jinja2.StrictUndefined
         if permit_undefined_jinja:
-            class UndefinedNeverFail(jinja2.Undefined):
-                """
-                A class for Undefined jinja variables.
-                This is even less strict than the default jinja2.Undefined class,
-                because it permits things like {{ MY_UNDEFINED_VAR[:2] }} and
-                {{ MY_UNDEFINED_VAR|int }}. This can mask lots of errors in jinja templates, so it
-                should only be used for a first-pass parse, when you plan on running a 'strict'
-                second pass later.
-                """
-                __add__ = __radd__ = __mul__ = __rmul__ = __div__ = __rdiv__ = \
-                __truediv__ = __rtruediv__ = __floordiv__ = __rfloordiv__ = \
-                __mod__ = __rmod__ = __pos__ = __neg__ = __call__ = \
-                __getitem__ = __lt__ = __le__ = __gt__ = __ge__ = \
-                __complex__ = __pow__ = __rpow__ = \
-                    lambda *args, **kwargs: UndefinedNeverFail()
-
-                __str__ = __repr__ = \
-                    lambda *args, **kwargs: u''
-
-                __int__ = lambda _: 0
-                __float__ = lambda _: 0.0
-
-                def __getattr__(self, k):
-                    try:
-                        return object.__getattr__(self, k)
-                    except AttributeError:
-                        return UndefinedNeverFail()
-
-                def __setattr__(self, k, v):
-                    pass
-
             undefined_type = UndefinedNeverFail
 
         loader = FilteredLoader(jinja2.ChoiceLoader(loaders))

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -75,9 +75,8 @@ def bldpkg_path(m):
 
 
 def parse_or_try_download(metadata, no_download_source, verbose, force_download=False):
-    if (("version" not in metadata.meta["package"] or
-         not metadata.meta["package"]["version"]) and
-         not no_download_source) or force_download:
+    if (force_download or (not no_download_source and
+                           any(var.startswith('GIT_') for var in metadata.undefined_jinja_vars))):
         # this try/catch is for when the tool to download source is actually in
         #    meta.yaml, and not previously installed in builder env.
         try:

--- a/tests/test-recipes/metadata/jinja2_build_str_template_only/bld.bat
+++ b/tests/test-recipes/metadata/jinja2_build_str_template_only/bld.bat
@@ -1,0 +1,26 @@
+if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
+git describe --tags --dirty
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
+if errorlevel 1 exit 1
+echo "%gitdesc%"
+if not "%gitdesc%"=="1.8.1" exit 1
+git status
+if errorlevel 1 exit 1
+git diff
+if errorlevel 1 exit 1
+set PYTHONPATH=.
+python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
+if errorlevel 1 exit 1
+
+
+rem check that GIT_* tags are present
+for %%i in (GIT_DESCRIBE_TAG GIT_DESCRIBE_NUMBER GIT_DESCRIBE_HASH GIT_FULL_HASH) DO (
+  if defined %%i (
+      echo %%i
+  ) else (
+    exit 1
+  )
+)

--- a/tests/test-recipes/metadata/jinja2_build_str_template_only/build.sh
+++ b/tests/test-recipes/metadata/jinja2_build_str_template_only/build.sh
@@ -1,0 +1,17 @@
+# We test the environment variables in a different recipe
+
+# Ensure we are in a git repo
+[ -d .git ]
+git describe
+[ "$(git describe)" = 1.8.1 ]
+PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.8.1', conda_build.__version__"
+
+# check if GIT_* variables are defined
+for i in GIT_DESCRIBE_TAG GIT_DESCRIBE_NUMBER GIT_DESCRIBE_HASH GIT_FULL_HASH
+do
+  if [ -n "eval $i" ]; then
+    eval echo \$$i
+  else
+    exit 1
+  fi
+done

--- a/tests/test-recipes/metadata/jinja2_build_str_template_only/meta.yaml
+++ b/tests/test-recipes/metadata/jinja2_build_str_template_only/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: conda-build-test-source-git-jinja2-2
+  version: 1.0
+
+source:
+  git_url: https://github.com/conda/conda-build
+  git_tag: 1.8.1
+
+build:
+  string: {{ PKG_BUILDNUM }}_g{{ GIT_FULL_HASH[:7] }}
+
+requirements:
+  build:
+    # To test the conda_build version
+    - python


### PR DESCRIPTION
**Background:**
Some of the functions that decide whether or not to download the source before jinja rendering changed recently.  (For example, 1a7ebcac287de48493fdb58e0f981f40d85f0ef3 / cc6a3f92999854a58130a7eadea6242be552fcbd)

The function `parse_or_try_download()` decides whether the source is needed before the final parse.  Previously, the decision was made based on the contents of the `package/version` field.  As it turns out, this is not a sufficient condition, because it fails for a recipe like this:

```yaml
package:
  name: foo
  version: 1.0

source:
  git_url: http://github.com/foo/foo

build:
  string: g{{ GIT_FULL_HASH[:7] }}
```

```
$ conda build foo
Error: Failed to render jinja template in foo/meta.yaml:
'GIT_FULL_HASH' is undefined
```

**Solution:**
During the first parse, we permit undefined jinja variables using a special class named `UndefinedNeverFail`.  I tweaked that class so that it *records* the names of the undefined variables.  These names are stored in `Metadata.undefined_jinja_vars`.  Now, during `parse_or_try_download()`, we can just check the names of the variables that remain undefined.  If any `GIT_` variables were undefined, we need to download the source.

**Note:** This PR looks big, but that's just because the first commit moves some lines of code around (without changing them).  I recommend reviewing these commits individually, not as a combined diff.

cc @msarahan 