### PR TITLE
explicitly test that condarc channels are available in build

### DIFF
--- a/tests/test-recipes/metadata/_condarc_channel/meta.yaml
+++ b/tests/test-recipes/metadata/_condarc_channel/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: test_recipe_needing_channel
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    # this is only available at conda-forge, and is a test of whether that channel is available.
+    - conda-smithy

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -585,3 +585,22 @@ def test_rendering_env_var():
     if PY3:
         out = out.decode("UTF-8")
     assert "Rendering environment variable set OK" in out
+
+
+def test_condarc_channel_available():
+    with TemporaryDirectory() as tmp:
+        rcfile = os.path.join(tmp, ".condarc")
+        with open(rcfile, 'w') as f:
+            f.write("channels:\n")
+            f.write("  - conda-forge\n")
+            f.write("  - defaults\n")
+        env = os.environ.copy()
+        env["CONDARC"] = rcfile
+        cmd = "conda build {}/_condarc_channel".format(metadata_dir)
+        subprocess.check_call(cmd.split(), env=env)
+        # ensure that the test fails without the channel
+        with open(rcfile, 'w') as f:
+            f.write("channels:\n")
+            f.write("  - defaults\n")
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.check_call(cmd.split(), env=env)


### PR DESCRIPTION
This is an explicit test for https://github.com/conda/conda-build/issues/1120#issuecomment-234803420

All appears to be well for me, but it's good to have this test anyway.