### PR TITLE
Try to fix src_dir must be bytestring on Windows.

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -13,7 +13,7 @@ from .conda_interface import download, TemporaryDirectory
 from .conda_interface import hashsum_file
 
 from conda_build.os_utils import external
-from conda_build.utils import (tar_xf, unzip, safe_print_unicode, copy_into, on_win,
+from conda_build.utils import (tar_xf, unzip, safe_print_unicode, copy_into, on_win, codec,
                                check_output_env, check_call_env, convert_path_for_cygwin_or_msys2)
 
 # legacy exports for conda
@@ -446,6 +446,9 @@ def _get_patch_file_details(path):
 
 
 def apply_patch(src_dir, path, config, git=None):
+    if on_win:
+        src_dir = src_dir.encode(codec)
+
     if not isfile(path):
         sys.exit('Error: no such patch: %s' % path)
 


### PR DESCRIPTION
Second try. This replaces #1377

Again, I do not have a Windows machine to check if this works... Sorry... So feel free to just close it. But I if get the `traceback` correctly it is the `src_dir` that needs fixing.

```shell
Applying patch: u'C:\\projects\\conda-recipes\\recipes\\libiconv\\CMakeLists.txt.patch'
Traceback (most recent call last):
  File "C:\Miniconda\Scripts\conda-build-all-script.py", line 11, in <module>
    load_entry_point('conda-build-all==1.0.0', 'console_scripts', 'conda-build-all')()
  File "C:\Miniconda\lib\site-packages\conda_build_all\cli.py", line 90, in main
    b.main()
  File "C:\Miniconda\lib\site-packages\conda_build_all\builder.py", line 263, in main
    built_dist_location = self.build(meta, build_config)
  File "C:\Miniconda\lib\site-packages\conda_build_all\builder.py", line 200, in build
    conda_build.api.build(meta.meta, config=config)
  File "C:\Miniconda\lib\site-packages\conda_build\api.py", line 83, in build
    need_source_download=need_source_download, config=config)
  File "C:\Miniconda\lib\site-packages\conda_build\build.py", line 998, in build_tree
    config=recipe_config)
  File "C:\Miniconda\lib\site-packages\conda_build\build.py", line 590, in build
    config=config)
  File "C:\Miniconda\lib\site-packages\conda_build\render.py", line 86, in parse_or_try_download
    source.provide(metadata.path, metadata.get_section('source'), config=config)
  File "C:\Miniconda\lib\site-packages\conda_build\source.py", line 519, in provide
    apply_patch(src_dir, join(recipe_dir, patch), config, git)
  File "C:\Miniconda\lib\site-packages\conda_build\source.py", line 478, in apply_patch
    check_call_env([patch] + patch_args, cwd=src_dir)
  File "C:\Miniconda\lib\site-packages\conda_build\utils.py", line 452, in check_call_env
    return _func_defaulting_env_to_os_environ(subprocess.check_call, *popenargs, **kwargs)
  File "C:\Miniconda\lib\site-packages\conda_build\utils.py", line 448, in _func_defaulting_env_to_os_environ
    return func(*popenargs, **kwargs)
  File "C:\Miniconda\lib\subprocess.py", line 536, in check_call
    retcode = call(*popenargs, **kwargs)
  File "C:\Miniconda\lib\subprocess.py", line 523, in call
    return Popen(*popenargs, **kwargs).wait()
  File "C:\Miniconda\lib\subprocess.py", line 711, in __init__
    errread, errwrite)
  File "C:\Miniconda\lib\subprocess.py", line 959, in _execute_child
    startupinfo)
TypeError: environment can only contain strings
Command exited with code 1
```