### PR TITLE
Add `build/noarch` to recipe metadata.

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -222,6 +222,7 @@ default_structs = {
     'build/osx_is_app': bool,
     'build/preserve_egg_dir': bool,
     'build/binary_relocation': bool,
+    'build/noarch': bool,
     'build/noarch_python': bool,
     'build/detect_binary_files_with_prefix': bool,
     'build/skip': bool,
@@ -291,7 +292,7 @@ FIELDS = {
                ],
     'build': ['number', 'string', 'entry_points', 'osx_is_app',
               'features', 'track_features', 'preserve_egg_dir',
-              'no_link', 'binary_relocation', 'script', 'noarch_python',
+              'no_link', 'binary_relocation', 'script', 'noarch', 'noarch_python',
               'has_prefix_files', 'binary_has_prefix_files', 'ignore_prefix_files',
               'detect_binary_files_with_prefix', 'rpaths', 'script_env',
               'always_include_files', 'skip', 'msvc_compiler',
@@ -567,7 +568,7 @@ class MetaData(object):
                 raise RuntimeError("%s cannot depend on itself" % self.name())
             for name, ver in name_ver_list:
                 if ms.name == name:
-                    if self.get_value('build/noarch_python'):
+                    if self.get_value('build/noarch_python') or self.get_value('build/noarch'):
                         continue
                     ms = handle_config_version(ms, ver, typ)
 
@@ -669,7 +670,7 @@ class MetaData(object):
             d['features'] = ' '.join(self.get_value('build/features'))
         if self.get_value('build/track_features'):
             d['track_features'] = ' '.join(self.get_value('build/track_features'))
-        if self.get_value('build/noarch_python'):
+        if self.get_value('build/noarch_python') or self.get_value('build/noarch'):
             d['platform'] = d['arch'] = None
             d['subdir'] = 'noarch'
         if self.is_app():

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -150,6 +150,7 @@ def render_recipe(recipe_path, config, no_download_source=False):
         sys.stderr.write(e.error_msg())
         sys.exit(1)
 
+    config.noarch = m.get_value('build/noarch')
     m, need_download, need_reparse_in_env = parse_or_try_download(m,
                                                 no_download_source=no_download_source,
                                                 config=config)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -600,3 +600,20 @@ def test_relative_git_url_submodule_clone(testing_workdir):
         output = api.get_output_file_path(testing_workdir)
         assert ("relative_submodules-{}-0".format(tag) in output)
         api.build(testing_workdir)
+
+
+def test_noarch(testing_workdir):
+    filename = os.path.join(testing_workdir, 'meta.yaml')
+    for noarch in (False, True):
+        data = OrderedDict([
+            ('package', OrderedDict([
+                ('name', 'test'),
+                ('version', '0.0.0')])),
+            ('build', OrderedDict([
+                 ('noarch', str(noarch))]))
+            ])
+        with open(filename, 'w') as outfile:
+            outfile.write(yaml.dump(data, default_flow_style=False, width=999999999))
+        output = api.get_output_file_path(testing_workdir)
+        assert ("noarch" in output or not noarch)
+        assert ("noarch" not in output or noarch)


### PR DESCRIPTION
This is needed for many nodejs projects that generate OS independent
.js and .css files.