### PR TITLE
Fix #1378 and #1379

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -335,7 +335,8 @@ def meta_vars(meta, config):
     elif external.find_executable('hg', config.build_prefix) and os.path.exists(hg_dir):
         d.update(get_hg_build_info(hg_dir))
 
-    d['PKG_NAME'] = meta.name()
+    # use `get_value` to prevent early exit while name is still unresolved during rendering
+    d['PKG_NAME'] = meta.get_value('package/name')
     d['PKG_VERSION'] = meta.version()
     d['PKG_BUILDNUM'] = str(meta.build_number())
     d['PKG_BUILD_STRING'] = str(meta.build_id())


### PR DESCRIPTION
#1378 boils down to `environ.meta_vars` calling `MetaData.name` which `sys.exit`s because the package's name is not set during rendering. `MetaData.name` gets called due to the following call stack:
```python
render.parse_or_try_download
  metadata.MetaData.parse_again
    metadata.MetaData._get_contents
      jinja_context.context_processor
        environ.get_dict
          environ.meta_vars
            metadata.MetaData.name
```
I did **not** check the implications of replacing `meta.name()` by `meta.get_value('package/name')` for other code paths. If the patch is thus not applicable, other potential solutions are:
- either guard the `meta.name()` call inside `meta_vars` by some optional Boolean argument which has to be handed down all the way from `parse_again` down to `meta_vars`,
- or simply artificially fulfil `MetaData.name`'s precondition by setting `MetaData.meta['package']['name'] = some_random_string` inside `MetaData.parse_again` prior to calling `MetaData._get_contents` and removing it after the call from the new `meta` if it did not change.