### PR TITLE
fix breakage related to Windows env vars being strings

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -12,7 +12,7 @@ from conda.compat import (PY3, StringIO, configparser, input, iteritems, lchmod,
                           text_type)  # NOQA
 from conda.connection import CondaSession  # NOQA
 from conda.fetch import TmpDownload, download, fetch_index, handle_proxy_407  # NOQA
-from conda.install import (delete_trash, is_linked, linked, linked_data, move_to_trash,  # NOQA
+from conda.install import (delete_trash, is_linked, linked, linked_data, move_path_to_trash,  # NOQA
                            prefix_placeholder, rm_rf, symlink_conda)  # NOQA
 from conda.lock import Locked  # NOQA
 from conda.misc import untracked, walk_prefix  # NOQA

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -18,7 +18,6 @@ import subprocess
 import yaml
 
 from .conda_interface import PY3
-from .conda_interface import move_to_trash, rm_rf
 from .conda_interface import Locked
 
 from conda_build import exceptions, utils
@@ -129,9 +128,9 @@ def render_recipe(recipe_path, no_download_source, verbose, dirty=False):
         if not dirty:
             if sys.platform == 'win32':
                 if isdir(source.WORK_DIR):
-                    move_to_trash(source.WORK_DIR, '')
+                    utils.move_to_trash(source.WORK_DIR, '')
             else:
-                rm_rf(source.WORK_DIR)
+                utils.rm_rf(source.WORK_DIR)
 
             assert not isdir(source.WORK_DIR), ("Failed to clean work directory.  Please close open"
                                         " programs/terminals/folders and try again.")

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import fnmatch
 from locale import getpreferredencoding
+import logging
 import os
 import sys
 import shutil
@@ -23,6 +24,7 @@ from .conda_interface import rm_rf  # NOQA
 
 codec = getpreferredencoding() or 'utf-8'
 on_win = sys.platform == "win32"
+log = logging.getLogger(__file__)
 
 
 def find_recipe(path):
@@ -257,3 +259,8 @@ def get_site_packages(prefix):
     else:
         sp = os.path.join(prefix, 'lib', 'python%s' % sys.version[:3], 'site-packages')
     return sp
+
+
+def move_to_trash(path, placeholder=""):
+    from .conda_interface import move_path_to_trash as trash
+    return trash(path)

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -76,7 +76,7 @@ def build_vcvarsall_vs_path(version):
 
     flatversion = str(version).replace('.', '')
     vstools = "VS{0}COMNTOOLS".format(flatversion)
-    
+
     if vstools in os.environ:
         return os.path.join(os.environ[vstools], '..\\..\\VC\\vcvarsall.bat')
     else:
@@ -223,6 +223,6 @@ def build(m, bld_bat, dirty=False, activate=True):
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)
 
-        cmd = [os.environ['COMSPEC'], '/c', 'bld.bat']
+        cmd = ['cmd.exe', '/c', 'bld.bat']
         _check_call(cmd, cwd=src_dir)
         fix_staged_scripts()


### PR DESCRIPTION
Windows variables are touchy - you should never change the type of the key, or else it is no longer the same key.  This steps back a bit on #1216.  It also makes the trash function local, for wrapping permission setting (https://github.com/conda/conda/pull/3280), though in practice, I could not get permission setting to work here.