### PR TITLE
Whitelist MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -385,6 +385,8 @@ def unix_vars(prefix):
 
 def osx_vars(compiler_vars, config):
     OSX_ARCH = 'i386' if config.arch == 32 else 'x86_64'
+    MACOSX_DEPLOYMENT_TARGET = os.environ.get('MACOSX_DEPLOYMENT_TARGET', '10.7')
+
     compiler_vars['CFLAGS'] += ' -arch {0}'.format(OSX_ARCH)
     compiler_vars['CXXFLAGS'] += ' -arch {0}'.format(OSX_ARCH)
     compiler_vars['LDFLAGS'] += ' -arch {0}'.format(OSX_ARCH)
@@ -393,7 +395,7 @@ def osx_vars(compiler_vars, config):
     # d['LDFLAGS'] = ldflags + rpath + ' -arch %(OSX_ARCH)s' % d
     return {
         'OSX_ARCH': OSX_ARCH,
-        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+        'MACOSX_DEPLOYMENT_TARGET': MACOSX_DEPLOYMENT_TARGET,
     }
 
 


### PR DESCRIPTION
Closes https://github.com/conda/conda-build/issues/1269 (though I suppose PR https://github.com/conda/conda-build/pull/1278 should have already)

As promised, whitelist the environment variable `MACOSX_DEPLOYMENT_TARGET` so that people can override it with an external environment variable easily.

cc @msarahan