### PR TITLE
allow case insensitive matches of prefix path in binaries

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -109,7 +109,7 @@ def have_prefix_files(files):
         double_backslash_prefix = prefix.replace('\\', '\\\\')
         double_backslash_prefix_bytes = double_backslash_prefix.encode('utf-8')
         # moar escapes for regex
-        prefix_bytes = prefix_bytes.replace('\\', '\\\\')
+        prefix_bytes = prefix_bytes.replace(b'\\', b'\\\\')
 
     for f in files:
         if f.endswith(('.pyc', '.pyo', '.a')):

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -141,7 +141,7 @@ def have_prefix_files(files):
                 mm = mmap.mmap(fi.fileno(), 0)
         prefix_matches = re.findall(prefix_bytes, mm, re.IGNORECASE)
         for match in prefix_matches:
-            yield (match, mode, f)
+            yield (match.decode('utf-8'), mode, f)
         if on_win and mm.find(forward_slash_prefix_bytes) != -1:
             # some windows libraries use unix-style path separators
             yield (forward_slash_prefix, mode, f)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -7,6 +7,7 @@ import io
 import json
 import logging
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -107,6 +108,8 @@ def have_prefix_files(files):
         forward_slash_prefix_bytes = forward_slash_prefix.encode('utf-8')
         double_backslash_prefix = prefix.replace('\\', '\\\\')
         double_backslash_prefix_bytes = double_backslash_prefix.encode('utf-8')
+        # moar escapes for regex
+        prefix_bytes = prefix_bytes.replace('\\', '\\\\')
 
     for f in files:
         if f.endswith(('.pyc', '.pyo', '.a')):
@@ -136,8 +139,9 @@ def have_prefix_files(files):
                 mm.close() and fi.close()
                 fi = open(path, 'rb+')
                 mm = mmap.mmap(fi.fileno(), 0)
-        if mm.find(prefix_bytes) != -1:
-            yield (prefix, mode, f)
+        prefix_matches = re.findall(prefix_bytes, mm, re.IGNORECASE)
+        for match in prefix_matches:
+            yield (match, mode, f)
         if on_win and mm.find(forward_slash_prefix_bytes) != -1:
             # some windows libraries use unix-style path separators
             yield (forward_slash_prefix, mode, f)

--- a/tests/test-recipes/metadata/_binary_has_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/_binary_has_prefix_files/run_test.py
@@ -8,6 +8,9 @@ def main():
     with open(fn, 'rb') as f:
         data = f.read()
 
+    print("Prefix: ")
+    print(prefix)
+    print("Binary data (prefix should be in this): ")
     print(data)
     assert prefix.encode('utf-8') in data
 

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -85,8 +85,6 @@ def test_build_with_no_activate_does_not_activate():
     subprocess.check_call(cmd.split(), cwd=metadata_dir)
 
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="no binary prefix manipulation done on windows.")
 def test_binary_has_prefix_files():
     cmd = 'conda build --no-anaconda-upload {}/_binary_has_prefix_files'.format(metadata_dir)
     subprocess.check_call(cmd.split())

--- a/tests/test_build_recipes.py
+++ b/tests/test_build_recipes.py
@@ -85,6 +85,7 @@ def test_build_with_no_activate_does_not_activate():
     subprocess.check_call(cmd.split(), cwd=metadata_dir)
 
 
+@pytest.mark.xfail(sys.platform == 'win32', reason="Binary replacement not supported in conda yet.")
 def test_binary_has_prefix_files():
     cmd = 'conda build --no-anaconda-upload {}/_binary_has_prefix_files'.format(metadata_dir)
     subprocess.check_call(cmd.split())


### PR DESCRIPTION
I've seen prefixes that are all lowercase embedded in pip-created entry point exe's.  This PR should catch those as well as ordinary ones.