### PR TITLE
Add forgotten encoding argument to open()

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -244,7 +244,7 @@ def create_info_files(m, files, include_recipe=True):
         # make sure we use '/' path separators in metadata
         files = [_f.replace('\\', '/') for _f in files]
 
-    with open(join(config.info_dir, 'files'), 'w') as fo:
+    with open(join(config.info_dir, 'files'), **mode_dict) as fo:
         if m.get_value('build/noarch_python'):
             fo.write('\n')
         else:


### PR DESCRIPTION
Without this, conda-build fails on a certain Windows package as follows:
```
An unexpected error has occurred, please consider sending the
following traceback to the conda GitHub issue tracker at:

    https://github.com/conda/conda-build/issues

Include the output of the command 'conda info' in your report.


Traceback (most recent call last):
  File "c:\slave32\miniconda\Scripts\conda-build-script.py", line 4, in <module>
    sys.exit(main())
  File "c:\slave32\miniconda\lib\site-packages\conda_build\main_build.py", line 192, in main
    args_func(args, p)
  File "c:\slave32\miniconda\lib\site-packages\conda_build\main_build.py", line 486, in args_func
    args.func(args, p)
  File "c:\slave32\miniconda\lib\site-packages\conda_build\main_build.py", line 409, in execute
    include_recipe=args.include_recipe)
  File "c:\slave32\miniconda\lib\site-packages\conda_build\build.py", line 489, in build
    include_recipe=bool(m.path) and include_recipe)
  File "c:\slave32\miniconda\lib\site-packages\conda_build\build.py", line 226, in create_info_files
    fo.write(f + '\n')
  File "c:\slave32\miniconda\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 41-42: character maps to <undefined>
```

I do not know why it fails exactly, but since the error and the fix were straightforward, I did not investigate it any further.