### PR TITLE
Automatically pass through `CPU_COUNT`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+XXXX-YY-ZZ 1.21.x:
+------------------
+
+Enhancements:
+-------------
+
+* Whitelist the CPU_COUNT environment variable. #1149
+
+Bug fixes:
+----------
+
+Contributors:
+-------------
+
+* @jakirkham
+
 2016-08-06 1.21.11:
 -------------------
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -345,7 +345,11 @@ def system_vars(env_dict, prefix):
     if 'MAKEFLAGS' in os.environ:
         d['MAKEFLAGS'] = os.environ['MAKEFLAGS']
 
-    d['CPU_COUNT'] = get_cpu_count()
+    if 'CPU_COUNT' in os.environ:
+        d['CPU_COUNT'] = os.environ['CPU_COUNT']
+    else:
+        d['CPU_COUNT'] = get_cpu_count()
+
     if "LANG" in os.environ:
         d['LANG'] = os.environ['LANG']
     d['PATH'] = os.environ['PATH']


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/1117

In some situations, users find the processor information to be reported incorrectly by the infrastructure they may be running a build on. For instance, a user may be running a build on a node where the node supports more cores than the user is actually provided. As a result, the detection of the number of cores will be too high and cause issues completing the build.

Previously it was thought `MAKEFLAGS` would be an acceptable way to accomplish this. Please see PR ( https://github.com/conda/conda-build/pull/917 ). In fact, that strategy does work. Most of the cases where a parallel build is desired are using `make` and thus can easily leverage this. Though it doesn't really catch all cases and so something else still needs to be done for them. Also, using it in this way can result in an implicit setting of parallel builds. Thus there were some cases where a parallel build was not reliable. As a result, users had to unset `MAKEFLAGS` entirely. This is problematic as other flags not related to parallelism may be lost in the process. Please see PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/18 ) for references to this problem.

The strategy proposed here is to allow the environment variable `CPU_COUNT` to be automatically passed through to the recipe. This allows users to opt-in to parallelism if it helps their build. However, if their build does not work well in parallel it is not forced upon them. As it simply overrides an existing environment variable used to specify the number of cores available, recipes that use this feature can be safely built in different environments by setting this environment variable to the appropriate value in that setting. Further strategies build strategies that don't use `make`, but do have the ability to build in parallel can be set appropriately using the `CPU_COUNT` environment variable. Finally, by allowing `CPU_COUNT` to be passed through we provide a useful tool in debugging recipes. Instead of having to tinker with hard-coded values in recipes, a user can set this environment variable to different values externally and see how it affects there build.

In short, this proposal should hopefully provide a useful feature for those eager to support parallel builds by putting that control more firmly in the hand of the users. Further, this should help separate what is appropriate for build infrastructure from the recipes themselves resulting in greater flexibility.

cc @ocefpaf @pelson @msarahan @jschueller @frol