### PR TITLE
Add `GPL` as a license family

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -140,6 +140,7 @@ allowed_license_families = set("""
 AGPL
 Apache
 BSD
+GPL
 GPL2
 GPL3
 LGPL


### PR DESCRIPTION
Closes https://github.com/conda/conda-build/issues/1300

As stated, adds `GPL` as a license family. This seems more appropriate as the `license` itself should have license version; whereas the license family should merely note the style of license. It is also more consistent as no other license family listed requires version in this way.

Note: Would like to drop `GPL2` and `GPL3` from the list, but have kept them as that feels like a breaking change.