### PR TITLE
fix features being None -> list

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -868,6 +868,6 @@ class MetaData(object):
         return None
 
     def validate_features(self):
-        if any('-' in feature for feature in self.get_value('build/features')):
+        if any('-' in feature for feature in ensure_list(self.get_value('build/features'))):
             raise ValueError("- is a disallowed character in features.  Please change this "
                              "character in your recipe.")


### PR DESCRIPTION
closes #1634

In feature validation, if features was None, the code barfed.  This ensures that None gets translated into a list - the value should always be a list.

CC @jakirham