### PR TITLE
Package consistency

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -199,7 +199,7 @@ def get_pure_py_file_map(t, platform):
     dest_plat, dest_arch = platform.split('-')
     dest_type = 'unix' if dest_plat in {'osx', 'linux'} else 'win'
 
-    files = t.extractfile('info/files').read().decode("utf-8")
+    files = t.extractfile('info/files').read().decode("utf-8").splitlines()
 
     if source_type == 'unix' and dest_type == 'win':
         mapping = path_mapping_unix_windows
@@ -268,7 +268,8 @@ def get_pure_py_file_map(t, platform):
                 assert member.path == oldpath
                 file_map[oldpath] = None
                 file_map[newpath] = newmember
-                files = files.replace(oldpath, newpath)
+                loc = files.index(oldpath)
+                files[loc] = newpath
                 break
         else:
             file_map[oldpath] = member
@@ -289,9 +290,9 @@ def get_pure_py_file_map(t, platform):
                     newmember.size = len(data)
                     file_map[newpath] = newmember, bytes_io(data)
                     batseen.add(oldpath)
-                    files = files + newpath + "\n"
+                    files.append(newpath)
 
-    files = '\n'.join(sorted(files.splitlines())) + '\n'
+    files = '\n'.join(sorted(files)) + '\n'
     if PY3:
         files = bytes(files, 'utf-8')
     filemember.size = len(files)

--- a/tests/test-recipes/metadata/entry_points/meta.yaml
+++ b/tests/test-recipes/metadata/entry_points/meta.yaml
@@ -8,6 +8,11 @@ source:
 build:
   entry_points:
     - test-script-manual = conda_build_test.manual_entry:main
+    # One entry point which is longer than test-script-manual
+    - test-script-manual-postfix = conda_build_test.manual_entry:main
+    # One entry point which is shorter than test-script-manual
+    # (and also a substring of test-script-setup.py)
+    - test-script = conda_build_test.manual_entry:main
 
 requirements:
   build:

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -6,7 +6,7 @@ from conda_build.conda_interface import download
 from conda_build import api
 from conda_build.utils import package_has_file
 
-from .utils import testing_workdir, test_config, on_win, metadata_dir
+from .utils import testing_workdir, test_config, on_win, metadata_dir, assert_package_consistency
 
 def test_convert_wheel_raises():
     with pytest.raises(RuntimeError) as exc:
@@ -38,7 +38,9 @@ def test_convert_from_unix_to_win_creates_entry_points(test_config):
     api.build(recipe_dir, config=test_config)
     for platform in ['win-64', 'win-32']:
         api.convert(fn, platforms=[platform], force=True)
-        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-manual-script.py")
-        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-manual.bat")
-        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-setup-script.py")
-        assert package_has_file(os.path.join(platform, os.path.basename(fn)), "Scripts/test-script-setup.bat")
+        converted_fn = os.path.join(platform, os.path.basename(fn))
+        assert package_has_file(converted_fn, "Scripts/test-script-manual-script.py")
+        assert package_has_file(converted_fn, "Scripts/test-script-manual.bat")
+        assert package_has_file(converted_fn, "Scripts/test-script-setup-script.py")
+        assert package_has_file(converted_fn, "Scripts/test-script-setup.bat")
+        assert_package_consistency(converted_fn)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,7 @@ from os.path import join, dirname
 import stat
 import subprocess
 import sys
+import shlex
 
 
 import pytest
@@ -101,6 +102,74 @@ def add_mangling(filename):
         filename = os.path.join(os.path.dirname(filename), '__pycache__',
                                 os.path.basename(filename))
     return filename + 'c'
