### PR TITLE
remove egg removal.  Simplifies and fixes issue with pyc compilation

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -191,9 +191,9 @@ def compile_missing_pyc(files, cwd=config.build_prefix, python_exe=config.build_
 
 
 def post_process(files, preserve_egg_dir=False):
+    compile_missing_pyc(files)
     remove_easy_install_pth(files, preserve_egg_dir=preserve_egg_dir)
     rm_py_along_so()
-    compile_missing_pyc(files)
 
 
 def find_lib(link, path=None):


### PR DESCRIPTION
Discussed with @ilanschnell.  Should fix any issues with compilation, which was finding python files to compile, but then this removal was moving them out from under it before compilation.

CC @quasiben