### PR TITLE
Use setuptools entry points

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ install:
   - conda update -q --all
   - conda install -q --force --no-deps conda requests
   - conda install -q pip pytest requests jinja2 patchelf flake8 mock python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
-  - conda install -q anaconda-client conda-build
-  - pip install pytest-cov
-  - python setup.py install
+  - conda install -q anaconda-client pip pytest-cov
+  - pip install --no-deps .
   - conda info -a
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,12 +60,11 @@ install:
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install -q pytest pytest-cov mock requests pycrypto git anaconda-client
+  - conda install -q pytest pytest-cov mock requests pycrypto git anaconda-client pip
   # this is to ensure dependencies
-  - conda install -q conda-build
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
-  - python setup.py install
+  - pip install --no-deps .
   - set PATH
   - conda build --version
   - call appveyor\setup_x64.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,8 @@ install:
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install -q pytest pytest-cov mock requests pycrypto git anaconda-client pip
+  - conda install -q pip pytest requests jinja2 patch flake8 mock python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
+  - conda install -q anaconda-client pip pytest-cov
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install -q pip pytest requests jinja2 patch flake8 mock python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
+  - conda install -q pip pytest requests jinja2 patch flake8 mock pyflakes=1.1
   - conda install -q anaconda-client pip pytest-cov
   # this is to ensure dependencies
   - python --version

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 import sys
-from glob import glob
 
 import versioneer
 
-if 'develop' in sys.argv:
-    from setuptools import setup
-else:
-    from distutils.core import setup
+from setuptools import setup
 
 if sys.version_info[:2] < (2, 7):
     sys.exit("conda-build is only meant for Python >=2.7"
@@ -24,9 +20,9 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     author="Continuum Analytics, Inc.",
-    author_email="ilan@continuum.io",
+    author_email="conda@continuum.io",
     url="https://github.com/conda/conda-build",
-    license="BSD",
+    license="BSD 3-clause",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -39,8 +35,19 @@ setup(
     ],
     description="tools for building conda packages",
     long_description=open('README.rst').read(),
-    packages=['conda_build'],
-    scripts=glob('bin/*'),
+    packages=['conda_build', ],
+    entry_points={
+        'console_scripts': ['conda-build = conda_build.main_build:main',
+                            'conda-convert = conda_build.main_convert:main',
+                            'conda-develop = conda_build.main_develop:main',
+                            'conda-index = conda_build.main_index:main',
+                            'conda-inspect = conda_build.main_inspect:main',
+                            'conda-metapackage = conda_build.main_metapackage:main',
+                            'conda-pipbuild = conda_build.main_pipbuild:main',
+                            'conda-render = conda_build.main_render:main',
+                            'conda-sign = conda_build.main_sign:main',
+                            'conda-skeleton = conda_build.main_skeleton:main',
+                            ]},
     install_requires=['conda'],
     package_data={'conda_build': ['templates/*', 'cli-*.exe']},
 )

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
                             ]},
     install_requires=['conda'],
     package_data={'conda_build': ['templates/*', 'cli-*.exe']},
+    zip_safe=False,
 )


### PR DESCRIPTION
Something was going wrong with the conda-based entry points in the conda-build conda-forge feedstock: https://github.com/conda-forge/pyferret-feedstock/pull/8

As near as I can tell, these entry points were manually created, and then the legacy build system did the right thing with the contents of the scripts entry.  This apparently is not working with conda-build.

This PR uses setuptools entry points instead.  It introduces the constraint that pip be used to install during the build process - otherwise, egg-based entry points are created.  With pip, we get entry points similar to the ones that were manually created.