### PR TITLE
add  selectors for Intel platforms

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -50,6 +50,8 @@ def ns_cfg():
         win=plat.startswith('win-'),
         win32=bool(plat == 'win-32'),
         win64=bool(plat == 'win-64'),
+        x86=plat.endswith(('-32', '-64')),
+        x86_64=plat.endswith('-64'),
         pl=pl,
         py=py,
         lua=lua,


### PR DESCRIPTION
In this PR, we add new selectors for `x86` and `x86_64` for Intel platforms.  Note that `x86` is `True` on either 32 or 64-bit.  This is consistent with the selectors currently in use in constructor.