### PR TITLE
fix noarch value propagation from meta.yaml to config

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -248,7 +248,7 @@ def detect_and_record_prefix_files(m, files, prefix, config):
         else:
             files_with_prefix = []
 
-    is_noarch = m.get_value('build/noarch_python') or is_noarch_python(m)
+    is_noarch = m.get_value('build/noarch_python') or is_noarch_python(m) or m.get_value('build/noarch')
 
     if files_with_prefix and not is_noarch:
         if on_win:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -109,6 +109,8 @@ def parse_or_try_download(metadata, no_download_source, config,
             metadata.parse_until_resolved(config=config)
         except exceptions.UnableToParseMissingSetuptoolsDependencies:
             need_reparse_in_env = True
+    if metadata.get_value('build/noarch'):
+        config.noarch = True
     return metadata, need_source_download, need_reparse_in_env
 
 


### PR DESCRIPTION
This fixes an issue where if one has a config object passed in, like so:

api.build('some_recipe_path', config=config)

then the noarch value in meta.yaml does not affect the config.noarch value, leading to inaccurate output folders.