### PR TITLE
clarify error message when extracting egg fails due to existing files

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -119,8 +119,17 @@ def remove_easy_install_pth(files, prefix, config, preserve_egg_dir=False):
                     # so the package directory already exists
                     # from another installed dependency
                     if os.path.exists(join(sp_dir, fn)):
-                        utils.copy_into(join(egg_path, fn), join(sp_dir, fn), config.timeout)
-                        utils.rm_rf(join(egg_path, fn))
+                        try:
+                            utils.copy_into(join(egg_path, fn), join(sp_dir, fn), config.timeout)
+                            utils.rm_rf(join(egg_path, fn))
+                        except IOError as e:
+                            fn = os.path.basename(str(e).split()[-1])
+                            raise IOError("Tried to merge folder {egg_path} into {sp_dir}, but {fn}"
+                                          " exists in both locations.  Please either add "
+                                          "build/preserve_egg_dir: True to meta.yaml, or manually "
+                                          "remove the file during your install process to avoid "
+                                          "this conflict."
+                                          .format(egg_path=egg_path, sp_dir=sp_dir, fn=fn))
                     else:
                         os.rename(join(egg_path, fn), join(sp_dir, fn))
 


### PR DESCRIPTION
This is meant to address #1463 

I don't consider this a proper fix, but it is the best I can do right now.  Conda-build really should not be left to decide which is the correct file to overwrite - this must be a user choice.  The best we can do is try to be clear about what is happening, and how to work around it.

CC @janssen @jreback