### PR TITLE
fix directly testing packages; freeze more meta.yaml data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ install:
       conda config --set always_yes yes;
     else
       if [ -n "$CONDA" ]; then
-        conda install -y --no-deps conda=${CONDA} requests;
+        conda install -y --no-deps conda=${CONDA};
       fi
     fi
 
-  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION pyflakes=1.1 conda-verify
+  - conda install -q anaconda-client requests=2.11.1 filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION pyflakes=1.1 conda-verify
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
   - python -c "import sys; print(sys.version)"
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests=2.11.1 contextlib2
   - conda install -q pyflakes=1.1 pycrypto posix m2-git anaconda-client numpy conda-verify
   - conda install -c conda-forge -q perl
   - conda update -q --all

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -110,11 +110,11 @@ def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwar
                 if os.path.basename(local_location).startswith(platform + "-"):
                     local_location = os.path.dirname(local_location)
             update_index(local_location, config=config)
-            local_location = url_path(local_location)
+            local_url = url_path(local_location)
             # channel_urls is an iterable, but we don't know if it's a tuple or list.  Don't know
             #    how to add elements.
             recipe_config.channel_urls = list(recipe_config.channel_urls)
-            recipe_config.channel_urls.insert(0, local_location)
+            recipe_config.channel_urls.insert(0, local_url)
             is_package = True
             if metadata.meta.get('test') and metadata.meta['test'].get('source_files'):
                 source.provide(metadata.path, metadata.get_section('source'), config=config)
@@ -128,7 +128,8 @@ def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwar
         recipe_config.compute_build_id(metadata.name())
         test_result = test(metadata, config=recipe_config, move_broken=move_broken)
 
-        if test_result and is_package and hasattr(recipe_config, 'output_folder'):
+        if (test_result and is_package and hasattr(recipe_config, 'output_folder') and
+                recipe_config.output_folder):
             os.rename(recipedir_or_package_or_metadata,
                       os.path.join(recipe_config.output_folder,
                                    os.path.basename(recipedir_or_package_or_metadata)))

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1033,7 +1033,7 @@ def test(m, config, move_broken=True):
     shell_files = create_shell_files(tmp_dir, m, config)
     if not (py_files or shell_files or pl_files or lua_files):
         print("Nothing to test for:", m.dist())
-        return
+        return True
 
     print("TEST START:", m.dist())
 
@@ -1128,6 +1128,7 @@ def test(m, config, move_broken=True):
         tests_failed(m, move_broken=move_broken, broken_dir=config.broken_dir, config=config)
 
     print("TEST END:", m.dist())
+    return True
 
 
 def tests_failed(m, move_broken, broken_dir, config):

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -131,7 +131,7 @@ def execute(args):
     if args.output:
         logging.basicConfig(level=logging.ERROR)
         silence_loggers(show_warnings_and_errors=False)
