### PR TITLE
add --dirty flag to skip download/extraction step

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -374,7 +374,7 @@ def rm_pkgs_cache(dist):
 
 
 def build(m, post=None, include_recipe=True, keep_old_work=False,
-          need_source_download=True, verbose=True):
+          need_source_download=True, verbose=True, dirty=False):
     '''
     Build the package with the specified metadata.
 
@@ -419,14 +419,15 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
 
         if post in [False, None]:
             print("Removing old build environment")
-            if on_win:
-                if isdir(config.short_build_prefix):
-                    move_to_trash(config.short_build_prefix, '')
-                if isdir(config.long_build_prefix):
-                    move_to_trash(config.long_build_prefix, '')
-            else:
-                rm_rf(config.short_build_prefix)
-                rm_rf(config.long_build_prefix)
+            if not dirty:
+                if on_win:
+                    if isdir(config.short_build_prefix):
+                        move_to_trash(config.short_build_prefix, '')
+                    if isdir(config.long_build_prefix):
+                        move_to_trash(config.long_build_prefix, '')
+                else:
+                    rm_rf(config.short_build_prefix)
+                    rm_rf(config.long_build_prefix)
 
             # Display the name only
             # Version number could be missing due to dependency on source info.
@@ -445,7 +446,8 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
                     m, need_source_download = parse_or_try_download(m,
                                                                     no_download_source=False,
                                                                     force_download=True,
-                                                                    verbose=verbose)
+                                                                    verbose=verbose,
+                                                                    dirty=dirty)
                     assert not need_source_download, "Source download failed.  Please investigate."
                 finally:
                     os.environ['PATH'] = _old_path

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -420,20 +420,19 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
         if post in [False, None]:
             print("Removing old build environment")
             print("BUILD START:", m.dist())
-            if not dirty:
-                if on_win:
-                    if isdir(config.short_build_prefix):
-                        move_to_trash(config.short_build_prefix, '')
-                    if isdir(config.long_build_prefix):
-                        move_to_trash(config.long_build_prefix, '')
-                else:
-                    rm_rf(config.short_build_prefix)
-                    rm_rf(config.long_build_prefix)
+            if on_win:
+                if isdir(config.short_build_prefix):
+                    move_to_trash(config.short_build_prefix, '')
+                if isdir(config.long_build_prefix):
+                    move_to_trash(config.long_build_prefix, '')
+            else:
+                rm_rf(config.short_build_prefix)
+                rm_rf(config.long_build_prefix)
 
-                # Display the name only
-                # Version number could be missing due to dependency on source info.
-                create_env(config.build_prefix,
-                        [ms.spec for ms in m.ms_depends('build')])
+            # Display the name only
+            # Version number could be missing due to dependency on source info.
+            create_env(config.build_prefix,
+                    [ms.spec for ms in m.ms_depends('build')])
 
             if need_source_download:
                 # Execute any commands fetching the source (e.g., git) in the _build environment.

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -419,6 +419,7 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
 
         if post in [False, None]:
             print("Removing old build environment")
+            print("BUILD START:", m.dist())
             if not dirty:
                 if on_win:
                     if isdir(config.short_build_prefix):
@@ -429,11 +430,10 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
                     rm_rf(config.short_build_prefix)
                     rm_rf(config.long_build_prefix)
 
-            # Display the name only
-            # Version number could be missing due to dependency on source info.
-            print("BUILD START:", m.dist())
-            create_env(config.build_prefix,
-                    [ms.spec for ms in m.ms_depends('build')])
+                # Display the name only
+                # Version number could be missing due to dependency on source info.
+                create_env(config.build_prefix,
+                        [ms.spec for ms in m.ms_depends('build')])
 
             if need_source_download:
                 # Execute any commands fetching the source (e.g., git) in the _build environment.
@@ -503,7 +503,7 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
                 import conda_build.windows as windows
                 windows.build(m, build_file)
             else:
-                env = environ.get_dict(m)
+                env = environ.get_dict(m, dirty=dirty)
                 build_file = join(m.path, 'build.sh')
 
                 if script:

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -143,12 +143,12 @@ def get_git_info(repo):
     return d
 
 
-def get_dict(m=None, prefix=None):
+def get_dict(m=None, prefix=None, dirty=False):
     if not prefix:
         prefix = config.build_prefix
 
     # conda-build specific vars
-    d = conda_build_vars(prefix)
+    d = conda_build_vars(prefix, dirty)
 
     # languages
     d.update(python_vars())
@@ -164,7 +164,7 @@ def get_dict(m=None, prefix=None):
     return d
 
 
-def conda_build_vars(prefix):
+def conda_build_vars(prefix, dirty):
     return {
         'CONDA_BUILD': '1',
         'PYTHONNOUSERSITE': '1',
@@ -176,6 +176,7 @@ def conda_build_vars(prefix):
         'SRC_DIR': source.get_dir(),
         'HTTPS_PROXY': os.getenv('HTTPS_PROXY', ''),
         'HTTP_PROXY': os.getenv('HTTP_PROXY', ''),
+        'DIRTY': '1' if dirty else '',
     }
 
 

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -324,8 +324,7 @@ def execute(args, parser):
                             include_recipe=args.include_recipe,
                             keep_old_work=args.keep_old_work,
                             need_source_download=need_source_download,
-                            dirty=args.dirty
-                )
+                            dirty=args.dirty)
             except (NoPackagesFound, Unsatisfiable) as e:
                 error_str = str(e)
                 # Typically if a conflict is with one of these

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -112,6 +112,12 @@ different sets of packages."""
         callstacks involving multiple packages/recipes. """
     )
     p.add_argument(
+        '--dirty',
+        action='store_true',
+        help='Do not remove work directory or _build environment, '
+        'to speed up debugging.  Does not apply patches or download source.'
+    )
+    p.add_argument(
         '-q', "--quiet",
         action="store_true",
         help="do not display progress bar",
@@ -317,7 +323,9 @@ def execute(args, parser):
                 build.build(m, post=post,
                             include_recipe=args.include_recipe,
                             keep_old_work=args.keep_old_work,
-                            need_source_download=need_source_download)
+                            need_source_download=need_source_download,
+                            dirty=args.dirty
+                )
             except (NoPackagesFound, Unsatisfiable) as e:
                 error_str = str(e)
                 # Typically if a conflict is with one of these

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -99,7 +99,7 @@ def parse_or_try_download(metadata, no_download_source, verbose,
     return metadata, need_source_download
 
 
-def render_recipe(recipe_path, no_download_source, verbose):
+def render_recipe(recipe_path, no_download_source, verbose, dirty=False):
     with Locked(config.croot):
         arg = recipe_path
         # Don't use byte literals for paths in Python 2
@@ -129,7 +129,7 @@ def render_recipe(recipe_path, no_download_source, verbose):
             sys.exit(1)
 
         m = parse_or_try_download(m, no_download_source=no_download_source,
-                                  verbose=verbose)
+                                  verbose=verbose, dirty=dirty)
 
         if need_cleanup:
             shutil.rmtree(recipe_dir)

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -74,13 +74,15 @@ def bldpkg_path(m):
     return os.path.join(config.bldpkgs_dir, '%s.tar.bz2' % m.dist())
 
 
-def parse_or_try_download(metadata, no_download_source, verbose, force_download=False):
+def parse_or_try_download(metadata, no_download_source, verbose,
+                          force_download=False, dirty=False):
     if (force_download or (not no_download_source and
                            any(var.startswith('GIT_') for var in metadata.undefined_jinja_vars))):
         # this try/catch is for when the tool to download source is actually in
         #    meta.yaml, and not previously installed in builder env.
         try:
-            source.provide(metadata.path, metadata.get_section('source'), verbose=verbose)
+            source.provide(metadata.path, metadata.get_section('source'),
+                           verbose=verbose, dirty=dirty)
             metadata.parse_again(permit_undefined_jinja=False)
             need_source_download = False
         except subprocess.CalledProcessError:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -346,7 +346,7 @@ Error:
         os.remove(patch_args[-1])  # clean up .patch_unix file
 
 
-def provide(recipe_dir, meta, verbose=False, patch=True):
+def provide(recipe_dir, meta, verbose=False, patch=True, dirty=False):
     """
     given a recipe_dir:
       - download (if necessary)
@@ -354,35 +354,37 @@ def provide(recipe_dir, meta, verbose=False, patch=True):
       - apply patches (if any)
     """
 
-    if sys.platform == 'win32':
-        if isdir(WORK_DIR):
-            move_to_trash(WORK_DIR, '')
-    else:
-        rm_rf(WORK_DIR)
+    if not dirty:
+        if sys.platform == 'win32':
+            if isdir(WORK_DIR):
+                move_to_trash(WORK_DIR, '')
+        else:
+            rm_rf(WORK_DIR)
 
-    if any(k in meta for k in ('fn', 'url')):
-        unpack(meta, verbose=verbose)
-    elif 'git_url' in meta:
-        git_source(meta, recipe_dir, verbose=verbose)
-    # build to make sure we have a work directory with source in it.  We want to make sure that
-    # build to make sure we have a work directory with source in it.  We want to make sure that
-    #    whatever version that is does not interfere with the test we run next.
-    #    whatever version that is does not interfere with the test we run next.
-    elif 'hg_url' in meta:
-        hg_source(meta, verbose=verbose)
-    elif 'svn_url' in meta:
-        svn_source(meta, verbose=verbose)
-    elif 'path' in meta:
-        if verbose:
-            print("Copying %s to %s" % (abspath(join(recipe_dir, meta.get('path'))), WORK_DIR))
-        copytree(abspath(join(recipe_dir, meta.get('path'))), WORK_DIR)
-    else:  # no source
-        os.makedirs(WORK_DIR)
+    if not os.path.exists(WORK_DIR):
+        if any(k in meta for k in ('fn', 'url')):
+            unpack(meta, verbose=verbose)
+        elif 'git_url' in meta:
+            git_source(meta, recipe_dir, verbose=verbose)
+        # build to make sure we have a work directory with source in it.  We want to make sure that
+        # build to make sure we have a work directory with source in it.  We want to make sure that
+        #    whatever version that is does not interfere with the test we run next.
+        #    whatever version that is does not interfere with the test we run next.
+        elif 'hg_url' in meta:
+            hg_source(meta, verbose=verbose)
+        elif 'svn_url' in meta:
+            svn_source(meta, verbose=verbose)
+        elif 'path' in meta:
+            if verbose:
+                print("Copying %s to %s" % (abspath(join(recipe_dir, meta.get('path'))), WORK_DIR))
+            copytree(abspath(join(recipe_dir, meta.get('path'))), WORK_DIR)
+        else:  # no source
+            os.makedirs(WORK_DIR)
 
-    if patch:
-        src_dir = get_dir()
-        for patch in meta.get('patches', []):
-            apply_patch(src_dir, join(recipe_dir, patch))
+        if patch:
+            src_dir = get_dir()
+            for patch in meta.get('patches', []):
+                apply_patch(src_dir, join(recipe_dir, patch))
 
 
 if __name__ == '__main__':

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -367,8 +367,6 @@ def provide(recipe_dir, meta, verbose=False, patch=True, dirty=False):
         elif 'git_url' in meta:
             git_source(meta, recipe_dir, verbose=verbose)
         # build to make sure we have a work directory with source in it.  We want to make sure that
-        # build to make sure we have a work directory with source in it.  We want to make sure that
-        #    whatever version that is does not interfere with the test we run next.
         #    whatever version that is does not interfere with the test we run next.
         elif 'hg_url' in meta:
             hg_source(meta, verbose=verbose)

--- a/tests/test-recipes/metadata/_dirty_skip_section/bld.bat
+++ b/tests/test-recipes/metadata/_dirty_skip_section/bld.bat
@@ -1,0 +1,3 @@
+:: ensure that the DIRTY environment variable is available for logic in build scripts
+IF "%DIRTY%" == "1" exit 0
+exit 1

--- a/tests/test-recipes/metadata/_dirty_skip_section/build.sh
+++ b/tests/test-recipes/metadata/_dirty_skip_section/build.sh
@@ -1,0 +1,3 @@
+# ensure that the DIRTY environment variable is available for logic in build scripts
+[ -n "$DIRTY" ] && exit 0
+exit 1

--- a/tests/test-recipes/metadata/_dirty_skip_section/meta.yaml
+++ b/tests/test-recipes/metadata/_dirty_skip_section/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: conda-build-test-dirty-skip-section
+  version: 1.0
+
+about:
+  summary: ensure that the DIRTY environment variable is available to bld.bat and build.sh

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -104,7 +104,7 @@ def test_dirty_variable_available_in_build_scripts():
                                                                     "_dirty_skip_section"))
     subprocess.check_call(cmd.split())
     with pytest.raises(subprocess.CalledProcessError):
-        cmd=cmd.replace(" --dirty", "")
+        cmd = cmd.replace(" --dirty", "")
         subprocess.check_call(cmd.split())
 
 

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -99,6 +99,15 @@ def test_recipe_builds(recipe):
     subprocess.check_call(cmd.split(), env=env)
 
 
+def test_dirty_variable_available_in_build_scripts():
+    cmd = 'conda build --no-anaconda-upload --dirty {}'.format(os.path.join(metadata_dir,
+                                                                    "_dirty_skip_section"))
+    subprocess.check_call(cmd.split())
+    with pytest.raises(subprocess.CalledProcessError):
+        cmd=cmd.replace(" --dirty", "")
+        subprocess.check_call(cmd.split())
+
+
 def test_checkout_tool_as_dependency():
     # "hide" svn by putting a known bad one on PATH
     tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
I've been working on Qt5 builds.  Extracting the source takes 5-10 *minutes*.  This PR avoids it.  This is a gun pointed at your foot - use it to iterate quickly on recipes, but keep in mind that it may bite you if you forget to capture any source code changes as patches or changes to your recipe.