### PR TITLE
FEATURE_ environment variables

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -20,7 +20,7 @@ import mmap
 import conda.config as cc
 import conda.plan as plan
 from conda.api import get_index
-from conda.compat import PY3
+from conda.compat import PY3, iteritems
 from conda.fetch import fetch_index
 from conda.install import prefix_placeholder, linked, move_to_trash
 from conda.lock import Locked
@@ -38,6 +38,7 @@ from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
 from conda_build.exceptions import indent
+from conda_build.metadata import get_features
 
 
 on_win = (sys.platform == 'win32')
@@ -309,6 +310,11 @@ def create_env(prefix, specs, clear_cache=True):
     '''
     Create a conda envrionment for the given prefix and specs.
     '''
+    specs = list(specs)
+    for feature, value in iteritems(get_features()):
+        if value:
+            specs.append('%s@' % feature)
+
     for d in config.bldpkgs_dirs:
         if not isdir(d):
             os.makedirs(d)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -20,7 +20,7 @@ import mmap
 import conda.config as cc
 import conda.plan as plan
 from conda.api import get_index
-from conda.compat import PY3, iteritems
+from conda.compat import PY3
 from conda.fetch import fetch_index
 from conda.install import prefix_placeholder, linked, move_to_trash
 from conda.lock import Locked
@@ -39,7 +39,7 @@ from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
 from conda_build.exceptions import indent
-from conda_build.metadata import get_features
+from conda_build.features import feature_list
 
 
 on_win = (sys.platform == 'win32')
