### PR TITLE
remove killing msbuild at end of win build.  No psutil req anymore.

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - python
   run:
     - python
-    - psutil
     - conda  >=4.1
     - jinja2
     - patchelf      [linux]

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -163,29 +163,6 @@ def msvc_env_cmd(bits, override=None):
     return '\n'.join(msvc_env_lines) + '\n'
 
 
-def kill_processes(process_names=["msbuild.exe"]):
-    # for things that uniform across both APIs
-    import psutil
-    # list of pids changed APIs from v1 to v2.
-    try:
-        # V1 API
-        from psutil import get_pid_list
-    except:
-        try:
-            # V2 API
-            from psutil import pids as get_pid_list
-        except:
-            raise ImportError("psutil failed to import.")
-    for n in get_pid_list():
-        try:
-            p = psutil.Process(n)
-            if p.name.lower() in (process_name.lower() for process_name in process_names):
-                print('Terminating:', p.name)
-                p.terminate()
-        except:
-            continue
-
-
 def build(m, bld_bat, dirty=False, activate=True):
     env = environ.get_dict(m, dirty=dirty)
 
@@ -214,5 +191,4 @@ def build(m, bld_bat, dirty=False, activate=True):
 
         cmd = [os.environ['COMSPEC'], '/c', 'call', 'bld.bat']
         _check_call(cmd, cwd=src_dir)
-        kill_processes()
         fix_staged_scripts()


### PR DESCRIPTION
msbuild hangs around a little while after a build to reduce startup time of subsequent builds.  Unless we see problems with this, we should not be forcefully killing it.  Removing this allows us to not depend on psutil.