### PR TITLE
chdir to recipe dir before using git

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -286,8 +286,11 @@ def get_repository_info(recipe_path):
     """This tries to get information about where a recipe came from.  This is different
     from the source - you can have a recipe in svn that gets source via git."""
     if isdir(join(recipe_path, ".git")):
+        owd = os.getcwd()
+        os.chdir(recipe_path)
         origin = check_output(["git", "config", "--get", "remote.origin.url"], cwd=recipe_path)
         rev = check_output(["git", "rev-parse", "HEAD"], cwd=recipe_path)
+        os.chdir(owd)
         return "Origin {}, commit {}".format(origin, rev)
     elif isdir(join(recipe_path, ".hg")):
         origin = check_output(["hg", "paths", "default"], cwd=recipe_path)


### PR DESCRIPTION
It checks for .git in the recipe dir, not in cwd, so we have to chdir there first.
This might need fixing for hg, svn etc. E.g. by chdir first and then check for the .git, .hg in '.'.
@ilanschnell @msarahan 