### PR TITLE
lock rework: try to acquire, let go if any locks fail; retry

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,7 @@ test_script:
   - set PATH
   - mkdir C:\cbtmp
   - py.test -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
+  - rd /S /Q C:\cbtmp
   - py.test -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial"
 
 on_failure:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,17 +22,18 @@ requirements:
   build:
     - python
   run:
-    - conda-verify
     - conda  >=4.1
     - contextlib2   [py<34]
+    - conda-verify
+    - enum34        [py<34]
     - filelock
+    - futures       [py<3]
     - jinja2
     - patchelf      [linux]
+    - pkginfo
     - pycrypto
     - python
     - pyyaml
-    - pkginfo
-    - enum34        [py<34]
 
 test:
   requires:

--- a/conda_build/__init__.py
+++ b/conda_build/__init__.py
@@ -4,11 +4,12 @@
 # conda is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
+import logging
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-import logging
 
 # Sub commands added by conda-build to the conda command
 sub_commands = [

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -657,8 +657,11 @@ def create_env(prefix, specs, config, clear_cache=True, retry=0):
                                 os.makedirs(folder)
                             lock = utils.get_lock(folder, timeout=config.timeout)
                             if not folder.endswith('pkgs'):
-                                update_index(folder, config=config, lock=lock, could_be_mirror=False)
+                                update_index(folder, config=config, lock=lock,
+                                             could_be_mirror=False)
                             locks.append(lock)
+                        # lock used to generally indicate a conda operation occurring
+                        locks.append(utils.get_lock('conda-operation', timeout=config.timeout))
 
                     with utils.try_acquire_locks(locks, timeout=config.timeout):
                         index = get_build_index(config=config, clear_cache=True)
@@ -1012,7 +1015,8 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                             bf.write(data)
                     else:
                         if not isfile(work_file):
-                            utils.copy_into(build_file, work_file, config.timeout, locking=config.locking)
+                            utils.copy_into(build_file, work_file, config.timeout,
+                                            locking=config.locking)
                     os.chmod(work_file, 0o766)
 
                     if isfile(work_file):

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -689,7 +689,8 @@ def create_env(prefix, specs, config, clear_cache=True):
                             isinstance(exc, PaddingError)) and
                             config.prefix_length > 80):
                         if config.prefix_length_fallback:
