### PR TITLE
always use long prefix

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -94,11 +94,7 @@ class Config(object):
 
     @property
     def build_prefix(self):
-        if self.use_long_build_prefix is None:
-            raise Exception("I don't know which build prefix to use yet")
-        if self.use_long_build_prefix:
-            return self.long_build_prefix
-        return self.short_build_prefix
+        return self.long_build_prefix
 
     @property
     def build_python(self):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -212,7 +212,7 @@ def build(m, bld_bat, dirty=False, activate=True):
             fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
             fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
             if activate:
-                fo.write("call activate.bat _build\n")
+                fo.write("call activate.bat {0}\n".format(config.build_prefix))
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -27,6 +27,8 @@ def test_find_prefix_files():
     """
     # create a temporary folder
     prefix = os.path.join(sys.prefix, "envs", "_build")
+    # duplicate long build prefix
+    prefix = max(prefix, (prefix + 8 * '_placehold')[:80])
     if not os.path.isdir(prefix):
         os.makedirs(prefix)
     with TemporaryDirectory(prefix=prefix + os.path.sep) as tmpdir:


### PR DESCRIPTION
We've had problems with the build prefix losing its state in different parts of the build process:

https://github.com/conda-forge/staged-recipes/pull/678#issuecomment-237053396
https://github.com/conda-forge/staged-recipes/pull/582#issuecomment-236981508

The root of this is that the builds were done with the long prefix, but later parts (post-processing, like compiling pyc) was not.  We should just use the long prefix and not worry about it.  This is how it is done in #953 (conda-build 2.0) anyway.