### PR TITLE
don't index pkgs folder

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -407,10 +407,10 @@ def create_env(prefix, specs, config, clear_cache=True):
                     if not os.path.isdir(folder):
                         os.makedirs(folder)
                     lock = filelock.SoftFileLock(join(folder, '.conda_lock'))
-                    update_index(folder, config=config, lock=lock, could_be_mirror=False)
-                    locks.append(lock)
-                for lock in locks:
                     lock.acquire(timeout=config.timeout)
+                    if not folder.endswith('pkgs'):
+                        update_index(folder, config=config, lock=lock, could_be_mirror=False)
+                    locks.append(lock)
 
                 index = get_build_index(config=config, clear_cache=True)
 


### PR DESCRIPTION
Fixes #1339 

(maybe)

It seems like indexing the pkgs folder when it has never been indexed before takes quite a long time.  Since this was not done before, and because the index creation is not incremental - this can simply fail all builds because it never succeeds a first time (after which it would be fast).

CC @patricksnape 