### PR TITLE
ensure need_source_download exists

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -81,6 +81,9 @@ def parse_or_try_download(metadata, no_download_source, verbose,
     need_reparse_in_env = False
     if (force_download or (not no_download_source and (metadata.uses_vcs_in_meta() or
                                                        metadata.uses_setuptools_in_meta()))):
+        if dirty:
+            need_source_download = False
+
         # this try/catch is for when the tool to download source is actually in
         #    meta.yaml, and not previously installed in builder env.
         try:


### PR DESCRIPTION
This is a quick fix to an issue where 

`conda build <recipe> --dirty`

would raise:

```
File "/conda-build/conda_build/render.py", line 113, in parse_or_try_download
    return metadata, need_source_download, need_reparse_in_env
UnboundLocalError: local variable 'need_source_download' referenced before assignment
```
