### PR TITLE
fix: detect VS installation directory 

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -66,7 +66,7 @@ def build_vcvarsall_vs_path(version):
     """
     Given the Visual Studio version, returns the default path to the
     Microsoft Visual Studio vcvarsall.bat file.
-    Expected versions are of the form {9, 10, 12, 14}
+    Expected versions are of the form {9.0, 10.0, 12.0, 14.0}
     """
     # Set up a load of paths that can be imported from the tests
     if 'ProgramFiles(x86)' in os.environ:
@@ -74,7 +74,9 @@ def build_vcvarsall_vs_path(version):
     else:
         PROGRAM_FILES_PATH = os.environ['ProgramFiles']
 
-    vstools = "VS{0}0COMNTOOLS".format(version)
+    flatversion = str(version).replace('.', '')
+    vstools = "VS{0}COMNTOOLS".format(flatversion)
+    
     if vstools in os.environ:
         return os.path.join(os.environ[vstools], '..\\..\\VC\\vcvarsall.bat')
     else:


### PR DESCRIPTION
Really fix #560. 

Allow ``build_vcvarsall_vs_path(v)`` to be invoked with VS version strings in ``Major.Minor`` format. Currently this function assumes that its argument is in ``MajorMinor`` format, which is not always the case. This causes VS installation path detection to fail.