### PR TITLE
update MACOSX_DEPLOYMENT_TARGET to 10.7 for more modern compat

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -384,7 +384,7 @@ def osx_vars(compiler_vars, config):
     # d['LDFLAGS'] = ldflags + rpath + ' -arch %(OSX_ARCH)s' % d
     return {
         'OSX_ARCH': OSX_ARCH,
-        'MACOSX_DEPLOYMENT_TARGET': '10.6',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
     }
 
 


### PR DESCRIPTION
tiny fix for #1269 - more of a band-aid.  The correct fix will be to make user settings override hard-coded defaults like this.

Long-term, this default should not exist in conda-build, but should be defined on a build system basis.  Target for that is the next major release of conda-build.