### PR TITLE
Fix/license family

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+2016-11-01 2.0.8:
+-----------------
+
+Enhancements:
+-------------
+
+* Improved logic to guess the appropriate license_family to add to package's index. This improves filtering.
+* Logic for the license_family is now shared between open-source conda-build, and proprietary cas-mirror packages.
+
+Contributors:
+-------------
+
+* @caseyclements
+* @minrk
+* @msarahan
+
 2016-10-24 2.0.7:
 -----------------
 

--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -23,7 +23,7 @@ NONE
 # regular expressions
 gpl2_regex = re.compile('GPL[^3]*2')  # match GPL2
 gpl3_regex = re.compile('GPL[^2]*3')  # match GPL3
-gpl23_regex = re.compile('GPL *>= *2')  # match GPL >= 2
+gpl23_regex = re.compile('GPL[^2]*>= *2')  # match GPL >= 2
 punk_regex = re.compile('[%s]' % re.escape(string.punctuation))  # removes punks
 
 

--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -1,0 +1,108 @@
+from __future__ import absolute_import, division, print_function
+
+from difflib import get_close_matches
+import re
+import string
+
+allowed_license_families = """
+AGPL
+LGPL
+GPL3
+GPL2
+GPL
+BSD
+MIT
+APACHE
+PSF
+PUBLICDOMAIN
+PROPRIETARY
+OTHER
+NONE
+""".split()
+
+# regular expressions
+gpl2_regex = re.compile('GPL[^3]*2')  # match GPL2
+gpl3_regex = re.compile('GPL[^2]*3')  # match GPL3
+gpl23_regex = re.compile('GPL *>= *2')  # match GPL >= 2
+punk_regex = re.compile('[%s]' % re.escape(string.punctuation))  # removes punks
+
+
+def match_gpl3(family):
+    """True if family matches GPL3 and GPL >= 2, else False"""
+    return (gpl23_regex.search(family) or
+            gpl3_regex.search(family))
+
+
+def normalize(s):
+    """Set to ALL CAPS, replace common GPL patterns, and strip"""
+    s = s.upper()
+    s = re.sub('GENERAL PUBLIC LICENSE', 'GPL', s)
+    s = re.sub('LESSER *', 'L', s)
+    s = re.sub('AFFERO *', 'A', s)
+    return s.strip()
+
+
+def remove_special_characters(s):
+    """Remove punctuation, spaces, tabs, and line feeds"""
+    s = punk_regex.sub(' ', s)
+    s = re.sub('\s+', '', s)
+    return s
+
+
+def guess_license_family_from_index(index=None,
+                                    recognized=allowed_license_families):
+    """Return best guess of license_family from the conda package index.
+
+    Note: Logic here is simple, and focuses on existing set of allowed families
+    """
+
+    if isinstance(index, dict):
+        license_name = index.get('license_family', index.get('license'))
+    else:  # index argument is actually a string
+        license_name = index
+
+    return guess_license_family(license_name, recognized)
+
+
+def guess_license_family(license_name=None,
+                         recognized=allowed_license_families):
+    """Return best guess of license_family from the conda package index.
+
+    Note: Logic here is simple, and focuses on existing set of allowed families
+    """
+
+    if license_name is None:
+        return 'NONE'
+
+    license_name = normalize(license_name)
+
+    # Handle GPL families as special cases
+    # Remove AGPL and LGPL before looking for GPL2 and GPL3
+    sans_lgpl = re.sub('[A,L]GPL', '', license_name)
+    if match_gpl3(sans_lgpl):
+        return 'GPL3'
+    elif gpl2_regex.search(sans_lgpl):
+        return 'GPL2'
+
+    license_name = remove_special_characters(license_name)
+    for family in recognized:
+        if family in license_name:
+            return family
+    for family in recognized:  # TODO - Necessary? What cases does this catch?
+        if license_name in family:
+            return family
+    return 'OTHER'
+
+
+def deprecated_guess_license_family(license_name, recognized=allowed_license_families):
+    """Deprecated guess of license_family from license
+
+    Use fuzzy_license_family instead
+    """
+    # Tend towards the more clear GPL3 and away from the ambiguity of GPL2.
+    if 'GPL (>= 2)' in license_name or license_name == 'GPL':
+        return 'GPL3'
+    elif 'LGPL' in license_name:
+        return 'LGPL'
+    else:
+        return get_close_matches(license_name, recognized, 1, 0.0)[0]

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -16,6 +16,7 @@ from conda_build import exceptions
 from conda_build.features import feature_list
 from conda_build.config import Config
 from conda_build.utils import rec_glob, ensure_list
