### PR TITLE
Re-add logic for activating C++ Compiler for Python 2.7

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -174,8 +174,7 @@ def msvc_env_cmd(bits, override=None):
 
         error1 = 'if errorlevel 1 {}'
 
-        # Setuptools captures the logic of preferring the Microsoft Visual C++
-        # Compiler for Python 2.7 - falls back to VS2008 if necessary
+        # Prefer VS9 proper over Microsoft Visual C++ Compiler for Python 2.7
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))
         # The Visual Studio 2008 Express edition does not properly contain
         # the amd64 build files, so we call the vcvars64.bat manually,
@@ -184,6 +183,10 @@ def msvc_env_cmd(bits, override=None):
         if arch_selector == 'amd64' and VCVARS64_VS9_BAT_PATH:
             msvc_env_lines.append(error1.format(
                 build_vcvarsall_cmd(VCVARS64_VS9_BAT_PATH)))
+        # Otherwise, fall back to icrosoft Visual C++ Compiler for Python 2.7+
+        # by using the logic provided by setuptools
+        msvc_env_lines.append(error1.format(
+            build_vcvarsall_cmd(distutils_find_vcvarsall(9))))
     else:
         # Visual Studio 14 or otherwise
         msvc_env_lines.append(build_vcvarsall_cmd(vcvarsall_vs_path))


### PR DESCRIPTION
Prefer the 'full' VS and fallback to Python tools after. At the moment, conda-build will never seek the Python tools which is a regression in behaviour. I understand why VS9 'full' is preferred (CMake) but we should still fallback to looking for the tools if available. @msarahan 