### PR TITLE
fix lack of call in bat script exiting early

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -745,7 +745,8 @@ def test(m, move_broken=True, activate=True):
 
         with open(test_script, 'w') as tf:
             if activate:
-                tf.write("{source}activate _test\n".format(source="" if on_win else "source "))
+                tf.write("{source}activate _test\n".format(source="call " if on_win
+                                                           else "source "))
             if py_files:
                 tf.write("{python} -s {test_file}\n".format(
                     python=config.test_python,

--- a/tests/test-recipes/metadata/_test_early_abort/meta.yaml
+++ b/tests/test-recipes/metadata/_test_early_abort/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: foobar
+  version: 1.0
+
+test:
+  commands:
+    - python --version

--- a/tests/test-recipes/metadata/_test_early_abort/run_test.py
+++ b/tests/test-recipes/metadata/_test_early_abort/run_test.py
@@ -1,0 +1,1 @@
+print("Hello World")

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -444,3 +444,16 @@ def test_no_include_recipe_meta_yaml():
            '{}/_no_include_recipe').format(metadata_dir)
     subprocess.check_call(cmd.split(), cwd=metadata_dir)
     assert not package_has_file(output_file, "info/recipe/meta.yaml")
+
+
+def test_early_abort():
+    """There have been some problems with conda-build dropping out early.
+    Make sure we aren't causing them"""
+    cmd = 'conda build {}'.format(os.path.join(metadata_dir,
+                                               "_test_early_abort"))
+    process = subprocess.Popen(cmd.split(),
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = process.communicate()
+    output = output.decode('utf-8')
+    error = error.decode('utf-8')
+    assert "Hello World" in output, error


### PR DESCRIPTION
bug observed in https://ci.appveyor.com/project/JonathanHelmus/conda-build-test-bug/build/1.0.3 - reported by @jjhelmus 

```
activate _test
```

can exit early without running tests - and probably with exit code 0, leading you to believe that tests succeeded.

This changes the call to:

```
call activate _test
```

and adds a test for the early exit behavior.