### PR TITLE
fix create workdir logic in build

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -541,7 +541,7 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
             print("Package:", m.dist())
 
             src_dir = source.get_dir()
-            if isdir(source.WORK_DIR) and os.listdir(src_dir):
+            if isdir(source.WORK_DIR):
                 print("source tree in:", src_dir)
             else:
                 print("no source - creating empty work folder")


### PR DESCRIPTION
If the source workdir was created, but was empty, the code would try to create it again, raising an exception.  This removes the check for files in the folder, and only checks for its existence.