### PR TITLE
fix load_setuptools in jinja2 context

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -5,17 +5,17 @@ Created on Jan 16, 2014
 '''
 from __future__ import absolute_import, division, print_function
 
+from functools import partial
 import json
 import os
-from functools import partial
+import sys
 
 import jinja2
 
 from conda.compat import PY3
 from .environ import get_dict as get_environ
 from .metadata import select_lines, ns_cfg
-
-_setuptools_data = None
+from .source import WORK_DIR
 
 
 class UndefinedNeverFail(jinja2.Undefined):
@@ -76,40 +76,51 @@ class FilteredLoader(jinja2.BaseLoader):
         return select_lines(contents, ns_cfg()), filename, uptodate
 
 
-def load_setuptools(setup_file='setup.py', from_recipe_dir=False,
-                    recipe_dir=None):
-    global _setuptools_data
+def load_setuptools(setup_file='setup.py', from_recipe_dir=False, recipe_dir=None,
+                    unload_modules=None):
+    _setuptools_data = {}
 
-    if _setuptools_data is None:
-        _setuptools_data = {}
+    def setup(**kw):
+        _setuptools_data.update(kw)
 
-        def setup(**kw):
-            _setuptools_data.update(kw)
+    import setuptools
+    import distutils.core
 
-        import setuptools
-        import distutils.core
-        # Add current directory to path
-        import sys
-        sys.path.append('.')
+    cd_to_work = False
 
-        if from_recipe_dir and recipe_dir:
-            setup_file = os.path.abspath(os.path.join(recipe_dir, setup_file))
+    if from_recipe_dir and recipe_dir:
+        setup_file = os.path.abspath(os.path.join(recipe_dir, setup_file))
+    else:
+        cd_to_work = True
+        cwd = os.getcwd()
+        os.chdir(WORK_DIR)
+        if not os.path.isabs(setup_file):
+            setup_file = os.path.join(WORK_DIR, setup_file)
+        # this is very important - or else if versioneer or otherwise is in the start folder,
+        # things will pick up the wrong versioneer/whatever!
+        sys.path.insert(0, WORK_DIR)
 
-        # Patch setuptools, distutils
-        setuptools_setup = setuptools.setup
-        distutils_setup = distutils.core.setup
-        setuptools.setup = distutils.core.setup = setup
-        ns = {
-            '__name__': '__main__',
-            '__doc__': None,
-            '__file__': setup_file,
-        }
-        code = compile(open(setup_file).read(), setup_file, 'exec',
-                       dont_inherit=1)
+    # Patch setuptools, distutils
+    setuptools_setup = setuptools.setup
+    distutils_setup = distutils.core.setup
+    setuptools.setup = distutils.core.setup = setup
+    ns = {
+        '__name__': '__main__',
+        '__doc__': None,
+        '__file__': setup_file,
+    }
+    try:
+        code = compile(open(setup_file).read(), setup_file, 'exec', dont_inherit=1)
         exec(code, ns, ns)
         distutils.core.setup = distutils_setup
         setuptools.setup = setuptools_setup
-        del sys.path[-1]
+    # this happens if setup.py is used in load_setuptools, but source is not yet downloaded
+    except IOError:
+        pass
+    finally:
+        if cd_to_work:
+            os.chdir(cwd)
+    del sys.path[-1]
     return _setuptools_data
 
 

--- a/tests/test-recipes/metadata/source_setuptools/bld.bat
+++ b/tests/test-recipes/metadata/source_setuptools/bld.bat
@@ -1,0 +1,18 @@
+if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
+git describe --tags --dirty
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
+if errorlevel 1 exit 1
+echo "%gitdesc%"
+if not "%gitdesc%"=="1.21.5" exit 1
+echo "%PKG_VERSION%"
+if not "%PKG_VERSION%"=="1.21.5" exit 1
+git status
+if errorlevel 1 exit 1
+git diff
+if errorlevel 1 exit 1
+set PYTHONPATH=.
+python -c "import conda_build; assert conda_build.__version__ == '1.21.5', conda_build.__version__"
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/source_setuptools/build.sh
+++ b/tests/test-recipes/metadata/source_setuptools/build.sh
@@ -1,0 +1,9 @@
+# We test the environment variables in a different recipe
+
+# Ensure we are in a git repo
+[ -d .git ]
+git describe
+[ "$(git describe)" = 1.21.5 ]
+echo "\$PKG_VERSION = $PKG_VERSION"
+[ "${PKG_VERSION}" = 1.21.5 ]
+PYTHONPATH=. python -c "import conda_build; assert conda_build.__version__ == '1.21.5', conda_build.__version__"

--- a/tests/test-recipes/metadata/source_setuptools/meta.yaml
+++ b/tests/test-recipes/metadata/source_setuptools/meta.yaml
@@ -1,0 +1,19 @@
+# This recipe exercises the use of GIT_ variables in jinja template strings,
+# including use cases involving expressions such as FOO[:7] or FOO.replace(...)
+
+# it uses load_setuptools from conda_build.jinja_context to populate some fields
+# with values fed from setuptools.
+
+{% set data = load_setuptools() %}
+
+package:
+  name: conda-build-test-source-setuptools
+  version: {{ data.get('version') }}
+
+source:
+  git_url: ../../../../
+  git_tag: 1.21.5
+
+requirements:
+  build:
+    - python {{ PY_VER }}*


### PR DESCRIPTION
There were a couple of strange problems happening here.  The context was not in the same directory as the work directory, so any setup.py present was the wrong one (conda-build's, in the case of running the test suite!)  Next, we were not setting sys.path, so any versioneer (or equivalent) along the path would get picked up and be very confused.

Might help with #1061 - haven't tested yet.  This certainly shouldn't hurt anything.

CC @janschulz