### PR TITLE
copy files when breaking hardlinks, not rename

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -93,7 +93,7 @@ def create_post_scripts(m, config):
         if not isdir(dst_dir):
             os.makedirs(dst_dir, int('755', 8))
         dst = join(dst_dir, '.%s-%s%s' % (m.name(), tp, ext))
-        copy_into(src, dst, config)
+        copy_into(src, dst, config.timeout)
         os.chmod(dst, int('755', 8))
 
 
@@ -195,7 +195,7 @@ def create_info_files(m, files, config, prefix):
                 continue
             src_path = join(m.path, fn)
             dst_path = join(recipe_dir, fn)
-            copy_into(src_path, dst_path, config=config)
+            copy_into(src_path, dst_path, timeout=config.timeout)
 
         # store the rendered meta.yaml file, plus information about where it came from
         #    and what version of conda-build created it
@@ -209,12 +209,12 @@ def create_info_files(m, files, config, prefix):
                 f.write("# ------------------------------------------------\n\n")
                 f.write(rendered)
             copy_into(original_recipe, os.path.join(recipe_dir, 'meta.yaml.template'),
-                      config=config)
+                      timeout=config.timeout)
 
     license_file = m.get_value('about/license_file')
     if license_file:
         copy_into(join(source.get_dir(config), license_file),
-                        join(config.info_dir, 'LICENSE.txt'), config)
+                        join(config.info_dir, 'LICENSE.txt'), config.timeout)
 
     readme = m.get_value('about/readme')
     if readme:
@@ -222,7 +222,7 @@ def create_info_files(m, files, config, prefix):
         if not isfile(src):
             sys.exit("Error: no readme file: %s" % readme)
         dst = join(config.info_dir, readme)
-        copy_into(src, dst, config)
+        copy_into(src, dst, config.timeout)
         if os.path.split(readme)[1] not in {"README.md", "README.rst", "README"}:
             print("WARNING: anaconda.org only recognizes about/readme "
                   "as README.md and README.rst", file=sys.stderr)
@@ -330,7 +330,7 @@ def create_info_files(m, files, config, prefix):
     if m.get_value('app/icon'):
         copy_into(join(m.path, m.get_value('app/icon')),
                         join(config.info_dir, 'icon.png'),
-                  config)
+                  config.timeout)
 
 
 def get_build_index(config, clear_cache=True, arg_channels=None):
@@ -633,7 +633,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                                 bf.write(data)
                         else:
                             if not isfile(work_file):
-                                copy_into(build_file, work_file, config)
+                                copy_into(build_file, work_file, config.timeout)
                         os.chmod(work_file, 0o766)
 
                         if isfile(work_file):
