### PR TITLE
remove packaged files from build prefix, to give next script fresh start

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -75,6 +75,8 @@ def create_shell_files(dir_path, m, config):
     ext = '.bat' if sys.platform == 'win32' else '.sh'
     name = 'no-file'
 
+    # the way this works is that each output needs to explicitly define a test script to run.
+    #   They do not automatically pick up run_test.*, but can be pointed at that explicitly.
     for out in m.meta.get('outputs', []):
         if m.name() == out['name']:
             out_test_script = out.get('test', {}).get('script', 'no-file')
@@ -115,6 +117,8 @@ def create_py_files(dir_path, m):
 
         try:
             name = 'run_test.py'
+            # the way this works is that each output needs to explicitly define a test script to run
+            #   They do not automatically pick up run_test.*, but can be pointed at that explicitly.
             for out in m.meta.get('outputs', []):
                 if m.name() == out['name']:
                     out_test_script = out.get('test', {}).get('script', 'no-file')
@@ -160,6 +164,9 @@ def create_pl_files(dir_path, m):
 
         try:
             name = 'run_test.pl'
+
+            # the way this works is that each output needs to explicitly define a test script to run
+            #   They do not automatically pick up run_test.*, but can be pointed at that explicitly.
             for out in m.meta.get('outputs', []):
                 if m.name() == out['name']:
                     out_test_script = out.get('test', {}).get('script', 'no-file')


### PR DESCRIPTION
Fixes a couple of minor issues with split packages:

1. remove files in build prefix prior to next script, so that each script starts "fresh" and duplicates in packages are OK (though discouraged).
2. only make a metapackage if an output with the same name is not explicitly listed in the outputs
3. add cmd.exe execution flags