### PR TITLE
add 'aggressive_update' field to index.json

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -291,13 +291,13 @@ default_structs = {
     'build/script_env': list,
     'build/features': list,
     'build/track_features': list,
+    'build/aggressive_update': text_type,
     'requirements/build': list,
     'requirements/host': list,
     'requirements/run': list,
     'requirements/conflicts': list,
     'requirements/preferred_env': text_type,
     'requirements/preferred_env_executable_paths': list,
-    'requirements/aggressive_update': text_type,
     'test/requires': list,
     'test/files': list,
     'test/source_files': list,
@@ -387,7 +387,7 @@ FIELDS = {
                'svn_url', 'svn_rev', 'svn_ignore_externals',
                'patches'
                ],
-    'build': ['number', 'string', 'entry_points', 'osx_is_app',
+    'build': ['number', 'string', 'entry_points', 'osx_is_app', 'aggressive_update',
               'features', 'track_features', 'preserve_egg_dir',
               'no_link', 'binary_relocation', 'script', 'noarch', 'noarch_python',
               'has_prefix_files', 'binary_has_prefix_files', 'ignore_prefix_files',
@@ -396,7 +396,7 @@ FIELDS = {
               'pin_depends', 'include_recipe',  # pin_depends is experimental still
               'preferred_env', 'preferred_env_executable_paths',
               ],
-    'requirements': ['build', 'run', 'conflicts', 'aggressive_update'],
+    'requirements': ['build', 'run', 'conflicts', ],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
     'test': ['requires', 'commands', 'files', 'imports', 'source_files'],
@@ -933,8 +933,8 @@ class MetaData(object):
                 d['noarch'] = build_noarch
         if self.is_app():
             d.update(self.app_meta())
-        if self.get_value('requirements/aggressive_update'):
-            d['aggressive_update'] = self.get_value('requirements/aggressive_update')
+        if self.get_value('build/aggressive_update'):
+            d['aggressive_update'] = self.get_value('build/aggressive_update')
         return d
 
     def has_prefix_files(self):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -295,6 +295,9 @@ default_structs = {
     'requirements/host': list,
     'requirements/run': list,
     'requirements/conflicts': list,
+    'requirements/preferred_env': text_type,
+    'requirements/preferred_env_executable_paths': list,
+    'requirements/aggressive_update': text_type,
     'test/requires': list,
     'test/files': list,
     'test/source_files': list,
@@ -393,7 +396,7 @@ FIELDS = {
               'pin_depends', 'include_recipe',  # pin_depends is experimental still
               'preferred_env', 'preferred_env_executable_paths',
               ],
-    'requirements': ['build', 'host', 'run', 'conflicts'],
+    'requirements': ['build', 'run', 'conflicts', 'aggressive_update'],
     'app': ['entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'],
     'test': ['requires', 'commands', 'files', 'imports', 'source_files'],
@@ -930,6 +933,8 @@ class MetaData(object):
                 d['noarch'] = build_noarch
         if self.is_app():
             d.update(self.app_meta())
+        if self.get_value('requirements/aggressive_update'):
+            d['aggressive_update'] = self.get_value('requirements/aggressive_update')
         return d
 
     def has_prefix_files(self):

--- a/tests/test-recipes/metadata/_no_include_recipe/meta.yaml
+++ b/tests/test-recipes/metadata/_no_include_recipe/meta.yaml
@@ -4,3 +4,4 @@ package:
 
 build:
   include_recipe: False
+  aggressive_update: '<2.0'

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -152,6 +152,10 @@ def test_no_include_recipe_meta_yaml(testing_metadata, testing_config):
                             config=testing_config)[0]
     assert not package_has_file(output_file, "info/recipe/meta.yaml")
 
+    # also test aggressive_update here
+    index_json = json.loads(package_has_file(output_file, 'info/index.json').decode())
+    assert index_json['aggressive_update'] == "<2.0"
+
 
 def test_early_abort(testing_config, capfd):
     """There have been some problems with conda-build dropping out early.


### PR DESCRIPTION
Once an environment is created, the conda solver optimizes for minimum changes to packages on each successive operation.  @mcg1969 and I have iterated a lot on this behavior, and found the 'minimum change' case to generally be what users expect.  However there are certain packages you want to always be up-to-date, i.e. aggressively updated.  This adds a field `aggressive_update` to index.json that takes a version specification string.  When `aggressive_update` is specified in the recipe meta.yaml, the conda solver will override the minimum change behavior.

This will replace the need for the hard-coded `add_defaults_to_specs()` function in conda.

An example use of this is for python.  The `aggressive_update` field for a `2.7.x` python package should be

    requirements:
      aggressive_update: 2.7.*

In conda, we will also create a new configuration parameter to ignore aggressive update directives.  This will be useful (and perhaps needed) for package builders and recipe maintainers.

CC @mcg1969 