### PR TITLE
source: Don't clone git submodules until after checkout

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -155,9 +155,12 @@ def git_source(meta, recipe_dir, verbose=False):
     if checkout and verbose:
         print('checkout: %r' % checkout)
 
-    check_call([git, 'clone', '--recursive', cache_repo_arg, WORK_DIR], stdout=stdout)
+    check_call([git, 'clone', cache_repo_arg, WORK_DIR], stdout=stdout)
     if checkout:
         check_call([git, 'checkout', checkout], cwd=WORK_DIR, stdout=stdout)
+
+    # Submodules must be updated after checkout.
+    check_call([git, 'submodule', 'update', '--init', '--recursive'], cwd=WORK_DIR, stdout=stdout)
 
     git_info(verbose=verbose)
 


### PR DESCRIPTION
The problem with `git clone --recursive` is that git submodules (if any) are cloned according to whatever the repo `HEAD` wants them to be.  Then weird conflicts can occur when we actually `checkout` the commit specified by the `git_rev` field.

Instead of `git clone --recursive`, we can avoid this issue by using just `git clone`, followed by `git submodule --init --recursive`, *after* we've called `checkout` to select the correct commit.

(@svenpeter42 discovered this problem and proposed the fix.)