### PR TITLE
don't use long prefix on windows

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -388,7 +388,7 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
     '''
 
     if (m.get_value('build/detect_binary_files_with_prefix') or
-            m.binary_has_prefix_files()):
+            m.binary_has_prefix_files()) and not on_win:
         # We must use a long prefix here as the package will only be
         # installable into prefixes shorter than this one.
         config.use_long_build_prefix = True


### PR DESCRIPTION
Windows paths have a shorter max length than *nix.  The long prefix stuff is for the sake of binary path embedding, which is not relevant to Windows.  This avoids issues where users set the binary prefix to True, and then the recipe breaks on Windows.  Nicer than requiring everyone to have selectors for unix on these things, IMHO.