### PR TITLE
set PY_VCRUNTIME_REDIST for VS 2015+

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -111,6 +111,12 @@ def msvc_env_cmd(bits, override=None):
         else:
             version = '9.0'
 
+    if float(version) >= 14.0:
+        # For Python 3.5+, ensure that we link with the dynamic runtime.  See
+        # http://stevedower.id.au/blog/building-for-python-3-5-part-two/ for more info
+        msvc_env_lines.append('set PY_VCRUNTIME_REDIST=%LIBRARY_BIN%\vcruntime{0}.dll'.format(
+            version.replace('.', '')))
+
     vcvarsall_vs_path = build_vcvarsall_vs_path(version)
 
     def build_vcvarsall_cmd(cmd, arch=arch_selector):


### PR DESCRIPTION
Per http://stevedower.id.au/blog/building-for-python-3-5-part-two/, if PY_VCRUNTIME_REDIST is not set, then things will use the static vcruntime.  This might have something to do with #1111.

Thanks @pitrou for the suggestion. 