### PR TITLE
revert to list all packages for pypi skeleton

### DIFF
--- a/conda_build/main_skeleton.py
+++ b/conda_build/main_skeleton.py
@@ -113,7 +113,7 @@ Create recipe skeleton for packages hosted on the Python Packaging Index
     pypi.add_argument(
         "--pypi-url",
         action="store",
-        default='https://pypi.io/pypi',
+        default='https://pypi.python.org/pypi',
         help="URL to use for PyPI (default: %(default)s).",
     )
     pypi.add_argument(

--- a/tests/test-skeleton/sympy-0.7.5-url/meta.yaml
+++ b/tests/test-skeleton/sympy-0.7.5-url/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: sympy-0.7.5.tar.gz
-  url: https://pypi.io/packages/source/s/sympy/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9
+  url: https://pypi.python.org/packages/8c/a5/5fa8adee81837687f7315122769fc0b0e8b042c69e2fe5809c41191c7183/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9
   md5: 7de1adb49972a15a3dd975e879a2bea9
 #  patches:
    # List any patch files here

--- a/tests/test-skeleton/sympy-0.7.5/meta.yaml
+++ b/tests/test-skeleton/sympy-0.7.5/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: sympy-0.7.5.tar.gz
-  url: https://files.pythonhosted.org/packages/8c/a5/5fa8adee81837687f7315122769fc0b0e8b042c69e2fe5809c41191c7183/sympy-0.7.5.tar.gz
+  url: https://pypi.python.org/packages/8c/a5/5fa8adee81837687f7315122769fc0b0e8b042c69e2fe5809c41191c7183/sympy-0.7.5.tar.gz
   md5: 7de1adb49972a15a3dd975e879a2bea9
 #  patches:
    # List any patch files here

--- a/tests/test-skeleton/test_skeleton.py
+++ b/tests/test-skeleton/test_skeleton.py
@@ -36,8 +36,7 @@ def test_name_with_version_specified(tmpdir):
 
 def test_url(tmpdir):
     cmd = "conda skeleton pypi --output-dir {} \
-https://pypi.io/packages/source/s/sympy/\
-sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9".format(tmpdir)
+https://pypi.python.org/packages/8c/a5/5fa8adee81837687f7315122769fc0b0e8b042c69e2fe5809c41191c7183/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9".format(tmpdir)  # NOQA
     subprocess.check_call(cmd.split())
     with open('{}/sympy-0.7.5-url/meta.yaml'.format(thisdir)) as f:
         expected = yaml.load(f)


### PR DESCRIPTION
Closes #1179 #1177 

This is a workaround for https://github.com/pypa/warehouse/issues/1417 - pypa seems to have broken the xmlrpc search function right now.  This workaround is undesirable - it is much slower, and much more data is transferred.  I don't know what the load implications are on their side.