### PR TITLE
prefix build and test envs with _ so conda can be installed

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -200,7 +200,7 @@ class Config(object):
 
     @property
     def _short_build_prefix(self):
-        return join(self.build_folder, 'b_env')
+        return join(self.build_folder, '_b_env')
 
     @property
     def _long_build_prefix(self):
@@ -219,7 +219,7 @@ class Config(object):
     @property
     def test_prefix(self):
         """The temporary folder where the test environment is created"""
-        return join(self.build_folder, 't_env')
+        return join(self.build_folder, '_t_env')
 
     @property
     def build_python(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ def test_set_build_id(config):
         assert config.build_prefix == os.path.join(config.croot, build_id, "b_env")
     else:
         long_prefix = os.path.join(config.croot, build_id,
-                                   "b_env" + "_placehold" * 25)[:config.prefix_length]
+                                   "_b_env" + "_placehold" * 25)[:config.prefix_length]
         assert config.build_prefix == long_prefix
 
 


### PR DESCRIPTION
Without the underscore, conda can't be installed.  Thus, conda-build cannot build itself.  Sad day.