### PR TITLE
expose CFLAGS and friends if defined in os.environ

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,22 @@
+2016-07-14 1.21.6:
+------------------
+
+Bug fixes:
+----------
+
+* Support PEP420 namespace packages (don't barf on existing folders.)  Do barf on existing files.  #1074
+* Fix handling of quotes in selectors #1104
+* Fix load_setuptools in jinja context.  Problem was incorrect cwd in function. #1106
+* Make Win activate script file extensions explicit #1107
+* Warn users on failed git repo info failure, rather than crash #1108
+* Remove killing MSBuild.exe at end of win build.  Remove psutil dependency.  #1109
+
+Contributors:
+-------------
+
+ * @ikalev
+ * @msarahan
+
 2016-07-07 1.21.5:
 ------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,27 @@
+2016-07-07 1.21.5:
+------------------
+
+Bug fixes:
+----------
+
+ * Make --skip-existing respect remote channels (s3, file, anaconda.org) #1102
+ * Reduce always_include_files glob fail exit to a warning #1101
+ * Fail more gracefully when finding a vcs executable fails #1100
+ * Add better error when PyPI fails with XMLRPC.  Add tests for published examples. #1098
+ * Fix lack of 'call' in windows test activate script that was terminating tests early #1097
+ * Take newest version from PyPI when creating skeleton #1092
+ * Fix unicode encoding error in conda skeleton pypi #1092
+ * Support PEP420 namespace packages (write into existing folders,
+   but raise error rather than overwrite existing files. #1090
+ * Fix an error where an intermediate None value broke jinja2 rendering #1088
+ * Add missing support for include_recipe in meta.yaml #1085
+
+Contributors:
+-------------
+ * @ikalev
+ * @msarahan
+
+
 2016-07-05 1.21.4:
 ------------------
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - python
   run:
     - python
-    - psutil
     - conda  >=4.1
     - jinja2
     - patchelf      [linux]

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -206,6 +206,10 @@ def create_info_files(m, files, include_recipe=True):
             f.write("# ------------------------------------------------\n\n")
             f.write(metayaml)
 
+        # record the current environment variables, to potentially help with reproducibility
+        with open(join(recipe_dir, "build_environment.json"), 'w') as f:
+            json.dump(environ.get_dict(m), f)
+
     license_file = m.get_value('about/license_file')
     if license_file:
         shutil.copyfile(join(source.get_dir(), license_file),

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -577,7 +577,7 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
             else:
                 build_file = join(m.path, 'build.sh')
 
-                env = environ.get_dict(m, dirty=dirty)
+                env = environ.get_dict(m, dirty=dirty, activate=activate)
                 work_file = join(source.get_dir(), 'conda_build.sh')
                 if script:
                     with open(work_file, 'w') as bf:

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -350,7 +350,6 @@ def system_vars(env_dict, prefix):
     if "LANG" in os.environ:
         d['LANG'] = os.environ['LANG']
     d['PATH'] = os.environ['PATH']
-    d = prepend_bin_path(d, prefix)
 
     if sys.platform == 'win32':
         d.update(windows_vars(prefix))

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -342,8 +342,9 @@ def system_vars(env_dict, prefix):
     d = dict()
     compiler_vars = defaultdict(text_type)
 
-    if 'MAKEFLAGS' in os.environ:
-        d['MAKEFLAGS'] = os.environ['MAKEFLAGS']
+    for env_var in ['MAKEFLAGS', 'CFLAGS', 'CXXFLAGS', 'LDFLAGS']:
+        if env_var in os.environ:
+            d[env_var] = os.environ[env_var]
 
     d['CPU_COUNT'] = get_cpu_count()
     if "LANG" in os.environ:

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -185,29 +185,6 @@ def msvc_env_cmd(bits, override=None):
     return '\n'.join(msvc_env_lines) + '\n'
 
 
-def kill_processes(process_names=["msbuild.exe"]):
-    # for things that uniform across both APIs
-    import psutil
-    # list of pids changed APIs from v1 to v2.
-    try:
-        # V1 API
-        from psutil import get_pid_list
-    except:
-        try:
-            # V2 API
-            from psutil import pids as get_pid_list
-        except:
-            raise ImportError("psutil failed to import.")
-    for n in get_pid_list():
-        try:
-            p = psutil.Process(n)
-            if p.name.lower() in (process_name.lower() for process_name in process_names):
-                print('Terminating:', p.name)
-                p.terminate()
-        except:
-            continue
-
-
 def build(m, bld_bat, dirty=False, activate=True):
     env = environ.get_dict(m, dirty=dirty)
 
@@ -235,5 +212,4 @@ def build(m, bld_bat, dirty=False, activate=True):
 
         cmd = [os.environ['COMSPEC'], '/c', 'bld.bat']
         _check_call(cmd, cwd=src_dir)
-        kill_processes()
         fix_staged_scripts()

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -207,6 +207,7 @@ def build(m, bld_bat, dirty=False, activate=True):
             fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
             if activate:
                 fo.write("call activate.bat _build\n")
+            fo.write("set > build_environment.txt\n")
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -197,20 +197,22 @@ def build(m, bld_bat, dirty=False, activate=True):
     if os.path.isfile(bld_bat):
         with open(bld_bat) as fi:
             data = fi.read()
-        with open(join(src_dir, 'bld.bat'), 'w') as fo:
-            # more debuggable with echo on
-            fo.write('@echo on\n')
-            for key, value in env.items():
-                fo.write('set "{key}={value}"\n'.format(key=key, value=value))
-            fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
-            fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
-            fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
-            if activate:
-                fo.write("call activate.bat _build\n")
-            fo.write("set > build_environment.txt\n")
-            fo.write("REM ===== end generated header =====\n")
-            fo.write(data)
+    else:
+        data = ""
+    with open(join(src_dir, 'bld.bat'), 'w') as fo:
+        # more debuggable with echo on
+        fo.write('@echo on\n')
+        for key, value in env.items():
+            fo.write('set "{key}={value}"\n'.format(key=key, value=value))
+        fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
+        fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
+        fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
+        if activate:
+            fo.write("call activate.bat _build\n")
+        fo.write("set > build_environment.txt\n")
+        fo.write("REM ===== end generated header =====\n")
+        fo.write(data)
 
-        cmd = [os.environ['COMSPEC'], '/c', 'bld.bat']
-        _check_call(cmd, cwd=src_dir)
-        fix_staged_scripts()
+    cmd = [os.environ['COMSPEC'], '/c', 'bld.bat']
+    _check_call(cmd, cwd=src_dir)
+    fix_staged_scripts()

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -565,18 +565,18 @@ def test_environment_recording():
     environ_file = package_has_file(output_file, "info/recipe/build_environment.txt")
     assert environ_file
     environ_file = environ_file.decode('UTF-8')
-    match = re.search(u"\s*PATH=(.*)", environ_file, re.I)
+    match = re.search(u"^\s*PATH=(.*)", environ_file, re.I | re.M)
     # output contents of environ_file if we don't find PATH
     assert match, environ_file
-    assert config.config.build_prefix in match.group(1)
+    assert config.config.build_prefix.decode('utf-8') in match.group(1)
     # this one is defined by a dependency's activate.d script
-    match = re.search(u"\s*TEST_VAR=(.*)", environ_file, re.I)
+    match = re.search(u"^\s*TEST_VAR=(.*)", environ_file, re.I | re.M)
     assert match
-    assert match.group(1) == u'1'
+    assert match.group(1).rstrip() == u'1'
 
     # assert that we did not pick up "BAD_VAR" from the calling environment
     match = re.search("BAD_VAR", environ_file, re.I)
-    assert not match
+    assert not match, environ_file
 
 
 def test_failed_tests_exit_build():

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -564,14 +564,15 @@ def test_environment_recording():
                                "conda-build-test-environment-vars-in-build-env-1.0-0.tar.bz2")
     environ_file = package_has_file(output_file, "info/recipe/build_environment.txt")
     assert environ_file
-    match = re.search("\s*PATH=(.*)", environ_file, re.I)
+    environ_file = environ_file.decode('UTF-8')
+    match = re.search(u"\s*PATH=(.*)", environ_file, re.I)
+    # output contents of environ_file if we don't find PATH
     assert match, environ_file
-    assert match.group(1) == scripts.prepend_bin_path(os.environ.copy(),
-                                                      config.config.build_prefix)["PATH"]
+    assert config.config.build_prefix in match.group(1)
     # this one is defined by a dependency's activate.d script
-    match = re.search("\s*TEST_VAR=(.*)", environ_file, re.I)
+    match = re.search(u"\s*TEST_VAR=(.*)", environ_file, re.I)
     assert match
-    assert match.group(1) == '1'
+    assert match.group(1) == u'1'
 
     # assert that we did not pick up "BAD_VAR" from the calling environment
     match = re.search("BAD_VAR", environ_file, re.I)


### PR DESCRIPTION
This allows easier pass-through of these, until the build customization provides a better way.
