### PR TITLE
define nomkl selector when FEATURE_NOMKL env var not set

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -69,6 +69,7 @@ def ns_cfg(config):
         np=np,
         os=os,
         environ=os.environ,
+        nomkl=bool(int(os.environ.get('FEATURE_NOMKL', False)))
     )
     for machine in non_x86_linux_machines:
         d[machine] = bool(plat == 'linux-%s' % machine)


### PR DESCRIPTION
Without this, when that environment variable is missing, recipes using nomkl feature will fail to render.