### PR TITLE
restore script exe creation on windows

### DIFF
--- a/tests/test-recipes/metadata/_script_win_creates_exe/meta.yaml
+++ b/tests/test-recipes/metadata/_script_win_creates_exe/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: script_win_creates_exe
+  version: 1.0
+
+source:
+  path: .
+
+build:
+  script: python setup.py install
+
+requirements:
+  build:
+    - python

--- a/tests/test-recipes/metadata/_script_win_creates_exe/setup.py
+++ b/tests/test-recipes/metadata/_script_win_creates_exe/setup.py
@@ -1,0 +1,5 @@
+from distutils.core import setup
+setup(name='foobar',
+      version='1.0',
+      scripts=['test-script']
+      )

--- a/tests/test-recipes/metadata/_script_win_creates_exe/test-script
+++ b/tests/test-recipes/metadata/_script_win_creates_exe/test-script
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import sys
+print(sys.version)


### PR DESCRIPTION
This was removed sometime in the 2.0 transition.  There's no reason for that - it is helpful.  Restore it and test it.

Fixes #1468 