### PR TITLE
comment canary build for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
       os: linux
     - python: '3.5'
       os: linux
-    - python: '3.5'
-      env: CANARY=true
-      os: linux
+    # - python: '3.5'
+    #   env: CANARY=true
+    #   os: linux
     - python: '3.5'
       env: FLAKE8=true
       os: linux


### PR DESCRIPTION
4.2.4 is broken.  Fix submitted at https://github.com/conda/conda/pull/3335

Until that is released, conda-build's test suite will always fail.  Fix that here.