### PR TITLE
Add regex Jinja preprocessor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Testing
 -------
 
 Running our test suite requires cloning one other repo at the same level as conda-build:
-https://github.com/conda/conda_build_test_repo - this is necessary for relative path tests
+https://github.com/conda/conda_build_test_recipe - this is necessary for relative path tests
 outside of conda build's build tree.
 
 The test suite runs with py.test. Some useful commands to run select tests,

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -167,15 +167,12 @@ def load_npm():
         return json.load(pkg)
 
 
-def load_file_regex(config, load_file=None, regex_pattern=None, from_recipe_dir=False,
+def load_file_regex(config, load_file, regex_pattern, from_recipe_dir=False,
                     recipe_dir=None, permit_undefined_jinja=True):
     import re
     match = False
 
     cd_to_work = False
-
-    if load_file is None:
-        raise RuntimeError('File to be searched is not specified.')
 
     if from_recipe_dir and recipe_dir:
         load_file = os.path.abspath(os.path.join(recipe_dir, load_file))

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -1,8 +1,3 @@
-'''
-Created on Jan 16, 2014
-
-@author: sean
-'''
 from __future__ import absolute_import, division, print_function
 
 from functools import partial
@@ -138,6 +133,9 @@ def load_setup_py_data(config, setup_file='setup.py', from_recipe_dir=False, rec
     if os.path.isfile(setup_file):
         code = compile(open(setup_file).read(), setup_file, 'exec', dont_inherit=1)
         exec(code, ns, ns)
+    else:
+        if not permit_undefined_jinja:
+            raise TypeError('{} is not a file that can be read'.format(setup_file))
 
     sys.modules['versioneer'] = versioneer
 
@@ -194,7 +192,8 @@ def load_file_regex(config, load_file, regex_pattern, from_recipe_dir=False,
     if os.path.isfile(load_file):
         match = re.search(regex_pattern, open(load_file, 'r').read())
     else:
-        raise TypeError('{} is not a file that can be read'.format(load_file))
+        if not permit_undefined_jinja:
+            raise TypeError('{} is not a file that can be read'.format(load_file))
 
     # Reset the working directory
     if cd_to_work:

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -193,6 +193,8 @@ def load_file_regex(config, load_file, regex_pattern, from_recipe_dir=False,
 
     if os.path.isfile(load_file):
         match = re.search(regex_pattern, open(load_file, 'r').read())
+    else:
+        raise TypeError('{} is not a file that can be read'.format(load_file))
 
     # Reset the working directory
     if cd_to_work:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -854,6 +854,10 @@ class MetaData(object):
         return "load_file_regex" in meta_text
 
     @property
+    def needs_source_for_render(self):
+        return self.uses_vcs_in_meta or self.uses_setup_py_in_meta or self.uses_regex_in_meta
+
+    @property
     def uses_jinja(self):
         if not self.meta_path:
             return False

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -848,6 +848,12 @@ class MetaData(object):
         return "load_setup_py_data" in meta_text or "load_setuptools" in meta_text
 
     @property
+    def uses_regex_in_meta(self):
+        with open(self.meta_path) as f:
+            meta_text = f.read()
+        return "load_file_regex" in meta_text
+
+    @property
     def uses_jinja(self):
         if not self.meta_path:
             return False

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -78,7 +78,8 @@ def parse_or_try_download(metadata, no_download_source, config,
 
     need_reparse_in_env = False
     if (force_download or (not no_download_source and (metadata.uses_vcs_in_meta or
-                                                       metadata.uses_setup_py_in_meta))):
+                                                       metadata.uses_setup_py_in_meta or
+                                                       metadata.uses_regex_in_meta))):
 
         # this try/catch is for when the tool to download source is actually in
         #    meta.yaml, and not previously installed in builder env.

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -77,10 +77,7 @@ def parse_or_try_download(metadata, no_download_source, config,
                           force_download=False):
 
     need_reparse_in_env = False
-    if (force_download or (not no_download_source and (metadata.uses_vcs_in_meta or
-                                                       metadata.uses_setup_py_in_meta or
-                                                       metadata.uses_regex_in_meta))):
-
+    if (force_download or (not no_download_source and metadata.needs_source_for_render)):
         # this try/catch is for when the tool to download source is actually in
         #    meta.yaml, and not previously installed in builder env.
         try:

--- a/tests/test-recipes/metadata/source_regex/bld.bat
+++ b/tests/test-recipes/metadata/source_regex/bld.bat
@@ -1,0 +1,11 @@
+if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
+git describe --tags --dirty
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
+if errorlevel 1 exit 1
+echo "%gitdesc%"
+if not "%gitdesc%"=="1.21.0" exit 1
+echo "%PKG_VERSION%"
+if not "%PKG_VERSION%"=="1.21.0" exit 1

--- a/tests/test-recipes/metadata/source_regex/build.sh
+++ b/tests/test-recipes/metadata/source_regex/build.sh
@@ -1,0 +1,8 @@
+# We test the environment variables in a different recipe
+
+# Ensure we are in a git repo
+[ -d .git ]
+git describe
+[ "$(git describe)" = 1.21.0 ]
+echo "\$PKG_VERSION = $PKG_VERSION"
+[ "${PKG_VERSION}" = 1.21.0 ]

--- a/tests/test-recipes/metadata/source_regex/meta.yaml
+++ b/tests/test-recipes/metadata/source_regex/meta.yaml
@@ -1,0 +1,26 @@
+# This recipe exercises the use of GIT_ variables in jinja template strings,
+# including use cases involving expressions such as FOO[:7] or FOO.replace(...)
+
+# it uses load_setup_py_data from conda_build.jinja_context to populate some fields
+# with values fed from setuptools.
+
+{% set data = load_file_regex(load_file='meta.yaml', regex_pattern='git_tag: ([\\d.]+)', from_recipe_dir=True) %}
+
+package:
+  name: conda-build-test-get-regex-data
+  version: {{ data.group(1) }}
+
+source:
+  git_url: ../../../../../conda_build_test_recipe
+  git_tag: 1.21.0
+
+build:
+  entry_points:
+    - entry = conda_version_test.manual_entry:main
+
+requirements:
+  build:
+    - python {{ PY_VER }}*
+    # cython inclusion here is to test https://github.com/conda/conda-build/issues/149
+    # cython chosen because it is implicated somehow in setup.py complications.  Numpy would also work.
+    - cython

--- a/tests/test-recipes/metadata/source_regex/meta.yaml
+++ b/tests/test-recipes/metadata/source_regex/meta.yaml
@@ -1,8 +1,8 @@
 # This recipe exercises the use of GIT_ variables in jinja template strings,
 # including use cases involving expressions such as FOO[:7] or FOO.replace(...)
 
-# it uses load_setup_py_data from conda_build.jinja_context to populate some fields
-# with values fed from setuptools.
+# it uses load_file_regex from conda_build.jinja_context to populate some fields
+# with values fed from meta.yaml files.
 
 {% set data = load_file_regex(load_file='meta.yaml', regex_pattern='git_tag: ([\\d.]+)', from_recipe_dir=True) %}
 

--- a/tests/test-recipes/metadata/source_regex_from_recipe_dir/bld.bat
+++ b/tests/test-recipes/metadata/source_regex_from_recipe_dir/bld.bat
@@ -7,6 +7,5 @@ for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
 if errorlevel 1 exit 1
 echo "%gitdesc%"
 if not "%gitdesc%"=="1.21.0" exit 1
-:: This looks weird, but it reflects accurately the meta.yaml in conda_build_test_recipe at 1.21.0 tag
 echo "%PKG_VERSION%"
-if not "%PKG_VERSION%"=="1.20.2" exit 1
+if not "%PKG_VERSION%"=="1.21.0" exit 1

--- a/tests/test-recipes/metadata/source_regex_from_recipe_dir/build.sh
+++ b/tests/test-recipes/metadata/source_regex_from_recipe_dir/build.sh
@@ -4,6 +4,5 @@
 [ -d .git ]
 git describe
 [ "$(git describe)" = 1.21.0 ]
-# This looks weird, but it reflects accurately the meta.yaml in conda_build_test_recipe at 1.21.0 tag
 echo "\$PKG_VERSION = $PKG_VERSION"
-[ "${PKG_VERSION}" = 1.20.2 ]
+[ "${PKG_VERSION}" = 1.21.0 ]

--- a/tests/test-recipes/metadata/source_regex_from_recipe_dir/meta.yaml
+++ b/tests/test-recipes/metadata/source_regex_from_recipe_dir/meta.yaml
@@ -3,7 +3,7 @@
 # it uses load_file_regex from conda_build.jinja_context to populate some fields
 # with values fed from meta.yaml files.
 
-{% set data = load_file_regex(load_file='meta.yaml', regex_pattern='git_tag: ([\\d.]+)') %}
+{% set data = load_file_regex(load_file='meta.yaml', regex_pattern='git_tag: ([\\d.]+)', from_recipe_dir=True) %}
 
 package:
   name: conda-build-test-get-regex-data


### PR DESCRIPTION
This PR adds a preprocessor function in the same vein as `load_setup_py_data` for the meta.yaml file. It takes a file and regex string as arguments, and returns the `match` object from a `search` of the given file. This is related to #1316 

The use case for this is to grab version and other information that is specified in files other than `setup.py`. This may be common, for instance, for packages that have multiple language interfaces and want to specify the version number in a Makefile or its equivalent so that the same version is used for all the interfaces during a build.

The only issue that I had in implementing this was that Jinja2 doesn't like Python raw strings, so the backslashes in the regex string have to be escaped by doubling where they're specified in the meta.yaml file. The specific error was `jinja2: TemplateSyntaxError: expected token ',', got 'string'` I'm not sure if this is an issue with my implementation, or a general issue with Jinja2.

If I should add or remove anything from this PR (such as the link fix in the README), please let me know.