### PR TITLE
decouple ignore_prefix_files from binary_relocation

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -717,6 +717,17 @@ class MetaData(object):
 
         return expand_globs(files, self.config.build_prefix)
 
+    def binary_relocation(self):
+        ret = self.get_value('build/binary_relocation', True)
+        if type(ret) not in (list, bool):
+            raise RuntimeError('build/ignore_prefix_files should be boolean or a list of paths '
+                               '(optionally globs)')
+        if sys.platform == 'win32':
+            if type(ret) is list and any('\\' in i for i in ret):
+                raise RuntimeError("build/ignore_prefix_files paths must use / "
+                                   "as the path delimiter on Windows")
+        return expand_globs(ret, self.config.build_prefix) if type(ret) is list else ret
+
     def include_recipe(self):
         return self.get_value('build/include_recipe', True)
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -388,12 +388,6 @@ def mk_relative(m, f, prefix):
     if not is_obj(path):
         return
 
-    # skip over this file
-    if (m.ignore_prefix_files() and (type(m.ignore_prefix_files()) is bool or
-                                     f in m.ignore_prefix_files())):
-        print("Skipping relocation path patch for " + f)
-        return
-
     if sys.platform.startswith('linux'):
         mk_relative_linux(f, prefix=prefix, rpaths=m.get_value('build/rpaths', ['lib']))
     elif sys.platform == 'darwin':
@@ -427,7 +421,7 @@ def post_build(m, files, prefix, build_python, croot):
     if sys.platform == 'win32':
         return
 
-    binary_relocation = bool(m.get_value('build/binary_relocation', True))
+    binary_relocation = m.binary_relocation()
     if not binary_relocation:
         print("Skipping binary relocation logic")
     osx_is_app = bool(m.get_value('build/osx_is_app', False))
@@ -437,7 +431,7 @@ def post_build(m, files, prefix, build_python, croot):
     for f in files:
         if f.startswith('bin/'):
             fix_shebang(f, prefix=prefix, build_python=build_python, osx_is_app=osx_is_app)
-        if binary_relocation:
+        if binary_relocation is True or (isinstance(f, list) and f in binary_relocation):
             mk_relative(m, f, prefix)
         make_hardlink_copy(f, prefix)
 


### PR DESCRIPTION
also makes binary_relocation accept list of files/globs to improve granularity