### PR TITLE
Handle quotes when matching selectors 

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -89,8 +89,14 @@ sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 
 def select_lines(data, namespace):
     lines = []
+
     for i, line in enumerate(data.splitlines()):
-        line = line.strip(' \'"')
+        line = line.rstrip()
+
+        trailing_quote = ""
+        if line and line[-1] in ("'", '"'):
+            trailing_quote = line[-1]
+
         if line.lstrip().startswith('#'):
             # Don't bother with comment only lines
             continue
@@ -99,7 +105,7 @@ def select_lines(data, namespace):
             cond = m.group(3)
             try:
                 if eval(cond, namespace, {}):
-                    lines.append(m.group(1))
+                    lines.append(m.group(1) + trailing_quote)
             except:
                 sys.exit('''\
 Error: Invalid selector in meta.yaml line %d:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -90,7 +90,7 @@ sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
 def select_lines(data, namespace):
     lines = []
     for i, line in enumerate(data.splitlines()):
-        line = line.rstrip()
+        line = line.strip(' \'"')
         if line.lstrip().startswith('#'):
             # Don't bother with comment only lines
             continue

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,8 +8,8 @@ from conda_build.metadata import select_lines, handle_config_version
 def test_select_lines():
     lines = """
 test
-test [abc] no
-test [abc] # no
+ ' test [abc] no '
+ "test [abc] # no "
 
 test [abc]
 test # [abc]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,12 +8,12 @@ from conda_build.metadata import select_lines, handle_config_version
 def test_select_lines():
     lines = """
 test
- ' test [abc] no '
- "test [abc] # no "
+test [abc] no
+test [abc] # no
 
 test [abc]
-test # [abc]
-test # [abc] yes
+ 'quoted # [abc] '
+ "quoted # [abc] yes "
 test # stuff [abc] yes
 test {{ JINJA_VAR[:2] }}
 test {{ JINJA_VAR[:2] }} # stuff [abc] yes
@@ -28,8 +28,8 @@ test [abc] no
 test [abc] # no
 
 test
-test
-test
+ 'quoted'
+ "quoted"
 test
 test {{ JINJA_VAR[:2] }}
 test {{ JINJA_VAR[:2] }}


### PR DESCRIPTION
This fixes an edge case in preprocessing selectors (#629), where quoted lines contain imbalanced quotes after removing the selector part. Generated yaml files will typically enclose in single quotes all entries containing ``#`` characters, so this PR adds support for generated recipes.