### PR TITLE
fallback path for PKG-INFO for pkgs without pkginfo.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     else
       conda install -q pytest pip pytest-cov numpy mock;
       conda install -c conda-forge -q perl;
-      $HOME/miniconda/bin/pip install pytest-xdist pytest-capturelog;
+      $HOME/miniconda/bin/pip install pytest-xdist pytest-capturelog pkginfo;
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
     fi
   - pip install --no-deps .
@@ -49,12 +49,12 @@ script:
       cp bdist_conda.py $HOME/miniconda/lib/python${TRAVIS_PYTHON_VERSION}/distutils/command;
       pushd tests/bdist-recipe && python setup.py bdist_conda && popd;
       conda build --help;
-      conda build conda.recipe --no-anaconda-upload;
+      conda build conda.recipe --no-anaconda-upload -c conda-forge;
       conda create -n _cbtest python=$TRAVIS_PYTHON_VERSION;
       source activate _cbtest;
       conda install $(conda render --output conda.recipe);
       conda install filelock;
-      conda build conda.recipe --no-anaconda-upload;
+      conda build conda.recipe --no-anaconda-upload -c conda-forge;
     else
       $HOME/miniconda/bin/py.test -v -n 2 --basetemp /tmp/cb --cov conda_build --cov-report xml tests;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,13 @@ install:
     fi
   - conda install -q --force --no-deps conda requests
   - conda install -q anaconda-client requests filelock jinja2 patchelf python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
+  - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;
     else
       conda install -q pytest pip pytest-cov numpy mock;
       conda install -c conda-forge -q perl;
-      $HOME/miniconda/bin/pip install pytest-xdist pytest-capturelog pkginfo;
+      $HOME/miniconda/bin/pip install pytest-xdist pytest-capturelog;
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
     fi
   - pip install --no-deps .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - pip install --no-deps .
-  - pip install pytest-xdist pytest-capturelog pytest-env filelock
+  - pip install pytest-xdist pytest-capturelog pytest-env filelock pkginfo
   - set PATH
   - conda build --version
   - call appveyor\setup_x64.bat

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - pycrypto
     - python
     - pyyaml
