### PR TITLE
win fixes: set LIB and INCLUDE better; use short prefix

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -9,6 +9,8 @@ from os.path import abspath, expanduser, join
 
 import conda.config as cc
 
+on_win = (sys.platform == 'win32')
+
 # Don't "save" an attribute of this module for later, like build_prefix =
 # conda_build.config.config.build_prefix, as that won't reflect any mutated
 # changes.
@@ -94,6 +96,8 @@ class Config(object):
 
     @property
     def build_prefix(self):
+        if on_win:
+            return self.short_build_prefix
         return self.long_build_prefix
 
     @property

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -208,8 +208,8 @@ def build(m, bld_bat, dirty=False, activate=True):
             fo.write('@echo on\n')
             for key, value in env.items():
                 fo.write('set "{key}={value}"\n'.format(key=key, value=value))
-            fo.write("set INCLUDE={};%INCLUDE%\n".format(env["LIBRARY_INC"]))
-            fo.write("set LIB={};%LIB%\n".format(env["LIBRARY_LIB"]))
+            fo.write('set "INCLUDE={};%INCLUDE%"\n'.format(env["LIBRARY_INC"]))
+            fo.write('set "LIB={};%LIB%"\n'.format(env["LIBRARY_LIB"]))
             fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
             if activate:
                 fo.write("call activate.bat {0}\n".format(config.build_prefix))

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -114,7 +114,7 @@ def msvc_env_cmd(bits, override=None):
     if float(version) >= 14.0:
         # For Python 3.5+, ensure that we link with the dynamic runtime.  See
         # http://stevedower.id.au/blog/building-for-python-3-5-part-two/ for more info
-        msvc_env_lines.append('set PY_VCRUNTIME_REDIST=%LIBRARY_BIN%\vcruntime{0}.dll'.format(
+        msvc_env_lines.append('set PY_VCRUNTIME_REDIST=%LIBRARY_BIN%\\vcruntime{0}.dll'.format(
             version.replace('.', '')))
 
     vcvarsall_vs_path = build_vcvarsall_vs_path(version)

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -208,9 +208,11 @@ def build(m, bld_bat, dirty=False, activate=True):
             fo.write('@echo on\n')
             for key, value in env.items():
                 fo.write('set "{key}={value}"\n'.format(key=key, value=value))
+            fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
+            # Reset echo on, because MSVC scripts might have turned it off
+            fo.write('@echo on\n')
             fo.write('set "INCLUDE={};%INCLUDE%"\n'.format(env["LIBRARY_INC"]))
             fo.write('set "LIB={};%LIB%"\n'.format(env["LIBRARY_LIB"]))
-            fo.write(msvc_env_cmd(bits=cc.bits, override=m.get_value('build/msvc_compiler', None)))
             if activate:
                 fo.write("call activate.bat {0}\n".format(config.build_prefix))
             fo.write("REM ===== end generated header =====\n")


### PR DESCRIPTION
Seeing errors with LIB paths being set without quotes.  Not sure why this would have changed.  Try to improve variable quoting in bld.bat variable setting.

Also, Windows has a path limit of 260 characters.  To minimize trouble that users encounter, keep to a short build prefix on windows.  This should not interfere with the pip-create entry point exes in Windows (https://github.com/conda/conda/pull/3224) because they re-create the binary, rather than editing the content.