### PR TITLE
post: Use os.path.normpath() in find_lib()

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -7,7 +7,7 @@ import sys
 import stat
 from glob import glob
 from os.path import (basename, dirname, join, splitext, isdir, isfile, exists,
-                     islink, realpath, relpath)
+                     islink, realpath, relpath, normpath)
 try:
     from os import readlink
 except ImportError:
@@ -169,7 +169,7 @@ def find_lib(link, path=None):
     from conda_build.build import prefix_files
     files = prefix_files()
     if link.startswith(config.build_prefix):
-        link = link[len(config.build_prefix) + 1:]
+        link = normpath(link[len(config.build_prefix) + 1:])
         if link not in files:
             sys.exit("Error: Could not find %s" % link)
         return link


### PR DESCRIPTION
dylibs can end up with path names such as:
'/Users/ray/qt5-x64-2.7/envs/_build/gcc/../lib/libstdc++.6.dylib'
.. and, after removing the build prefix we are left with:
'gcc/../lib/libstdc++.6.dylib'
find_lib will fail to find that in a list that contains:
'lib/libstdc++.6.dylib' because it compares strings, so we
must normalize the path first.

Rebuilding GCC 4.8.5 on OS X ran afoul of this.