### PR TITLE
allow MetaData objects passed to build and get_output_path

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -158,12 +158,12 @@ class bdist_conda(install):
         d = defaultdict(dict)
         # PyPI allows uppercase letters but conda does not, so we fix the
         # name here.
-        d['package']['name'] = metadata.name.lower()
-        d['package']['version'] = metadata.version
-        d['build']['number'] = metadata.conda_buildnum
+        d['package']['name'] = metadata.name().lower()
+        d['package']['version'] = metadata.version()
+        d['build']['number'] = metadata.conda_buildnum()
 
         # MetaData does the auto stuff if the build string is None
-        d['build']['string'] = metadata.conda_buildstr
+        d['build']['string'] = metadata.conda_buildstr()
 
         d['build']['binary_relocation'] = metadata.conda_binary_relocation
         d['build']['preserve_egg_dir'] = metadata.conda_preserve_egg_dir

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -887,13 +887,23 @@ def build_tree(recipe_list, config, check=False, build_only=False, post=False, n
             post = None
 
         recipe = recipe_list.popleft()
-        recipe_parent_dir = os.path.dirname(recipe)
-        to_build_recursive.append(os.path.basename(recipe))
-        try:
+        if hasattr(recipe, 'config'):
+            metadata = recipe
+            need_source_download = True
+            need_reparse_in_env = False
+            if config.set_build_id:
+                config.compute_build_id(metadata.name(), reset=True)
+            recipe_parent_dir = ""
+            to_build_recursive.append(metadata.name())
+        else:
+            recipe_parent_dir = os.path.dirname(recipe)
+            to_build_recursive.append(os.path.basename(recipe))
+
             if config.set_build_id:
                 config.compute_build_id(os.path.basename(recipe), reset=True)
             metadata, need_source_download, need_reparse_in_env = render_recipe(recipe,
                                                                                 config=config)
+        try:
             with config:
                 ok_to_test = build(metadata, post=post,
                                    need_source_download=need_source_download,

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -35,8 +35,11 @@ def read_index_tar(tar_path, config):
                                "File probably corrupt." % tar_path)
 
 
-def write_repodata(repodata, dir_path, config):
+def write_repodata(repodata, dir_path, config=None):
     """ Write updated repodata.json and repodata.json.bz2 """
+    if not config:
+        import conda_build.config
+        config = conda_build.config.config
     with filelock.SoftFileLock(join(dir_path, ".conda_lock"), timeout=config.timeout):
         data = json.dumps(repodata, indent=2, sort_keys=True)
         # strip trailing whitespace

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -362,7 +362,7 @@ def find_recipe(path):
     if len(results) > 1:
         base_recipe = os.path.join(path, "meta.yaml")
         if base_recipe in results:
-            return os.path.dirname(base_recipe)
+            return base_recipe
         else:
             raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:
@@ -379,8 +379,6 @@ class MetaData(object):
             config = Config()
 
         self.config = config
-
-        assert isdir(path)
 
         if isfile(path):
             self.meta_path = path
@@ -403,15 +401,21 @@ class MetaData(object):
         # In the second pass, we'll be more strict. See build.build()
         self.parse_again(config=config, permit_undefined_jinja=True)
 
-    def parse_again(self, config, permit_undefined_jinja=False):
+    def parse_again(self, config=None, permit_undefined_jinja=False):
         """Redo parsing for key-value pairs that are not initialized in the
         first pass.
+
+        config: a conda-build Config object.  If None, the config object passed at creation
+                time is used.
 
         permit_undefined_jinja: If True, *any* use of undefined jinja variables will
                                 evaluate to an emtpy string, without emitting an error.
         """
         if not self.meta_path:
             return
+
+        if not config:
+            config = self.config
 
         try:
             os.environ["CONDA_BUILD_STATE"] = "RENDER"
@@ -753,7 +757,8 @@ class MetaData(object):
         env = jinja2.Environment(loader=loader, undefined=undefined_type)
 
         env.globals.update(ns_cfg(config))
-        env.globals.update(context_processor(self, path, config=config))
+        env.globals.update(context_processor(self, path, config=config,
+                                             permit_undefined_jinja=permit_undefined_jinja))
 
         try:
             template = env.get_or_select_template(filename)
@@ -766,8 +771,10 @@ class MetaData(object):
 
             return rendered
         except jinja2.TemplateError as ex:
+            if "'None' has not attribute" in str(ex):
+                ex = "Failed to run jinja context function"
             sys.exit("Error: Failed to render jinja template in {}:\n{}"
-                     .format(self.meta_path, ex.message))
+                     .format(self.meta_path, str(ex)))
 
     def __unicode__(self):
         '''

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -2,7 +2,7 @@
 This module tests the build API.  These are high-level integration tests.
 """
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import logging
 import os
 import subprocess
@@ -18,6 +18,7 @@ import yaml
 
 from conda_build import api
 from conda_build.utils import copy_into, on_win
+from conda_build.metadata import MetaData
 
 from .utils import (metadata_dir, fail_dir, is_valid_dir, testing_workdir, test_config)
 
@@ -418,6 +419,24 @@ def test_debug_build_option(testing_workdir, test_config, caplog, capfd):
     assert info_message in caplog.text()
     # this comes from a debug message
     assert debug_message in caplog.text()
+
+
+def test_build_metadata_object(test_config):
+    d = defaultdict(dict)
+    d['package']['name'] = 'test_package'
+    d['package']['version'] = '1.0'
+    d['build']['number'] = '1'
+    d['build']['entry_points'] = []
+    # MetaData does the auto stuff if the build string is None
+    d['build']['string'] = None
+    d['requirements']['build'] = ['python']
+    d['requirements']['run'] = ['python']
+    d['about']['home'] = "sweet home"
+    d['about']['license'] = "contract in blood"
+    d['about']['summary'] = "a test package"
+
+    metadata = MetaData.fromdict(d)
+    api.build(metadata)
 
 
 @pytest.mark.skipif(on_win, reason="fortran compilers on win are hard.")


### PR DESCRIPTION
This is convenient for testing, to be able to write metadata without some separate file.  It is also used by conda-build-all, and this PR helps with compatibility there.