### PR TITLE
Build wheels with conda-build

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -63,7 +63,7 @@ def check(recipe_path, no_download_source=False, config=None, **kwargs):
 
 
 def build(recipe_paths_or_metadata, post=None, need_source_download=True,
-          build_only=False, notest=False, whl_build=False, config=None, **kwargs):
+          build_only=False, notest=False, config=None, **kwargs):
     import os
     from conda_build.build import build_tree
 
@@ -80,8 +80,7 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
             absolute_recipes.append(os.path.join(os.getcwd(), recipe))
 
     return build_tree(absolute_recipes, build_only=build_only, post=post, notest=notest,
-                      need_source_download=need_source_download,
-                      whl_build=whl_build, config=config)
+                      need_source_download=need_source_download, config=config)
 
 
 def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwargs):

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -63,7 +63,7 @@ def check(recipe_path, no_download_source=False, config=None, **kwargs):
 
 
 def build(recipe_paths_or_metadata, post=None, need_source_download=True,
-          build_only=False, notest=False, config=None, **kwargs):
+          build_only=False, notest=False, whl_build=False, config=None, **kwargs):
     import os
     from conda_build.build import build_tree
 
@@ -80,7 +80,8 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
             absolute_recipes.append(os.path.join(os.getcwd(), recipe))
 
     return build_tree(absolute_recipes, build_only=build_only, post=post, notest=notest,
-                      need_source_download=need_source_download, config=config)
+                      need_source_download=need_source_download,
+                      whl_build=whl_build, config=config)
 
 
 def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwargs):

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -525,7 +525,8 @@ to get the latest version.
 """ % (installed_version, available_packages[-1]), file=sys.stderr)
 
 
-def build(m, config, post=None, need_source_download=True, need_reparse_in_env=False):
+def build(m, config, post=None, need_source_download=True,
+          need_reparse_in_env=False, whl_build=False):
     '''
     Build the package with the specified metadata.
 
@@ -747,6 +748,26 @@ can lead to packages that include their dependencies.""" % meta_files))
             copy_into(tmp_path, path, config.timeout)
         update_index(config.bldpkgs_dir, config)
 
+    elif whl_build:
+        # copy whl file to the build output directory
+        src_dir = source.get_dir(config)
+        whl_files = glob(os.path.join(src_dir, 'dist', '*.whl'))
+        if len(whl_files) == 0:
+            sys.exit(indent("Error: No whl files found in dist directory"))
+        if len(whl_files) != 1:
+            sys.exit(indent("Error: Multiple whl files found in dist directory"))
+        whl_path = whl_files[0]
+        _, whl_filename = os.path.split(whl_path)
+
+        tarbz2_path = bldpkg_path(m, config)
+        dir_, tarbz2 = os.path.split(tarbz2_path)
+        path = os.path.join(dir_, whl_filename)
+
+        copy_into(whl_path, path, config.timeout)
+        # kludge, use the config object to pass the path to the wheel file
+        # back to the calling function
+        config.whl_path = path
+
     else:
         print("STOPPING BUILD BEFORE POST:", m.dist())
 
@@ -798,7 +819,7 @@ def clean_pkg_cache(dist, timeout):
                 os.remove(lock._lock_file)
 
 
