### PR TITLE
add setuptools import to monkeypatch distutils

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -4,6 +4,8 @@ import os
 import sys
 from os.path import isdir, join
 
+# importing setuptools patches distutils so that it knows how to find VC for python 2.7
+import setuptools  # noqa
 # Leverage the hard work done by setuptools/distutils to find vcvarsall using
 # either the registry or the VS**COMNTOOLS environment variable
 from distutils.msvc9compiler import find_vcvarsall as distutils_find_vcvarsall


### PR DESCRIPTION
In playing with Vagrant, I've discovered a flaw with our handling of VC9: it only works if setuptools is imported before distutils, because setuptools monkeypatches distutils.  See https://bugs.python.org/issue23246

CC @patricksnape 