### PR TITLE
take last element of pypi output; fix unicode skeleton encoding

### DIFF
--- a/conda_build/pypi.py
+++ b/conda_build/pypi.py
@@ -237,7 +237,7 @@ class RequestsTransport(Transport):
         Parse the xmlrpc response.
         """
         p, u = self.getparser()
-        p.feed(resp.text)
+        p.feed(resp.text.encode("utf-8"))
         p.close()
         return u.close()
 
@@ -327,9 +327,9 @@ def main(args, parser):
                           package)
                     for ver in versions:
                         print(ver)
-                    print("Using %s" % versions[0])
+                    print("Using %s" % versions[-1])
                     print("Use --version to specify a different version.")
-                d['version'] = versions[0]
+                d['version'] = versions[-1]
 
         data, d['pypiurl'], d['filename'], d['md5'] = get_download_data(args,
                                                                         client,


### PR DESCRIPTION
Fixes #1091 #1089 #974

The version ordering is pretty fragile still - assumes that data coming back from PyPI is sorted, with newest version last.  I think this assumption is what broke things in the first place: PyPI's behavior changed.  Will fix this better later.