### PR TITLE
look for cygpath, but fall back to conda's regex path conversion

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,11 +55,6 @@ install:
   - conda config --set always_yes yes
   # test with master of conda
   - conda update -q conda
-  - git clone https://github.com/conda/conda
-  - cd conda
-  - git checkout 4.1.0
-  - python setup.py install
-  - cd ../
   - conda info
   - conda update -q --all
   - python -c "import sys; print(sys.version)"

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -255,10 +255,10 @@ def meta_vars(meta):
         git_url = meta.get_value('source/git_url')
 
         if os.path.exists(git_url):
+            if sys.platform == 'win32':
+                git_url = utils.convert_unix_path_to_win(git_url)
             # If git_url is a relative path instead of a url, convert it to an abspath
             git_url = normpath(join(meta.path, git_url))
-            if sys.platform == 'win32':
-                remote_url = utils.convert_unix_path_to_win(git_url)
 
         _x = False
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -14,6 +14,7 @@ from conda.compat import text_type, PY3
 
 from conda_build import external
 from conda_build import source
+from conda_build import utils
 from conda_build.config import config
 from conda_build.features import feature_list
 from conda_build.scripts import prepend_bin_path
@@ -93,11 +94,7 @@ def verify_git_repo(git_dir, git_url, expected_rev='HEAD'):
         # on windows, remote URL comes back to us as cygwin or msys format.  Python doesn't
         # know how to normalize it.  Need to convert it to a windows path.
         if sys.platform == 'win32' and remote_url.startswith('/'):
-            cmd = "cygpath -w {0}".format(remote_url)
-            if PY3:
-                remote_url = subprocess.getoutput(cmd)
-            else:
-                remote_url = subprocess.check_output(cmd.split()).rstrip().rstrip("\\")
+            remote_url = utils.convert_unix_path_to_win(git_url)
 
         if os.path.exists(remote_url):
             # Local filepaths are allowed, but make sure we normalize them
@@ -261,11 +258,7 @@ def meta_vars(meta):
             # If git_url is a relative path instead of a url, convert it to an abspath
             git_url = normpath(join(meta.path, git_url))
             if sys.platform == 'win32':
-                cmd = "cygpath -w {0}".format(git_url)
-                if PY3:
-                    git_url = subprocess.getoutput(cmd)
-                else:
-                    git_url = subprocess.check_output(cmd.split()).rstrip().rstrip("\\")
+                remote_url = utils.convert_unix_path_to_win(git_url)
 
         _x = False
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -11,7 +11,7 @@ import operator
 from os.path import dirname, getmtime, getsize, isdir, join
 from collections import defaultdict
 
-from conda.utils import md5_file
+from conda.utils import md5_file, unix_path_to_win
 from conda.compat import PY3, iteritems
 
 from conda_build import external
@@ -214,3 +214,15 @@ def rec_glob(path, patterns):
         if m:
             result.extend([os.path.join(d_f[0], f) for f in m])
     return result
+
+def convert_unix_path_to_win(path):
+    if external.find_executable('cygpath'):
+        cmd = "cygpath -w {0}".format(path)
+        if PY3:
+            path = subprocess.getoutput(cmd)
+        else:
+            path = subprocess.check_output(cmd.split()).rstrip().rstrip("\\")
+
+    else:
+        path = unix_path_to_win(path)
+    return path

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -215,6 +215,7 @@ def rec_glob(path, patterns):
             result.extend([os.path.join(d_f[0], f) for f in m])
     return result
 
+
 def convert_unix_path_to_win(path):
     if external.find_executable('cygpath'):
         cmd = "cygpath -w {0}".format(path)


### PR DESCRIPTION
Earlier versions of git for windows do not include cygpath (current ones do, I think.)  Cygpath is probably always going to be more reliable than the regexes I cooked up, so we should try it first.  If we don't have it, Conda's regexes might be adequate, especially for git for windows, where we don't prefix our paths with /cygdrive/.

CC @jreback