### PR TITLE
use full path of test prefix for activation

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -760,7 +760,8 @@ def test(m, move_broken=True, activate=True):
             if activate:
                 source = "call " if on_win else "source "
                 ext = ".bat" if on_win else ""
-                tf.write("{source}activate{ext} _test\n".format(source=source, ext=ext))
+                tf.write("{source}activate{ext} {test_env}\n".format(source=source, ext=ext,
+                                                                     test_env=config.test_prefix))
                 tf.write("if errorlevel 1 exit 1\n") if on_win else None
 
             if py_files:


### PR DESCRIPTION
Possibly related to errors like https://github.com/conda-forge/staged-recipes/pull/1065#issuecomment-233194005 - but just a good idea in general.  We should be activating absolute paths to leave less room for confusion.