### PR TITLE
Fix pyver_re to avoid catching python-* packages

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -189,7 +189,7 @@ path_mapping_identity = [
     (r'bin/', 'bin/'),  # Not supported right now anyway
 ]
 
-pyver_re = re.compile(r'python(?:(?:\s+[<>=]*)(\d.\d))?')
+pyver_re = re.compile(r'python\s+(?:(?:[<>=]*)(\d.\d))?')
 
 
 def get_pure_py_file_map(t, platform):


### PR DESCRIPTION
This fix tries to avoid catching packages with a name that starts with `python` as if they represent additional python dependencies, which leads to a "Found more than one Python dependency in package" runtime error.

See also: https://github.com/conda/conda-build/pull/481#issuecomment-246673428