### PR TITLE
Fix building when --skip-existing flag is set

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -544,7 +544,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
         package_exists = is_package_built(m, config)
         if package_exists:
             print(m.dist(), "is already built in {0}, skipping.".format(package_exists))
-        return False
+            return False
 
     if post in [False, None]:
         print("BUILD START:", m.dist())

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
                             'conda-sign = conda_build.cli.main_sign:main',
                             'conda-skeleton = conda_build.cli.main_skeleton:main',
                             ]},
-    install_requires=['conda'],
+    install_requires=['conda', 'requests'],
     package_data={'conda_build': ['templates/*', 'cli-*.exe']},
     zip_safe=False,
 )


### PR DESCRIPTION
This PR fixes a bug when using the --skip-existing flag: any package, regardless of whether it exists or not, was not being built, because the `return False` appeared at the wrong indentation level.

Further, this adds a dependency to requests, which was previously used but not mentioned in the setup.py.