-def test(m, config, move_broken=True):
+def test(m, config, move_broken=True, whl_build=False):
     '''
     Execute any test scripts for the given package.
 
@@ -834,6 +855,8 @@ def test(m, config, move_broken=True):
 
         get_build_metadata(m, config=config)
         specs = ['%s %s %s' % (m.name(), m.version(), m.build_id())]
+        if whl_build:
+            specs = []
 
         # add packages listed in the run environment and test/requires
         specs.extend(ms.spec for ms in m.ms_depends('run'))
@@ -882,6 +905,12 @@ def test(m, config, move_broken=True):
                     ext=ext,
                     test_env=config.test_prefix,
                     squelch=">nul 2>&1" if on_win else "&> /dev/null"))
+                if on_win:
+                    tf.write("if errorlevel 1 exit 1\n")
+            if whl_build:
+                tf.write("{python} -m wheel install {whl_path}\n".format(
+                    python=config.test_python,
+                    whl_path=config.whl_path))
                 if on_win:
                     tf.write("if errorlevel 1 exit 1\n")
             if py_files:
@@ -954,7 +983,8 @@ Error:
 
 
 def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
-               need_source_download=True, need_reparse_in_env=False):
+               need_source_download=True, need_reparse_in_env=False,
+               whl_build=False):
 
     to_build_recursive = []
     recipe_list = deque(recipe_list)
@@ -966,6 +996,8 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
             post = False
             notest = True
             config.anaconda_upload = False
+        elif whl_build:
+            post = False
         elif post:
             post = True
             notest = True
@@ -995,9 +1027,10 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                 ok_to_test = build(metadata, post=post,
                                    need_source_download=need_source_download,
                                    need_reparse_in_env=need_reparse_in_env,
+                                   whl_build=whl_build,
                                    config=recipe_config)
                 if not notest and ok_to_test:
-                    test(metadata, config=recipe_config)
+                    test(metadata, config=recipe_config, whl_build=whl_build)
         except (NoPackagesFound, Unsatisfiable) as e:
             error_str = str(e)
             # Typically if a conflict is with one of these
@@ -1035,8 +1068,10 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
             recipe_list.extendleft(add_recipes)
 
         # outputs message, or does upload, depending on value of args.anaconda_upload
-        if post in [True, None]:
+        if post in [True, None] or whl_build:
             output_file = bldpkg_path(metadata, config=recipe_config)
+            if whl_build:
+                output_file = config.whl_path
             handle_anaconda_upload(output_file, config=recipe_config)
             already_built.add(output_file)
 

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -234,7 +234,7 @@ def execute(args):
     else:
         api.build(args.recipe, post=args.post, build_only=args.build_only,
                    notest=args.notest, keep_old_work=args.keep_old_work,
-                   already_built=None, whl_build=args.wheel, config=config)
+                   already_built=None, config=config)
 
     if len(build.get_build_folders(config.croot)) > 0:
         build.print_build_intermediate_warning(config)

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -149,6 +149,12 @@ different sets of packages."""
               "paths being too long."),
         dest='set_build_id',
     )
+    p.add_argument(
+        "--wheel",
+        action="store_true",
+        help=("build and test a Python wheel file. The dist directory is"
+              "searched for a whl file.")
+    )
 
     add_parser_channels(p)
 
@@ -228,7 +234,7 @@ def execute(args):
     else:
         api.build(args.recipe, post=args.post, build_only=args.build_only,
                    notest=args.notest, keep_old_work=args.keep_old_work,
-                   already_built=None, config=config)
+                   already_built=None, whl_build=args.wheel, config=config)
 
     if len(build.get_build_folders(config.croot)) > 0:
         build.print_build_intermediate_warning(config)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -92,7 +92,8 @@ class Config(object):
                   Setting('bits', bits),
                   Setting('platform', platform),
                   Setting('set_build_id', True),
-                  Setting('disable_pip', False)
+                  Setting('disable_pip', False),
+                  Setting('wheel', False)
                   ]
 
         # handle known values better than unknown (allow defaults)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -42,6 +42,7 @@ def ns_cfg(config):
     np = config.CONDA_NPY
     pl = config.CONDA_PERL
     lua = config.CONDA_LUA
+    wheel = config.wheel
     assert isinstance(py, int), py
     d = dict(
         linux=plat.startswith('linux-'),
@@ -69,6 +70,7 @@ def ns_cfg(config):
         np=np,
         os=os,
         environ=os.environ,
+        wheel=wheel,
     )
     for machine in non_x86_linux_machines:
         d[machine] = bool(plat == 'linux-%s' % machine)


### PR DESCRIPTION
Add a --wheel argument to the 'conda build' command that when included uses
conda build to create and test a Python wheel file.

closes #1294 
