### PR TITLE
move logging setup to entry points

### DIFF
--- a/conda_build/__init__.py
+++ b/conda_build/__init__.py
@@ -4,8 +4,6 @@
 # conda is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
-import logging
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
@@ -22,5 +20,3 @@ sub_commands = [
     'sign',
     'skeleton',
 ]
-
-logging.basicConfig(level=logging.INFO)

--- a/conda_build/main_build.py
+++ b/conda_build/main_build.py
@@ -28,6 +28,7 @@ from conda_build.utils import find_recipe
 from conda_build.main_render import (set_language_env_vars, RecipeCompleter, render_recipe)
 on_win = (sys.platform == 'win32')
 
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__file__)
 
 

--- a/conda_build/main_convert.py
+++ b/conda_build/main_convert.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, division, print_function
 
 import json
+import logging
 import pprint
 import re
 import sys
@@ -21,6 +22,8 @@ from conda_build.main_build import args_func
 
 from conda_build.convert import (has_cext, tar_update, get_pure_py_file_map,
                                  has_nonpy_entry_points)
+
+logging.basicConfig(level=logging.INFO)
 
 
 epilog = """

--- a/conda_build/main_develop.py
+++ b/conda_build/main_develop.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import sys
 from os.path import join, isdir, abspath, expanduser, exists
 import shutil
@@ -17,6 +18,8 @@ from conda_build.post import mk_relative_osx
 from conda_build.utils import _check_call, rec_glob
 
 from conda.install import linked
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main():

--- a/conda_build/main_inspect.py
+++ b/conda_build/main_inspect.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import sys
 import re
 import os
@@ -28,6 +29,8 @@ from conda_build.main_build import args_func
 from conda_build.ldd import get_linkages, get_package_obj_files, get_untracked_obj_files
 from conda_build.macho import get_rpaths, human_filetype
 from conda_build.utils import groupby, getter, comma_join
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main():

--- a/conda_build/main_pipbuild.py
+++ b/conda_build/main_pipbuild.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function, division, absolute_import
 
+import logging
 import sys
 import os
 import os.path
@@ -24,6 +25,8 @@ if sys.version_info < (3,):
     from xmlrpclib import ServerProxy
 else:
     from xmlrpc.client import ServerProxy
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main():

--- a/conda_build/main_render.py
+++ b/conda_build/main_render.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import sys
 
 from conda.cli.common import add_parser_channels
@@ -18,6 +19,8 @@ from conda_build.completers import (RecipeCompleter, PythonVersionCompleter, RVe
                                     LuaVersionsCompleter, NumPyVersionCompleter)
 
 on_win = (sys.platform == 'win32')
+
+logging.basicConfig(level=logging.INFO)
 
 
 def get_render_parser():

--- a/conda_build/main_sign.py
+++ b/conda_build/main_sign.py
@@ -4,6 +4,7 @@
 # conda is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
+import logging
 import os
 import sys
 import base64
@@ -22,6 +23,8 @@ Error: could not import Crypto (required for "conda sign").
 """)
 
 from conda.signature import KEYS_DIR, hash_file, verify, SignatureError
+
+logging.basicConfig(level=logging.INFO)
 
 
 def keygen(name, size=2048):

--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -6,12 +6,15 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import os
 
 from conda.config import default_python
 from conda_build.main_build import args_func
 from conda.cli.conda_argparse import ArgumentParser
 from conda.cli.common import Completer
+
+logging.basicConfig(level=logging.INFO)
 
 
 class PyPIPackagesCompleter(Completer):


### PR DESCRIPTION
The real issue was that conda installs outside of conda build were picking up conda build's root logger.  This moves the root logger to the build entry points to avoid that.

CC @kalefranz 