### PR TITLE
Run `ldd` after `patchelf`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1026,6 +1026,16 @@ def tests_failed(m, move_broken, broken_dir, config):
 
 def check_external():
     if sys.platform.startswith('linux'):
+        ldd = external.find_executable('ldd')
+        if ldd is None:
+            sys.exit("""\
+Error:
+    Did not find 'ldd' in: %s
+    'ldd' is necessary for building conda packages on Linux with
+    relocatable ELF libraries.  Please install with your system package
+    manager.
+""" % (os.pathsep.join(external.dir_paths)))
+
         patchelf = external.find_executable('patchelf')
         if patchelf is None:
             sys.exit("""\

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -329,6 +329,7 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
     elf = join(prefix, f)
     origin = dirname(elf)
 
+    ldd = external.find_executable('ldd')
     patchelf = external.find_executable('patchelf', prefix)
     try:
         existing = check_output([patchelf, '--print-rpath', elf]).decode('utf-8').splitlines()[0]
@@ -366,6 +367,8 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
     rpath = ':'.join(new)
     print('patchelf: file: %s\n    setting rpath to: %s' % (elf, rpath))
     call([patchelf, '--force-rpath', '--set-rpath', rpath, elf])
+    print('ldd: file: %s' % (elf,))
+    call([ldd, elf])
 
 
 def assert_relative_osx(path, prefix):


### PR DESCRIPTION
On Mac, when running `install_name_tool`, `conda-build` often provides some very helpful information about what things are linked to for free thanks to this [line](https://github.com/conda/conda-build/blob/714c1890c0ef0807648d52b6362f750baa539e54/conda_build/post.py#L252). However, we don't do a similar thing on Linux when running `patchelf`. This change runs `ldd` on each ELF after running `patchelf`. That way users have equivalent info in their logs about what things are linked to.
