### PR TITLE
fix missing dirty args.  Cleanup.

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -246,6 +246,7 @@ def meta_vars(meta):
             git_url = normpath(join(meta.path, git_url))
 
         _x = False
+
         if git_url:
             _x = verify_git_repo(git_dir,
                                  git_url,

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -279,7 +279,7 @@ def execute(args, parser):
 
         # this fully renders any jinja templating, throwing an error if any data is missing
         m, need_source_download = render_recipe(recipe_dir, no_download_source=False,
-                                                verbose=False)
+                                                verbose=False, dirty=args.dirty)
         if m.get_value('build/noarch_python'):
             config.noarch = True
 
@@ -305,7 +305,7 @@ def execute(args, parser):
         elif args.test:
             build.test(m, move_broken=False)
         elif args.source:
-            source.provide(m.path, m.get_section('source'), verbose=build.verbose)
+            source.provide(m.path, m.get_section('source'), verbose=build.verbose, dirty=args.dirty)
             print('Source tree in:', source.get_dir())
         else:
             # This loop recursively builds dependencies if recipes exist

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -14,7 +14,6 @@ from conda.cli.common import specs_from_url
 from conda_build import exceptions
 from conda_build.features import feature_list
 
-
 try:
     import yaml
 
@@ -643,6 +642,7 @@ class MetaData(object):
 
         loader = FilteredLoader(jinja2.ChoiceLoader(loaders))
         env = jinja2.Environment(loader=loader, undefined=undefined_type)
+
         env.globals.update(ns_cfg())
         env.globals.update(context_processor(self, path))
 

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -76,6 +76,7 @@ def bldpkg_path(m):
 
 def parse_or_try_download(metadata, no_download_source, verbose,
                           force_download=False, dirty=False):
+
     if (force_download or (not no_download_source and
                            any(var.startswith('GIT_') for var in metadata.undefined_jinja_vars))):
         # this try/catch is for when the tool to download source is actually in
@@ -89,8 +90,6 @@ def parse_or_try_download(metadata, no_download_source, verbose,
             print("Warning: failed to download source.  If building, will try "
                 "again after downloading recipe dependencies.")
             need_source_download = True
-        else:
-            need_source_download = no_download_source
     else:
         # we have not downloaded source in the render phase.  Download it in
         #     the build phase

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -22,6 +22,16 @@ def is_valid_dir(parent_dir, dirname):
     return valid
 
 
+def test_CONDA_BLD_PATH():
+    env = dict(os.environ)
+    cmd = 'conda build --no-anaconda-upload {}/source_git_jinja2'.format(metadata_dir)
+    with TemporaryDirectory() as tmp:
+        env["CONDA_BLD_PATH"] = tmp
+        subprocess.check_call(cmd.split(), env=env)
+        # trick is actually a second pass, to make sure that deletion/trash moving is working OK.
+        subprocess.check_call(cmd.split(), env=env)
+
+
 # TODO: this does not currently take into account post-build versioning changes with __conda_? files
 def test_output_build_path_git_source():
     cmd = 'conda build --output {}'.format(os.path.join(metadata_dir, "source_git_jinja2"))


### PR DESCRIPTION
This adds a test that currently fails on Windows, because Conda's move_to_trash isn't working correctly.