### PR TITLE
try prepending path before creating env for test

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -724,7 +724,11 @@ def test(m, move_broken=True, activate=True):
             # not sure how this shakes out
             specs += ['lua %s*' % environ.get_lua_ver()]
 
+        # FIXME: stupid hack to put test prefix on PATH so that runtime libs can be found
+        old_env = os.environ.copy()
+        os.environ = prepend_bin_path(os.environ.copy(), config.test_prefix, True)
         create_env(config.test_prefix, specs)
+        os.environ = old_env
         env = dict(os.environ)
         env.update(environ.get_dict(m, prefix=config.test_prefix))
 


### PR DESCRIPTION
This is a pretty terrible workaround for the fact that for post-link scripts, we may not have the actual environment being created on PATH yet.  This means things like runtime libraries may not actually be locatable yet.  This PR adds those to PATH before creation of the env, so that they are found.