### PR TITLE
Ci cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - conda install -q pip pytest requests jinja2 patchelf flake8 mock python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
   - conda install -q anaconda-client pip pytest-cov numpy
   - conda install -c conda-forge -q perl
-  - pip install pytest-cov pytest-xdist pytest-capturelog filelock pytest-timeout
+  - pip install pytest-cov pytest-xdist pytest-catchlog filelock pytest-timeout
   - if [[ "$CANARY" == "true" ]]; then
       conda install -y -q -c conda-canary conda;
     fi
@@ -50,7 +50,7 @@ script:
       pushd tests/bdist-recipe;
       python setup.py bdist_conda;
       popd;
-      conda build conda.recipe --no-anaconda-upload;
+      conda build conda.recipe --no-anaconda-upload -c conda-canary;
     else
       py.test -v -n 2 --cov conda_build --cov-report xml tests;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,19 +50,11 @@ script:
       pushd tests/bdist-recipe;
       python setup.py bdist_conda;
       popd;
+      conda build conda.recipe --no-anaconda-upload;
     else
       py.test -v -n 2 --cov conda_build --cov-report xml tests;
     fi
   - conda build --help
-  # create a package (this build is done with conda-build from source, and does not test entry points)
-  - conda build conda.recipe --no-anaconda-upload
-  # Create a new environment (with underscore, so that conda can be installed), to test entry points
-  - conda create -n _cbtest python=$TRAVIS_PYTHON_VERSION
-  - source activate _cbtest
-  - conda install $(conda render --output conda.recipe)
-  - pip install filelock
-  # this build should be done using actual entry points from the package we built above.
-  - conda build conda.recipe --no-anaconda-upload
 
 notifications:
     flowdock: ef3821a08a791106512ccfc04c92eccb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,4 +102,4 @@ on_failure:
 
 on_success:
   - pip install codecov
-  - codecov --env PYTHON_VERSION
+  - codecov --env PYTHON_VERSION --env PYTHON_ARCH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - pip install --no-deps .
-  - pip install pytest-xdist pytest-capturelog pytest-env filelock pytest-timeout
+  - pip install pytest-xdist pytest-catchlog pytest-env filelock pytest-timeout
   - set PATH
   - conda build --version
   - call appveyor\setup_x64.bat
@@ -83,7 +83,7 @@ test_script:
        mkdir C:\cbtmp
        py.test -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 2
     ) else (
-       conda build conda.recipe --no-anaconda-upload
+       conda build conda.recipe --no-anaconda-upload -c conda-canary
     )
 
 on_failure:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,11 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python35_64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+      BUILD_PACKAGE: "True"
+
     - PYTHON: "C:\\Python34_64"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
@@ -22,13 +27,6 @@ environment:
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27_32"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34_32"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "32"
 
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %HOME%
@@ -81,20 +79,12 @@ build: false
 test_script:
   - set "PATH=%CONDA_ROOT%;%CONDA_ROOT%\Scripts;%CONDA_ROOT%\Library\bin;%PATH%"
   - set PATH
-  - mkdir C:\cbtmp
-  - py.test -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 2
-  # create a package (this build is done with conda-build from source, and does not test entry points)
-  - conda build conda.recipe --no-anaconda-upload
-  # Create a new environment (with underscore, so that conda can be installed), to test entry points
-  - conda create -n _cbtest python=%PYTHON_VERSION%
-  - activate _cbtest
-  - conda render --output conda.recipe > tmpFile
-  - SET /p fn= < tmpFile
-  - DEL tmpFile
-  - conda install %fn%
-  - pip install filelock
-  # this build should be done using actual entry points from the package we built above.
-  - conda build conda.recipe --no-anaconda-upload
+  - if "%BUILD_PACKAGE%" == "" (
+       mkdir C:\cbtmp
+       py.test -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 2
+    ) else (
+       conda build conda.recipe --no-anaconda-upload
+    )
 
 on_failure:
   - 7z.exe a cbtmp.7z C:\cbtmp

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,11 +33,12 @@ requirements:
 test:
   requires:
     - pytest
-    - pytest-cov
+    - pytest-catchlog
     - pytest-timeout
     # Optional: you can use pytest-xdist to run the tests in parallel
-    # - pytest-env  # [win]
     # - pytest-xdist
+    #   If running tests in parallel on Win, this helps ensure reliable test discovery
+    # - pytest-env  # [win]
     - mock
   commands:
     - which conda-build  # [unix]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -71,6 +71,8 @@ test:
     - conda skeleton -h
     # test that conda sees entry points appropriately in help
     - conda --help
+    # run the full test suite
+    - py.test tests -v
   imports:
     - conda_build
   source_files:


### PR DESCRIPTION
Simplifies testing of entry points to depend on tests of them when building the package.  Centralizes build of that package to a single dedicated build.  Run test suite as part of that package build.

Removes Python 2.7 and 3.4 32-bit builds on Appveyor.  Adds additional flag to appveyor to distinguish architecture to codecov.io.
