### PR TITLE
Add missing command line options and tests for them

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -533,6 +533,25 @@ def add_parser(repos):
         help="Creates recipe as noarch python"
     )
 
+    pypi.add_argument(
+        "--setup-options",
+        action='append',
+        default=[],
+        help='Options to be added to setup.py install in the recipe. '
+             'The same options are passed to setup.py install in both '
+             'the construction of the recipe and in the recipe itself.'
+             'For options that include a double-hypen or to pass multiple '
+             'options, use the syntax '
+             '--setup-options="--option1 --option-with-arg arg"'
+    )
+
+    pypi.add_argument(
+        "--pin-numpy",
+        action='store_true',
+        help="Ensure that the generated recipe pins the version of numpy"
+             "to CONDA_NPY."
+    )
+
 
 def get_xmlrpc_client(pypi_url):
     return ServerProxy(pypi_url, transport=RequestsTransport())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,21 @@ def test_skeleton_pypi(testing_workdir, test_config):
     main_build.execute(args)
 
 
+def test_skeleton_pypi_arguments_work(testing_workdir, test_config):
+    """
+    These checks only test whether skeleton executes without error when these
+    options are specified on the command line. Separate unit tests check
+    whether the underlying functionality works.
+    """
+    args = ['pypi', 'msumastro', '--pin-numpy']
+    main_skeleton.execute(args)
+    assert os.path.isdir('msumastro')
+
+    args = ['pypi', 'photutils', '--setup-options="--offline"']
+    main_skeleton.execute(args)
+    assert os.path.isdir('photutils')
+
+
 def test_metapackage(test_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test', '1.0', '-d', 'bzip2']


### PR DESCRIPTION
This will close #1382. The first commit simply adds a test for the missing options. 

Assuming those test fail, as expected, I will push the fix.