### PR TITLE
Rework skeletonize api to be consistent

### DIFF
--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -57,7 +57,8 @@ def execute(args):
         parser.print_help()
         sys.exit()
 
-    api.skeletonize(config=config)
+    for package in args.packages:
+        api.skeletonize(package, args.repo, config=config)
 
 
 def main():

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -87,8 +87,8 @@ def test_api_list_skeletons():
 
 def test_api_skeletonize():
     argspec = getargspec(api.skeletonize)
-    assert argspec.args == ['config']
-    assert argspec.defaults is None
+    assert argspec.args == ['packages', 'repo', 'output_dir', 'version', 'recursive', 'config']
+    assert argspec.defaults == ('.', None, False, None)
 
 
 def test_api_develop():

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -18,11 +18,7 @@ repo_packages = [('', 'pypi', 'pip', "8.1.2"),
 
 @pytest.mark.parametrize("prefix,repo,package, version", repo_packages)
 def test_repo(prefix, repo, package, version, testing_workdir, test_config):
-    test_config.packages = package
-    test_config.output_dir = testing_workdir
-    test_config.version = version
-    test_config.repo = repo
-    api.skeletonize(config=test_config)
+    api.skeletonize(package, repo, version=version, output_dir=testing_workdir, config=test_config)
     try:
         package_name = "-".join([prefix, package]) if prefix else package
         assert os.path.isdir(os.path.join(testing_workdir, package_name.lower()))
@@ -31,10 +27,7 @@ def test_repo(prefix, repo, package, version, testing_workdir, test_config):
         raise
 
 def test_name_with_version_specified(testing_workdir, test_config):
-    test_config.packages = 'sympy'
-    test_config.repo = 'pypi'
-    test_config.version = '0.7.5'
-    api.skeletonize(config=test_config)
+    api.skeletonize(packages='sympy', repo='pypi', version='0.7.5', config=test_config)
     with open('{}/test-skeleton/sympy-0.7.5/meta.yaml'.format(thisdir)) as f:
         expected = yaml.load(f)
     with open('sympy/meta.yaml') as f:
@@ -43,26 +36,24 @@ def test_name_with_version_specified(testing_workdir, test_config):
 
 
 def test_pypi_url(testing_workdir, test_config):
-    test_config.packages = 'https://pypi.python.org/packages/source/s/sympy/sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9'
-    test_config.repo = 'pypi'
-    api.skeletonize(config=test_config)
+    api.skeletonize('https://pypi.python.org/packages/source/s/sympy/'
+                    'sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9',
+                    repo='pypi', config=test_config)
     with open('{}/test-skeleton/sympy-0.7.5-url/meta.yaml'.format(thisdir)) as f:
         expected = yaml.load(f)
     with open('sympy/meta.yaml') as f:
         actual = yaml.load(f)
     assert expected == actual, (expected, actual)
 
+
 def test_pypi_with_setup_options(testing_workdir, test_config):
-    # Use package below because  skeleton will fail unless the setup.py is given
+    # Use photutils package below because skeleton will fail unless the setup.py is given
     # the flag --offline because of a bootstrapping a helper file that
     # occurs by default.
 
     # Test that the setup option is used in constructing the skeleton.
-    test_config.packages = 'photutils'
-    test_config.repo = 'pypi'
-    test_config.version = '0.2.2'
-    test_config.setup_options = "--offline"
-    api.skeletonize(config=test_config)
+    api.skeletonize(packages='photutils', repo='pypi', version='0.2.2', setup_options='--offline',
+                    config=test_config)
 
     # Check that the setup option occurs in bld.bat and build.sh.
     for script in ['bld.bat', 'build.sh']:
@@ -74,11 +65,8 @@ def test_pypi_with_setup_options(testing_workdir, test_config):
 def test_pypi_pin_numpy(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
-    test_config.packages = 'msumastro'
-    test_config.repo = 'pypi'
-    test_config.version = '0.9.0'
-    test_config.pin_numpy = True
-    api.skeletonize(config=test_config)
+    api.skeletonize(packages='msumastro', repo='pypi', version='0.9.0', config=test_config,
+                    pin_numpy=True)
 
     with open('msumastro/meta.yaml') as f:
         actual = yaml.load(f)
@@ -90,9 +78,7 @@ def test_pypi_pin_numpy(testing_workdir, test_config):
 def test_pypi_version_sorting(testing_workdir, test_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
-    test_config.packages = 'impyla'
-    test_config.repo = 'pypi'
-    api.skeletonize(config=test_config)
+    api.skeletonize(packages='impyla', repo='pypi', config=test_config)
 
     with open('impyla/meta.yaml') as f:
         actual = yaml.load(f)


### PR DESCRIPTION
This partially reverts #1384 to keep the skeletonize api consistent, and fixes passing of arguments through the CLI accordingly.

CC @mwcraig @sooneecheah 