### PR TITLE
catch prefix length errors with openssl's custom replacement

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -313,6 +313,7 @@ def write_no_link(m, config, files):
                 if any(fnmatch.fnmatch(f, p) for p in no_link):
                     fo.write(f + '\n')
 
+
 def create_info_files(m, files, config, prefix):
     '''
     Creates the metadata files that will be stored in the built package.
@@ -439,7 +440,9 @@ def create_env(prefix, specs, config, clear_cache=True):
                             os.environ[k] = str(v)
                     plan.execute_actions(actions, index, verbose=config.debug)
                 except SystemExit as exc:
-                    if "too short in" in str(exc) and config.prefix_length > 80:
+                    if (("too short in" in str(exc) or
+                         'post-link failed for: openssl' in str(exc)) and
+                            config.prefix_length > 80):
                         log.warn("Build prefix failed with prefix length %d", config.prefix_length)
                         log.warn("Error was: ")
                         log.warn(str(exc))

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -162,7 +162,8 @@ def get_git_info(repo, config):
 
     try:
         output = subprocess.check_output(["git", "describe", "--tags", "--long", "HEAD"],
-                                         env=env, cwd=os.path.dirname(repo), stderr=stderr).splitlines()[0]
+                                         env=env, cwd=os.path.dirname(repo),
+                                         stderr=stderr).splitlines()[0]
         output = output.decode('utf-8')
 
         parts = output.rsplit('-', 2)
@@ -171,7 +172,8 @@ def get_git_info(repo, config):
 
         # get the _full_ hash of the current HEAD
         output = subprocess.check_output(["git", "rev-parse", "HEAD"],
-                                         env=env, cwd=os.path.dirname(repo), stderr=stderr).splitlines()[0]
+                                         env=env, cwd=os.path.dirname(repo),
+                                         stderr=stderr).splitlines()[0]
         output = output.decode('utf-8')
 
         d['GIT_FULL_HASH'] = output
@@ -180,7 +182,7 @@ def get_git_info(repo, config):
             d['GIT_BUILD_STR'] = '{}_{}'.format(d["GIT_DESCRIBE_NUMBER"],
                                                 d["GIT_DESCRIBE_HASH"])
 
-        # There have been issues on Windows with the next line of the command prompt being recorded here.
+        # issues on Windows with the next line of the command prompt being recorded here.
         assert not any("\n" in value for value in d.values())
 
     except subprocess.CalledProcessError as error:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -562,8 +562,8 @@ class MetaData(object):
             except AssertionError:
                 raise RuntimeError("Invalid package specification: %r" % spec)
             except AttributeError:
-                raise RuntimeError("Received dictionary as spec.  Note that pip requirements are not "
-                                   "supported in conda-build meta.yaml.")
+                raise RuntimeError("Received dictionary as spec.  Note that pip requirements are "
+                                   "not supported in conda-build meta.yaml.")
             if ms.name == self.name():
                 raise RuntimeError("%s cannot depend on itself" % self.name())
             for name, ver in name_ver_list:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -457,15 +457,18 @@ def check_output_env(*popenargs, **kwargs):
 
 
 _posix_exes_cache = {}
+
+
 def convert_path_for_cygwin_or_msys2(exe, path):
     "If exe is a Cygwin or MSYS2 executable then filters it through `cygpath -u`"
     if sys.platform != 'win32':
         return path
-    if not exe in _posix_exes_cache:
+    if exe not in _posix_exes_cache:
         with open(exe, "rb") as exe_file:
             exe_binary = exe_file.read()
             msys2_cygwin = re.findall(b'(cygwin1.dll|msys-2.0.dll)', exe_binary)
             _posix_exes_cache[exe] = True if msys2_cygwin else False
-    if _posix_exes_cache[exe] == True:
-        return check_output_env(['cygpath', '-u', path]).splitlines()[0].decode(getpreferredencoding())
+    if _posix_exes_cache[exe]:
+        return check_output_env(['cygpath', '-u',
+                                 path]).splitlines()[0].decode(getpreferredencoding())
     return path


### PR DESCRIPTION
Fixes #1306 

by recognizing the output of OpenSSL's custom prefix replacement program.