### PR TITLE
fix pypi skeleton version sorting

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -9,6 +9,7 @@ import keyword
 import os
 from os import makedirs, listdir, getcwd, chdir
 from os.path import join, isdir, exists, isfile, abspath
+from pkg_resources import parse_version
 import re
 from shutil import copy2
 import subprocess
@@ -356,7 +357,7 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
         if is_url:
             d['version'] = 'UNKNOWN'
         else:
-            versions = sorted(client.package_releases(package, True))
+            versions = sorted(client.package_releases(package, True), key=parse_version)
             if version_compare:
                 version_compare(versions)
             if version:

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -1,5 +1,6 @@
 import os
 
+from pkg_resources import parse_version
 import pytest
 import yaml
 
@@ -74,12 +75,11 @@ def test_pypi_pin_numpy(testing_workdir, test_config):
 def test_pypi_version_sorting(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
-    api.skeletonize("conda_version_test", "pypi")
+    api.skeletonize("impyla", "pypi")
 
-    with open('conda_version_test/meta.yaml') as f:
+    with open('impyla/meta.yaml') as f:
         actual = yaml.load(f)
-        assert actual['package']['version'] != "0.1.0"
-        assert actual['package']['version'] >= "0.1.0-1"
+        assert parse_version(actual['package']['version']) >= parse_version("0.13.8")
 
 
 def test_list_skeletons():


### PR DESCRIPTION
should now properly handle versions with more than one digit.

closes #1214 

cc @mingwandroid 