### PR TITLE
Copy CONDA_PATH_BACKUP into build/test env.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -32,7 +32,7 @@ from conda_verify.verify import Verify
 
 # used to get version
 from .conda_interface import cc
-from .conda_interface import envs_dirs, root_dir
+from .conda_interface import envs_dirs, env_path_backup_var_exists, root_dir
 from .conda_interface import plan
 from .conda_interface import get_index
 from .conda_interface import PY3
@@ -855,6 +855,8 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                     with path_prepended(config.build_prefix):
                         env = environ.get_dict(config=config, m=m)
                     env["CONDA_BUILD_STATE"] = "BUILD"
+                    if env_path_backup_var_exists:
+                        env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
                     work_file = join(config.work_dir, 'conda_build.sh')
                     if script:
                         with open(work_file, 'w') as bf:
@@ -1064,6 +1066,8 @@ def test(m, config, move_broken=True):
         env = dict(os.environ.copy())
         env.update(environ.get_dict(config=config, m=m, prefix=config.test_prefix))
         env["CONDA_BUILD_STATE"] = "TEST"
+        if env_path_backup_var_exists:
+            env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
 
     if not config.activate:
         # prepend bin (or Scripts) directory

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -25,6 +25,8 @@ import conda.config as cc  # NOQA
 from conda.config import rc_path  # NOQA
 from conda.version import VersionOrder  # NOQA
 
+import os
+
 if parse_version(conda.__version__) >= parse_version("4.2"):
     # conda 4.2.x
     import conda.base.context
@@ -57,6 +59,10 @@ if parse_version(conda.__version__) >= parse_version("4.2"):
 
     # disallow softlinks.  This avoids a lot of dumb issues, at the potential cost of disk space.
     conda.base.context.context.allow_softlinks = False
+
+    # when deactivating envs (e.g. switching from root to build/test) this env var is used,
+    # except the PR that removed this has been reverted (for now) and Windows doesnt need it.
+    env_path_backup_var_exists = os.environ.get('CONDA_PATH_BACKUP', None)
 
 else:
     from conda.config import get_default_urls, non_x86_linux_machines, load_condarc  # NOQA
@@ -91,6 +97,7 @@ else:
     class CondaValueError(Exception):
         pass
 
+    env_path_backup_var_exists = os.environ.get('CONDA_PATH_BACKUP', None)
 
 class SignatureError(Exception):
     pass


### PR DESCRIPTION
Hi @msarahan, this needs to be copied over to ensure that PATH is manipulated correctly (i.e. that the root env gets removed from it). Conda 4.3 will necessitate changing this again.