### PR TITLE
Better default for build/features in bdist_conda

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -92,7 +92,7 @@ class CondaDistribution(Distribution):
         'conda_command_tests': True,
         'conda_binary_relocation': True,
         'conda_preserve_egg_dir': None,
-        'conda_features': None,
+        'conda_features': [],
         'conda_track_features': None,
     }
 


### PR DESCRIPTION
It seems that `conda-build` now expects `build/features` to be an actual list not `None`. So make the default value of `build/features` an empty list. That way it is compliant with `conda-build`, but still has a sensible default that means there are no features.