### PR TITLE
use conda's rm_rf, rather than move_to_trash

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -14,8 +14,8 @@ from conda.compat import (PY3, StringIO, configparser, input, iteritems, lchmod,
                           text_type, TemporaryDirectory)  # NOQA
 from conda.connection import CondaSession  # NOQA
 from conda.fetch import TmpDownload, download, fetch_index, handle_proxy_407  # NOQA
-from conda.install import (delete_trash, is_linked, linked, linked_data, move_to_trash,  # NOQA
-                           prefix_placeholder, rm_rf, symlink_conda, rm_fetched, package_cache)  # NOQA
+from conda.install import (delete_trash, is_linked, linked, linked_data, prefix_placeholder,  # NOQA
+                           rm_rf, symlink_conda, rm_fetched, package_cache)  # NOQA
 from conda.lock import Locked  # NOQA
 from conda.misc import untracked, walk_prefix  # NOQA
 from conda.resolve import MatchSpec, NoPackagesFound, Resolve, Unsatisfiable, normalized_version  # NOQA

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -39,12 +39,7 @@ else:
 log = logging.getLogger(__file__)
 
 # elsewhere, kept here for reduced duplication.  NOQA because it is not used in this file.
-if sys.platform == 'win32':
-    from .conda_interface import move_to_trash  # NOQA
-    import functools
-    rm_rf = functools.partial(move_to_trash, f=None)  # NOQA
-else:
-    from .conda_interface import rm_rf  # NOQA
+from .conda_interface import rm_rf  # NOQA
 
 on_win = (sys.platform == 'win32')
 


### PR DESCRIPTION
This was breaking bokeh's build with conda 4.2.6 somehow.  Conda now calls the windows move to trash stuff in its rm_rf function.  There is no need to duplicate that here.

CC @brittainhard