### PR TITLE
utilize chardet and bs4 to guess file encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ install:
         hash -r;
         conda info;
     fi
-  - conda install -q anaconda-client requests=2.11.1 filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION pyflakes=1.1 conda-verify
+  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION
+  - conda install -q pyflakes conda-verify beautifulsoup4 chardet
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,8 +52,8 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2
-  - conda install -q pyflakes=1.1 pycrypto posix m2-git anaconda-client numpy conda-verify
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet
+  - conda install -q pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4
   - conda install -c conda-forge -q perl
   # this is to ensure dependencies
   - python --version

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   build:
     - python
   run:
+    - beautifulsoup4
+    - chardet
     - conda  >=4.1
     - contextlib2   [py<34]
     - conda-verify

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -4,6 +4,7 @@ import os
 import sys
 from os.path import isdir, join, dirname, isfile
 
+import bs4
 # importing setuptools patches distutils so that it knows how to find VC for python 2.7
 import setuptools  # noqa
 # Leverage the hard work done by setuptools/distutils to find vcvarsall using
@@ -43,7 +44,7 @@ def fix_staged_scripts(scripts_dir):
             continue
 
         with open(join(scripts_dir, fn)) as f:
-            line = f.readline().lower()
+            line = bs4.UnicodeDammit(f.readline()).unicode_markup.lower()
             # If it's a #!python script
             if not (line.startswith('#!') and 'python' in line.lower()):
                 continue


### PR DESCRIPTION
fixes #1632 

Chardet enhances bs4.  It is not directly imported.

Not sure if there's anywhere else that also needs this encoding guessing.  @jakirkham if you are aware of other recipes that are broken with encoding errors, please let me know.

@tarcisiofischer this works, sort of.  I can build the package, but the tests fail with some weird characters:

```(C:\MC2x64\conda-bld\recipe_1484008724922\_t_env) C:\MC2x64\conda-bld\recipe_1484008724922\test_tmp>waf --help
[91mError: run waf-light from a folder containing waflib[0m
```

Not sure if that's related, or just an artifact.  Sometimes that stuff shows up with bash involved.