### PR TITLE
[Bug-fix] Patch skeletonize to not ignore flags

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -172,11 +172,14 @@ def skeletonize(packages, repo, config=None, **kwargs):
                                 fromlist=[repo]),
                      repo)
     func_args = module.skeletonize.__code__.co_varnames
-    kwargs = {name: value for name, value in kwargs.items() if name in func_args}
 
-    skeleton_return = module.skeletonize(packages, output_dir=config.output_dir,
-                                         version=config.version, recursive=config.recursive,
-                                         config=config, **kwargs)
+    for arg in func_args:
+        try:
+            kwargs[arg] = getattr(config, arg)
+        except AttributeError:
+            pass
+
+    skeleton_return = module.skeletonize(config=config, **kwargs)
 
     return skeleton_return
 

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -160,13 +160,13 @@ def list_skeletons():
     return files
 
 
-def skeletonize(packages, repo, config=None, **kwargs):
+def skeletonize(config):
     """Generate a conda recipe from an external repo.  Translates metadata from external
     sources into expected conda recipe format."""
 
     config = get_or_merge_config(config, **kwargs)
     config.compute_build_id('skeleton')
-    packages = _ensure_list(packages)
+    config.packages = _ensure_list(config.packages)
 
     module = getattr(__import__("conda_build.skeletons", globals=globals(), locals=locals(),
                                 fromlist=[repo]),

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -172,7 +172,7 @@ def skeletonize(config, **kwargs):
                                 fromlist=[config.repo]),
                      config.repo)
     func_args = module.skeletonize.__code__.co_varnames
-
+    skeleton_args = {}
     for arg in func_args:
         try:
             skeleton_args[arg] = getattr(config, arg)

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -160,8 +160,7 @@ def list_skeletons():
     return files
 
 
-def skeletonize(packages, repo, output_dir=".", version=None, recursive=False,
-                config=None, **kwargs):
+def skeletonize(packages, repo, config=None, **kwargs):
     """Generate a conda recipe from an external repo.  Translates metadata from external
     sources into expected conda recipe format."""
 
@@ -174,9 +173,11 @@ def skeletonize(packages, repo, output_dir=".", version=None, recursive=False,
                      repo)
     func_args = module.skeletonize.__code__.co_varnames
     kwargs = {name: value for name, value in kwargs.items() if name in func_args}
-    with config:
-        skeleton_return = module.skeletonize(packages, output_dir=output_dir, version=version,
-                                                recursive=recursive, config=config, **kwargs)
+
+    skeleton_return = module.skeletonize(packages, output_dir=config.output_dir,
+                                         version=config.version, recursive=config.recursive,
+                                         config=config, **kwargs)
+
     return skeleton_return
 
 

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -169,8 +169,8 @@ def skeletonize(config, **kwargs):
     config.packages = _ensure_list(config.packages)
 
     module = getattr(__import__("conda_build.skeletons", globals=globals(), locals=locals(),
-                                fromlist=[repo]),
-                     repo)
+                                fromlist=[config.repo]),
+                     config.repo)
     func_args = module.skeletonize.__code__.co_varnames
 
     for arg in func_args:

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -160,11 +160,11 @@ def list_skeletons():
     return files
 
 
-def skeletonize(config):
+def skeletonize(config, **kwargs):
     """Generate a conda recipe from an external repo.  Translates metadata from external
     sources into expected conda recipe format."""
 
-    config = get_or_merge_config(config, **kwargs)
+    config = get_or_merge_config(config)
     config.compute_build_id('skeleton')
     config.packages = _ensure_list(config.packages)
 
@@ -175,11 +175,11 @@ def skeletonize(config):
 
     for arg in func_args:
         try:
-            kwargs[arg] = getattr(config, arg)
+            skeleton_args[arg] = getattr(config, arg)
         except AttributeError:
             pass
 
-    skeleton_return = module.skeletonize(config=config, **kwargs)
+    skeleton_return = module.skeletonize(config=config, **skeleton_args)
 
     return skeleton_return
 

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -57,8 +57,7 @@ def execute(args):
         parser.print_help()
         sys.exit()
 
