### PR TITLE
add prefix length arg.  Allow disabling of prefix length fallback

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -649,21 +649,24 @@ def create_env(prefix, specs, config, clear_cache=True):
                         'post-link failed for: openssl' in str(exc) or
                         isinstance(exc, PaddingError)) and
                         config.prefix_length > 80):
-                    log.warn("Build prefix failed with prefix length %d", config.prefix_length)
-                    log.warn("Error was: ")
-                    log.warn(str(exc))
-                    log.warn("One or more of your package dependencies needs to be rebuilt "
-                            "with a longer prefix length.")
-                    log.warn("Falling back to legacy prefix length of 80 characters.")
-                    log.warn("Your package will not install into prefixes > 80 characters.")
-                    config.prefix_length = 80
+                    if config.prefix_length_fallback:
+                        log.warn("Build prefix failed with prefix length %d", config.prefix_length)
+                        log.warn("Error was: ")
+                        log.warn(str(exc))
+                        log.warn("One or more of your package dependencies needs to be rebuilt "
+                                "with a longer prefix length.")
+                        log.warn("Falling back to legacy prefix length of 80 characters.")
+                        log.warn("Your package will not install into prefixes > 80 characters.")
+                        config.prefix_length = 80
 
-                    # Set this here and use to create environ
-                    #   Setting this here is important because we use it below (symlink)
-                    prefix = config.build_prefix
+                        # Set this here and use to create environ
+                        #   Setting this here is important because we use it below (symlink)
+                        prefix = config.build_prefix
 
-                    create_env(prefix, specs, config=config,
-                                clear_cache=clear_cache)
+                        create_env(prefix, specs, config=config,
+                                    clear_cache=clear_cache)
+                    else:
+                        raise
         warn_on_old_conda_build(index=index)
 
     # ensure prefix exists, even if empty, i.e. when specs are empty

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -187,7 +187,33 @@ different sets of packages."""
         help=("folder to dump output package to.  Package are moved here if build or test succeeds."
               "  Destination folder must exist prior to using this.")
     )
-
+    p.add_argument(
+        "--no-prefix-length-fallback", dest='prefix_length_fallback',
+        action="store_false",
+        help=("Disable fallback to older 80 character prefix length if environment creation"
+              " fails due to insufficient prefix length in dependency packages"),
+        default=True,
+    )
+    p.add_argument(
+        "--prefix-length-fallback", dest='prefix_length_fallback',
+        action="store_true",
+        help=("Disable fallback to older 80 character prefix length if environment creation"
+              " fails due to insufficient prefix length in dependency packages"),
+        # this default will change to false in the future, when we deem that the community has
+        #     had enough time to build long-prefix length packages.
+        default=True,
+    )
+    p.add_argument(
+        "--prefix-length", dest='_prefix_length',
+        help=("length of build prefix.  For packages with binaries that embed the path, this is"
+              " critical to ensuring that your package can run as many places as possible.  Note"
+              "that this value can be altered by the OS below conda-build (e.g. encrypted "
+              "filesystems on Linux), and you should prefer to set --croot to a non-encrypted "
+              "location instead, so that you maintain a known prefix length."),
+        # this default will change to false in the future, when we deem that the community has
+        #     had enough time to build long-prefix length packages.
+        default=255, type=int,
+    )
     add_parser_channels(p)
 
     args = p.parse_args(args)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -18,12 +18,12 @@ from .utils import get_build_folders, rm_rf
 
 log = logging.getLogger(__file__)
 on_win = (sys.platform == 'win32')
+DEFAULT_PREFIX_LENGTH = 255
 
 # Don't "save" an attribute of this module for later, like build_prefix =
 # conda_build.config.config.build_prefix, as that won't reflect any mutated
 # changes.
 
-DEFAULT_PREFIX_LENGTH = 255
 conda_build = "conda-build"
 
 
@@ -81,8 +81,6 @@ class Config(object):
             self.CONDA_NPY = int(self.CONDA_NPY.replace('.', '')) or None
 
         self._build_id = kwargs.get('build_id', getattr(self, '_build_id', ""))
-        self._prefix_length = kwargs.get("prefix_length", getattr(self, '_prefix_length',
-                                                                  DEFAULT_PREFIX_LENGTH))
         croot = kwargs.get('croot')
         if croot:
             self._croot = croot
@@ -111,6 +109,8 @@ class Config(object):
                   Setting('set_build_id', True),
                   Setting('disable_pip', False),
                   Setting('output_folder', None),
+                  Setting('prefix_length_fallback', True),
+                  Setting('_prefix_length', DEFAULT_PREFIX_LENGTH),
 
                   # pypi upload settings (twine)
                   Setting('password', None),


### PR DESCRIPTION
With Conda currently silencing conda-build's logger output, the warnings about prefix length fallback have been hidden, leading to some packages being built unintentionally with short prefixes.  This adds a flag to disable that fallback behavior.  This also adds the longstanding community request that prefix length be settable, but with the warning that they should really prefer to set croot to non-encrypted locations instead.

CC @mingwandroid @ilanschnell 