### PR TITLE
remove pyc files from test directory to avoid __file__ errors

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -5,10 +5,11 @@ Module to handle generating test files.
 from __future__ import absolute_import, division, print_function
 
 import glob
+import os
 from os.path import join, exists, isdir
 import sys
 
-from conda_build.utils import copy_into
+from conda_build.utils import copy_into, get_ext_files
 from conda_build import source
 
 
@@ -58,6 +59,8 @@ def create_files(dir_path, m, config):
         files = glob.glob(join(config.work_dir, pattern))
         for f in files:
             copy_into(f, f.replace(config.work_dir, config.test_dir), config.timeout)
+        for f in get_ext_files(config.test_dir, '.pyc'):
+            os.remove(f)
     return has_files
 
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -430,3 +430,11 @@ def guess_license_family(license, allowed_license_families):
     else:
         return get_close_matches(license,
                                  allowed_license_families, 1, 0.0)[0]
+
+
+# Return all files in dir, and all its subdirectories, ending in pattern
+def get_ext_files(start_path, pattern):
+    for _, subdirs, files in os.walk(start_path):
+        for f in files:
+            if f.endswith(pattern):
+                yield os.path.join(dirname, f)


### PR DESCRIPTION
Encountered this while testing conda-build: https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/conda-build/build/1.0.485/job/1fkl51cd969173yg#L1594