### PR TITLE
WIP: Concatenate multiple license files

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -56,6 +56,13 @@ from conda_build.create_test import (create_files, create_shell_files,
 from conda_build.exceptions import indent
 from conda_build.features import feature_list
 
+
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 if 'bsd' in sys.platform:
     shell_path = '/bin/sh'
 else:
@@ -217,10 +224,20 @@ def copy_readme(m, config):
 
 
 def copy_license(m, config):
-    license_file = m.get_value('about/license_file')
-    if license_file:
-        copy_into(join(source.get_dir(config), license_file),
-                        join(config.info_dir, 'LICENSE.txt'), config.timeout)
+    license_filenames = m.get_value('about/license_file')
+
+    if isinstance(license_filenames, basestring):
+        if license_filenames:
+            license_filenames = [license_filenames]
+        else:
+            license_filenames = []
+
+    if license_files:
+        with io.open(join(config.info_dir, 'LICENSE.txt'), "w") as pkg_license_file:
+            for each_license_filename in license_filenames:
+                with io.open(join(source.get_dir(config), each_license_file), "r") as each_license_file:
+                    for each_license_file_line in each_license_file:
+                        pkg_license_file.write(each_license_file_line)
 
 
 def detect_and_record_prefix_files(m, files, prefix, config):


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/1247

This is still WIP. Though maybe this will help start the discussion and provide some useful feedback.

Basically this tries to write all the license files from a list into one `LICENSE.txt`. It seems useful to have one place to look at for this info even if there are multiple licenses. An alternative strategy would be to include multiple license files like `LICENSE.1.txt` and so on.

One thing I'm a little unsure of is we appear to have been using a util function that had an API lock previously. This is not doing that right now (though it probably should). Is there a write util function that is equivalent? If not, how should we proceed.

There could also be some nice tweaks like mention where each text blob came from.
