### PR TITLE
Prevent GIT_* env. vars containing newlines

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -162,7 +162,7 @@ def get_git_info(repo, config):
 
     try:
         output = subprocess.check_output(["git", "describe", "--tags", "--long", "HEAD"],
-                                         env=env, cwd=os.path.dirname(repo), stderr=stderr)
+                                         env=env, cwd=os.path.dirname(repo), stderr=stderr).splitlines()[0]
         output = output.decode('utf-8')
 
         parts = output.rsplit('-', 2)
@@ -171,7 +171,7 @@ def get_git_info(repo, config):
 
         # get the _full_ hash of the current HEAD
         output = subprocess.check_output(["git", "rev-parse", "HEAD"],
-                                         env=env, cwd=os.path.dirname(repo), stderr=stderr)
+                                         env=env, cwd=os.path.dirname(repo), stderr=stderr).splitlines()[0]
         output = output.decode('utf-8')
 
         d['GIT_FULL_HASH'] = output


### PR DESCRIPTION
Here you go @msarahan.