### PR TITLE
post: Fixes and a test for fix_permissions

### DIFF
--- a/conda_build/_link.py
+++ b/conda_build/_link.py
@@ -82,7 +82,7 @@ def create_script(fn):
         with open(dst, 'w') as fo:
             fo.write('#!%s\n' % normpath(sys.executable))
             fo.write(data)
-        os.chmod(dst, 0o755)
+        os.chmod(dst, 0o775)
         FILES.append('bin/%s' % fn)
 
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -96,10 +96,10 @@ def create_post_scripts(m, config):
         dst_dir = join(config.build_prefix,
                        'Scripts' if on_win else 'bin')
         if not isdir(dst_dir):
-            os.makedirs(dst_dir, int('755', 8))
+            os.makedirs(dst_dir, 0o775)
         dst = join(dst_dir, '.%s-%s%s' % (m.name(), tp, ext))
         copy_into(src, dst, config.timeout)
-        os.chmod(dst, int('755', 8))
+        os.chmod(dst, 0o775)
 
 
 def have_prefix_files(files, prefix):

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -418,7 +418,7 @@ def create_entry_point(path, module, func, config):
         with open(path, 'w') as fo:
             fo.write('#!%s\n' % config.build_python)
             fo.write(pyscript)
-        os.chmod(path, int('755', 8))
+        os.chmod(path, 0o775)
 
 
 def create_entry_points(items, config):

--- a/tests/test-recipes/metadata/fix_permissions/README
+++ b/tests/test-recipes/metadata/fix_permissions/README
@@ -1,0 +1,1 @@
+Simple package to test fix_permissions.

--- a/tests/test-recipes/metadata/fix_permissions/meta.yaml
+++ b/tests/test-recipes/metadata/fix_permissions/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: fix_permissions
+  version: "1.0"
+
+source:
+  path: .
+
+build:
+  script:
+    - cp -rf "${SRC_DIR}"/* "${PREFIX}"/  # [unix]
+    - xcopy /s %SRC_DIR% %PREFIX%         # [win]

--- a/tests/test-recipes/metadata/fix_permissions/sub/lacks_grp_other_read_perms
+++ b/tests/test-recipes/metadata/fix_permissions/sub/lacks_grp_other_read_perms
@@ -1,0 +1,1 @@
+no_one_can_read

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -645,3 +645,12 @@ def test_skip_compile_pyc():
             assert basename == 'compile_pyc', "an unexpected .pyc was compiled: {}".format(filename)
             pyc_count = pyc_count+1
     assert pyc_count == 2, "there should be 2 .pyc files, instead there were {}".format(pyc_count)
+
+
+def test_fix_permissions():
+    recipe = os.path.join(metadata_dir, "fix_permissions")
+    fn = api.get_output_file_path(recipe)
+    api.build(recipe)
+    tf = tarfile.open(fn)
+    for f in tf.getmembers():
+        assert f.mode & 0o444 == 0o444, "tar member '{}' has invalid (read) mode".format(f.name)


### PR DESCRIPTION
We had a bug report https://github.com/ContinuumIO/anaconda-recipes/issues/52
where for some unknown reason qt.conf has no read permissions for
other, and our testing procedure did not spot this.

Our fix_permissions() function wasn't forcing read access. I took
the opportunity to change it in other ways too. Now, in total, it:

    1. Directories are all set to 0o755.
    2. Ensures the user can write to files.
    3. Broadcasts user execute to group and other for files.
    4. Ensures that user, group and other can read files.