### PR TITLE
add missing support for include_recipe in meta.yaml

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -182,7 +182,7 @@ def create_info_files(m, files, include_recipe=True):
     if not isdir(config.info_dir):
         os.makedirs(config.info_dir)
 
-    if include_recipe:
+    if include_recipe and m.include_recipe():
         recipe_dir = join(config.info_dir, 'recipe')
         os.makedirs(recipe_dir)
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -283,7 +283,7 @@ FIELDS = {
               'has_prefix_files', 'binary_has_prefix_files', 'ignore_prefix_files',
               'detect_binary_files_with_prefix', 'rpaths', 'script_env',
               'always_include_files', 'skip', 'msvc_compiler',
-              'pin_depends'  # pin_depends is experimental still
+              'pin_depends', 'include-recipe'  # pin_depends is experimental still
               ],
     'requirements': ['build', 'run', 'conflicts'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
@@ -604,6 +604,9 @@ class MetaData(object):
 
     def always_include_files(self):
         return self.get_value('build/always_include_files', [])
+
+    def include_recipe(self):
+        return self.get_value('build/include-recipe', True)
 
     def binary_has_prefix_files(self):
         ret = self.get_value('build/binary_has_prefix_files', [])

--- a/tests/test-recipes/metadata/_no_include_recipe/meta.yaml
+++ b/tests/test-recipes/metadata/_no_include_recipe/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: no_include_recipe
+  version: 0.0
+
+build:
+  include-recipe: False

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import shutil
 import sys
+import tarfile
 import tempfile
 
 import pytest
@@ -21,6 +22,21 @@ def is_valid_dir(parent_dir, dirname):
     valid &= not dirname.startswith("_")
     valid &= ('osx_is_app' != dirname or sys.platform == "darwin")
     return valid
+
+
+def package_has_file(package_path, file_path):
+    try:
+        with tarfile.open(package_path) as t:
+            try:
+                t.getmember(file_path)
+                return True
+            except KeyError:
+                return False
+            except OSError as e:
+                raise RuntimeError("Could not extract %s (%s)" % (package_path, e))
+    except tarfile.ReadError:
+        raise RuntimeError("Could not extract metadata from %s. "
+                           "File probably corrupt." % package_path)
 
 
 # def test_CONDA_BLD_PATH():
@@ -377,3 +393,41 @@ def test_patch():
                 lines = modified.readlines()
                 assert lines[0] == '43770\n'
         os.chdir(basedir)
+
+
+def test_no_include_recipe_cmd_line_arg():
+    """Two ways to not include recipe: build/include_recipe: False in meta.yaml; or this.
+    Former is tested with specific recipe."""
+    output_file = os.path.join(sys.prefix, "conda-bld", subdir,
+                               "empty_sections-0.0-0.tar.bz2")
+
+    # first, make sure that the recipe is there by default
+    cmd = ('conda build --no-anaconda-upload '
+           '{}/empty_sections').format(metadata_dir)
+    subprocess.check_call(cmd.split(), cwd=metadata_dir)
+    assert package_has_file(output_file, "info/recipe/meta.yaml")
+
+    # make sure that it is not there when the command line flag is passed
+    cmd = ('conda build --no-anaconda-upload --no-include-recipe '
+           '{}/empty_sections').format(metadata_dir)
+    subprocess.check_call(cmd.split(), cwd=metadata_dir)
+    assert not package_has_file(output_file, "info/recipe/meta.yaml")
+
+
+def test_no_include_recipe_meta_yaml():
+    # first, make sure that the recipe is there by default.  This test copied from above, but copied
+    # as a sanity check here.
+    output_file = os.path.join(sys.prefix, "conda-bld", subdir,
+                               "empty_sections-0.0-0.tar.bz2")
+
+    cmd = ('conda build --no-anaconda-upload '
+           '{}/empty_sections').format(metadata_dir)
+    subprocess.check_call(cmd.split(), cwd=metadata_dir)
+    assert package_has_file(output_file, "info/recipe/meta.yaml")
+
+    output_file = os.path.join(sys.prefix, "conda-bld", subdir,
+                               "no_include_recipe-0.0-0.tar.bz2")
+    cmd = ('conda build --no-anaconda-upload '
+           '{}/_no_include_recipe').format(metadata_dir)
+    subprocess.check_call(cmd.split(), cwd=metadata_dir)
+    assert not package_has_file(output_file, "info/recipe/meta.yaml")


### PR DESCRIPTION
Fixes #1080 

It looks like include_recipe was never actually implemented in meta.yaml.  You could use --no-include-recipes on the command line, but we do document include-recipe as a key in meta.yaml: http://conda.pydata.org/docs/building/meta-yaml.html#include-build-recipe

This adds tests for both the command line flag and the meta.yaml option.