### PR TITLE
centralize locks for sharing within a process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
       fi
     fi
 
-  - conda install -q anaconda-client requests filelock jinja2 patchelf python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
+  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION pyflakes=1.1
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2
   - conda install -q pyflakes=1.1 pycrypto posix m2-git anaconda-client numpy
   - conda install -c conda-forge -q perl
   - conda update -q --all

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python
   run:
     - conda  >=4.1
+    - contextlib2   [py2]
     - filelock
     - jinja2
     - patchelf      [linux]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
   run:
     - conda  >=4.1
-    - contextlib2   [py2]
+    - contextlib2   [py<3]
     - filelock
     - jinja2
     - patchelf      [linux]

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -4,6 +4,7 @@ Module that does most of the heavy lifting for the ``conda build`` command.
 from __future__ import absolute_import, division, print_function
 
 from collections import deque
+from contextlib import nested
 import fnmatch
 from glob import glob
 import io
@@ -53,7 +54,7 @@ from conda_build.post import (post_process, post_build,
 from conda_build.utils import (rm_rf, _check_call, copy_into, on_win, get_build_folders,
                                silence_loggers, path_prepended, create_entry_points,
                                prepend_bin_path, codec, root_script_dir, print_skip_message,
-                               ensure_list)
+                               ensure_list, get_lock)
 from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
@@ -485,23 +486,24 @@ def create_env(prefix, specs, config, clear_cache=True):
                 for folder in locked_folders:
                     if not os.path.isdir(folder):
                         os.makedirs(folder)
-                    lock = filelock.SoftFileLock(join(folder, '.conda_lock'))
+                    lock = get_lock(join(folder, '.conda_lock'),
+                                                 timeout=config.timeout)
                     if not folder.endswith('pkgs'):
                         update_index(folder, config=config, lock=lock, could_be_mirror=False)
-                    lock.acquire(timeout=config.timeout)
                     locks.append(lock)
 
-                index = get_build_index(config=config, clear_cache=True)
+                with nested(*locks):
+                    index = get_build_index(config=config, clear_cache=True)
 
