### PR TITLE
skip fixing rpath for files specified in ignore_prefix_files

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -352,6 +352,12 @@ def mk_relative(m, f, prefix):
     if not is_obj(path):
         return
 
+    # skip over this file
+    if (m.ignore_prefix_files() and (type(m.ignore_prefix_files()) is bool or
+                                     f in m.ignore_prefix_files())):
+        print("Skipping relocation path patch for " + f)
+        return
+
     if sys.platform.startswith('linux'):
         mk_relative_linux(f, prefix=prefix, rpaths=m.get_value('build/rpaths', ['lib']))
     elif sys.platform == 'darwin':


### PR DESCRIPTION
There are some programs (gcc, bazel) that contain prefixes, but which break when we change these prefixes.  These programs are written somehow to adjust the prefix themselves, and we break them when we put in our rpath stuff.  This provides a way to tell conda-build to leave them alone.