### PR TITLE
fix --source arg to build to only download source

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -327,8 +327,9 @@ def execute(args, parser):
             continue
         elif args.test:
             build.test(m, move_broken=False)
-        elif args.source and need_source_download:
-            source.provide(m.path, m.get_section('source'), verbose=build.verbose)
+        elif args.source:
+            if need_source_download:
+                source.provide(m.path, m.get_section('source'), verbose=build.verbose)
             print('Source tree in:', source.get_dir())
         else:
             # This loop recursively builds dependencies if recipes exist


### PR DESCRIPTION
Reported by @fschlimb - if --source was passed, but source had already been downloaded in rendering, then the --source section would be bypassed, and the recipe would be built, rather than exiting after download.