-                actions = plan.install_actions(prefix, index, specs)
-                if config.disable_pip:
-                    actions['LINK'] = [spec for spec in actions['LINK'] if not spec.startswith('pip-')]  # noqa
-                    actions['LINK'] = [spec for spec in actions['LINK'] if not spec.startswith('setuptools-')]  # noqa
-                plan.display_actions(actions, index)
-                if on_win:
-                    for k, v in os.environ.items():
-                        os.environ[k] = str(v)
-                plan.execute_actions(actions, index, verbose=config.debug)
+                    actions = plan.install_actions(prefix, index, specs)
+                    if config.disable_pip:
+                        actions['LINK'] = [spec for spec in actions['LINK'] if not spec.startswith('pip-')]  # noqa
+                        actions['LINK'] = [spec for spec in actions['LINK'] if not spec.startswith('setuptools-')]  # noqa
+                    plan.display_actions(actions, index)
+                    if on_win:
+                        for k, v in os.environ.items():
+                            os.environ[k] = str(v)
+                    plan.execute_actions(actions, index, verbose=config.debug)
             except (SystemExit, PaddingError, LinkError) as exc:
                 if (("too short in" in str(exc) or
                         'post-link failed for: openssl' in str(exc) or
@@ -520,23 +522,8 @@ def create_env(prefix, specs, config, clear_cache=True):
                     #   Setting this here is important because we use it below (symlink)
                     prefix = config.build_prefix
 
-                    for lock in locks:
-                        lock.release()
-                        if os.path.isfile(lock._lock_file):
-                            os.remove(lock._lock_file)
                     create_env(prefix, specs, config=config,
                                 clear_cache=clear_cache)
-                else:
-                    for lock in locks:
-                        lock.release()
-                        if os.path.isfile(lock._lock_file):
-                            os.remove(lock._lock_file)
-                    raise
-            finally:
-                for lock in locks:
-                    lock.release()
-                    if os.path.isfile(lock._lock_file):
-                        os.remove(lock._lock_file)
         warn_on_old_conda_build(index=index)
 
     # ensure prefix exists, even if empty, i.e. when specs are empty
@@ -683,7 +670,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
 
         print("Package:", m.dist())
 
-        with filelock.SoftFileLock(join(config.build_folder, ".conda_lock"),
+        with get_lock(join(config.build_folder, ".conda_lock"),
                                    timeout=config.timeout):
             # get_dir here might be just work, or it might be one level deeper,
             #    dependening on the source.
@@ -844,14 +831,8 @@ can lead to packages that include their dependencies.""" % meta_files))
 
 def clean_pkg_cache(dist, timeout):
     cc.pkgs_dirs = cc.pkgs_dirs[:1]
-    locks = []
-    for folder in cc.pkgs_dirs:
-        locks.append(filelock.SoftFileLock(join(folder, ".conda_lock")))
-
-    for lock in locks:
-        lock.acquire(timeout=timeout)
-
-    try:
+    locks = [get_lock(join(folder, ".conda_lock"), timeout=timeout) for folder in cc.pkgs_dirs]
+    with nested(*locks):
         rmplan = [
             'RM_EXTRACTED {0} local::{0}'.format(dist),
             'RM_FETCHED {0} local::{0}'.format(dist),
@@ -877,13 +858,6 @@ def clean_pkg_cache(dist, timeout):
                         del cache[pkg_id]
                 for entry in glob(os.path.join(folder, dist + '*')):
                     rm_rf(entry)
-    except:
-        raise
-    finally:
-        for lock in locks:
-            lock.release()
-            if os.path.isfile(lock._lock_file):
-                os.remove(lock._lock_file)
 
 
 def test(m, config, move_broken=True):
@@ -899,7 +873,7 @@ def test(m, config, move_broken=True):
 
     clean_pkg_cache(m.dist(), config.timeout)
 
-    with filelock.SoftFileLock(join(config.build_folder, ".conda_lock"), timeout=config.timeout):
+    with get_lock(join(config.build_folder, ".conda_lock"), timeout=config.timeout):
         tmp_dir = config.test_dir
         if not isdir(tmp_dir):
             os.makedirs(tmp_dir)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -4,6 +4,7 @@ Functions related to creating repodata index files.
 
 from __future__ import absolute_import, division, print_function
 
+from contextlib import nested
 import os
 import bz2
 import sys
@@ -11,9 +12,7 @@ import json
 import tarfile
 from os.path import isfile, join, getmtime
 
-import filelock
-
-from conda_build.utils import file_info
+from conda_build.utils import file_info, get_lock
 from .conda_interface import PY3, md5_file
 
 
@@ -21,43 +20,37 @@ def read_index_tar(tar_path, config, lock=None):
     """ Returns the index.json dict inside the given package tarball. """
 
     if not lock:
-        lock = filelock.SoftFileLock(join(os.path.dirname(tar_path), ".conda_lock"))
-    lock.acquire(timeout=config.timeout)
-    try:
-        with tarfile.open(tar_path) as t:
-            try:
-                return json.loads(t.extractfile('info/index.json').read().decode('utf-8'))
-            except EOFError:
-                raise RuntimeError("Could not extract %s. File probably corrupt."
-                    % tar_path)
-            except OSError as e:
-                raise RuntimeError("Could not extract %s (%s)" % (tar_path, e))
-    except tarfile.ReadError:
-        raise RuntimeError("Could not extract metadata from %s. "
+        lock = get_lock(join(os.path.dirname(tar_path), ".conda_lock"),
+                                     timeout=config.timeout)
+    with nested(lock, tarfile.open(tar_path)) as (_, t):
+        try:
+            return json.loads(t.extractfile('info/index.json').read().decode('utf-8'))
+        except EOFError:
+            raise RuntimeError("Could not extract %s. File probably corrupt."
+                % tar_path)
+        except OSError as e:
+            raise RuntimeError("Could not extract %s (%s)" % (tar_path, e))
+        except tarfile.ReadError:
+            raise RuntimeError("Could not extract metadata from %s. "
                             "File probably corrupt." % tar_path)
-    finally:
-        lock.release()
 
 
-def write_repodata(repodata, dir_path, config=None, lock=None):
+def write_repodata(repodata, dir_path, lock, config=None):
     """ Write updated repodata.json and repodata.json.bz2 """
     if not config:
         import conda_build.config
         config = conda_build.config.config
-    if not lock:
-        lock = filelock.SoftFileLock(join(dir_path, ".conda_lock"))
-    lock.acquire(timeout=config.timeout)
-    data = json.dumps(repodata, indent=2, sort_keys=True)
-    # strip trailing whitespace
-    data = '\n'.join(line.rstrip() for line in data.splitlines())
-    # make sure we have newline at the end
-    if not data.endswith('\n'):
-        data += '\n'
-    with open(join(dir_path, 'repodata.json'), 'w') as fo:
-        fo.write(data)
-    with open(join(dir_path, 'repodata.json.bz2'), 'wb') as fo:
-        fo.write(bz2.compress(data.encode('utf-8')))
-    lock.release()
+    with lock:
+        data = json.dumps(repodata, indent=2, sort_keys=True)
+        # strip trailing whitespace
+        data = '\n'.join(line.rstrip() for line in data.splitlines())
+        # make sure we have newline at the end
+        if not data.endswith('\n'):
+            data += '\n'
+        with open(join(dir_path, 'repodata.json'), 'w') as fo:
+            fo.write(data)
+        with open(join(dir_path, 'repodata.json.bz2'), 'wb') as fo:
+            fo.write(bz2.compress(data.encode('utf-8')))
 
 
 def update_index(dir_path, config, force=False, check_md5=False, remove=True, lock=None,
@@ -82,68 +75,67 @@ def update_index(dir_path, config, force=False, check_md5=False, remove=True, lo
         os.makedirs(dir_path)
 
     if not lock:
-        lock = filelock.SoftFileLock(join(dir_path, ".conda_lock"))
-    lock.acquire(timeout=config.timeout)
+        lock = get_lock(join(dir_path, ".conda_lock"))
 
-    if force:
-        index = {}
-    else:
-        try:
-            mode_dict = {'mode': 'r', 'encoding': 'utf-8'} if PY3 else {'mode': 'rb'}
-            with open(index_path, **mode_dict) as fi:
-                index = json.load(fi)
-        except (IOError, ValueError):
+    with lock:
+        if force:
             index = {}
-
-    files = set(fn for fn in os.listdir(dir_path) if fn.endswith('.tar.bz2'))
-    if could_be_mirror and any(fn.startswith('_license-') for fn in files):
-        sys.exit("""\
-Error:
-    Indexing a copy of the Anaconda conda package channel is neither
-    necessary nor supported.  If you wish to add your own packages,
-    you can do so by adding them to a separate channel.
-""")
-    for fn in files:
-        path = join(dir_path, fn)
-        if fn in index:
-            if check_md5:
-                if index[fn]['md5'] == md5_file(path):
-                    continue
-            elif index[fn]['mtime'] == getmtime(path):
-                continue
-        if config.verbose:
-            print('updating:', fn)
-        d = read_index_tar(path, config, lock=lock)
-        d.update(file_info(path))
-        index[fn] = d
-
-    for fn in files:
-        index[fn]['sig'] = '.' if isfile(join(dir_path, fn + '.sig')) else None
-
-    if remove:
-        # remove files from the index which are not on disk
-        for fn in set(index) - files:
-            if config.verbose:
-                print("removing:", fn)
-            del index[fn]
-
-    # Deal with Python 2 and 3's different json module type reqs
-    mode_dict = {'mode': 'w', 'encoding': 'utf-8'} if PY3 else {'mode': 'wb'}
-    with open(index_path, **mode_dict) as fo:
-        json.dump(index, fo, indent=2, sort_keys=True, default=str)
-
-    # --- new repodata
-    for fn in index:
-        info = index[fn]
-        for varname in 'arch', 'platform', 'mtime', 'ucs':
+        else:
             try:
-                del info[varname]
-            except KeyError:
-                pass
+                mode_dict = {'mode': 'r', 'encoding': 'utf-8'} if PY3 else {'mode': 'rb'}
+                with open(index_path, **mode_dict) as fi:
+                    index = json.load(fi)
+            except (IOError, ValueError):
+                index = {}
 
-        if 'requires' in info and 'depends' not in info:
-            info['depends'] = info['requires']
+        files = set(fn for fn in os.listdir(dir_path) if fn.endswith('.tar.bz2'))
+        if could_be_mirror and any(fn.startswith('_license-') for fn in files):
+            sys.exit("""\
+    Error:
+        Indexing a copy of the Anaconda conda package channel is neither
+        necessary nor supported.  If you wish to add your own packages,
+        you can do so by adding them to a separate channel.
+    """)
+        for fn in files:
+            path = join(dir_path, fn)
+            if fn in index:
+                if check_md5:
+                    if index[fn]['md5'] == md5_file(path):
+                        continue
+                elif index[fn]['mtime'] == getmtime(path):
+                    continue
+            if config.verbose:
+                print('updating:', fn)
+            d = read_index_tar(path, config, lock=lock)
+            d.update(file_info(path))
+            index[fn] = d
 
-    repodata = {'packages': index, 'info': {}}
-    write_repodata(repodata, dir_path, config, lock=lock)
-    lock.release()
+        for fn in files:
+            index[fn]['sig'] = '.' if isfile(join(dir_path, fn + '.sig')) else None
+
+        if remove:
+            # remove files from the index which are not on disk
+            for fn in set(index) - files:
+                if config.verbose:
+                    print("removing:", fn)
+                del index[fn]
+
+        # Deal with Python 2 and 3's different json module type reqs
+        mode_dict = {'mode': 'w', 'encoding': 'utf-8'} if PY3 else {'mode': 'wb'}
+        with open(index_path, **mode_dict) as fo:
+            json.dump(index, fo, indent=2, sort_keys=True, default=str)
+
+        # --- new repodata
+        for fn in index:
+            info = index[fn]
+            for varname in 'arch', 'platform', 'mtime', 'ucs':
+                try:
+                    del info[varname]
+                except KeyError:
+                    pass
+
+            if 'requires' in info and 'depends' not in info:
+                info['depends'] = info['requires']
+
+        repodata = {'packages': index, 'info': {}}
+        write_repodata(repodata, dir_path, lock=lock, config=config)

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -98,8 +98,6 @@ def parse_or_try_download(metadata, no_download_source, config,
 
     elif not metadata.get_section('source'):
         need_source_download = False
-        if not os.path.isdir(config.work_dir):
-            os.makedirs(config.work_dir)
     else:
         # we have not downloaded source in the render phase.  Download it in
         #     the build phase

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -32,9 +32,13 @@ from conda_build.os_utils import external
 if PY3:
     import urllib.parse as urlparse
     import urllib.request as urllib
+    # NOQA because it is not used in this file.
+    from contextlib import ExitStack  # NOQA
 else:
     import urlparse
     import urllib
+    # NOQA because it is not used in this file.
+    from contextlib2 import ExitStack  # NOQA
 
 
 log = logging.getLogger(__file__)

--- a/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
+++ b/tests/test-recipes/fail/source_git_jinja2_oops/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: {{ GIT_DSECRIBE_TAG }}
 
 source:
-  git_url: https://github.com/conda/conda-build
-  git_tag: 1.8.1
+  git_url: ../../../../../conda_build_test_recipe
+  git_tag: 1.20.2
 
 requirements:
   build:

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -337,20 +337,23 @@ def test_skip_existing(testing_workdir, test_config, capfd):
     output, error = capfd.readouterr()
     assert "is already built" in output
 
+
 def test_skip_existing_url(test_metadata, testing_workdir, capfd):
     # make sure that it is built
     output_file = api.get_output_file_path(test_metadata)
     api.build(test_metadata)
 
     # Copy our package into some new folder
-    platform = os.path.join(testing_workdir, test_metadata.config.subdir)
+    output_dir = os.path.join(testing_workdir, 'someoutput')
+    platform = os.path.join(output_dir, test_metadata.config.subdir)
+    os.makedirs(platform)
     copy_into(output_file, os.path.join(platform, os.path.basename(output_file)))
 
     # create the index so conda can find the file
     api.update_index(platform, config=test_metadata.config)
 
     test_metadata.config.skip_existing = True
-    test_metadata.config.channel_urls = [url_path(testing_workdir)]
+    test_metadata.config.channel_urls = [url_path(output_dir)]
     api.build(test_metadata)
 
     output, error = capfd.readouterr()


### PR DESCRIPTION
This is meant to address #1494.  The idea is that lockfile only keeps track of one SoftFileLock instance, but is reentrant for that instance.  However, we had cases where more than one instance for a single file in a single process could be created.  This implements a central collection of SoftFileLock instances within each process, keyed on file location.  Any re-use of a location should get the in-process instance, and be reentrant.  This also uses context managers because the reentrancy should make file removal more robust.