+
+
+def assert_package_consistency(package_path):
+    """Assert internal consistency of package
+
+    - All files in info/files are included in package
+    - All files in info/has_prefix is included in info/files
+    - All info in paths.json is correct (not implemented - currently fails for conda-convert)
+
+    Return nothing, but raise RuntimeError if inconsistencies are found.
+    """
+    import tarfile
+    try:
+        with tarfile.open(package_path) as t:
+            # Read info from tar file
+            member_list = t.getnames()
+            files = t.extractfile('info/files').read().decode('utf-8')
+            # Read info/has_prefix if present
+            if 'info/has_prefix' in member_list:
+                has_prefix_present = True
+                has_prefix = t.extractfile('info/has_prefix').read().decode('utf-8')
+            else:
+                has_prefix_present = False
+    except tarfile.ReadError:
+        raise RuntimeError("Could not extract metadata from %s. "
+                           "File probably corrupt." % package_path)
+    errors = []
+    member_set = set(member_list)  # The tar format allows duplicates in member_list
+    # Read info from info/files
+    file_list = files.splitlines()
+    file_set = set(file_list)
+    # Check that there are no duplicates in info/files
+    if len(file_list) != len(file_set):
+        errors.append("Duplicate files in info/files in %s" % package_path)
+    # Compare the contents of files and members
+    unlisted_members = member_set.difference(file_set)
+    missing_members = file_set.difference(member_set)
+    # Find any unlisted members outside the info directory
+    missing_files = [m for m in unlisted_members if not m.startswith('info/')]
+    if len(missing_files) > 0:
+        errors.append("The following package files are not listed in "
+                           "info/files: %s" % ', '.join(missing_files))
+    # Find any files missing in the archive
+    if len(missing_members) > 0:
+        errors.append("The following files listed in info/files are missing: "
+                           "%s" % ', '.join(missing_members))
+    # Find any files in has_prefix that are not present in files
+    if has_prefix_present:
+        prefix_path_list = []
+        for line in has_prefix.splitlines():
+            # (parsing from conda/gateways/disk/read.py::read_has_prefix() in conda repo)
+            parts = tuple(x.strip('"\'') for x in shlex.split(line, posix=False))
+            if len(parts) == 1:
+                prefix_path_list.append(parts[0])
+            elif len(parts) == 3:
+                prefix_path_list.append(parts[2])
+            else:
+                errors.append("Invalid has_prefix file in package: %s" % package_path)
+        prefix_path_set = set(prefix_path_list)
+        if len(prefix_path_list) != len(prefix_path_set):
+            errors.append("Duplicate files in info/has_prefix in %s" % package_path)
+        prefix_not_in_files = prefix_path_set.difference(file_set)
+        if len(prefix_not_in_files) > 0:
+            errors.append("The following files listed in info/prefix are missing "
+                          "from info/files: %s" % ', '.join(prefix_not_in_files))
+
+    # Assert that no errors are detected
+    assert len(errors) == 0, '\n'.join(errors)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This is really a bugfix for issue #712. 

The actual fix is in commit 
https://github.com/gomyhr/conda-build/commit/23230c65c0bfad50f4bca755603514ed56bfbe51. It is a bit more elaborate than the simplest solution in the issue, in that info/files is read as a list instead of a string straight away. This should tie better in with the change when info/paths.json will be used instead of info/files later.

The first two commits (
https://github.com/gomyhr/conda-build/commit/8f5b3d19e2e6a168baf060e08b7af9a5deb8f393 and 
https://github.com/gomyhr/conda-build/commit/eb459b13243714e66caf5178fe14f598e0e84c02) add a package consistency check to the convert test with entry points.  I wasn't quite sure tests/utils.py was the right place to add a function for checking package consistency, but I could not see any better place.

The third commit 
(https://github.com/gomyhr/conda-build/commit/ccb82c54698c68f133fbf00940eec504acbe403a) adds another entry point to the test, which generates an inconsistent package, and this is picked up by the newly added test.

The last commit (
https://github.com/gomyhr/conda-build/commit/8adc066e415a4dfdcfb3d9331e5650eea0552c97) adds a warning if things go wrong. I thought it was more transparent to split this off from the bugfix itself.