### PR TITLE
provide fallback path for builds where dep still has 80 char prefix

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -397,7 +397,21 @@ def create_env(prefix, specs, clear_cache=True, debug=False):
         cc.pkgs_dirs = cc.pkgs_dirs[:1]
         actions = plan.install_actions(prefix, index, specs)
         plan.display_actions(actions, index)
-        plan.execute_actions(actions, index, verbose=debug)
+
+        try:
+            plan.execute_actions(actions, index, verbose=debug)
+        except SystemExit as exc:
+            if "too short in" in exc.message and config.prefix_length > 80:
+                log.warn("Build prefix failed with prefix length {0}."
+                         .format(config.prefix_length))
+                log.warn("Error was: ")
+                log.warn(exc.message)
+                log.warn("One or more of your package dependencies needs to be rebuilt with a "
+                         "longer prefix length.")
+                log.warn("Falling back to legacy prefix length of 80 characters.")
+                log.warn("Your package will not install into prefixes longer than 80 characters.")
+                config.prefix_length = 80
+                create_env(prefix, specs, clear_cache=clear_cache, debug=debug)
 
         os.environ['PATH'] = old_path
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -59,8 +59,10 @@ class Config(object):
     else:
         croot = abspath(expanduser('~/conda-bld'))
 
+    prefix_length = 255
+
     short_build_prefix = join(cc.envs_dirs[0], '_build')
-    long_build_prefix = max(short_build_prefix, (short_build_prefix + 25 * '_placehold')[:255])
+
     # XXX: Make this None to be more rigorous about requiring the build_prefix
     # to be known before it is used.
     use_long_build_prefix = False
@@ -93,6 +95,12 @@ class Config(object):
         else:
             res = join(prefix, 'bin/{}'.format(binary_name))
         return res
+
+    @property
+    def long_build_prefix(self):
+        return max(self.short_build_prefix,
+                            (self.short_build_prefix +
+                             int(self.prefix_length / 10) * '_placehold')[:self.prefix_length])
 
     @property
     def build_prefix(self):


### PR DESCRIPTION
The problem with long prefixes is that they have to be rebuilt all the way back down the dependency chain.  The fundamental snag is that you can't install a package with a short prefix into a long prefix build environment.  This workaround makes it so that conda-build will not die on encountering this condition, but will fall back to building with an 80-character build prefix, after vomiting a healthy amount of text trying to explain the situation.

CC @pelson - would appreciate your feedback on this approach.