### PR TITLE
change metadata test output filenames to avoid race conditions

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,31 +178,35 @@ def test_metapackage(test_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test', '1.0', '-d', 'bzip2']
     main_metapackage.execute(args)
-    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir, 'metapackage_test-1.0-0.tar.bz2')
+    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir,
+                             'metapackage_test-1.0-0.tar.bz2')
     assert os.path.isfile(test_path)
 
 
 def test_metapackage_build_number(test_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
-    args = ['metapackage_test', '1.0', '-d', 'bzip2', '--build-number', '1']
+    args = ['metapackage_test_build_number', '1.0', '-d', 'bzip2', '--build-number', '1']
     main_metapackage.execute(args)
-    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir, 'metapackage_test-1.0-1.tar.bz2')
+    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir,
+                             'metapackage_test_build_number-1.0-1.tar.bz2')
     assert os.path.isfile(test_path)
 
 
 def test_metapackage_build_string(test_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
-    args = ['metapackage_test', '1.0', '-d', 'bzip2', '--build-string', 'frank']
+    args = ['metapackage_test_build_string', '1.0', '-d', 'bzip2', '--build-string', 'frank']
     main_metapackage.execute(args)
-    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir, 'metapackage_test-1.0-frank.tar.bz2')
+    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir,
+                             'metapackage_test_build_string-1.0-frank.tar.bz2')
     assert os.path.isfile(test_path)
 
 
 def test_metapackage_metadata(test_config, testing_workdir):
-    args = ['metapackage_test', '1.0', '-d', 'bzip2', "--home", "http://abc.com", "--summary", "wee",
-            "--license", "BSD"]
+    args = ['metapackage_test_metadata', '1.0', '-d', 'bzip2', "--home", "http://abc.com",
+            "--summary", "wee", "--license", "BSD"]
     main_metapackage.execute(args)
-    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir, 'metapackage_test-1.0-0.tar.bz2')
+    test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir,
+                             'metapackage_test_metadata-1.0-0.tar.bz2')
     assert os.path.isfile(test_path)
     info = json.loads(package_has_file(test_path, 'info/index.json').decode('utf-8'))
     assert info['license'] == 'BSD'


### PR DESCRIPTION
Should fix sporadic failures we're seeing on Travis.