### PR TITLE
convert popen args to bytestrings if unicode

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -13,7 +13,7 @@ from .conda_interface import download, TemporaryDirectory
 from .conda_interface import hashsum_file
 
 from conda_build.os_utils import external
-from conda_build.utils import (tar_xf, unzip, safe_print_unicode, copy_into, on_win,
+from conda_build.utils import (tar_xf, unzip, safe_print_unicode, copy_into, on_win, codec,
                                check_output_env, check_call_env, convert_path_for_cygwin_or_msys2)
 
 # legacy exports for conda

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -455,7 +455,13 @@ def _func_defaulting_env_to_os_environ(func, *popenargs, **kwargs):
         kwargs = kwargs.copy()
         env_copy = os.environ.copy()
         kwargs.update({'env': env_copy})
-    return func(*popenargs, **kwargs)
+    args = []
+    for arg in popenargs:
+        # arguments to subprocess need to be bytestrings
+        if hasattr(arg, 'encode'):
+            arg = arg.encode(codec)
+        args.append(arg)
+    return func(*args, **kwargs)
 
 
 def check_call_env(*popenargs, **kwargs):


### PR DESCRIPTION
fixes #1412 

confirmed by building freexl for py27 and py35 on win.