### PR TITLE
specify full path to activate scripts

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -48,7 +48,7 @@ from conda_build.post import (post_process, post_build,
                               fix_permissions, get_build_metadata)
 from conda_build.utils import (rm_rf, _check_call, copy_into, on_win, get_build_folders,
                                silence_loggers, path_prepended, create_entry_points,
-                               prepend_bin_path, codec)
+                               prepend_bin_path, codec, root_script_dir)
 from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
@@ -627,8 +627,9 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                             else:
                                 data = open(work_file).read()
                             with open(work_file, 'w') as bf:
-                                bf.write("source activate {build_prefix} &> /dev/null\n".format(
-                                    build_prefix=config.build_prefix))
+                                bf.write("source {conda_root}activate {build_prefix} &> "
+                                    "/dev/null\n".format(conda_root=root_script_dir + os.path.sep,
+                                                         build_prefix=config.build_prefix))
                                 bf.write(data)
                         else:
                             if not isfile(work_file):
@@ -790,7 +791,8 @@ def test(m, config, move_broken=True):
         with open(test_script, 'w') as tf:
             if config.activate:
                 ext = ".bat" if on_win else ""
-                tf.write("{source} activate{ext} {test_env} {squelch}\n".format(
+                tf.write("{source} {conda_root}activate{ext} {test_env} {squelch}\n".format(
+                    conda_root=root_script_dir + os.path.sep,
                     source="call" if on_win else "source",
                     ext=ext,
                     test_env=config.test_prefix,

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -24,7 +24,7 @@ import filelock
 from .conda_interface import md5_file, unix_path_to_win, win_path_to_unix
 from .conda_interface import PY3, iteritems
 from .conda_interface import linked
-from .conda_interface import bits
+from .conda_interface import bits, root_dir
 
 from conda_build.os_utils import external
 
@@ -51,6 +51,7 @@ on_win = (sys.platform == 'win32')
 codec = getpreferredencoding() or 'utf-8'
 on_win = sys.platform == "win32"
 log = logging.getLogger(__file__)
+root_script_dir = os.path.join(root_dir, 'Scripts' if on_win else 'bin')
 
 
 PY_TMPL = """\

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -13,7 +13,7 @@ from .conda_interface import bits
 
 from conda_build import environ
 from conda_build import source
-from conda_build.utils import _check_call
+from conda_build.utils import _check_call, root_script_dir
 
 
 assert sys.platform == 'win32'
@@ -188,7 +188,9 @@ def build(m, bld_bat, config):
             fo.write('set "INCLUDE={};%INCLUDE%"\n'.format(env["LIBRARY_INC"]))
             fo.write('set "LIB={};%LIB%"\n'.format(env["LIBRARY_LIB"]))
             if config.activate:
-                fo.write("call activate.bat {0}\n".format(config.build_prefix))
+                fo.write("call {conda_root}\\activate.bat {prefix}\n".format(
+                    conda_root=root_script_dir,
+                    prefix=config.build_prefix))
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)
 


### PR DESCRIPTION
Virtualenv's activate scripts sometimes get found instead of conda's.  Whoops.  This makes sure to find conda's, unless someone clobbers those with virtualenv's in the root environment.

https://github.com/Anaconda-Platform/anaconda-server/pull/2782

CC @dsludwig