### PR TITLE
install pytest-timeouts from pip instead of defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ install:
   - conda update -q --all
   - conda install -q --force --no-deps conda requests
   - conda install -q pip pytest requests jinja2 patchelf flake8 mock python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
-  - conda install -q anaconda-client pip pytest-cov numpy pytest-timeout
+  - conda install -q anaconda-client pip pytest-cov numpy
   - conda install -c conda-forge -q perl
-  - pip install pytest-cov pytest-xdist pytest-capturelog filelock
+  - pip install pytest-cov pytest-xdist pytest-capturelog filelock pytest-timeout
   - if [[ "$CANARY" == "true" ]]; then
       conda install -y -q -c conda-canary conda;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,14 +59,14 @@ install:
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install -q pip pytest pytest-cov pytest-timeout jinja2 patch flake8 mock requests
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests
   - conda install -q pyflakes=1.1 pycrypto posix m2-git anaconda-client numpy
   - conda install -c conda-forge -q perl
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - pip install --no-deps .
-  - pip install pytest-xdist pytest-capturelog pytest-env filelock
+  - pip install pytest-xdist pytest-capturelog pytest-env filelock pytest-timeout
   - set PATH
   - conda build --version
   - call appveyor\setup_x64.bat


### PR DESCRIPTION
Travis is having a hard time with pytest-timeout: https://travis-ci.org/conda/conda-build/jobs/154635762#L686

Try to install from pip to see if we fare any better.