### PR TITLE
create croot folder if missing before locking

### DIFF
--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -6,6 +6,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
+
 from conda.config import default_python
 from conda_build.main_build import args_func
 from conda.cli.conda_argparse import ArgumentParser
@@ -329,6 +331,8 @@ def execute(args, parser):
 
     if not args.repo:
         parser.print_help()
+    if not os.path.isdir(config.croot):
+        os.makedirs(config.croot)
     with Locked(config.croot):
         if args.repo == "pypi":
             pypi.main(args, parser)

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -123,6 +123,8 @@ def reparse(metadata):
 
 
 def render_recipe(recipe_path, no_download_source, verbose, dirty=False):
+    if not isdir(config.croot):
+        os.makedirs(config.croot)
     with Locked(config.croot):
         if not dirty:
             if sys.platform == 'win32':


### PR DESCRIPTION
Reported by @mingwandroid - if conda-build is run on a totally fresh install, the conda-bld folder may not have been created yet, and locking it will fail.  This PR ensures that the folder is created before locking.