### PR TITLE
WIP: support for build.sh on win

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - jinja2
     - patchelf      [linux]
     - pkginfo
+    - posix         [win]
     - pycrypto
     - python
     - pyyaml

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -847,8 +847,10 @@ class MetaData(object):
 
     @property
     def uses_vcs_in_build(self):
-        build_script = "bld.bat" if on_win else "build.sh"
-        build_script = os.path.join(os.path.dirname(self.meta_path), build_script)
+        build_script = "bld.bat" if (on_win and
+                                     os.path.isfile(os.path.join(self.path, 'bld.bat'))) else \
+                                     "build.sh"
+        build_script = os.path.join(self.path, build_script)
         for recipe_file in (build_script, self.meta_path):
             if os.path.isfile(recipe_file):
                 vcs_types = ["git", "svn", "hg"]

--- a/tests/test-recipes/metadata/_build_sh/build.sh
+++ b/tests/test-recipes/metadata/_build_sh/build.sh
@@ -1,0 +1,1 @@
+echo "test" > $PREFIX/test_file

--- a/tests/test-recipes/metadata/_build_sh/meta.yaml
+++ b/tests/test-recipes/metadata/_build_sh/meta.yaml
@@ -1,0 +1,5 @@
+# test that build.sh works on windows as well as on mac and linux
+
+package:
+  name: test_build_sh
+  version: 1.0

--- a/tests/test-recipes/metadata/_build_sh/run_test.sh
+++ b/tests/test-recipes/metadata/_build_sh/run_test.sh
@@ -1,0 +1,2 @@
+test -f $PREFIX/test_file
+echo "Running test in shell"

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -789,3 +789,12 @@ def test_build_expands_wildcards(mocker, testing_workdir):
     output = [os.path.join(os.getcwd(), path, 'meta.yaml') for path in files]
     build_tree.assert_called_once_with(output, post=None, need_source_download=True,
                                        build_only=False, notest=False, config=config)
+
+
+@pytest.mark.skipif(not on_win, reason="windows-only functionality")
+def test_build_sh_on_win(test_config, capfd):
+    recipe = os.path.join(metadata_dir, "_build_sh")
+    outputs = api.build(recipe, config=test_config)
+    assert package_has_file(outputs[0], 'test_file'), "expected file doesn't exist - build.sh didn't run"
+    output, error = capfd.readouterr()
+    assert "Running test in shell" in output, "didn't run run_test.sh"


### PR DESCRIPTION
fixes #1605 

This presently runs build.sh and run_test.sh.  It does so by preferentially running those, and putting in shims to run the older bat files from within a .sh file, calling out to cmd.exe.  This is a philosophical shift to having sh files be the standard everywhere.

This is not done.  We still have gaping questions to answer about how the Visual Studio variable activation should happen.  I think the best way forward is to move all of that activation logic out of conda-build and into conda packages that set the appropriate variables in their activate.d scripts.

CC @mingwandroid 