### PR TITLE
export default config locations for conda clean

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -330,5 +330,8 @@ def show(config):
     print('build packages directory:', config.bldpkgs_dir)
 
 
+# legacy exports for conda
+croot = Config().croot
+
 if __name__ == '__main__':
     show(Config())

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -15,6 +15,13 @@ from .conda_interface import hashsum_file
 from conda_build.os_utils import external
 from conda_build.utils import tar_xf, unzip, safe_print_unicode, copy_into, on_win
 
+# legacy exports for conda
+from .config import Config as _Config
+SRC_CACHE = _Config().src_cache
+GIT_CACHE = _Config().git_cache
+SVN_CACHE = _Config().svn_cache
+HG_CACHE = _Config().hg_cache
+
 if on_win:
     from conda_build.utils import convert_unix_path_to_win
 


### PR DESCRIPTION
fixes #1249 

This is easier than the equivalent fix on the conda side.

CC @ericdill 