### PR TITLE
remove pytest timeout.  It is incompatible with xdist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;
     else
-      conda install -q pytest pip pytest-cov pytest-timeout numpy mock;
+      conda install -q pytest pip pytest-cov numpy mock;
       conda install -c conda-forge -q perl;
       $HOME/miniconda/bin/pip install pytest-xdist pytest-capturelog;
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - pip install --no-deps .
-  - pip install pytest-xdist pytest-capturelog pytest-env filelock pytest-timeout
+  - pip install pytest-xdist pytest-capturelog pytest-env filelock
   - set PATH
   - conda build --version
   - call appveyor\setup_x64.bat

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -34,7 +34,6 @@ test:
   requires:
     - pytest
     - pytest-cov
-    - pytest-timeout
     # Optional: you can use pytest-xdist to run the tests in parallel
     # - pytest-env  # [win]
     # - pytest-xdist

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -55,7 +55,6 @@ def test_build_preserves_PATH(testing_workdir, test_config):
     assert os.environ['PATH'] == ref_path
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.skipif(on_win, reason=("Windows binary prefix replacement (for pip exes)"
                                     " not length dependent"))
 def test_env_creation_with_short_prefix_does_not_deadlock(caplog):


### PR DESCRIPTION
We have periodic errors that look like 

```
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/main.py", line 94, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/main.py", line 125, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 595, in execute
INTERNALERROR>     return _wrapped_call(hook_impl.function(*args), self.execute)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 253, in _wrapped_call
INTERNALERROR>     return call_outcome.get_result()
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 279, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 264, in __init__
INTERNALERROR>     self.result = func()
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "<remote exec>", line 61, in pytest_runtestloop
INTERNALERROR>   File "<remote exec>", line 77, in run_tests
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 595, in execute
INTERNALERROR>     return _wrapped_call(hook_impl.function(*args), self.execute)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 244, in _wrapped_call
INTERNALERROR>     next(wrap_controller)   # first yield
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/pytest_timeout.py", line 73, in pytest_runtest_protocol
INTERNALERROR>     timeout_setup(item)
INTERNALERROR>   File "/home/travis/miniconda/lib/python2.7/site-packages/pytest_timeout.py", line 106, in timeout_setup
INTERNALERROR>     signal.signal(signal.SIGALRM, handler)
INTERNALERROR> ValueError: signal only works in main thread
```

https://travis-ci.org/conda/conda-build/jobs/159747106#L661

This appears to be due to the pytest-timeout constrained test being run on a thread.

https://bitbucket.org/pytest-dev/pytest-timeout/issues/8/internalerror-valueerror-signal-only-works

We don't really need this timeout constraint.  We should keep the test, and watch out for if test runs go way too long due to deadlock, but these errors are more pernicious than the benefits of the timeout constraint.