-        print(bldpkg_path(metadata, config=config))
+        print(bldpkg_path(metadata))
     else:
         logging.basicConfig(level=logging.INFO)
         print(output_yaml(metadata, args.file))

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -93,7 +93,7 @@ class Config(object):
         Setting = namedtuple("ConfigSetting", "name, default")
         values = [Setting('activate', True),
                   Setting('anaconda_upload', binstar_upload),
-                  Setting('channel_urls', ()),
+                  Setting('channel_urls', []),
                   Setting('dirty', False),
                   Setting('include_recipe', True),
                   Setting('keep_old_work', False),

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import json
 import logging
 import multiprocessing
 import os
@@ -441,6 +442,63 @@ def system_vars(env_dict, prefix, config):
     d.update(compiler_vars)
 
     return d
+
+
+class InvalidEnvironment(Exception):
+    pass
+
+
+# Stripped-down Environment class from conda-tools ( https://github.com/groutr/conda-tools )
+# Vendored here to avoid the whole dependency for just this bit.
+def _load_json(path):
+    with open(path, 'r') as fin:
+        x = json.load(fin)
+    return x
+
+
+def _load_all_json(path):
+    """
+    Load all json files in a directory.  Return dictionary with filenames mapped to json
+    dictionaries.
+    """
+    root, _, files = next(os.walk(path))
+    result = {}
+    for f in files:
+        if f.endswith('.json'):
+            result[f] = _load_json(join(root, f))
+    return result
+
+
+class Environment(object):
+    def __init__(self, path):
+        """
+        Initialize an Environment object.
+
+        To reflect changes in the underlying environment, a new Environment object should be
+        created.
+        """
+        self.path = path
+        self._meta = join(path, 'conda-meta')
+        if os.path.isdir(path) and os.path.isdir(self._meta):
+            self._packages = {}
+        else:
+            raise InvalidEnvironment('Unable to load environment {}'.format(path))
+
+    def _read_package_json(self):
+        if not self._packages:
+            self._packages = _load_all_json(self._meta)
+
+    def package_specs(self):
+        """
+        List all package specs in the environment.
+        """
+        self._read_package_json()
+        json_objs = self._packages.values()
+        specs = []
+        for i in json_objs:
+            p, v, b = i['name'], i['version'], i['build']
+            specs.append('{} {} {}'.format(p, v, b))
+        return specs
 
 
 if __name__ == '__main__':

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -65,12 +65,12 @@ def set_language_env_vars(args, parser, config, execute=None):
             os.environ[var] = str(getattr(config, var))
 
 
-def bldpkg_path(m, config):
+def bldpkg_path(m):
     '''
     Returns path to built package's tarball given its ``Metadata``.
     '''
     output_dir = m.info_index()['subdir']
-    return os.path.join(os.path.dirname(config.bldpkgs_dir), output_dir, '%s.tar.bz2' % m.dist())
+    return os.path.join(os.path.dirname(m.config.bldpkgs_dir), output_dir, '%s.tar.bz2' % m.dist())
 
 
 def parse_or_try_download(metadata, no_download_source, config,

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -86,6 +86,8 @@ def get_recipe_abspath(recipe):
     else:
         recipe_dir = abspath(recipe)
         need_cleanup = False
+    if not os.path.exists(recipe_dir):
+        raise ValueError("Package or recipe at path {0} does not exist".format(recipe_dir))
     return recipe_dir, need_cleanup
 
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -727,3 +727,19 @@ def test_script_win_creates_exe(test_config):
     api.build(recipe, config=test_config)
     assert package_has_file(fn, 'Scripts/test-script.exe')
     assert package_has_file(fn, 'Scripts/test-script-script.py')
+
+
+def test_build_output_folder_moves_file(test_metadata, testing_workdir):
+    output_path = api.get_output_file_path(test_metadata)
+    test_metadata.config.output_folder = testing_workdir
+    api.build(test_metadata, no_test=True)
+    assert not os.path.exists(output_path)
+    assert os.path.isfile(os.path.join(testing_workdir, os.path.basename(output_path)))
+
+
+def test_test_output_folder_moves_file(test_metadata, testing_workdir):
+    output_path = api.get_output_file_path(test_metadata)
+    api.build(test_metadata, no_test=True)
+    api.test(output_path, output_folder=testing_workdir)
+    assert not os.path.exists(output_path)
+    assert os.path.isfile(os.path.join(testing_workdir, os.path.basename(output_path)))


### PR DESCRIPTION
This fixes ```conda build --test``` so that the actual package provided is the one that gets installed for the test.  It no longer tries to go download it from somewhere, based on metadata provided by rendering the recipe in the package.

This hard-codes important information in the rendered meta.yaml file:
* exact pins for build dependencies (even those not explicitly listed - it is whatever is present in the build env)
* absolute path substituted for relative source/path or source/git_url entries (necessary for testing)
* the build string, so that no further rendering is necessary to come up with a similar package spec.

Finally, this adds one option to conda build, ```--output-folder```, which dumps the output package to some folder.  This is useful for CI (particularly concourse CI), where output folder affects how artifacts are carried to the next stage.

closes #1534 