### PR TITLE
add simple function for finding packages with short binary prefixes

### DIFF
--- a/conda_build/main_inspect.py
+++ b/conda_build/main_inspect.py
@@ -29,6 +29,8 @@ from conda_build.main_build import args_func
 from conda_build.ldd import get_linkages, get_package_obj_files, get_untracked_obj_files
 from conda_build.macho import get_rpaths, human_filetype
 from conda_build.utils import groupby, getter, comma_join
+from conda_build.tarcheck import check_prefix_lengths
+from conda_build.config import config
 
 logging.basicConfig(level=logging.INFO)
 
@@ -154,6 +156,22 @@ Tools for investigating conda channels.
         nargs='?',
         default="defaults",
         help="The channel to test. The default is %(default)s."
+    )
+    prefix_lengths = subcommand.add_parser(
+        "prefix-lengths",
+        help="""Inspect packages in given path, finding those with binary
+            prefixes shorter than specified""",
+        description=linkages_help,
+    )
+    prefix_lengths.add_argument(
+        'folder',
+        help='folder containing packages to inspect.',
+    )
+    prefix_lengths.add_argument(
+        '--min-prefix-length', '-m',
+        help='Minimum length.  Only packages with prefixes below this are shown.',
+        default=config.prefix_length,
+        type=int,
     )
 
     p.set_defaults(func=execute)
@@ -299,6 +317,18 @@ def execute(args, parser):
             parser.error("At least one option (--test-installable) is required.")
         else:
             sys.exit(not test_installable(channel=args.channel, verbose=args.verbose))
+
+    if args.subcommand == 'prefix-lengths':
+        prefix_lengths = check_prefix_lengths(args.folder, args.min_prefix_length)
+        if prefix_lengths:
+            print("Packages with binary prefixes shorter than %d characters:"
+                  % args.min_prefix_length)
+            for fn, length in prefix_lengths.items():
+                print("{0} ({1} chars)".format(fn, length))
+        else:
+            print("No packages found with binary prefixes shorter than %d characters."
+                  % args.min_prefix_length)
+        sys.exit(len(prefix_lengths) == 0)
 
     prefix = get_prefix(args)
     installed = conda.install.linked_data(prefix)


### PR DESCRIPTION
With the extended length prefixes coming soon, it is helpful to know which packages in an ecosystem need to be rebuilt.  This PR introduces a function for identifying packages with short prefixes.  It can be used as a Python function (see tarcheck.py, check_prefix_lengths(folder, min_prefix_length=255)), returning a dictionary of filenames and prefix lengths, or as a command-line tool:

```
conda inspect prefix-lengths
```

This command takes one mandatory argument: the folder to inspect; and one optional argument - a prefix length threshold, by default set to the value of the default prefix length in our config.  Only packages with prefix lengths shorter than this value will be show.

This functionality is perhaps best employed on a package host, because otherwise we have to download packages to inspect them.  Perhaps an SSH filesystem would allow remote inspection without downloading complete packages?

CC @jakirkham @bollwyvl @ilanschnell @csoja 