### PR TITLE
allow relative local channels

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - conda-verify
     - conda  >=4.1
-    - contextlib2   [py<3]
+    - contextlib2   [py<34]
     - filelock
     - jinja2
     - patchelf      [linux]

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -111,6 +111,9 @@ def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwar
                 if os.path.basename(local_location).startswith(platform + "-"):
                     local_location = os.path.dirname(local_location)
             update_index(local_location, config=config)
+            if not os.path.abspath(local_location):
+                local_location = os.path.normpath(os.path.abspath(
+                    os.path.join(os.getcwd(), local_location)))
             local_url = url_path(local_location)
             # channel_urls is an iterable, but we don't know if it's a tuple or list.  Don't know
             #    how to add elements.


### PR DESCRIPTION
For example, if you have a local folder ``packages`` that has the standard directory structure:

```
packages
    osx-64
    noarch
```

This PR will allow you to pass ```-c packages``` to conda build, and it will flesh out the full absolute path on whatever machine you're on.

This PR is critical for operation of the Concourse CI system.