### PR TITLE
add source_files test arg that copies source files into test folder

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -4,11 +4,12 @@ Module to handle generating test files.
 
 from __future__ import absolute_import, division, print_function
 
+import glob
+from os.path import join, exists, isdir
 import sys
 
-from os.path import join, exists
-
 from conda_build.utils import copy_into
+from conda_build import source
 
 
 header = '''
@@ -49,6 +50,14 @@ def create_files(dir_path, m, config):
         has_files = True
         path = join(m.path, fn)
         copy_into(path, join(dir_path, fn), config)
+    # need to re-download source in order to do tests
+    if m.get_value('test/source_files') and not isdir(config.work_dir):
+        source.provide(m.path, m.get_section('source'), config=config)
+    for pattern in m.get_value('test/source_files', []):
+        has_files = True
+        files = glob.glob(join(config.work_dir, pattern))
+        for f in files:
+            copy_into(f, f.replace(config.work_dir, config.test_dir), config)
     return has_files
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -206,6 +206,7 @@ default_structs = {
     'requirements/conflicts': list,
     'test/requires': list,
     'test/files': list,
+    'test/source_files': list,
     'test/commands': list,
     'test/imports': list,
     'package/version': text_type,

--- a/tests/test-recipes/metadata/test_source_files/meta.yaml
+++ b/tests/test-recipes/metadata/test_source_files/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: test_source_files
+  version: 1.0
+
+source:
+  path: ../../test-package
+
+test:
+  source_files:
+    - conda_build_test
+    - setup.py
+  commands:
+    - test -e setup.py  # [unix]
+    - test -e conda_build_test  # [unix]
+    - test -e conda_build_test/__init__.py  # [unix]
+    - test -e conda_build_test/empty.py  # [unix]
+    - test -e conda_build_test/manual_entry.py  # [unix]
+    - if not exist conda_build_test exit 1  # [win]
+    - if not exist conda_build_test\\__init__.py exit 1  # [win]
+    - if not exist conda_build_test\\empty.py exit 1  # [win]
+    - if not exist conda_build_test\\manual_entry.py exit 1  # [win]


### PR DESCRIPTION
A frequent source of confusion is that test files are copied from the recipe directory, and there is no clear way to copy files from the source directory into the test folder.  This PR adds a new entry to the test section of meta.yaml, ```source_files``` that copies files from the source folder into the test folder.  It should also download the source if necessary (for example, if a package is being tested separately from a build).