### PR TITLE
fix warn_on_old_conda_build to ignore testing versions

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -38,6 +38,7 @@ from .conda_interface import url_path
 from .conda_interface import Resolve, MatchSpec, NoPackagesFound, Unsatisfiable
 from .conda_interface import TemporaryDirectory
 from .conda_interface import get_rc_urls, get_local_urls
+from .conda_interface import VersionOrder
 
 from conda_build import __version__
 from conda_build import environ, source, tarcheck
@@ -487,7 +488,10 @@ def warn_on_old_conda_build(index):
         return
     r = Resolve(index)
     try:
-        pkgs = sorted(r.get_pkgs(MatchSpec('conda-build')))
+        pkgs = sorted(r.get_pkgs(MatchSpec('conda-build')), key=VersionOrder)
+        # cuts out packages wth rc/alpha/beta.  VersionOrder described in conda/version.py
+        # this breaks up the version into pieces, and depends on version formats like x.y.z[alpha/beta]  # noqa
+        pkgs = [pkg for pkg in pkgs if len(VersionOrder(pkg).version[3]) == 1]
     except NoPackagesFound:
         print("WARNING: Could not find any versions of conda-build in the channels", file=sys.stderr)  # noqa
         return

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -23,6 +23,7 @@ from conda.signature import KEYS, KEYS_DIR, hash_file, verify  # NOQA
 from conda.utils import human_bytes, hashsum_file, md5_file, memoized, unix_path_to_win, win_path_to_unix, url_path  # NOQA
 import conda.config as cc  # NOQA
 from conda.config import sys_rc_path  # NOQA
+from conda.version import VersionOrder  # NOQA
 
 if parse_version(conda.__version__) >= parse_version("4.2"):
     # conda 4.2.x


### PR DESCRIPTION
Employ's conda's VersionOrder, and also filters out conda-build packages that have text join with their bugfix release number.

Fixes #1291 