### PR TITLE
make activate script file extensions explicit

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -746,8 +746,9 @@ def test(m, move_broken=True, activate=True):
 
         with open(test_script, 'w') as tf:
             if activate:
-                tf.write("{source}activate _test\n".format(source="call " if on_win
-                                                           else "source "))
+                source = "call " if on_win else "source "
+                ext = ".bat" if on_win else ""
+                tf.write("{source}activate{ext} _test\n".format(source=source, ext=ext))
             if py_files:
                 tf.write("{python} -s {test_file}\n".format(
                     python=config.test_python,

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -229,7 +229,7 @@ def build(m, bld_bat, dirty=False, activate=True):
             fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
             fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
             if activate:
-                fo.write("call activate _build\n")
+                fo.write("call activate.bat _build\n")
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)
 


### PR DESCRIPTION
Seems to be an issue where in some cases the bash scripts are being called in windows:

https://github.com/conda-forge/ca-certificates-feedstock/pull/4#issuecomment-231399300

This makes the file extension explicit, and should clear up confusion.

CC @jakirkham 