### PR TITLE
normalize slashes to forward slashes for path checks in tarfiles

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -480,6 +480,8 @@ def package_has_file(package_path, file_path):
     try:
         with tarfile.open(package_path) as t:
             try:
+                # internal paths are always forward slashed on all platforms
+                file_path = file_path.replace('\\', '/')
                 text = t.extractfile(file_path).read()
                 return text
             except KeyError:


### PR DESCRIPTION
Fixes py3.5 corresponding tests on appveyor