@@ -704,7 +704,7 @@ can lead to packages that include their dependencies.""" % meta_files))
             # we're done building, perform some checks
             tarcheck.check_all(tmp_path)
 
-            copy_into(tmp_path, path, config=config)
+            copy_into(tmp_path, path, config.timeout)
         update_index(config.bldpkgs_dir, config)
 
     else:

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -49,7 +49,7 @@ def create_files(dir_path, m, config):
     for fn in m.get_value('test/files', []):
         has_files = True
         path = join(m.path, fn)
-        copy_into(path, join(dir_path, fn), config)
+        copy_into(path, join(dir_path, fn), config.timeout)
     # need to re-download source in order to do tests
     if m.get_value('test/source_files') and not isdir(config.work_dir):
         source.provide(m.path, m.get_section('source'), config=config)
@@ -57,7 +57,7 @@ def create_files(dir_path, m, config):
         has_files = True
         files = glob.glob(join(config.work_dir, pattern))
         for f in files:
-            copy_into(f, f.replace(config.work_dir, config.test_dir), config)
+            copy_into(f, f.replace(config.work_dir, config.test_dir), config.timeout)
     return has_files
 
 
@@ -69,7 +69,7 @@ def create_shell_files(dir_path, m, config):
         name = 'run_test.sh'
 
     if exists(join(m.path, name)):
-        copy_into(join(m.path, name), dir_path, config)
+        copy_into(join(m.path, name), dir_path, config.timeout)
         has_tests = True
 
     with open(join(dir_path, name), 'a') as f:

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -118,7 +118,7 @@ def remove_easy_install_pth(files, prefix, config, preserve_egg_dir=False):
                     # so the package directory already exists
                     # from another installed dependency
                     if os.path.exists(join(sp_dir, fn)):
-                        utils.copy_into(join(egg_path, fn), join(sp_dir, fn), config)
+                        utils.copy_into(join(egg_path, fn), join(sp_dir, fn), config.timeout)
                         utils.rm_rf(join(egg_path, fn))
                     else:
                         os.rename(join(egg_path, fn), join(sp_dir, fn))
@@ -415,14 +415,17 @@ def make_hardlink_copy(path, prefix):
     if not os.path.isabs(path) and not os.path.exists(path):
         path = os.path.normpath(os.path.join(prefix, path))
     nlinks = os.lstat(path).st_nlink
+    dest = 'tmpfile'
+    if os.path.isabs(path):
+        dest = os.path.join(os.getcwd(), dest)
     if nlinks > 1:
         # copy file to new name
-        shutil.copy2(path, "tmpfile")
+        utils.copy_into(path, dest)
         # remove old file
-        os.remove(path)
+        utils.rm_rf(path)
         # rename copy to original filename
-        shutil.copy2("tmpfile", path)
-        os.remove("tmpfile")
+        utils.copy_into(dest, path)
+        utils.rm_rf(dest)
 
 
 def get_build_metadata(m, config):

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -421,7 +421,8 @@ def make_hardlink_copy(path, prefix):
         # remove old file
         os.remove(path)
         # rename copy to original filename
-        os.rename("tmpfile", path)
+        shutil.copy2("tmpfile", path)
+        os.remove("tmpfile")
 
 
 def get_build_metadata(m, config):

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -96,7 +96,7 @@ def unpack(meta, config):
     else:
         # In this case, the build script will need to deal with unpacking the source
         print("Warning: Unrecognized source format. Source file will be copied to the SRC_DIR")
-        copy_into(src_path, get_dir(config), config)
+        copy_into(src_path, get_dir(config), config.timeout)
 
 
 def git_mirror_checkout_recursive(git, mirror_dir, checkout_dir, git_url, config, git_ref=None,
@@ -352,7 +352,7 @@ def svn_source(meta, config):
         assert isdir(cache_repo)
 
     # now copy into work directory
-    copy_into(cache_repo, config.work_dir, config, symlinks=True)
+    copy_into(cache_repo, config.work_dir, config.timeout, symlinks=True)
 
     if not config.verbose:
         FNULL.close()
@@ -506,7 +506,7 @@ def provide(recipe_dir, meta, config, patch=True):
                                         config.work_dir))
         # careful here: we set test path to be outside of conda-build root in setup.cfg.
         #    If you don't do that, this is a recursive function
-        copy_into(abspath(join(recipe_dir, meta.get('path'))), config.work_dir, config)
+        copy_into(abspath(join(recipe_dir, meta.get('path'))), config.work_dir, config.timeout)
     else:  # no source
         if not isdir(config.work_dir):
             os.makedirs(config.work_dir)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -89,13 +89,12 @@ def get_recipe_abspath(recipe):
     return recipe_dir, need_cleanup
 
 
-def copy_into(src, dst, config, symlinks=False):
+def copy_into(src, dst, timeout=90, symlinks=False):
     "Copy all the files and directories in src to the directory dst"
     lock = None
     if isdir(dst):
-        lock = filelock.SoftFileLock(join(dst, ".conda_lock"),
-                                     timeout=config.timeout)
-        lock.acquire()
+        lock = filelock.SoftFileLock(join(dst, ".conda_lock"))
+        lock.acquire(timeout=timeout)
 
     try:
         if isdir(src):
@@ -108,7 +107,7 @@ def copy_into(src, dst, config, symlinks=False):
                 dst_fn = dst
 
             try:
-                if not os.path.isdir(os.path.dirname(dst_fn)):
+                if os.path.sep in dst_fn and not os.path.isdir(os.path.dirname(dst_fn)):
                     os.makedirs(os.path.dirname(dst_fn))
                 shutil.copy2(src, dst_fn)
             except shutil.Error:
@@ -405,7 +404,7 @@ def create_entry_point(path, module, func, config):
             if 'debug' in packages_names:
                 fo.write('#!python_d\n')
             fo.write(pyscript)
-        copy_into(join(dirname(__file__), 'cli-%d.exe' % bits), path + '.exe', config)
+        copy_into(join(dirname(__file__), 'cli-%d.exe' % bits), path + '.exe', config.timeout)
     else:
         with open(path, 'w') as fo:
             fo.write('#!%s\n' % config.build_python)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -327,7 +327,7 @@ def test_skip_existing_url(testing_workdir, test_config, capfd):
     output_file = os.path.join(test_config.croot, test_config.subdir, "empty_sections-0.0-0.tar.bz2")
 
     platform = os.path.join(testing_workdir, test_config.subdir)
-    copy_into(output_file, os.path.join(platform, os.path.basename(output_file)), test_config)
+    copy_into(output_file, os.path.join(platform, os.path.basename(output_file)))
 
     # create the index so conda can find the file
     api.update_index(platform, config=test_config)

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -8,81 +8,60 @@ import pytest
 from conda_build import post
 from conda_build.utils import on_win
 
-from .utils import test_config
+from .utils import test_config, testing_workdir
 
 
-def test_compile_missing_pyc():
-    cwd = os.getcwd()
+def test_compile_missing_pyc(testing_workdir):
     good_files = ['f1.py', 'f3.py']
     bad_file = 'f2_bad.py'
-    with TemporaryDirectory() as tmp:
-        tmpdir = os.path.join(tmp, 'files')
-        shutil.copytree(os.path.join(os.path.dirname(__file__), 'test-recipes',
-                                     'metadata', '_compile-test'),
-                        tmpdir)
-        os.chdir(tmpdir)
-        try:
-            post.compile_missing_pyc(os.listdir(tmpdir), cwd=tmpdir, python_exe=sys.executable)
-            files = os.listdir(tmpdir)
-            for f in good_files:
-                assert f + 'c' in files
-            assert bad_file + 'c' not in files
-        except:
-            raise
-        finally:
-            os.chdir(cwd)
+    tmp = os.path.join(testing_workdir, 'tmp')
+    shutil.copytree(os.path.join(os.path.dirname(__file__), 'test-recipes',
+                                 'metadata', '_compile-test'), tmp)
+    post.compile_missing_pyc(os.listdir(tmp), cwd=tmp,
+                                python_exe=sys.executable)
+    files = os.listdir(tmp)
+    for f in good_files:
+        assert f + 'c' in files
+    assert bad_file + 'c' not in files
 
 
 @pytest.mark.skipif(not PY3, reason="test applies to py3 only")
-def test_coerce_pycache_to_old_style():
-    cwd = os.getcwd()
-    with TemporaryDirectory() as tmp:
-        os.makedirs(os.path.join(tmp, '__pycache__'))
-        os.makedirs(os.path.join(tmp, 'testdir', '__pycache__'))
-        with open(os.path.join(tmp, 'test.py'), 'w') as f:
-            f.write("\n")
-        with open(os.path.join(tmp, '__pycache__', 'test.cpython-{0}{1}.pyc'.format(
-                sys.version_info.major, sys.version_info.minor)), 'w') as f:
-            f.write("\n")
-        with open(os.path.join(tmp, 'testdir', 'test.py'), 'w') as f:
-            f.write("\n")
-        with open(os.path.join(tmp, 'testdir', '__pycache__', 'test.cpython-{0}{1}.pyc'.format(
-                sys.version_info.major, sys.version_info.minor)), 'w') as f:
-            f.write("\n")
+def test_coerce_pycache_to_old_style(testing_workdir):
+    os.makedirs(os.path.join(testing_workdir, '__pycache__'))
+    os.makedirs(os.path.join(testing_workdir, 'testdir', '__pycache__'))
+    with open(os.path.join(testing_workdir, 'test.py'), 'w') as f:
+        f.write("\n")
+    with open(os.path.join(testing_workdir, '__pycache__', 'test.cpython-{0}{1}.pyc'.format(
+            sys.version_info.major, sys.version_info.minor)), 'w') as f:
+        f.write("\n")
+    with open(os.path.join(testing_workdir, 'testdir', 'test.py'), 'w') as f:
+        f.write("\n")
+    with open(os.path.join(testing_workdir, 'testdir', '__pycache__',
+                           'test.cpython-{0}{1}.pyc'.format(
+                               sys.version_info.major, sys.version_info.minor)), 'w') as f:
+        f.write("\n")
 
-        os.chdir(tmp)
-        for root, dirs, files in os.walk(tmp):
-            fs = [os.path.join(root, _) for _ in files]
-            post.coerce_pycache_to_old_style(fs, cwd=tmp)
-        try:
-            assert os.path.isfile(os.path.join(tmp, 'test.pyc')), os.listdir(tmp)
-            assert os.path.isfile(os.path.join(tmp, 'testdir', 'test.pyc')), \
-                os.listdir(os.path.join(tmp, 'testdir'))
-            for root, dirs, files in os.walk(tmp):
-                assert '__pycache__' not in dirs
-        except:
-            raise
-        finally:
-            os.chdir(cwd)
+    for root, dirs, files in os.walk(testing_workdir):
+        fs = [os.path.join(root, _) for _ in files]
+        post.coerce_pycache_to_old_style(fs, cwd=testing_workdir)
+    assert os.path.isfile(os.path.join(testing_workdir, 'test.pyc')), os.listdir(testing_workdir)
+    assert os.path.isfile(os.path.join(testing_workdir, 'testdir', 'test.pyc')), \
+        os.listdir(os.path.join(testing_workdir, 'testdir'))
+    for root, dirs, files in os.walk(testing_workdir):
+        assert '__pycache__' not in dirs
 
 
 @pytest.mark.skipif(on_win, reason="no linking on win")
-def test_hardlinks_to_copies():
+def test_hardlinks_to_copies(testing_workdir):
     with open('test1', 'w') as f:
         f.write("\n")
-    try:
-        os.link('test1', 'test2')
-        assert os.lstat('test1').st_nlink == 2
-        assert os.lstat('test2').st_nlink == 2
 
-        post.make_hardlink_copy('test1', os.getcwd())
-        post.make_hardlink_copy('test2', os.getcwd())
+    os.link('test1', 'test2')
+    assert os.lstat('test1').st_nlink == 2
+    assert os.lstat('test2').st_nlink == 2
 
-        assert os.lstat('test1').st_nlink == 1
-        assert os.lstat('test2').st_nlink == 1
-    except:
-        raise
-    finally:
-        os.remove('test1')
-        if os.path.exists('test2'):
-            os.remove('test2')
+    post.make_hardlink_copy('test1', os.getcwd())
+    post.make_hardlink_copy('test2', os.getcwd())
+
+    assert os.lstat('test1').st_nlink == 1
+    assert os.lstat('test2').st_nlink == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,17 +28,17 @@ def namespace_setup(testing_workdir, request):
     return testing_workdir
 
 
-def test_copy_source_tree(namespace_setup, test_config):
+def test_copy_source_tree(namespace_setup):
     dst = os.path.join(namespace_setup, 'dest')
-    utils.copy_into(namespace_setup, dst, test_config)
+    utils.copy_into(namespace_setup, dst)
     assert os.path.isfile(os.path.join(dst, 'namespace', 'package', 'module.py'))
 
 
-def test_merge_namespace_trees(namespace_setup, test_config):
+def test_merge_namespace_trees(namespace_setup):
     dep = os.path.join(namespace_setup, 'other_tree', 'namespace', 'package', 'dependency.py')
     makefile(dep)
 
-    utils.copy_into(os.path.join(namespace_setup, 'other_tree'), namespace_setup, test_config)
+    utils.copy_into(os.path.join(namespace_setup, 'other_tree'), namespace_setup)
     assert os.path.isfile(os.path.join(namespace_setup, 'namespace', 'package',
                                                 'module.py'))
     assert os.path.isfile(dep)
@@ -49,7 +49,7 @@ def test_disallow_merge_conflicts(namespace_setup, test_config):
     makefile(duplicate)
     with pytest.raises(IOError):
         utils.merge_tree(os.path.dirname(duplicate), os.path.join(namespace_setup, 'namespace',
-                                                 'package'), test_config)
+                                                 'package'))
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
Bumped into errors with Docker image, where exception was about an invalid link operation across file systems.  Copying files helps here.

Fixes #1275 