### PR TITLE
define CONDA_BUILD_STATE env var during RENDER, BUILD, TEST phases

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -615,6 +615,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                     # There is no sense in trying to run an empty build script.
                     if isfile(build_file) or script:
                         env = environ.get_dict(config=config, m=m, dirty=config.dirty)
+                        env["CONDA_BUILD_STATE"] = "BUILD"
                         work_file = join(source.get_dir(config), 'conda_build.sh')
                         if script:
                             with open(work_file, 'w') as bf:
@@ -768,6 +769,7 @@ def test(m, config, move_broken=True):
 
         env = dict(os.environ.copy())
         env.update(environ.get_dict(config=config, m=m, prefix=config.test_prefix))
+        env["CONDA_BUILD_STATE"] = "TEST"
 
         if not config.activate:
             # prepend bin (or Scripts) directory
@@ -820,6 +822,7 @@ def test(m, config, move_broken=True):
                     # TODO: Run the test/commands here instead of in run_test.py
                     tf.write("{shell_path} -x -e {test_file}\n".format(shell_path=shell_path,
                                                                        test_file=test_file))
+
         if on_win:
             cmd = ['cmd.exe', "/d", "/c", test_script]
         else:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -411,13 +411,13 @@ class MetaData(object):
             return
 
         try:
-            os.environ["CONDA_BUILD_RENDERING"] = "True"
+            os.environ["CONDA_BUILD_STATE"] = "RENDER"
             self.meta = parse(self._get_contents(permit_undefined_jinja, config=config),
                               config=config, path=self.meta_path)
         except:
             raise
         finally:
-            del os.environ["CONDA_BUILD_RENDERING"]
+            del os.environ["CONDA_BUILD_STATE"]
 
         if (isfile(self.requirements_path) and
                    not self.meta['requirements']['run']):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -197,6 +197,7 @@ def msvc_env_cmd(bits, config, override=None):
 
 def build(m, bld_bat, config):
     env = environ.get_dict(config=config, m=m, dirty=config.dirty)
+    env["CONDA_BUILD_STATE"] = "BUILD"
 
     for name in 'BIN', 'INC', 'LIB':
         path = env['LIBRARY_' + name]

--- a/tests/test-recipes/metadata/state_variables/meta.yaml
+++ b/tests/test-recipes/metadata/state_variables/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  # should be defined as "RENDER" during rendering phase
+  name: {{ CONDA_BUILD_STATE|lower }}
+  version: 1.0
+
+build:
+  script:
+    - test "$PKG_NAME" = "render"  # [unix]
+    - test "$CONDA_BUILD_STATE" = "BUILD"  # [unix]
+    - IF NOT "%PKG_NAME%" == "render" exit 1  # [win]
+    - IF NOT "%CONDA_BUILD_STATE%" == "BUILD" exit 1  # [win]
+
+test:
+  commands:
+    - test "$CONDA_BUILD_STATE" = "TEST"  # [unix]
+    - IF NOT "%CONDA_BUILD_STATE%" == "TEST" exit 1  # [win]

--- a/tests/test-recipes/test-package/setup.py
+++ b/tests/test-recipes/test-package/setup.py
@@ -1,8 +1,5 @@
 from distutils.core import setup
-import os
 
-if "CONDA_BUILD_RENDERING" in os.environ:
-    print("Rendering environment variable set OK")
 
 setup(
     name="conda-build-test-project",

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -360,17 +360,6 @@ def test_compileall_compiles_all_good_files(testing_workdir, test_config):
     assert not package_has_file(output_file, bad_file + 'c')
 
 
-def test_rendering_env_var(testing_workdir, test_config, capfd):
-    """
-    This environment variable is provided for users to selectively change what they do
-    during the rendering phase, regarding their recipe.  For example, only part of
-    setup.py might be processed.
-    """
-    api.build(os.path.join(metadata_dir, "_source_setuptools_env_var"), config=test_config)
-    output, error = capfd.readouterr()
-    assert "Rendering environment variable set OK" in output, error
-
-
 def test_render_setup_py_old_funcname(testing_workdir, test_config, caplog):
     api.build(os.path.join(metadata_dir, "_source_setuptools"), config=test_config)
     assert "Deprecation notice: the load_setuptools function has been renamed to " in caplog.text()


### PR DESCRIPTION
This is in response to a suggestion by @janssen: https://github.com/conda/conda-build/pull/1154#issuecomment-236718919

The idea here is that you might have scripts behave differently base on whether they are being run in rendering, building, or test phases.  Rather than define a variable per phase, this has one variable with string values for the phases.  This replaces the earlier CONDA_BUILD_RENDERING variable and breaks anyone using that code.