### PR TITLE
consolidate get_site_packages defines throughout

### DIFF
--- a/conda_build/develop.py
+++ b/conda_build/develop.py
@@ -13,7 +13,7 @@ import sys
 from .conda_interface import string_types
 
 from conda_build.post import mk_relative_osx
-from conda_build.utils import _check_call, rec_glob
+from conda_build.utils import _check_call, rec_glob, get_site_packages
 from conda_build.os_utils.external import find_executable
 
 
@@ -60,22 +60,6 @@ def write_to_conda_pth(sp_dir, pkg_path):
         else:
             f.write(pkg_path + '\n')
             print("added " + pkg_path)
-
-
-def get_site_pkg(prefix, py_ver):
-    '''
-    Given the path to conda environment, find the site-packages directory
-
-    :param prefix: path to conda environment. Look here for current
-        environment's site-packages
-    :returns: absolute path to site-packages directory
-    '''
-    # get site-packages directory
-    stdlib_dir = join(prefix, 'Lib' if sys.platform == 'win32' else
-                      'lib/python%s' % py_ver)
-    sp_dir = join(stdlib_dir, 'site-packages')
-
-    return sp_dir
 
 
 def get_setup_py(path_):
@@ -162,8 +146,7 @@ Error: environment does not exist: %s
     assert find_executable('python', prefix=prefix)
 
     # current environment's site-packages directory
-    py_ver = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
-    sp_dir = get_site_pkg(prefix, py_ver)
+    sp_dir = get_site_packages(prefix)
 
     if type(recipe_dirs) == string_types:
         recipe_dirs = [recipe_dirs]

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -43,17 +43,8 @@ def get_npy_ver(config):
     return ''
 
 
-def get_stdlib_dir(config):
-    return join(config.build_prefix, 'Lib' if sys.platform == 'win32' else
-                'lib/python%s' % get_py_ver(config))
-
-
 def get_lua_include_dir(config):
     return join(config.build_prefix, "include")
-
-
-def get_sp_dir(config):
-    return join(get_stdlib_dir(config), 'site-packages')
 
 
 def verify_git_repo(git_dir, git_url, config, expected_rev='HEAD'):
@@ -261,8 +252,8 @@ def python_vars(config):
     d = {
         'PYTHON': config.build_python,
         'PY3K': str(config.PY3K),
-        'STDLIB_DIR': get_stdlib_dir(config),
-        'SP_DIR': get_sp_dir(config),
+        'STDLIB_DIR': utils.get_stdlib_dir(config.build_prefix),
+        'SP_DIR': utils.get_site_packages(config.build_prefix),
         'PY_VER': get_py_ver(config),
         'CONDA_PY': str(config.CONDA_PY),
     }

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -25,7 +25,6 @@ from .conda_interface import walk_prefix
 from .conda_interface import md5_file
 from .conda_interface import PY3
 
-from conda_build import environ
 from conda_build import utils
 
 if sys.platform.startswith('linux'):
@@ -86,7 +85,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
 
 def write_pth(egg_path, config):
     fn = basename(egg_path)
-    with open(join(environ.get_sp_dir(config),
+    with open(join(utils.get_site_packages(config.build_prefix),
                    '%s.pth' % (fn.split('-')[0])), 'w') as fo:
         fo.write('./%s\n' % fn)
 
@@ -97,7 +96,7 @@ def remove_easy_install_pth(files, prefix, config, preserve_egg_dir=False):
     itself
     """
     absfiles = [join(prefix, f) for f in files]
-    sp_dir = environ.get_sp_dir(config)
+    sp_dir = utils.get_site_packages(prefix)
     for egg_path in glob(join(sp_dir, '*-py*.egg')):
         if isdir(egg_path):
             if preserve_egg_dir or not any(join(egg_path, i) in absfiles for i
@@ -202,7 +201,8 @@ def post_process(files, prefix, config, preserve_egg_dir=False, noarch=False, sk
     if noarch:
         rm_pyc(files, prefix)
     else:
-        compile_missing_pyc(files, cwd=prefix, python_exe=config.build_python, skip_compile_pyc=skip_compile_pyc)
+        compile_missing_pyc(files, cwd=prefix, python_exe=config.build_python,
+                            skip_compile_pyc=skip_compile_pyc)
     remove_easy_install_pth(files, prefix, config, preserve_egg_dir=preserve_egg_dir)
     rm_py_along_so(prefix)
 
@@ -406,7 +406,7 @@ def fix_permissions(files, prefix):
         if old_mode & stat.S_IXUSR:
             new_mode = new_mode | stat.S_IXGRP | stat.S_IXOTH
         # ensure user and group can write and all can read
-        new_mode = new_mode | stat.S_IWUSR | stat.S_IWGRP | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+        new_mode = new_mode | stat.S_IWUSR | stat.S_IWGRP | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH  # noqa
         if old_mode != new_mode:
             lchmod(path, new_mode)
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -344,11 +344,24 @@ def path2url(path):
     return urlparse.urljoin('file:', urllib.pathname2url(path))
 
 
-def get_site_packages(prefix):
+def get_stdlib_dir(prefix):
     if sys.platform == 'win32':
-        sp = os.path.join(prefix, 'Lib', 'site-packages')
+        stdlib_dir = os.path.join(prefix, 'Lib', 'site-packages')
     else:
-        sp = os.path.join(prefix, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+        lib_dir = os.path.join(prefix, 'lib')
+        stdlib_dir = glob(os.path.join(lib_dir, 'python[0-9\.]*'))
+        if not stdlib_dir:
+            stdlib_dir = ''
+        else:
+            stdlib_dir = stdlib_dir[0]
+    return stdlib_dir
+
+
+def get_site_packages(prefix):
+    stdlib_dir = get_stdlib_dir(prefix)
+    sp = ''
+    if stdlib_dir:
+        sp = os.path.join(stdlib_dir, 'site-packages')
     return sp
 
 

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -7,6 +7,8 @@ from os.path import dirname, join, exists
 from conda_build.develop import _uninstall, write_to_conda_pth
 from conda_build.utils import rm_rf
 
+from .utils import testing_workdir
+
 import pytest
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,16 @@ def makefile(name, contents=""):
         f.write(contents)
 
 
+@pytest.mark.skipif(utils.on_win, reason="only unix has python version in site-packages path")
+def test_get_site_packages(testing_workdir):
+    # https://github.com/conda/conda-build/issues/1055#issuecomment-250961576
+
+    # crazy unreal python version that should show up in a second
+    crazy_path = os.path.join(testing_workdir, 'lib', 'python8.2', 'site-packages')
+    os.makedirs(crazy_path)
+    site_packages = utils.get_site_packages(testing_workdir)
+    assert site_packages == crazy_path
+
 
 @pytest.fixture(scope='function')
 def namespace_setup(testing_workdir, request):


### PR DESCRIPTION
This should address https://github.com/conda/conda-build/issues/1055#issuecomment-250961576 in which the site-packages folder being computed didn't actually match the site-packages folder in a given environment.  That was caused by the root environment determining the python version, which was incorrect for develop installations into non-root prefixes.

cc @jorisvandenbossche