### PR TITLE
Set prefix to config.build_prefix

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -415,7 +415,8 @@ def create_env(prefix, specs, clear_cache=True, debug=False):
                     os.environ = {k.encode(codec) if hasattr(k, 'encode') else k:
                                     v.encode(codec) if hasattr(v, 'encode') else v
                                     for k, v in os.environ.items()}
-                create_env(config.build_prefix, specs, clear_cache=clear_cache, debug=debug)
+                prefix = config.build_prefix
+                create_env(prefix, specs, clear_cache=clear_cache, debug=debug)
 
         os.environ['PATH'] = old_path
 


### PR DESCRIPTION
After we've discovered we need to use a smaller prefix, that variable
is re-used, but it still contains the bigger value.