-                            log.warn("Build prefix failed with prefix length %d", config.prefix_length)
+                            log.warn("Build prefix failed with prefix length %d",
+                                     config.prefix_length)
                             log.warn("Error was: ")
                             log.warn(str(exc))
                             log.warn("One or more of your package dependencies needs to be rebuilt "
@@ -777,7 +778,8 @@ def filter_files(files_list, prefix, filter_patterns=('.*[\\\\/]?\.git[\\\\/].*'
     for pattern in filter_patterns:
         r = re.compile(pattern)
         files_list = set(files_list) - set(filter(r.match, files_list))
-    return [f.replace(prefix + os.path.sep, '') for f in files_list if not os.path.isdir(os.path.join(prefix, f))]
+    return [f.replace(prefix + os.path.sep, '') for f in files_list
+            if not os.path.isdir(os.path.join(prefix, f))]
 
 
 def bundle_conda(output, metadata, config, env, **kw):
@@ -803,9 +805,14 @@ def bundle_conda(output, metadata, config, env, **kw):
         if f not in files:
             files.append(f)
     files = filter_files(files, prefix=config.build_prefix)
+<<<<<<< d25fc98c88facda4bac230950daebd121a798965
     output_folder = None
     if config.output_folder:
         output_folder = os.path.join(config.output_folder, config.subdir)
+=======
+    output_folder = os.path.join(config.output_folder,
+                                 config.subdir) if config.output_folder else None
+>>>>>>> try FileLock instead of SoftFileLock.  Centralize lock file location to root_dir/locks
     final_output = os.path.join(output_folder or config.bldpkgs_dir, output_filename)
 
     # lock the output directory while we build this file

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -699,6 +699,11 @@ def create_env(prefix, specs, config, clear_cache=True, retry=0):
                                         clear_cache=clear_cache)
                         else:
                             raise
+                    elif 'lock' in str(exc):
+                        if retry < config.max_env_retry:
+                            log.warn("failed to create env, retrying.  exception was: %s", str(exc))
+                            create_env(prefix, specs, config=config,
+                                    clear_cache=clear_cache, retry=retry + 1)
                 # HACK: some of the time, conda screws up somehow and incomplete packages result.
                 #    Just retry.
                 except (AssertionError, IOError, ValueError, RuntimeError, LockError) as exc:

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -215,6 +215,11 @@ different sets of packages."""
         #     had enough time to build long-prefix length packages.
         default=255, type=int,
     )
+    p.add_argument(
+        "--no-locking", dest='locking', default=True, action="store_false",
+        help=("Disable locking, to avoid unresolved race condition issues.  Unsafe to run multiple"
+              "builds at once on one system with this set.")
+    )
     add_parser_channels(p)
 
     args = p.parse_args(args)

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -15,6 +15,7 @@ import filelock
 
 import conda_build.api as api
 import conda_build.build as build
+import conda_build.utils as utils
 from conda_build.cli.main_render import (set_language_env_vars, RecipeCompleter,
                                          get_render_parser, bldpkg_path)
 from conda_build.conda_interface import cc, add_parser_channels, url_path
@@ -297,7 +298,7 @@ def execute(args):
                    notest=args.notest, keep_old_work=args.keep_old_work,
                    already_built=None, config=config, noverify=args.no_verify)
 
-    if not args.output and len(build.get_build_folders(config.croot)) > 0:
+    if not args.output and len(utils.get_build_folders(config.croot)) > 0:
         build.print_build_intermediate_warning(config)
 
 

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -128,7 +128,8 @@ def execute(args):
     set_language_env_vars(args, p, config)
 
     with LoggingContext(logging.CRITICAL + 1):
-        metadata, _, _ = render_recipe(args.recipe, no_download_source=args.no_source, config=config)
+        metadata, _, _ = render_recipe(args.recipe, no_download_source=args.no_source,
+                                       config=config)
         if args.output:
             print(bldpkg_path(metadata))
         else:

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -57,6 +57,7 @@ if parse_version(conda.__version__) >= parse_version("4.2"):
     LinkError = conda.exceptions.LinkError
     NoPackagesFoundError = conda.exceptions.NoPackagesFoundError
     CondaValueError = conda.exceptions.CondaValueError
+    LockError = conda.exceptions.LockError
 
     # disallow softlinks.  This avoids a lot of dumb issues, at the potential cost of disk space.
     conda.base.context.context.allow_softlinks = False
@@ -87,6 +88,9 @@ else:
     cc.allow_softlinks = False
 
     class PaddingError(Exception):
+        pass
+
+    class LockError(Exception):
         pass
 
     class LinkError(Exception):

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -156,8 +156,8 @@ else:
 
     class PathType(Enum):
         """
-        Refers to if the file in question is hard linked or soft linked. Originally designed to be used
-        in paths.json
+        Refers to if the file in question is hard linked or soft linked. Originally designed to be
+        used in paths.json
         """
         hardlink = "hardlink"
         softlink = "softlink"
@@ -167,7 +167,6 @@ else:
 
         def __json__(self):
             return self.name
-
 
     class FileMode(Enum):
         """
@@ -179,7 +178,6 @@ else:
 
         def __str__(self):
             return "%s" % self.value
-
 
     class EntityEncoder(JSONEncoder):
         # json.dumps(obj, cls=SetEncoder)
@@ -193,7 +191,6 @@ else:
             elif hasattr(obj, 'as_json'):
                 return obj.as_json()
             return JSONEncoder.default(self, obj)
-
 
     # work-around for python bug on Windows prior to python 3.2
     # https://bugs.python.org/issue10027
@@ -277,7 +274,6 @@ else:
                                 ("nFileIndexLow", DWORD)]
 
                 cls.BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION
-
 
                 # http://msdn.microsoft.com/en-us/library/windows/desktop/aa364952
                 cls.GetFileInformationByHandle = ctypes.windll.kernel32.GetFileInformationByHandle

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -110,6 +110,7 @@ class Config(object):
                   Setting('output_folder', None),
                   Setting('prefix_length_fallback', True),
                   Setting('_prefix_length', DEFAULT_PREFIX_LENGTH),
+                  Setting('locking', True),
 
                   # pypi upload settings (twine)
                   Setting('password', None),

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -111,6 +111,7 @@ class Config(object):
                   Setting('prefix_length_fallback', True),
                   Setting('_prefix_length', DEFAULT_PREFIX_LENGTH),
                   Setting('locking', True),
+                  Setting('max_env_retry', 3),
 
                   # pypi upload settings (twine)
                   Setting('password', None),

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -50,7 +50,7 @@ def create_files(dir_path, m, config):
     for fn in ensure_list(m.get_value('test/files', [])):
         has_files = True
         path = join(m.path, fn)
-        copy_into(path, join(dir_path, fn), config.timeout)
+        copy_into(path, join(dir_path, fn), config.timeout, locking=config.locking)
     # need to re-download source in order to do tests
     if m.get_value('test/source_files') and not isdir(config.work_dir):
         source.provide(m.path, m.get_section('source'), config=config)
@@ -63,7 +63,8 @@ def create_files(dir_path, m, config):
         if not files:
             raise RuntimeError("Did not find any source_files for test with pattern %s", pattern)
         for f in files:
-            copy_into(f, f.replace(config.work_dir, config.test_dir), config.timeout)
+            copy_into(f, f.replace(config.work_dir, config.test_dir), config.timeout,
+                      locking=config.locking)
         for ext in '.pyc', '.pyo':
             for f in get_ext_files(config.test_dir, ext):
                 os.remove(f)
@@ -87,7 +88,7 @@ def create_shell_files(dir_path, m, config):
         name = "run_test{}".format(ext)
 
     if exists(join(m.path, name)):
-        copy_into(join(m.path, name), dir_path, config.timeout)
+        copy_into(join(m.path, name), dir_path, config.timeout, locking=config.locking)
         has_tests = True
 
     with open(join(dir_path, name), 'a') as f:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -15,11 +15,8 @@ from conda_build.utils import file_info, get_lock, ExitStack
 from .conda_interface import PY3, md5_file
 
 
-def read_index_tar(tar_path, config, lock=None):
+def read_index_tar(tar_path, config, lock):
     """ Returns the index.json dict inside the given package tarball. """
-
-    if not lock:
-        lock = get_lock(os.path.dirname(tar_path), timeout=config.timeout)
     with ExitStack() as stack:
         stack.enter_context(lock)
         t = tarfile.open(tar_path)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -11,7 +11,7 @@ import json
 import tarfile
 from os.path import isfile, join, getmtime
 
-from conda_build.utils import file_info, get_lock, ExitStack, try_acquire_locks
+from conda_build.utils import file_info, get_lock, try_acquire_locks
 from .conda_interface import PY3, md5_file
 
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -11,7 +11,7 @@ import json
 import tarfile
 from os.path import isfile, join, getmtime
 
-from conda_build.utils import file_info, get_lock, ExitStack
+from conda_build.utils import file_info, get_lock, ExitStack, try_acquire_locks
 from .conda_interface import PY3, md5_file
 
 
@@ -38,7 +38,7 @@ def write_repodata(repodata, dir_path, lock, config=None):
     if not config:
         import conda_build.config
         config = conda_build.config.config
-    with lock:
+    with try_acquire_locks([lock], config.timeout):
         data = json.dumps(repodata, indent=2, sort_keys=True)
         # strip trailing whitespace
         data = '\n'.join(line.rstrip() for line in data.splitlines())
@@ -75,7 +75,7 @@ def update_index(dir_path, config, force=False, check_md5=False, remove=True, lo
     if not lock:
         lock = get_lock(dir_path)
 
-    with lock:
+    with try_acquire_locks([lock], config.timeout):
         if force:
             index = {}
         else:

--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -101,8 +101,7 @@ def ensure_valid_license_family(meta):
         license_family = meta['about']['license_family']
     except KeyError:
         return
-    if (remove_special_characters(normalize(license_family))
-            not in allowed_license_families):
+    if remove_special_characters(normalize(license_family)) not in allowed_license_families:
         raise RuntimeError(exceptions.indent(
             "about/license_family '%s' not allowed. Allowed families are %s." %
             (license_family, comma_join(sorted(allowed_license_families)))))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import glob
-import logging
 import os
 from os.path import isfile, join
 import re

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -6,8 +6,6 @@ import shutil
 import locale
 from os.path import basename, dirname, isdir, join, isfile
 
-from conda_build.post import SHEBANG_PAT
-
 ISWIN = sys.platform.startswith('win')
 
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -120,7 +120,8 @@ def remove_easy_install_pth(files, prefix, config, preserve_egg_dir=False):
                     # from another installed dependency
                     if os.path.exists(join(sp_dir, fn)):
                         try:
-                            utils.copy_into(join(egg_path, fn), join(sp_dir, fn), config.timeout)
+                            utils.copy_into(join(egg_path, fn), join(sp_dir, fn), config.timeout,
+                                            locking=config.locking)
                             utils.rm_rf(join(egg_path, fn))
                         except IOError as e:
                             fn = os.path.basename(str(e).split()[-1])

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -85,7 +85,7 @@ def unpack(meta, config):
     else:
         # In this case, the build script will need to deal with unpacking the source
         print("Warning: Unrecognized source format. Source file will be copied to the SRC_DIR")
-        copy_into(src_path, config.work_dir, config.timeout)
+        copy_into(src_path, config.work_dir, config.timeout, locking=config.locking)
 
 
 def git_mirror_checkout_recursive(git, mirror_dir, checkout_dir, git_url, config, git_ref=None,
@@ -341,7 +341,7 @@ def svn_source(meta, config):
         assert isdir(cache_repo)
 
     # now copy into work directory
-    copy_into(cache_repo, config.work_dir, config.timeout, symlinks=True)
+    copy_into(cache_repo, config.work_dir, config.timeout, symlinks=True, locking=config.locking)
 
     if not config.verbose:
         FNULL.close()
@@ -495,7 +495,7 @@ def provide(recipe_dir, meta, config, patch=True):
             print("Copying %s to %s" % (path, config.work_dir))
         # careful here: we set test path to be outside of conda-build root in setup.cfg.
         #    If you don't do that, this is a recursive function
-        copy_into(path, config.work_dir, config.timeout)
+        copy_into(path, config.work_dir, config.timeout, locking=config.locking)
     else:  # no source
         if not isdir(config.work_dir):
             os.makedirs(config.work_dir)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -106,7 +106,8 @@ def try_acquire_locks(locks, timeout):
         break
     yield
     for lock in locks:
-        lock.release()
+        if lock:
+            lock.release()
 
 
 def copy_into(src, dst, timeout=90, symlinks=False, lock=None):
@@ -137,7 +138,7 @@ def copy_into(src, dst, timeout=90, symlinks=False, lock=None):
 
         if not lock:
             lock = get_lock(src_folder, timeout=timeout)
-        with lock:
+        with try_acquire_locks([lock], timeout):
             # if intermediate folders not not exist create them
             dst_folder = os.path.dirname(dst)
             if dst_folder and not os.path.exists(dst_folder):
@@ -226,7 +227,7 @@ def merge_tree(src, dst, symlinks=False, timeout=90, lock=None):
 
     if not lock:
         lock = get_lock(src, timeout=timeout)
-    with lock:
+    with try_acquire_locks([lock], timeout):
         copytree(src, dst, symlinks=symlinks)
 
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -244,7 +244,10 @@ _locations = {}
 
 def get_lock(folder, timeout=90, filename=".conda_lock"):
     global _locations
-    location = os.path.abspath(os.path.normpath(folder))
+    try:
+        location = os.path.abspath(os.path.normpath(folder))
+    except OSError:
+        location = folder
     b_location = location
     if hasattr(b_location, 'encode'):
         b_location = b_location.encode()
@@ -641,7 +644,6 @@ def package_has_file(package_path, file_path):
 
 
 def ensure_list(arg):
-    from .conda_interface import string_types
     if (isinstance(arg, string_types) or not hasattr(arg, '__iter__')):
         if arg:
             arg = [arg]

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -329,6 +329,7 @@ def test_jinja_typo(testing_workdir, test_config):
         assert "'GIT_DSECRIBE_TAG' is undefined" in exc
 
 
+@pytest.mark.serial
 def test_skip_existing(testing_workdir, test_config, capfd):
     # build the recipe first
     api.build(empty_sections, config=test_config)
@@ -337,6 +338,7 @@ def test_skip_existing(testing_workdir, test_config, capfd):
     assert "is already built" in output
 
 
+@pytest.mark.serial
 def test_skip_existing_url(test_metadata, testing_workdir, capfd):
     # make sure that it is built
     outputs = api.build(test_metadata)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,36 +60,39 @@ def test_build_without_channel_fails(testing_workdir):
     main_build.execute(args)
 
 
-def test_render_output_build_path(testing_workdir, capfd):
-    args = ['--output', os.path.join(metadata_dir, "python_run")]
+def test_render_output_build_path(testing_workdir, test_metadata, capfd):
+    api.output_yaml(test_metadata, 'meta.yaml')
+    args = ['--output', testing_workdir]
     main_render.execute(args)
-    test_path = "conda-build-test-python-run-1.0-py{}{}_0.tar.bz2".format(
+    test_path = "test_render_output_build_path-1.0-py{}{}_1.tar.bz2".format(
                                       sys.version_info.major, sys.version_info.minor)
     output, error = capfd.readouterr()
     assert error == ""
     assert os.path.basename(output.rstrip()) == test_path, error
 
 
-def test_build_output_build_path(testing_workdir, test_config, capfd):
-    args = ['--output', os.path.join(metadata_dir, "python_run")]
+def test_build_output_build_path(testing_workdir, test_config, test_metadata, capfd):
+    api.output_yaml(test_metadata, 'meta.yaml')
+    args = ['--output', testing_workdir]
     main_build.execute(args)
     test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir,
-                                  "conda-build-test-python-run-1.0-py{}{}_0.tar.bz2".format(
+                                  "test_build_output_build_path-1.0-py{}{}_1.tar.bz2".format(
                                       sys.version_info.major, sys.version_info.minor))
     output, error = capfd.readouterr()
     assert error == ""
     assert output.rstrip() == test_path, error
 
 
-def test_build_output_build_path_multiple_recipes(testing_workdir, test_config, capfd):
+def test_build_output_build_path_multiple_recipes(testing_workdir, test_config, test_metadata, capfd):
     skip_recipe = os.path.join(metadata_dir, "build_skip")
-    args = ['--output', os.path.join(metadata_dir, "python_run"), skip_recipe]
+    api.output_yaml(test_metadata, 'meta.yaml')
+    args = ['--output', testing_workdir, skip_recipe]
 
     main_build.execute(args)
 
     test_path = lambda pkg: os.path.join(sys.prefix, "conda-bld", test_config.subdir, pkg)
     test_paths = [test_path(
-        "conda-build-test-python-run-1.0-py{}{}_0.tar.bz2".format(
+        "test_build_output_build_path_multiple_recipes-1.0-py{}{}_1.tar.bz2".format(
         sys.version_info.major, sys.version_info.minor)),
         "Skipped: {} defines build/skip for this "
         "configuration.".format(os.path.abspath(skip_recipe))]
@@ -123,16 +126,17 @@ def test_build_no_build_id(testing_workdir, test_config, capfd):
     assert 'has_prefix_files_1' not in data
 
 
-def test_render_output_build_path_set_python(testing_workdir, capfd):
+def test_render_output_build_path_set_python(testing_workdir, test_metadata, capfd):
+    api.output_yaml(test_metadata, 'meta.yaml')
     # build the other major thing, whatever it is
     if sys.version_info.major == 3:
         version = "2.7"
     else:
         version = "3.5"
 
-    args = ['--output', os.path.join(metadata_dir, "python_run"), '--python', version]
+    args = ['--output', testing_workdir, '--python', version]
     main_render.execute(args)
-    test_path = "conda-build-test-python-run-1.0-py{}{}_0.tar.bz2".format(
+    test_path = "test_render_output_build_path_set_python-1.0-py{}{}_1.tar.bz2".format(
                                       version.split('.')[0], version.split('.')[1])
     output, error = capfd.readouterr()
     assert os.path.basename(output.rstrip()) == test_path, error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,6 +260,7 @@ def test_inspect_objects(testing_workdir, capfd):
         assert 'rpath: @loader_path' in output
 
 
+@pytest.mark.serial
 @pytest.mark.skipif(on_win, reason="Windows prefix length doesn't matter (yet?)")
 def test_inspect_prefix_length(testing_workdir, capfd):
     from conda_build import api
@@ -287,6 +288,7 @@ def test_inspect_prefix_length(testing_workdir, capfd):
     assert 'No packages found with binary prefixes shorter' in output
 
 
+@pytest.mark.serial
 def test_develop(testing_env):
     f = "https://pypi.io/packages/source/c/conda_version_test/conda_version_test-0.1.0-1.tar.gz"
     download(f, "conda_version_test.tar.gz")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,8 +67,6 @@ def test_metadata(request, test_config):
     d['package']['version'] = '1.0'
     d['build']['number'] = '1'
     d['build']['entry_points'] = []
-    # MetaData does the auto stuff if the build string is None
-    d['build']['string'] = None
     d['requirements']['build'] = ['python']
     d['requirements']['run'] = ['python']
     d['test']['commands'] = ['echo "A-OK"', 'exit 0']


### PR DESCRIPTION
There's a potential race condition when working with multiple locks, as we do with locking multiple folders at once.  If one set of locks is partially done, and another set is acquired, we can deadlock.

This PR implements a scheme where we try to acquire locks one-by-one, and if any fail (quickly), let go of all currently held locks in that group.  The overall timeout still applies, but it applies to the whole group, not each individual lock.

Derived from http://stackoverflow.com/questions/9814008/multiple-mutex-locking-strategies-and-why-libraries-dont-use-address-comparison

This also refactors build.py to use the utils module, rather than its small pieces.