### PR TITLE
only compile pyc files if python is in the build prefix

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -183,7 +183,7 @@ def compile_missing_pyc(files, cwd, python_exe):
         if fn.endswith(".py") and fn + 'c' not in files:
             compile_files.append(fn)
 
-    if compile_files:
+    if compile_files and os.path.isfile(python_exe):
         print('compiling .pyc files...')
         for f in compile_files:
             call([python_exe, '-Wi', '-m', 'py_compile', f], cwd=cwd)


### PR DESCRIPTION
This mostly breaks repackaging scripts.  Example: https://github.com/conda-forge/inkscape-feedstock/issues/4