### PR TITLE
Fix pypi skeleton args

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -171,6 +171,12 @@ def skeletonize(config, **kwargs):
     module = getattr(__import__("conda_build.skeletons", globals=globals(), locals=locals(),
                                 fromlist=[config.repo]),
                      config.repo)
+
+    # This is a little bit of black magic.  The idea is that for any keyword argument that
+    #    we inspect from the given module's skeletonize funtion, we should hoist the argument
+    #    off of the config object, and pass it as a keyword argument.  This is sort of the
+    #    inverse of what we do in the CLI code - there we take CLI arguments and dangle them
+    #    all on the config object as attributes.
     func_args = module.skeletonize.__code__.co_varnames
     skeleton_args = {}
     for arg in func_args:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,7 +160,7 @@ def test_skeleton_pypi_arguments_work(testing_workdir, test_config):
     assert 'numpy x.x' in actual['requirements']['run']
     assert 'numpy x.x' in actual['requirements']['build']
 
-    args = ['pypi', 'photutils', '--version=0.2', '--setup-options=--offline']
+    args = ['pypi', 'photutils', '--version=0.2.2', '--setup-options=--offline']
     main_skeleton.execute(args)
     assert os.path.isdir('photutils')
     # Check that the setup option occurs in bld.bat and build.sh.
@@ -171,7 +171,7 @@ def test_skeleton_pypi_arguments_work(testing_workdir, test_config):
 
     with open(os.path.join('photutils', 'meta.yaml')) as f:
         content = f.read()
-        assert 'version: "0.2"' in content
+        assert 'version: "0.2.2"' in content
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,7 +174,6 @@ def test_skeleton_pypi_arguments_work(testing_workdir, test_config):
         assert 'version: "0.2.2"' in content
 
 
-
 def test_metapackage(test_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test', '1.0', '-d', 'bzip2']


### PR DESCRIPTION
@mwcraig @sooneecheah between your two PRs, things were working fine, aside from one glitch already fixed with photutils and py3.  I added a comment explaining how the translation to/from function arguments works.  It's a little bit tricky to understand just by looking at it, but simple enough once you know what you're looking at.