@@ -323,7 +323,7 @@ def create_env(prefix, specs, clear_cache=True):
     Create a conda envrionment for the given prefix and specs.
     '''
     specs = list(specs)
-    for feature, value in iteritems(get_features()):
+    for feature, value in feature_list:
         if value:
             specs.append('%s@' % feature)
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -9,7 +9,7 @@ from os.path import join, normpath
 from subprocess import STDOUT, check_output, CalledProcessError, Popen, PIPE
 
 import conda.config as cc
-from conda.compat import text_type
+from conda.compat import iteritems, text_type
 
 from conda_build import external
 from conda_build import source
@@ -163,8 +163,8 @@ def get_dict(m=None, prefix=None):
     d.update(system_vars(d, prefix))
 
     # features
-    d.update({ket.upper(): str(int(value)) for key, value in
-              iteritems(get_features)})
+    d.update({key.upper(): str(int(value)) for key, value in
+              iteritems(get_features())})
 
     return d
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -163,7 +163,7 @@ def get_dict(m=None, prefix=None):
     d.update(system_vars(d, prefix))
 
     # features
-    d.update({key.upper(): str(int(value)) for key, value in
+    d.update({'FEATURE_%s' % key.upper(): str(int(value)) for key, value in
               iteritems(get_features())})
 
     return d

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -178,6 +178,7 @@ def conda_build_vars(prefix):
         'PREFIX': prefix,
         'SYS_PREFIX': sys.prefix,
         'SYS_PYTHON': sys.executable,
+        'SUBDIR': cc.subdir,
         'SRC_DIR': source.get_dir(),
         'HTTPS_PROXY': os.getenv('HTTPS_PROXY', ''),
         'HTTP_PROXY': os.getenv('HTTP_PROXY', ''),

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -14,6 +14,7 @@ from conda.compat import text_type
 from conda_build import external
 from conda_build import source
 from conda_build.config import config
+from conda_build.metadata import get_features
 from conda_build.scripts import prepend_bin_path
 
 
@@ -160,6 +161,10 @@ def get_dict(m=None, prefix=None):
 
     # system
     d.update(system_vars(d, prefix))
+
+    # features
+    d.update({ket.upper(): str(int(value)) for key, value in
+              iteritems(get_features)})
 
     return d
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -9,12 +9,12 @@ from os.path import join, normpath
 from subprocess import STDOUT, check_output, CalledProcessError, Popen, PIPE
 
 import conda.config as cc
-from conda.compat import iteritems, text_type
+from conda.compat import text_type
 
 from conda_build import external
 from conda_build import source
 from conda_build.config import config
-from conda_build.metadata import get_features
+from conda_build.features import feature_list
 from conda_build.scripts import prepend_bin_path
 
 
@@ -163,8 +163,8 @@ def get_dict(m=None, prefix=None):
     d.update(system_vars(d, prefix))
 
     # features
-    d.update({'FEATURE_%s' % key.upper(): str(int(value)) for key, value in
-              iteritems(get_features())})
+    d.update({feat.upper(): str(int(value)) for feat, value in
+              feature_list})
 
     return d
 

--- a/conda_build/features.py
+++ b/conda_build/features.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import re
+import sys
+
+from conda.compat import iteritems
+
+
+sel_pat = re.compile('FEATURE_(\w+)')
+
+# list of features, where each element is a tuple(name, boolean), i.e.
+# having FEATURE_A=1 and FEATURE_B=0 -> [('a', True), ('b', False)]
+feature_list = []
+for key, value in iteritems(os.environ):
+    m = sel_pat.match(key)
+    if m:
+        if value not in ('0', '1'):
+            sys.exit("Error: did not expect environment variable '%s' "
+                     "being set to '%s' (not '0' or '1')" % (key, value))
+        feature_list.append((m.group(1).lower(), bool(int(value))))

--- a/conda_build/features.py
+++ b/conda_build/features.py
@@ -1,21 +1,23 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import re
 import sys
 
 from conda.compat import iteritems
 
 
-sel_pat = re.compile('FEATURE_(\w+)')
+env_vars = [
+    'FEATURE_DEBUG',
+    'FEATURE_NOMKL',
+    'FEATURE_OPT',
+]
 
-# list of features, where each element is a tuple(name, boolean), i.e.
-# having FEATURE_A=1 and FEATURE_B=0 -> [('a', True), ('b', False)]
+# list of features, where each element is a tuple(name, boolean), i.e. having
+# FEATURE_DEBUG=1 and FEATURE_NOMKL=0 -> [('debug', True), ('nomkl', False)]
 feature_list = []
 for key, value in iteritems(os.environ):
-    m = sel_pat.match(key)
-    if m:
+    if key in env_vars:
         if value not in ('0', '1'):
             sys.exit("Error: did not expect environment variable '%s' "
                      "being set to '%s' (not '0' or '1')" % (key, value))
-        feature_list.append((m.group(1).lower(), bool(int(value))))
+        feature_list.append((key[8:].lower(), bool(int(value))))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -65,6 +65,15 @@ def ns_cfg():
     for machine in cc.non_x86_linux_machines:
         d[machine] = bool(plat == 'linux-%s' % machine)
 
+    sel_pat = re.compile('SELECTOR_(\w+)')
+    for key, value in iteritems(os.environ):
+        m = sel_pat.match(key)
+        if m:
+            if value not in ('0', '1'):
+                sys.exit("Error: did not expect environment variable '%s' "
+                         "being set to '%s' (not '0' or '1')" % (key, value))
+            d[m.group(1)] = bool(int(value))
+
     d.update(os.environ)
     return d
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -12,6 +12,8 @@ from conda.resolve import MatchSpec
 from conda.cli.common import specs_from_url
 
 from conda_build import exceptions
+from conda_build.features import feature_list
+
 
 try:
     import yaml
@@ -28,25 +30,6 @@ except ImportError:
 from conda_build.config import config
 from conda_build.utils import comma_join
 
-
-
-@memoized
-def get_features():
-    """
-    Returns a dict mapping feature names to booleans, corresponding to
-    environment variables starting with 'FEATURE_'.  For example having
-    FEATURE_A=1 and FEATURE_B=0 will return {'a': True, 'b': False}
-    """
-    sel_pat = re.compile('FEATURE_(\w+)')
-    res = {}
-    for key, value in iteritems(os.environ):
-        m = sel_pat.match(key)
-        if m:
-            if value not in ('0', '1'):
-                sys.exit("Error: did not expect environment variable '%s' "
-                         "being set to '%s' (not '0' or '1')" % (key, value))
-            res[m.group(1).lower()] = bool(int(value))
-    return res
 
 
 def ns_cfg():
@@ -85,7 +68,8 @@ def ns_cfg():
     for machine in cc.non_x86_linux_machines:
         d[machine] = bool(plat == 'linux-%s' % machine)
 
-    d.update(get_features())
+    for feature, value in feature_list:
+        d[feature] = value
     d.update(os.environ)
     return d
 


### PR DESCRIPTION
In this PR, I want to make it easier to create recipes with support features.  By setting `FEATURE_*` environment variables, the user can select whatever feature they need for building a recipe with and without that feature enabled.
For example, having `FEATURE_DEBUG=0` will add the `debug` variable (set to `False`) to the selector namespace, and set `DEBUG=0` in the environment of the build script.

It is also important to see that during building and testing, the feature is enabled (when set to `1`).