### PR TITLE
add codecov.yml to disable commenting on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
The purpose here is to turn off the commenting feature of codecov.io, but keep the status updates, for easier examination of how much a given PR changes coverage.

cc @jakirkham 