### PR TITLE
Add build/skip_compile_pyc option

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -766,7 +766,8 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                      prefix=config.build_prefix,
                      config=config,
                      preserve_egg_dir=bool(m.get_value('build/preserve_egg_dir')),
-                     noarch=m.get_value('build/noarch'))
+                     noarch=m.get_value('build/noarch'),
+                     skip_compile_pyc=m.get_value('build/skip_compile_pyc'))
 
         # The post processing may have deleted some files (like easy-install.pth)
         files2 = prefix_files(prefix=config.build_prefix)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -237,6 +237,7 @@ default_structs = {
     'build/noarch_python': bool,
     'build/detect_binary_files_with_prefix': bool,
     'build/skip': bool,
+    'build/skip_compile_pyc': list,
     'app/own_environment': bool
 }
 
@@ -305,8 +306,8 @@ FIELDS = {
               'features', 'track_features', 'preserve_egg_dir',
               'no_link', 'binary_relocation', 'script', 'noarch', 'noarch_python',
               'has_prefix_files', 'binary_has_prefix_files', 'ignore_prefix_files',
-              'detect_binary_files_with_prefix', 'rpaths', 'script_env',
-              'always_include_files', 'skip', 'msvc_compiler',
+              'detect_binary_files_with_prefix', 'skip_compile_pyc', 'rpaths',
+              'script_env', 'always_include_files', 'skip', 'msvc_compiler',
               'pin_depends', 'include_recipe'  # pin_depends is experimental still
               ],
     'requirements': ['build', 'run', 'conflicts'],

--- a/tests/test-recipes/metadata/skip_compile_pyc/README
+++ b/tests/test-recipes/metadata/skip_compile_pyc/README
@@ -1,0 +1,1 @@
+Simple package to test skip_compile_pyc package building.

--- a/tests/test-recipes/metadata/skip_compile_pyc/compile_pyc.py
+++ b/tests/test-recipes/metadata/skip_compile_pyc/compile_pyc.py
@@ -1,0 +1,2 @@
+import os
+

--- a/tests/test-recipes/metadata/skip_compile_pyc/meta.yaml
+++ b/tests/test-recipes/metadata/skip_compile_pyc/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: skip_compile_pyc
+  version: "1.0"
+
+source:
+  path: .
+
+requirements:
+  build:
+    - python
+
+build:
+  script:
+    - cp -rf "${SRC_DIR}"/* "${PREFIX}"/  # [unix]
+    - xcopy /s %SRC_DIR% %PREFIX%         # [win]
+  skip_compile_pyc:
+    # rec_glob is used to find files:
+    - sub/skip*
+    # test that path normalization happens:
+    - ./sub/../skip_compile_pyc.py

--- a/tests/test-recipes/metadata/skip_compile_pyc/skip_compile_pyc.py
+++ b/tests/test-recipes/metadata/skip_compile_pyc/skip_compile_pyc.py
@@ -1,0 +1,2 @@
+import os
+

--- a/tests/test-recipes/metadata/skip_compile_pyc/sub/compile_pyc.py
+++ b/tests/test-recipes/metadata/skip_compile_pyc/sub/compile_pyc.py
@@ -1,0 +1,2 @@
+import os
+

--- a/tests/test-recipes/metadata/skip_compile_pyc/sub/skip_compile_pyc.py
+++ b/tests/test-recipes/metadata/skip_compile_pyc/sub/skip_compile_pyc.py
@@ -1,0 +1,2 @@
+import os
+

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -16,6 +16,7 @@ from binstar_client.commands import remove, show
 from binstar_client.errors import NotFound
 import pytest
 import yaml
+import tarfile
 
 from conda_build import api, exceptions
 from conda_build.utils import (copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2,
@@ -626,3 +627,21 @@ def test_noarch_python():
     noarch = json.loads(package_has_file(fn, 'info/noarch.json').decode())
     assert 'entry_points' in noarch
     assert 'type' in noarch
+
+
+def test_skip_compile_pyc():
+    recipe = os.path.join(metadata_dir, "skip_compile_pyc")
+    fn = api.get_output_file_path(recipe)
+    api.build(recipe)
+    tf = tarfile.open(fn)
+    pyc_count = 0
+    for f in tf.getmembers():
+        filename = os.path.basename(f.name)
+        _, ext = os.path.splitext(filename)
+        basename = filename.split('.',1)[0]
+        if basename == 'skip_compile_pyc':
+            assert not ext == '.pyc', "a skip_compile_pyc .pyc was compiled: {}".format(filename)
+        if ext == '.pyc':
+            assert basename == 'compile_pyc', "an unexpected .pyc was compiled: {}".format(filename)
+            pyc_count = pyc_count+1
+    assert pyc_count == 2, "there should be 2 .pyc files, instead there were {}".format(pyc_count)


### PR DESCRIPTION
@msarahan: It's strangely coincedental that I'm making changes in the same area of compiling `.pyc` files two days in a row, as other than the location, this is not related to yesterday's fix.

Some packages ship .py files that should not be compiled because either they
cannot be compiled (for example they contain templates) or should not be
compiled yet because the Python interpreter that will be used cannot be known
at build-time.

An example of such a package is `qtcreator` which uses GDB's embedded Python
interpreter to give a richer debugging experience. This package falls foul of
both scenarios given above.

Closes #686 