+from conda_build.license_family import allowed_license_families
 
 try:
     import yaml
@@ -134,22 +135,6 @@ def yamlize(data):
             except ImportError:
                 raise exceptions.UnableToParseMissingJinja2(original=e)
         raise exceptions.UnableToParse(original=e)
-
-
-allowed_license_families = set("""
-AGPL
-Apache
-BSD
-GPL
-GPL2
-GPL3
-LGPL
-MIT
-Other
-PSF
-Proprietary
-Public-Domain
-""".split())
 
 
 def ensure_valid_license_family(meta):

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -23,9 +23,10 @@ except ImportError:
 
 from conda_build import source, metadata
 from conda_build.config import Config
-from conda_build.utils import rm_rf, guess_license_family
+from conda_build.utils import rm_rf
 from conda_build.conda_interface import text_type, iteritems
 from conda_build.conda_interface import Completer
+from conda_build.license_family import allowed_license_families, guess_license_family
 
 CRAN_META = """\
 {{% set posix = 'm2-' if win else '' %}}
@@ -582,8 +583,7 @@ def skeletonize(packages, output_dir=".", version=None, git_tag=None,
 
         # XXX: We should maybe normalize these
         d['license'] = cran_package.get("License", "None")
-        d['license_family'] = guess_license_family(d['license'],
-                                                         metadata.allowed_license_families)
+        d['license_family'] = guess_license_family(d['license'], allowed_license_families)
 
         if 'License_is_FOSS' in cran_package:
             d['license'] += ' (FOSS)'

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -29,11 +29,12 @@ from conda_build.conda_interface import normalized_version
 from conda_build.conda_interface import human_bytes, hashsum_file
 from conda_build.conda_interface import default_python
 
-from conda_build.utils import tar_xf, unzip, rm_rf, guess_license_family
+from conda_build.utils import tar_xf, unzip, rm_rf
 from conda_build.source import apply_patch
 from conda_build.build import create_env
 from conda_build.config import Config
-from conda_build.metadata import MetaData, allowed_license_families
+from conda_build.metadata import MetaData
+from conda_build.license_family import allowed_license_families, guess_license_family
 
 if PY3:
     try:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -513,17 +513,6 @@ def create_entry_points(items, config):
         create_entry_point(join(bin_dir, cmd), module, func, config)
 
 
-def guess_license_family(license_name, allowed_license_families):
-    # Tend towards the more clear GPL3 and away from the ambiguity of GPL2.
-    if 'GPL (>= 2)' in license_name or license_name == 'GPL':
-        return 'GPL3'
-    elif 'LGPL' in license_name:
-        return 'LGPL'
-    else:
-        return get_close_matches(license_name,
-                                 allowed_license_families, 1, 0.0)[0]
-
-
 # Return all files in dir, and all its subdirectories, ending in pattern
 def get_ext_files(start_path, pattern):
     for root, _, files in os.walk(start_path):

--- a/tests/test_license_family.py
+++ b/tests/test_license_family.py
@@ -1,13 +1,9 @@
 from conda_build.license_family import guess_license_family, deprecated_guess_license_family
+from conda_build.license_family import allowed_license_families
 
 
-def test_guess_license_family_matching():
-    cens = "GPL"
-    fam = guess_license_family(cens)
-    assert fam == 'GPL'
-    prev = deprecated_guess_license_family(cens)
-    assert fam != prev, 'new and deprecated guesses are unexpectedly the same'
-    assert prev == 'GPL3'  # bizarre when GPL is an allowed license family
+def test_new_vs_previous_guesses_match():
+    """Test cases where new and deprecated functions match"""
 
     cens = "GPL (>= 3)"
     fam = guess_license_family(cens)
@@ -33,13 +29,125 @@ def test_guess_license_family_matching():
     prev = deprecated_guess_license_family(cens)
     assert fam == prev, 'new and deprecated guesses differ'
 
+
+def test_new_vs_previous_guess_differ_gpl():
+    """Test cases where new and deprecated functions differ
+
+    license = 'GPL'
+    New guess is GPL, which is an allowed family, hence the most accurate.
+    Previously, GPL3 was chosen over GPL
+    """
+    cens = "GPL"
+    fam = guess_license_family(cens)
+    assert fam == 'GPL'
+    prev = deprecated_guess_license_family(cens)
+    assert fam != prev, 'new and deprecated guesses are unexpectedly the same'
+    assert prev == 'GPL3'  # bizarre when GPL is an allowed license family
+
+
+def test_new_vs_previous_guess_differ_multiple_gpl():
+    """Test cases where new and deprecated functions differ
+
+    license = 'GPL-2 | GPL-3 | file LICENSE'
+    New guess is GPL-3, which is the most accurate.
+    Previously, somehow PUBLICDOMAIN is closer than GPL2 or GPL3!
+    """
     cens = u'GPL-2 | GPL-3 | file LICENSE'
     fam = guess_license_family(cens)
     assert fam == 'GPL3', 'guess_license_family_from_index({}) is {}'.format(cens, fam)
     prev = deprecated_guess_license_family(cens)
     assert fam != prev, 'new and deprecated guesses are unexpectedly the same'
-    # Somehow PUBICDOMAIN is closer to cens than GPL2 or GPL3
     assert prev == 'PUBLICDOMAIN'
 
+
+def test_old_warnings_no_longer_fail():
+    # the following previously threw warnings. Came from r/linux-64
+    warnings = {u'MIT License', u'GNU Lesser General Public License (LGPL)',
+         u'GPL-2 | GPL-3 | file LICENSE', u'GPL (>= 3) | file LICENCE',
+         u'BSL-1.0', u'GPL (>= 2)', u'file LICENSE (FOSS)',
+         u'Open Source (http://www.libpng.org/pub/png/src/libpng-LICENSE.txt)',
+         u'MIT + file LICENSE', u'GPL-2 | GPL-3', u'GPL (>= 2) | file LICENSE',
+         u'Unlimited', u'GPL-3 | file LICENSE',
+         u'GNU General Public License v2 or later (GPLv2+)', u'LGPL-2.1',
+         u'LGPL-2', u'LGPL-3', u'GPL',
+         u'zlib (http://zlib.net/zlib_license.html)',
+         u'Free software (X11 License)', u'Custom free software license',
+         u'Old MIT', u'GPL 3', u'Apache License (== 2.0)', u'GPL (>= 3)', None,
+         u'LGPL (>= 2)', u'BSD_2_clause + file LICENSE', u'GPL-3', u'GPL-2',
+         u'BSD License and GNU Library or Lesser General Public License (LGPL)',
+         u'GPL-2 | file LICENSE', u'BSD_3_clause + file LICENSE', u'CC0',
+         u'MIT + file LICENSE | Unlimited', u'Apache License 2.0',
+         u'BSD License', u'Lucent Public License'}
+
+    for cens in warnings:
+        fam = guess_license_family(cens)
+        print('{}:{}'.format(cens, fam))
+        assert fam in allowed_license_families
+
+
+def test_gpl2():
+    licenses = {u'GPL (>= 2)', u'GNU General Public License v2 or later (GPLv2+)'
+                u'GPL-2', u'GPL-2 | file LICENSE'}
+    for cens in licenses:
+        fam = guess_license_family(cens)
+        assert fam == u'GPL2'
+
+
+def test_not_gpl2():
+    licenses = {u'GPL (>= 2)', u'LGPL (>= 2)', u'GPL',
+                u'LGPL-3', u'GPL 3', u'GPL (>= 3)',
+                u'Apache License (== 2.0)'}
+    for cens in licenses:
+        fam = guess_license_family(cens)
+        assert fam != u'GPL2'
+
+
+def test_gpl3():
+    licenses = {u'GPL 3', u'GPL-3', u'GPL-3 | file LICENSE',
+                u'GPL-2 | GPL-3 | file LICENSE', u'GPL (>= 3) | file LICENCE',
+                u'GPL (>= 2)', u'GPL-2 | GPL-3', u'GPL (>= 2) | file LICENSE'}
+    for cens in licenses:
+        fam = guess_license_family(cens)
+        assert fam == u'GPL3'
+
+
+def test_lgpl():
+    licenses = {u'GNU Lesser General Public License (LGPL)', u'LGPL-2.1',
+                u'LGPL-2', u'LGPL-3', u'LGPL (>= 2)',
+                u'BSD License and GNU Library or Lesser General Public License (LGPL)'}
+    for cens in licenses:
+        fam = guess_license_family(cens)
+        assert fam == u'LGPL'
+
+
+def test_mit():
+    licenses = {u'MIT License', u'MIT + file LICENSE', u'Old MIT'}
+    for cens in licenses:
+        fam = guess_license_family(cens)
+        assert fam == u'MIT'
+
+
+def test_unlimited():
+    """The following is an unfortunate case where MIT is in UNLIMITED
+
+    We could add words to filter out, but it would be hard to keep track of...
+    """
+    cens = u'Unlimited'
+    assert guess_license_family(cens) == 'MIT'
+
+
+def test_other():
+    licenses = {u'file LICENSE (FOSS)', u'CC0',
+                u'Open Source (http://www.libpng.org/pub/png/src/libpng-LICENSE.txt)',
+                u'zlib (http://zlib.net/zlib_license.html)',
+                u'Free software (X11 License)', u'Custom free software license'}
+    for cens in licenses:
+        fam = guess_license_family(cens)
+        assert fam == u'OTHER'
+
 if __name__ == '__main__':
-    test_guess_license_family_matching()
+    test_new_vs_previous_guesses_match()
+    #test_old_warnings_no_longer_fail()
+    #test_not_gpl2()
+    #test_other()
+    #test_gpl3()

--- a/tests/test_license_family.py
+++ b/tests/test_license_family.py
@@ -86,8 +86,8 @@ def test_old_warnings_no_longer_fail():
 
 
 def test_gpl2():
-    licenses = {u'GPL (>= 2)', u'GNU General Public License v2 or later (GPLv2+)'
-                u'GPL-2', u'GPL-2 | file LICENSE'}
+    licenses = {u'GPL-2', u'GPL-2 | file LICENSE',
+                u'GNU General Public License v2 or later (GPLv2+)'  }
     for cens in licenses:
         fam = guess_license_family(cens)
         assert fam == u'GPL2'
@@ -146,8 +146,9 @@ def test_other():
         assert fam == u'OTHER'
 
 if __name__ == '__main__':
-    test_new_vs_previous_guesses_match()
+    #test_new_vs_previous_guesses_match()
     #test_old_warnings_no_longer_fail()
     #test_not_gpl2()
     #test_other()
     #test_gpl3()
+    test_gpl2()

--- a/tests/test_license_family.py
+++ b/tests/test_license_family.py
@@ -1,0 +1,45 @@
+from conda_build.license_family import guess_license_family, deprecated_guess_license_family
+
+
+def test_guess_license_family_matching():
+    cens = "GPL"
+    fam = guess_license_family(cens)
+    assert fam == 'GPL'
+    prev = deprecated_guess_license_family(cens)
+    assert fam != prev, 'new and deprecated guesses are unexpectedly the same'
+    assert prev == 'GPL3'  # bizarre when GPL is an allowed license family
+
+    cens = "GPL (>= 3)"
+    fam = guess_license_family(cens)
+    assert fam == 'GPL3'
+    prev = deprecated_guess_license_family(cens)
+    assert fam == prev, 'new and deprecated guesses differ'
+
+    cens = 'GNU Lesser General Public License'
+    fam = guess_license_family(cens)
+    assert fam == 'LGPL', 'guess_license_family({}) is {}'.format(cens, fam)
+    prev = deprecated_guess_license_family(cens)
+    assert fam == prev, 'new and deprecated guesses differ'
+
+    cens = 'GNU General Public License some stuff then a 3 then stuff'
+    fam = guess_license_family(cens)
+    assert fam == 'GPL3', 'guess_license_family({}) is {}'.format(cens, fam)
+    prev = deprecated_guess_license_family(cens)
+    assert fam == prev, 'new and deprecated guesses differ'
+
+    cens = 'Affero GPL'
+    fam = guess_license_family(cens)
+    assert fam == 'AGPL', 'guess_license_family({}) is {}'.format(cens, fam)
+    prev = deprecated_guess_license_family(cens)
+    assert fam == prev, 'new and deprecated guesses differ'
+
+    cens = u'GPL-2 | GPL-3 | file LICENSE'
+    fam = guess_license_family(cens)
+    assert fam == 'GPL3', 'guess_license_family_from_index({}) is {}'.format(cens, fam)
+    prev = deprecated_guess_license_family(cens)
+    assert fam != prev, 'new and deprecated guesses are unexpectedly the same'
+    # Somehow PUBICDOMAIN is closer to cens than GPL2 or GPL3
+    assert prev == 'PUBLICDOMAIN'
+
+if __name__ == '__main__':
+    test_guess_license_family_matching()


### PR DESCRIPTION
  * improve logic used to filter by license_family.
  * make consistent with conda-build by moving logic to there.

Plan is to merge, then create a new release. See changelog