+    - pkginfo
 
 test:
   requires:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -326,8 +326,6 @@ def create_info_files(m, files, config, prefix):
     :param include_recipe: Whether or not to include the recipe (True by default)
     :type include_recipe: bool
     '''
-    if not isdir(config.info_dir):
-        os.makedirs(config.info_dir)
 
     copy_recipe(m, config)
     copy_readme(m, config)
@@ -688,7 +686,6 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
         get_build_metadata(m, config=config)
         create_post_scripts(m, config=config)
         create_entry_points(m.get_value('build/entry_points'), config=config)
-        assert not exists(config.info_dir)
         files2 = prefix_files(prefix=config.build_prefix)
 
         post_process(sorted(files2 - files1),

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -11,7 +11,7 @@ import json
 import logging
 import mmap
 import os
-from os.path import exists, isdir, isfile, islink, join
+from os.path import isdir, isfile, islink, join
 import shutil
 import stat
 import subprocess

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -26,6 +26,11 @@ on_win = (sys.platform == 'win32')
 DEFAULT_PREFIX_LENGTH = 255
 
 
+def _ensure_dir(path):
+    if not os.path.isdir(path):
+        os.makedirs(path)
+
+
 class Config(object):
     __file__ = __path__ = __file__
     __package__ = __package__
@@ -259,23 +264,31 @@ class Config(object):
 
     @property
     def info_dir(self):
-        return join(self.build_prefix, 'info')
+        path = join(self.build_prefix, 'info')
+        _ensure_dir(path)
+        return path
 
     @property
     def meta_dir(self):
-        return join(self.build_prefix, 'conda-meta')
+        path = join(self.build_prefix, 'conda-meta')
+        _ensure_dir(path)
+        return path
 
     @property
     def broken_dir(self):
-        return join(self.croot, "broken")
+        path = join(self.croot, "broken")
+        _ensure_dir(path)
+        return path
 
     @property
     def bldpkgs_dir(self):
         """ Dir where the package is saved. """
         if self.noarch:
-            return join(self.croot, "noarch")
+            path = join(self.croot, "noarch")
         else:
-            return join(self.croot, self.subdir)
+            path = join(self.croot, self.subdir)
+        _ensure_dir(path)
+        return path
 
     @property
     def bldpkgs_dirs(self):
@@ -284,28 +297,40 @@ class Config(object):
 
     @property
     def src_cache(self):
-        return join(self.croot, 'src_cache')
+        path = join(self.croot, 'src_cache')
+        _ensure_dir(path)
+        return path
 
     @property
     def git_cache(self):
-        return join(self.croot, 'git_cache')
+        path = join(self.croot, 'git_cache')
+        _ensure_dir(path)
+        return path
 
     @property
     def hg_cache(self):
-        return join(self.croot, 'hg_cache')
+        path = join(self.croot, 'hg_cache')
+        _ensure_dir(path)
+        return path
 
     @property
     def svn_cache(self):
-        return join(self.croot, 'svn_cache')
+        path = join(self.croot, 'svn_cache')
+        _ensure_dir(path)
+        return path
 
     @property
     def work_dir(self):
-        return join(self.build_folder, 'work')
+        path = join(self.build_folder, 'work')
+        _ensure_dir(path)
+        return path
 
     @property
     def test_dir(self):
         """The temporary folder where test files are copied to, and where tests start execution"""
-        return join(self.build_folder, 'test_tmp')
+        path = join(self.build_folder, 'test_tmp')
+        _ensure_dir(path)
+        return path
 
     def clean(self):
         # build folder is the whole burrito containing envs and source folders

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -797,8 +797,8 @@ class MetaData(object):
                 self.undefined_jinja_vars = UndefinedNeverFail.all_undefined_names
             else:
                 self.undefined_jinja_vars = []
-
             return rendered
+
         except jinja2.TemplateError as ex:
             if "'None' has not attribute" in str(ex):
                 ex = "Failed to run jinja context function"
@@ -843,7 +843,8 @@ class MetaData(object):
     @property
     def uses_setup_py_in_meta(self):
         with open(self.meta_path) as f:
-            return ("load_setup_py_data" in f.read()) or ("load_setuptools" in f.read())
+            meta_text = f.read()
+        return "load_setup_py_data" in meta_text or "load_setuptools" in meta_text
 
     @property
     def uses_jinja(self):

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -319,9 +319,10 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
         elif old.startswith('/'):
             # Test if this absolute path is outside of prefix. That is fatal.
             relpath = os.path.relpath(old, prefix)
-            assert not relpath.startswith('..' + os.sep), 'rpath {0} is outside prefix {1}'.format(old, prefix)
+            assert not relpath.startswith('..' + os.sep), \
+                'rpath {0} is outside prefix {1}'.format(old, prefix)
             relpath = '$ORIGIN/' + os.path.relpath(old, origin)
-            if not relpath in new:
+            if relpath not in new:
                 new.append(relpath)
     # Ensure that the asked-for paths are also in new.
     for rpath in rpaths:
@@ -331,10 +332,11 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
             # gives the same result and assert if not. Yeah, I am a chicken.
             rel_ours = utils.relative(f, rpath)
             rel_stdlib = os.path.relpath(rpath, os.path.dirname(f))
-            assert rel_ours == rel_stdlib, 'utils.relative {0} and relpath {1} disagree for {2}, {3}'.format(
+            assert rel_ours == rel_stdlib, \
+                'utils.relative {0} and relpath {1} disagree for {2}, {3}'.format(
                 rel_ours, rel_stdlib, f, rpath)
             rpath = '$ORIGIN/' + rel_stdlib
-        if not rpath in new:
+        if rpath not in new:
             new.append(rpath)
     rpath = ':'.join(new)
     print('patchelf: file: %s\n    setting rpath to: %s' % (elf, rpath))

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -479,3 +479,18 @@ def convert_path_for_cygwin_or_msys2(exe, path):
 def print_skip_message(metadata):
     print("Skipped: {} defines build/skip for this "
           "configuration.".format(metadata.path))
+
+
+def package_has_file(package_path, file_path):
+    try:
+        with tarfile.open(package_path) as t:
+            try:
+                text = t.extractfile(file_path).read()
+                return text
+            except KeyError:
+                return False
+            except OSError as e:
+                raise RuntimeError("Could not extract %s (%s)" % (package_path, e))
+    except tarfile.ReadError:
+        raise RuntimeError("Could not extract metadata from %s. "
+                           "File probably corrupt." % package_path)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -17,11 +17,12 @@ import pytest
 import yaml
 
 from conda_build import api, exceptions
-from conda_build.utils import copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2
+from conda_build.utils import (copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2,
+                               package_has_file)
 from conda_build.os_utils.external import find_executable
 
 from .utils import (metadata_dir, fail_dir, is_valid_dir, testing_workdir, test_config,
-                    add_mangling, test_metadata, package_has_file)
+                    add_mangling, test_metadata)
 
 # define a few commonly used recipes - use os.path.join(metadata_dir, recipe) elsewhere
 empty_sections = os.path.join(metadata_dir, "empty_sections")

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -4,8 +4,9 @@ import pytest
 
 from conda_build.conda_interface import download
 from conda_build import api
+from conda_build.utils import package_has_file
 
-from .utils import testing_workdir, package_has_file, test_config, on_win, metadata_dir
+from .utils import testing_workdir, test_config, on_win, metadata_dir
 
 def test_convert_wheel_raises():
     with pytest.raises(RuntimeError) as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ from conda_build.conda_interface import download
 from conda_build.tarcheck import TarCheck
 
 from conda_build import api
-from conda_build.utils import get_site_packages, on_win, get_build_folders
-from .utils import testing_workdir, metadata_dir, package_has_file, testing_env, test_config, test_metadata
+from conda_build.utils import get_site_packages, on_win, get_build_folders, package_has_file
+from .utils import testing_workdir, metadata_dir, testing_env, test_config, test_metadata
 
 import conda_build.cli.main_build as main_build
 import conda_build.cli.main_sign as main_sign

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,21 +92,6 @@ def testing_env(testing_workdir, request):
     return env_path
 
 
-def package_has_file(package_path, file_path):
-    try:
-        with tarfile.open(package_path) as t:
-            try:
-                text = t.extractfile(file_path).read()
-                return text
-            except KeyError:
-                return False
-            except OSError as e:
-                raise RuntimeError("Could not extract %s (%s)" % (package_path, e))
-    except tarfile.ReadError:
-        raise RuntimeError("Could not extract metadata from %s. "
-                           "File probably corrupt." % package_path)
-
-
 def add_mangling(filename):
     if PY3:
         filename = os.path.splitext(filename)[0] + '.cpython-{0}{1}.py'.format(


### PR DESCRIPTION
fixes #1352 

Some packages do not contain the pkginfo.yaml file.  Instead, they only have PKG-INFO.  That is an incomplete collection of information - it is potentially missing multiple fields.  If it's all we have, then we go with it, and provide empty values where appropriate.