### PR TITLE
reset errorcode to 0 on win before entering bld.bat

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -160,6 +160,9 @@ def msvc_env_cmd(bits, override=None):
         # Visual Studio 14 or otherwise
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
 
+    # reset errorlevel to 0 so that bld.bat starts with success for sake of error checks
+    msvc_env_lines.append("ver > nul")
+
     return '\n'.join(msvc_env_lines)
 
 


### PR DESCRIPTION
For simple metapackages that have code like this:

```
echo some package info %PKG_VERSION%
if errorlevel 1 exit 1
```

The build will fail if Visual Studio of the appropriate version is not installed.  This is because the activation of VS vars fails, and leaves an errorlevel of 1.  echo does not reset the errorlevel.

This PR is a workaround.  A better fix is to add either an explicit notion of when a compiler is required, and only activate VS when required, or detect necessary compilation, and do said activation.

I don't think this PR affects error messages where the compiler is actually necessary, but isn't found, because we already aren't killing builds when this activation fails.

ping @patricksnape @mingwandroid  - any thoughts one way or another on this?  I don't feel certain about this one, and would value your input.

CC @joelhullcio
