### PR TITLE
fix error message due to missing recipe dep being covered up

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   run:
     - python
     - conda  >=4.1
+    - filelock
     - jinja2
     - patchelf      [linux]
 
@@ -26,7 +27,9 @@ test:
   requires:
     - pytest
     - pytest-cov
-    - pytest-env
+    - pytest-env  # [win]
+    # Optional: you can use pytest-xdist to run the tests in parallel
+    # - pytest-xdist
     - mock
   commands:
     - conda-build -h

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -927,7 +927,8 @@ def build_tree(recipe_list, config, check=False, build_only=False, post=False, n
                                 "{0} first").format(pkg))
                         add_recipes.append(recipe_dir)
                 else:
-                    raise
+                    raise RuntimeError("Can't build {0} due to unsatisfiable dependencies:\n"
+                                       .format(recipe) + error_str)
             recipe_list.extendleft(add_recipes)
 
         # outputs message, or does upload, depending on value of args.anaconda_upload

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -254,6 +254,9 @@ Include the output of the command 'conda info' in your report.
 def main():
     try:
         execute(sys.argv[1:])
+    except RuntimeError as e:
+        print(str(e))
+        sys.exit(1)
     except Exception as e:
         print_issue_message(str(e))
         sys.exit(1)

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -24,7 +24,7 @@ import conda.config as cc  # NOQA
 try:
     # conda 4.2.x
     import conda.base.context
-    from conda.base.context import get_prefix as context_get_prefix, non_x86_linux_machines  # NOQA
+    from conda.base.context import get_prefix as context_get_prefix, non_x86_linux_machines, load_condarc  # NOQA
     from conda.base.constants import DEFAULT_CHANNELS  # NOQA
     get_prefix = partial(context_get_prefix, conda.base.context.context)
     get_default_urls = lambda: DEFAULT_CHANNELS
@@ -40,13 +40,14 @@ try:
     root_dir = conda.base.context.context.root_dir
     root_writable = conda.base.context.context.root_writable
     subdir = conda.base.context.context.subdir
+    sys_rc_path = conda.base.context.context.sys_rc_path
 
     get_rc_urls = lambda: list(conda.base.context.context.channels)
     from conda.models.channel import get_conda_build_local_url
     get_local_urls = lambda: list(get_conda_build_local_url()) or []
 
 except ImportError:
-    from conda.config import get_default_urls, non_x86_linux_machines  # NOQA
+    from conda.config import get_default_urls, non_x86_linux_machines, load_condarc  # NOQA
     from conda.cli.common import get_prefix  # NOQA
 
     arch_name = cc.arch_name
@@ -60,6 +61,7 @@ except ImportError:
     root_dir = cc.root_dir
     root_writable = cc.root_writable
     subdir = cc.subdir
+    sys_rc_path = cc.sys_rc_path
 
     get_rc_urls = cc.get_rc_urls
     get_local_urls = cc.get_local_urls


### PR DESCRIPTION
This fixes the error message output when a build fails because some dependency is unsatisfiable AND no recipe exists in the folder with the current recipe.

Also adds some dependency stuff in the recipe.

Thanks @mingwandroid for pointing this out.