### PR TITLE
Add creation of intermediate folders for `utils.copy_into`

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -115,8 +115,11 @@ def copy_into(src, dst, timeout=90, symlinks=False, lock=None):
         with lock:
             # if intermediate folders not not exist create them
             dst_folder = os.path.dirname(dst)
-            if not os.path.exists(dst_folder):
-                os.makedirs(dst_folder)
+            if dst_folder and not os.path.exists(dst_folder):
+                try:
+                    os.makedirs(dst_folder)
+                except OSError:
+                    pass
 
             # with each of these, we are copying less metadata.  This seems to be necessary
             #   to cope with some shared filesystems with some virtual machine setups.

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -113,6 +113,11 @@ def copy_into(src, dst, timeout=90, symlinks=False, lock=None):
         if not lock:
             lock = get_lock(src_folder, timeout=timeout)
         with lock:
+            # if intermediate folders not not exist create them
+            dst_folder = os.path.dirname(dst)
+            if not os.path.exists(dst_folder):
+                os.makedirs(dst_folder)
+
             # with each of these, we are copying less metadata.  This seems to be necessary
             #   to cope with some shared filesystems with some virtual machine setups.
             #  See https://github.com/conda/conda-build/issues/1426


### PR DESCRIPTION
Resolves #1510 .

If `copy_into` is now used and you want to copy a file in a (nested) folder the intermediate folders for the destination are created. In case you were copying folders this was already the default. This enables the same for single file copies. 