### PR TITLE
break hardlinks in post

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -407,6 +407,8 @@ def check_symlinks(files):
 def make_hardlink_copy(path):
     """Hardlinks create invalid packages.  Copy files to break the link.
     Symlinks are OK, and unaffected here."""
+    if not os.path.isabs(path) and not os.path.exists(path):
+        path = os.path.normpath(os.path.join(config.build_prefix, path))
     nlinks = os.lstat(path).st_nlink
     if nlinks > 1:
         # copy file to new name

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -20,6 +20,8 @@ from conda_build import external
 # Backwards compatibility import. Do not remove.
 from .conda_interface import rm_rf  # NOQA
 
+on_win = (sys.platform == 'win32')
+
 
 def find_recipe(path):
     """recurse through a folder, locating meta.yaml.  Raises error if more than one is found.

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -6,6 +6,7 @@ from conda.compat import TemporaryDirectory, PY3
 import pytest
 
 from conda_build import post
+from conda_build.utils import on_win
 
 
 def test_compile_missing_pyc():
@@ -63,6 +64,7 @@ def test_coerce_pycache_to_old_style():
             os.chdir(cwd)
 
 
+@pytest.mark.skipif(on_win, reason="no linking on win")
 def test_hardlinks_to_copies():
     with open('test1', 'w') as f:
         f.write("\n")

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -71,7 +71,8 @@ def test_hardlinks_to_copies():
         assert os.lstat('test1').st_nlink == 2
         assert os.lstat('test2').st_nlink == 2
 
-        post.make_hardlinks_copies(['test1', 'test2'])
+        post.make_hardlink_copy('test1')
+        post.make_hardlink_copy('test2')
 
         assert os.lstat('test1').st_nlink == 1
         assert os.lstat('test2').st_nlink == 1

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -61,3 +61,22 @@ def test_coerce_pycache_to_old_style():
             raise
         finally:
             os.chdir(cwd)
+
+
+def test_hardlinks_to_copies():
+    with open('test1', 'w') as f:
+        f.write("\n")
+    try:
+        os.link('test1', 'test2')
+        assert os.lstat('test1').st_nlink == 2
+        assert os.lstat('test2').st_nlink == 2
+
+        post.make_hardlinks_copies(['test1', 'test2'])
+
+        assert os.lstat('test1').st_nlink == 1
+        assert os.lstat('test2').st_nlink == 1
+    except:
+        raise
+    finally:
+        os.remove('test1')
+        os.remove('test2')

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -80,4 +80,5 @@ def test_hardlinks_to_copies():
         raise
     finally:
         os.remove('test1')
-        os.remove('test2')
+        if os.path.exists('test2'):
+            os.remove('test2')


### PR DESCRIPTION
hardlinks break installation of some packages.  This copies linked files, and should make things work. More importantly, this makes anaconda-verify happy again.

CC @mingwandroid @ilanschnell 