### PR TITLE
Corrected logic for printout of meta.dist determination.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -476,7 +476,7 @@ def build(m, post=None, include_recipe=True, keep_old_work=False,
         if post in [False, None]:
             print("Removing old build environment")
             print("BUILD START:", m.dist())
-            if not need_source_download or not need_reparse_in_env:
+            if need_source_download or need_reparse_in_env:
                 print("    (actual version deferred until further download or env creation)")
             if on_win:
                 if isdir(config.short_build_prefix):


### PR DESCRIPTION
Looks to me that we are only deferring the version if we need to get the source, or we need the environment created. I fully confess though - I'm on pretty shaky ground with my understanding of this bit of the code at present though.