### PR TITLE
Two tiny fixes

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -93,7 +93,7 @@ def verify_git_repo(git_dir, git_url, expected_rev='HEAD'):
 
         # If the current source directory in conda-bld/work doesn't match the user's
         # metadata git_url or git_rev, then we aren't looking at the right source.
-        if remote_url != git_url:
+        if remote_url.lower() != git_url.lower():
             return False
     except CalledProcessError:
         return False

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -39,7 +39,10 @@ class UndefinedNeverFail(jinja2.Undefined):
     __mod__ = __rmod__ = __pos__ = __neg__ = __call__ = \
     __getitem__ = __lt__ = __le__ = __gt__ = __ge__ = \
     __complex__ = __pow__ = __rpow__ = \
-        lambda *args, **kwargs: UndefinedNeverFail()
+        lambda self, *args, **kwargs: UndefinedNeverFail(hint=self._undefined_hint,
+                                                         obj=self._undefined_obj,
+                                                         name=self._undefined_name,
+                                                         exc=self._undefined_exception)
 
     __str__ = __repr__ = \
         lambda *args, **kwargs: u''
@@ -51,10 +54,10 @@ class UndefinedNeverFail(jinja2.Undefined):
         try:
             return object.__getattr__(self, k)
         except AttributeError:
-            return UndefinedNeverFail()
-
-    def __setattr__(self, k, v):
-        pass
+            return UndefinedNeverFail(hint=self._undefined_hint,
+                                      obj=self._undefined_obj,
+                                      name=self._undefined_name + '.' + k,
+                                      exc=self._undefined_exception)
 
 
 class FilteredLoader(jinja2.BaseLoader):


### PR DESCRIPTION
These commits were meant to be tacked on to #964, but I didn't push them in time before it was merged.  Sorry about that.

The `jinja_context` commit is pretty minor, but will hopefully it will help avoid potential surprises in the future.

The `environ` change here is important if you build a recipe with a `git_url` and then accidentally change the capitalization in the URL.

For example, if your recipe says:

```yaml
source:
  git_url: https://github.com/Foo/bar
```

and later you accidentally change it to:

```yaml
source:
  git_url: https://github.com/Foo/Bar
```

... then you'll encounter a weird error. `verify_git_repo()` will think that the git cache is out-of-sync, so `GIT_*` variables won't work.  Oops.  This PR just makes the comparison case-insensitive.

cc @msarahan -- Sorry again for the double-PR.