### PR TITLE
add debug option that shows conda log output

### DIFF
--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -139,7 +139,11 @@ different sets of packages."""
         help="do not display progress bar",
         dest='activate',
     )
-
+    p.add_argument(
+        '--debug',
+        action='store_true',
+        help="show debugging output from conda and conda-build",
+    )
     add_parser_channels(p)
     p.set_defaults(func=execute)
 
@@ -237,7 +241,7 @@ def execute(args, parser):
     # change globals in build module, see comment there as well
     build.channel_urls = args.channel or ()
     build.override_channels = args.override_channels
-    build.verbose = not args.quiet
+    build.verbose = not args.quiet or args.debug
 
     if on_win:
         try:
@@ -326,7 +330,7 @@ def execute(args, parser):
             print(bldpkg_path(m))
             continue
         elif args.test:
-            build.test(m, move_broken=False)
+            build.test(m, move_broken=False, debug=args.debug)
         elif args.source:
             if need_source_download:
                 source.provide(m.path, m.get_section('source'), verbose=build.verbose)
@@ -349,7 +353,8 @@ def execute(args, parser):
                             keep_old_work=args.keep_old_work,
                             need_source_download=need_source_download,
                             need_reparse_in_env=need_reparse_in_env,
-                            dirty=args.dirty, activate=args.activate)
+                            dirty=args.dirty, activate=args.activate,
+                            debug=args.debug)
             except (NoPackagesFound, Unsatisfiable) as e:
                 error_str = str(e)
                 # Typically if a conflict is with one of these
@@ -393,7 +398,7 @@ def execute(args, parser):
                 continue
 
             if not args.notest:
-                build.test(m, activate=args.activate)
+                build.test(m, activate=args.activate, debug=args.debug)
 
         if need_cleanup:
             shutil.rmtree(recipe_dir)

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -633,3 +633,22 @@ def test_condarc_channel_available():
             f.write("  - defaults\n")
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.check_call(cmd.split(), env=env)
+
+
+def test_debug_build_option():
+    cmd = 'conda build --debug --no-anaconda-upload {}'.format(os.path.join(metadata_dir,
+                                                        "jinja2"))
+    process = subprocess.Popen(cmd.split(),
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = process.communicate()
+    output = output.decode('utf-8')
+    error = error.decode('utf-8')
+    assert "DEBUG:" in error
+
+    cmd = cmd.replace("--debug ", "")
+    process = subprocess.Popen(cmd.split(),
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, error = process.communicate()
+    output = output.decode('utf-8')
+    error = error.decode('utf-8')
+    assert "DEBUG:" not in error


### PR DESCRIPTION
After creation of a root handler in conda-build 1.21.8, conda's debug log was showing up.  This silences it by default, but makes it available by passing the --debug flag to conda build.