### PR TITLE
fix not-yet-rendered version raising validation error

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -544,7 +544,8 @@ class MetaData(object):
         if res is None:
             sys.exit("Error: package/version missing in: %r" % self.meta_path)
         check_bad_chrs(res, 'package/version')
-        assert not res.startswith('.'), "Version can't start with leading period -  got %s" % res
+        assert self.undefined_jinja_vars or not res.startswith('.'), "Fully-rendered version can't\
+        start with leading period -  got %s" % res
         return res
 
     def build_number(self):

--- a/tests/test-recipes/metadata/_git_describe_number_branch/meta.yaml
+++ b/tests/test-recipes/metadata/_git_describe_number_branch/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: git_describe_number_branch
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ GIT_DESCRIBE_TAG }}.0
 
 source:
   git_url: https://github.com/conda/conda_build_test_recipe

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -125,7 +125,7 @@ def test_no_anaconda_upload_condarc(service_name, testing_workdir, test_config, 
 def test_git_describe_info_on_branch(test_config):
     output = api.get_output_file_path(os.path.join(metadata_dir, "_git_describe_number_branch"))
     test_path = os.path.join(sys.prefix, "conda-bld", test_config.subdir,
-                             "git_describe_number_branch-1.20.2-1_g82c6ba6.tar.bz2")
+                             "git_describe_number_branch-1.20.2.0-1_g82c6ba6.tar.bz2")
     assert test_path == output
 
 


### PR DESCRIPTION
fixes #1640 - the exception should only be there if the recipe is fully rendered and yet still has periods at the start of version