### PR TITLE
fix perl file access error on win skeleton cpan

### DIFF
--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -157,12 +157,11 @@ def get_cpan_api_url(url, colons):
         url = url.replace("::", "-")
     with PerlTmpDownload(url) as json_path:
         try:
-            dist_json_file = gzip.open(json_path)
-            output = dist_json_file.read()
+            with gzip.open(json_path) as dist_json_file:
+                output = dist_json_file.read()
             if hasattr(output, "decode"):
                 output = output.decode('utf-8-sig')
             rel_dict = json.loads(output)
-            dist_json_file.close()
         except IOError:
             rel_dict = json.loads(open(json_path).read())
     return rel_dict


### PR DESCRIPTION
Fixes errors as shown in https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/conda-build/build/1.0.783/job/pcj1jjhfkqce8xxl#L996 : 

```
_______________________ test_repo[perl-cpan-Shell-Cmd-] _______________________
[gw0] win32 -- Python 3.5.2 C:\Miniconda35-x64\python.exe
Traceback (most recent call last):
  File "C:\projects\conda-build\tests\test_api_skeleton.py", line 21, in test_repo
    api.skeletonize(package, repo, version=version, output_dir=testing_workdir, config=test_config)
  File "C:\projects\conda-build\conda_build\api.py", line 192, in skeletonize
    recursive=recursive, config=config, **kwargs)
  File "C:\projects\conda-build\conda_build\skeletons\cpan.py", line 215, in skeletonize
    package = dist_for_module(meta_cpan_url, package, perl_version, config=config)
  File "C:\Miniconda35-x64\lib\site-packages\conda\utils.py", line 45, in __call__
    value = self.func(*args, **kw)
  File "C:\projects\conda-build\conda_build\skeletons\cpan.py", line 547, in dist_for_module
    rel_dict = get_cpan_api_url('{0}/v0/release/{1}'.format(cpan_url, module), colons=False)
  File "C:\projects\conda-build\conda_build\skeletons\cpan.py", line 167, in get_cpan_api_url
    rel_dict = json.loads(open(json_path).read())
  File "C:\Miniconda35-x64\lib\site-packages\conda\fetch.py", line 487, in __exit__
    shutil.rmtree(self.tmp_dir)
  File "C:\Miniconda35-x64\lib\shutil.py", line 488, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Miniconda35-x64\lib\shutil.py", line 383, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Miniconda35-x64\lib\shutil.py", line 381, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\tmp6aemqixh\\Shell-Cmd'
```