### PR TITLE
Only set os.environ for non-None config vars

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -62,7 +62,7 @@ def set_language_env_vars(args, parser, execute=None):
     # Using --python, --numpy etc. is equivalent to using CONDA_PY, CONDA_NPY, etc.
     # Auto-set those env variables
     for var in conda_version.values():
-        if hasattr(config, var):
+        if hasattr(config, var) and getattr(config, var):
             # Set the env variable.
             os.environ[var] = str(getattr(config, var))
 


### PR DESCRIPTION
Otherwise we end up stringifying None as 'None' and the
version parsing code falls over later (if you call conda
from a build script for example).

Specifically, for me, the rendered batch file contained:
"set CONDA_NPY=None"
