### PR TITLE
fix convert unix->win not creating entry point py scripts

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -269,8 +269,9 @@ def get_pure_py_file_map(t, platform):
                 file_map[oldpath] = None
                 file_map[newpath] = newmember
                 files = files.replace(oldpath, newpath)
-            else:
-                file_map[oldpath] = member
+                break
+        else:
+            file_map[oldpath] = member
 
         # Make Windows compatible entry-points
         batseen = set()

--- a/tests/test-recipes/metadata/noarch/meta.yaml
+++ b/tests/test-recipes/metadata/noarch/meta.yaml
@@ -6,19 +6,19 @@ source:
   path: ./noarch_test_package
 
 build:
-  script: pip install --no-deps .
+  script: python setup.py install --single-version-externally-managed --record=record.txt
   noarch_python: True
+  entry_points:
+    - noarch_test_package_script = noarch_test_package:main
 
 requirements:
   build:
     - python
     - setuptools
-
   run:
     - python
 
 test:
-  # Python imports
   imports:
     - noarch_test_package
   commands:

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -3,19 +3,19 @@ import os
 import pytest
 
 from conda_build.conda_interface import download
-from conda_build.api import convert
+from conda_build import api
 
-from .utils import testing_workdir, package_has_file, test_config
+from .utils import testing_workdir, package_has_file, test_config, on_win, metadata_dir
 
 def test_convert_wheel_raises():
     with pytest.raises(RuntimeError) as exc:
-        convert("some_wheel.whl")
+        api.convert("some_wheel.whl")
         assert "Conversion from wheel packages" in str(exc)
 
 
 def test_convert_exe_raises():
     with pytest.raises(RuntimeError) as exc:
-        convert("some_wheel.exe")
+        api.convert("some_wheel.exe")
         assert "cannot convert:" in str(exc)
 
 
@@ -24,8 +24,20 @@ def test_convert_platform_to_others(testing_workdir, base_platform):
     f = 'http://repo.continuum.io/pkgs/free/{}-64/itsdangerous-0.24-py27_0.tar.bz2'.format(base_platform)
     fn = "itsdangerous-0.24-py27_0.tar.bz2"
     download(f, fn)
-    convert(fn, platforms='all', quiet=False, verbose=True)
+    api.convert(fn, platforms='all', quiet=False, verbose=True)
     for platform in ['osx-64', 'win-64', 'win-32', 'linux-64', 'linux-32']:
         python_folder = 'lib/python2.7' if not platform.startswith('win') else 'Lib'
         assert package_has_file(os.path.join(platform, fn),
                                 '{}/site-packages/itsdangerous.py'.format(python_folder))
+
+@pytest.mark.skipif(on_win, reason="we create the package to be converted in *nix, so don't run on win.")
+def test_convert_from_unix_to_win_creates_entry_points(test_config):
+    recipe_dir = os.path.join(metadata_dir, "entry_points")
+    fn = api.get_output_file_path(recipe_dir, config=test_config)
+    api.build(recipe_dir, config=test_config)
+    for platform in ['win-64', 'win-32']:
+        api.convert(fn, platforms=[platform], force=True)
+        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-manual-script.py")
+        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-manual.bat")
+        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-setup-script.py")
+        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-setup.bat")


### PR DESCRIPTION
The problem logic here was in convert.py.  The file_map was being updated on the first non-matching pattern, so later patterns were not being evaluated.  The unix script to win pattern was the last of 3, so its files were missing.

fixes #1346 