### PR TITLE
add test for metapackage; add token and user args

### DIFF
--- a/conda_build/main_metapackage.py
+++ b/conda_build/main_metapackage.py
@@ -46,6 +46,14 @@ command line with the conda metapackage command.
         default=conda.config.binstar_upload,
     )
     p.add_argument(
+        '--token',
+        help="Token to pass through to anaconda upload"
+    )
+    p.add_argument(
+        '--user',
+        help="User/organization to upload packages to on anaconda.org"
+    )
+    p.add_argument(
         "name",
         action="store",
         help="Name of the created package.",

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -633,3 +633,10 @@ def test_condarc_channel_available():
             f.write("  - defaults\n")
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.check_call(cmd.split(), env=env)
+
+
+def test_metapackage():
+    cmd = ('conda metapackage --no-anaconda-upload --build-number 0 '
+           '--dependencies python zlib openssl '
+           '--summary "test" test-metapackage 0.1')
+    subprocess.check_call(cmd.split())


### PR DESCRIPTION
This is a test that verifies functionality of conda metapackage.  It is meant as a regression test of #1158 