### PR TITLE
Support for python 3.6

### DIFF
--- a/conda_build/completers.py
+++ b/conda_build/completers.py
@@ -4,7 +4,7 @@ from .conda_interface import Completer
 
 
 all_versions = {
-    'python': [26, 27, 33, 34, 35],
+    'python': [26, 27, 33, 34, 35, 36],
     'numpy': [16, 17, 18, 19, 110, 111],
     'perl': None,
     'R': None,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -65,6 +65,7 @@ def ns_cfg(config):
         py33=bool(py == 33),
         py34=bool(py == 34),
         py35=bool(py == 35),
+        py36=bool(py == 36),
         np=np,
         os=os,
         environ=os.environ,


### PR DESCRIPTION
Currently conda-build does not understand recipes with
```yaml
build:
  skip: true  # [py36]
```
This patch should add the missing variable for the upcoming Python version.