-    for package in args.packages:
-        api.skeletonize(package, repo=args.repo, config=config)
+    api.skeletonize(config=config)
 
 
 def main():

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -249,10 +249,10 @@ def skeletonize(packages, output_dir=".", version=None,
         core_version = core_module_version(package, perl_version, config=config)
         release_data = get_release_info(meta_cpan_url, package,
                                         (LooseVersion(version) if
-                                            version is not None else
-                                            core_version),
-                                        perl_version,
-                                        config=config)
+                                         version not in [None, ''] else
+                                         core_version),
+                                         perl_version,
+                                         config=config)
         # Check if recipe directory already exists
         dir_path = join(output_dir, packagename)
         if exists(dir_path):
@@ -287,7 +287,7 @@ def skeletonize(packages, output_dir=".", version=None,
 
         # Add Perl version to core module requirements, since these are empty
         # packages, unless we're newer than what's in core
-        if core_version is not None and ((version is None) or
+        if core_version is not None and ((version in [None, '']) or
                                             (core_version >=
                                             LooseVersion(version))):
             d['useurl'] = '#'
@@ -394,7 +394,7 @@ def core_module_version(module, version, config):
     '''
     # In case we were given a dist, convert to module
     module = module.replace('-', '::')
-    if version is None:
+    if version in [None, '']:
         version = LooseVersion(config.CONDA_PERL)
     else:
         version = LooseVersion(version)

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -87,8 +87,8 @@ def test_api_list_skeletons():
 
 def test_api_skeletonize():
     argspec = getargspec(api.skeletonize)
-    assert argspec.args == ['packages', 'repo', 'output_dir', 'version', 'recursive', 'config']
-    assert argspec.defaults == ('.', None, False, None)
+    assert argspec.args == ['config']
+    assert argspec.defaults == ()
 
 
 def test_api_develop():

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -88,7 +88,7 @@ def test_api_list_skeletons():
 def test_api_skeletonize():
     argspec = getargspec(api.skeletonize)
     assert argspec.args == ['config']
-    assert argspec.defaults == ()
+    assert argspec.defaults is None
 
 
 def test_api_develop():

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -18,7 +18,11 @@ repo_packages = [('', 'pypi', 'pip', "8.1.2"),
 
 @pytest.mark.parametrize("prefix,repo,package, version", repo_packages)
 def test_repo(prefix, repo, package, version, testing_workdir, test_config):
-    api.skeletonize(package, output_dir=testing_workdir, repo=repo, config=test_config)
+    test_config.packages = package
+    test_config.output_dir = testing_workdir
+    test_config.version = version
+    test_config.repo = repo
+    api.skeletonize(config=test_config)
     try:
         package_name = "-".join([prefix, package]) if prefix else package
         assert os.path.isdir(os.path.join(testing_workdir, package_name.lower()))

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -32,7 +32,7 @@ def test_repo(prefix, repo, package, version, testing_workdir, test_config):
 
 def test_name_with_version_specified(testing_workdir, test_config):
     test_config.packages = 'sympy'
-    test_config.repos = 'pypi'
+    test_config.repo = 'pypi'
     test_config.version = '0.7.5'
     api.skeletonize(config=test_config)
     with open('{}/test-skeleton/sympy-0.7.5/meta.yaml'.format(thisdir)) as f:
@@ -44,7 +44,7 @@ def test_name_with_version_specified(testing_workdir, test_config):
 
 def test_pypi_url(testing_workdir, test_config):
     test_config.packages = 'https://pypi.python.org/packages/source/s/sympy/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9'
-    test_config.repos = 'pypi'
+    test_config.repo = 'pypi'
     api.skeletonize(config=test_config)
     with open('{}/test-skeleton/sympy-0.7.5-url/meta.yaml'.format(thisdir)) as f:
         expected = yaml.load(f)
@@ -59,7 +59,7 @@ def test_pypi_with_setup_options(testing_workdir, test_config):
 
     # Test that the setup option is used in constructing the skeleton.
     test_config.packages = 'photutils'
-    test_config.repos = 'pypi'
+    test_config.repo = 'pypi'
     test_config.version = '0.2.2'
     test_config.setup_options = "--offline"
     api.skeletonize(config=test_config)
@@ -75,7 +75,7 @@ def test_pypi_pin_numpy(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
     test_config.packages = 'msumastro'
-    test_config.repos = 'pypi'
+    test_config.repo = 'pypi'
     test_config.version = '0.9.0'
     test_config.pin_numpy = True
     api.skeletonize(config=test_config)
@@ -91,7 +91,7 @@ def test_pypi_version_sorting(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
     test_config.packages = 'impyla'
-    test_config.repos = 'pypi'
+    test_config.repo = 'pypi'
     api.skeletonize(config=test_config)
 
     with open('impyla/meta.yaml') as f:

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -27,7 +27,10 @@ def test_repo(prefix, repo, package, version, testing_workdir, test_config):
         raise
 
 def test_name_with_version_specified(testing_workdir, test_config):
-    api.skeletonize('sympy', 'pypi', version='0.7.5', config=test_config)
+    test_config.packages = 'sympy'
+    test_config.repos = 'pypi'
+    test_config.version = '0.7.5'
+    api.skeletonize(config=test_config)
     with open('{}/test-skeleton/sympy-0.7.5/meta.yaml'.format(thisdir)) as f:
         expected = yaml.load(f)
     with open('sympy/meta.yaml') as f:
@@ -36,9 +39,9 @@ def test_name_with_version_specified(testing_workdir, test_config):
 
 
 def test_pypi_url(testing_workdir, test_config):
-    api.skeletonize('https://pypi.python.org/packages/source/s/sympy/'
-                    'sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9',
-                    repo='pypi', config=test_config)
+    test_config.packages = 'https://pypi.python.org/packages/source/s/sympy/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9'
+    test_config.repos = 'pypi'
+    api.skeletonize(config=test_config)
     with open('{}/test-skeleton/sympy-0.7.5-url/meta.yaml'.format(thisdir)) as f:
         expected = yaml.load(f)
     with open('sympy/meta.yaml') as f:
@@ -51,7 +54,11 @@ def test_pypi_with_setup_options(testing_workdir, test_config):
     # occurs by default.
 
     # Test that the setup option is used in constructing the skeleton.
-    api.skeletonize('photutils', 'pypi', version="0.2.2", setup_options="--offline")
+    test_config.packages = 'photutils'
+    test_config.repos = 'pypi'
+    test_config.version = '0.2.2'
+    test_config.setup_options = "--offline"
+    api.skeletonize(config=test_config)
 
     # Check that the setup option occurs in bld.bat and build.sh.
     for script in ['bld.bat', 'build.sh']:
@@ -63,7 +70,11 @@ def test_pypi_with_setup_options(testing_workdir, test_config):
 def test_pypi_pin_numpy(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
-    api.skeletonize("msumastro", "pypi", version='0.9.0', pin_numpy=True)
+    test_config.packages = 'msumastro'
+    test_config.repos = 'pypi'
+    test_config.version = '0.9.0'
+    test_config.pin_numpy = True
+    api.skeletonize(config=test_config)
 
     with open('msumastro/meta.yaml') as f:
         actual = yaml.load(f)
@@ -75,7 +86,9 @@ def test_pypi_pin_numpy(testing_workdir, test_config):
 def test_pypi_version_sorting(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
-    api.skeletonize("impyla", "pypi")
+    test_config.packages = 'impyla'
+    test_config.repos = 'pypi'
+    api.skeletonize(config=test_config)
 
     with open('impyla/meta.yaml') as f:
         actual = yaml.load(f)


### PR DESCRIPTION
## Description
Currently invoking conda skeleton with:
```bash
conda skeleton pypi --version 2.9.2 pytest
```
ignores the version flag due to the way skeletonize is called by main_skeleton.py. main_skeleton.py rolls all command line arguments into the config object which is passed into skeletonize. This caused version, recursive and output_dir to take on the default values in skeletonize (None, False, and ".", respectively).

This PR fixes that bug.