### PR TITLE
use only check_call_env.  Fix coercion of args to string therein

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -797,7 +797,7 @@ def bundle_conda(output, metadata, config, env, **kw):
         if not interpreter:
             interpreter = guess_interpreter(output['script'])
         initial_files_snapshot = prefix_files(config.build_prefix)
-        utils._check_call(interpreter.split(' ') +
+        utils.check_call_env(interpreter.split(' ') +
                     [os.path.join(metadata.path, output['script'])],
                     cwd=config.build_prefix, env=env)
         files = prefix_files(config.build_prefix) - initial_files_snapshot
@@ -1029,7 +1029,7 @@ def build(m, config, post=None, need_source_download=True, need_reparse_in_env=F
                     if isfile(work_file):
                         cmd = [shell_path, '-x', '-e', work_file]
                         # this should raise if any problems occur while building
-                        utils._check_call(cmd, env=env, cwd=src_dir)
+                        utils.check_call_env(cmd, env=env, cwd=src_dir)
 
     if post in [True, None]:
         if post:
@@ -1323,7 +1323,7 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
     else:
         cmd = [shell_path, '-x', '-e', test_script]
     try:
-        subprocess.check_call(cmd, env=env, cwd=config.test_dir)
+        utils.check_call_env(cmd, env=env, cwd=config.test_dir)
     except subprocess.CalledProcessError:
         tests_failed(metadata, move_broken=move_broken, broken_dir=config.broken_dir, config=config)
 
@@ -1556,7 +1556,7 @@ def handle_pypi_upload(f, config):
 
     args.append(f)
     try:
-        subprocess.check_call()
+        utils.check_call_env(args)
     except:
         logging.getLogger(__name__).warn("wheel upload failed - is twine installed?"
                                          "  Is this package registered?")

--- a/conda_build/develop.py
+++ b/conda_build/develop.py
@@ -13,7 +13,7 @@ import sys
 from .conda_interface import string_types
 
 from conda_build.post import mk_relative_osx
-from conda_build.utils import _check_call, rec_glob, get_site_packages
+from conda_build.utils import check_call_env, rec_glob, get_site_packages
 from conda_build.os_utils.external import find_executable
 
 
@@ -82,7 +82,7 @@ def _clean(setup_py):
     '''
     # first call setup.py clean
     cmd = ['python', setup_py, 'clean']
-    _check_call(cmd)
+    check_call_env(cmd)
     print("Completed: " + " ".join(cmd))
     print("===============================================")
 
@@ -100,7 +100,7 @@ def _build_ext(setup_py):
 
     # next call setup.py develop
     cmd = ['python', setup_py, 'build_ext', '--inplace']
-    _check_call(cmd)
+    check_call_env(cmd)
     print("Completed: " + " ".join(cmd))
     print("===============================================")
 

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -20,7 +20,7 @@ from conda_build.conda_interface import MatchSpec, Resolve
 from conda_build.conda_interface import memoized
 
 from conda_build.config import Config
-from conda_build.utils import on_win
+from conda_build.utils import on_win, check_call_env
 
 CPAN_META = """\
 package:
@@ -173,7 +173,7 @@ def package_exists(package_name):
         if on_win:
             cmd.insert(0, '/c')
             cmd.insert(0, 'cmd.exe')
-        subprocess.check_call(cmd)
+        check_call_env(cmd)
         in_repo = True
     except subprocess.CalledProcessError:
         in_repo = False

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -29,7 +29,7 @@ from conda_build.conda_interface import normalized_version
 from conda_build.conda_interface import human_bytes, hashsum_file
 from conda_build.conda_interface import default_python
 
-from conda_build.utils import tar_xf, unzip, rm_rf
+from conda_build.utils import tar_xf, unzip, rm_rf, check_call_env
 from conda_build.source import apply_patch
 from conda_build.build import create_env
 from conda_build.config import Config
@@ -993,7 +993,7 @@ def run_setuppy(src_dir, temp_dir, python_version, config, setup_options):
     cmdargs = [config.build_python, 'setup.py', 'install']
     cmdargs.extend(setup_options)
     try:
-        subprocess.check_call(cmdargs, env=env)
+        check_call_env(cmdargs, env=env)
     except subprocess.CalledProcessError:
         print('$PYTHONPATH = %s' % env['PYTHONPATH'])
         sys.exit('Error: command failed: %s' % ' '.join(cmdargs))

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -410,6 +410,9 @@ def safe_print_unicode(*args, **kwargs):
 def rec_glob(path, patterns):
     result = []
     for d_f in os.walk(path):
+        # ignore the .git folder
+        # if '.git' in d_f[0]:
+        #     continue
         m = []
         for pattern in patterns:
             m.extend(fnmatch.filter(d_f[2], pattern))
@@ -589,7 +592,8 @@ def check_call_env(popenargs, **kwargs):
 
 
 def check_output_env(popenargs, **kwargs):
-    return _func_defaulting_env_to_os_environ(subprocess.check_output, *popenargs, **kwargs)
+    return _func_defaulting_env_to_os_environ(subprocess.check_output, *popenargs, **kwargs)\
+        .rstrip()
 
 
 _posix_exes_cache = {}
@@ -676,7 +680,7 @@ def find_recipe(path):
     if len(results) > 1:
         base_recipe = os.path.join(path, "meta.yaml")
         if base_recipe in results:
-            return base_recipe
+            results = [base_recipe]
         else:
             raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -280,15 +280,6 @@ def relative(f, d='lib'):
     return '/'.join(((['..'] * len(f)) if f else ['.']) + d)
 
 
-def _check_call(args, **kwargs):
-    if 'env' in kwargs:
-        kwargs['env'] = {str(key): str(value) for key, value in kwargs['env'].items()}
-    try:
-        subprocess.check_call(args, **kwargs)
-    except subprocess.CalledProcessError as e:
-        sys.exit('Command failed: %s, output: %s' % (' '.join(args), str(e)))
-
-
 def tar_xf(tarball, dir_path, mode='r:*'):
     if tarball.lower().endswith('.tar.z'):
         uncompress = external.find_executable('uncompress')
@@ -298,7 +289,7 @@ def tar_xf(tarball, dir_path, mode='r:*'):
             sys.exit("""\
 uncompress (or gunzip) is required to unarchive .z source files.
 """)
-        subprocess.check_call([uncompress, '-f', tarball])
+        check_call_env([uncompress, '-f', tarball])
         tarball = tarball[:-2]
     if not PY3 and tarball.endswith('.tar.xz'):
         unxz = external.find_executable('unxz')
@@ -307,7 +298,7 @@ uncompress (or gunzip) is required to unarchive .z source files.
 unxz is required to unarchive .xz source files.
 """)
 
-        subprocess.check_call([unxz, '-f', '-k', tarball])
+        check_call_env([unxz, '-f', '-k', tarball])
         tarball = tarball[:-3]
     t = tarfile.open(tarball, mode)
     t.extractall(path=dir_path)
@@ -581,6 +572,7 @@ def _func_defaulting_env_to_os_environ(func, *popenargs, **kwargs):
         kwargs = kwargs.copy()
         env_copy = os.environ.copy()
         kwargs.update({'env': env_copy})
+    kwargs['env'] = {str(key): str(value) for key, value in kwargs['env'].items()}
     _args = []
     for arg in popenargs:
         # arguments to subprocess need to be bytestrings

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -14,7 +14,7 @@ from distutils.msvc9compiler import Reg, WINSDK_BASE
 from .conda_interface import bits
 
 from conda_build import environ
-from conda_build.utils import _check_call, root_script_dir, path_prepended, copy_into
+from conda_build.utils import check_call_env, root_script_dir, path_prepended, copy_into
 
 
 assert sys.platform == 'win32'
@@ -227,6 +227,6 @@ def build(m, bld_bat, config):
             fo.write(data)
 
         cmd = ['cmd.exe', '/c', 'bld.bat']
-        _check_call(cmd, cwd=src_dir)
+        check_call_env(cmd, cwd=src_dir)
 
     fix_staged_scripts(join(config.build_prefix, 'Scripts'))

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -212,7 +212,7 @@ def test_dirty_variable_available_in_build_scripts(testing_workdir, test_config)
     test_config.dirty = True
     api.build(recipe, config=test_config)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(subprocess.CalledProcessError):
         test_config.dirty = False
         api.build(recipe, config=test_config)
 
@@ -594,11 +594,11 @@ def test_disable_pip(test_config):
     metadata, _, _ = api.render(recipe_path, config=test_config)
 
     metadata.meta['build']['script'] = 'python -c "import pip"'
-    with pytest.raises(SystemExit):
+    with pytest.raises(subprocess.CalledProcessError):
         api.build(metadata)
 
     metadata.meta['build']['script'] = 'python -c "import setuptools"'
-    with pytest.raises(SystemExit):
+    with pytest.raises(subprocess.CalledProcessError):
         api.build(metadata)
 
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -26,7 +26,7 @@ import tarfile
 from conda_build import api, exceptions, __version__
 from conda_build.build import VersionOrder
 from conda_build.utils import (copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2,
-                               package_has_file)
+                               package_has_file, check_output_env)
 from conda_build.os_utils.external import find_executable
 
 from .utils import (metadata_dir, fail_dir, is_valid_dir, testing_workdir, test_config,
@@ -65,7 +65,7 @@ class AnacondaClientArgs(object):
 def describe_root(cwd=None):
     if not cwd:
         cwd = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    tag = subprocess.check_output(["git", "describe", "--abbrev=0"], cwd=cwd).rstrip()
+    tag = check_output_env(["git", "describe", "--abbrev=0"], cwd=cwd).rstrip()
     if PY3:
         tag = tag.decode("utf-8")
     return tag
@@ -486,43 +486,43 @@ def test_relative_git_url_submodule_clone(testing_workdir):
     for tag in range(2):
         os.chdir(absolute_sub)
         if tag == 0:
-            subprocess.check_call([git, 'init'], env=sys_git_env)
+            check_call_env([git, 'init'], env=sys_git_env)
         with open('absolute', 'w') as f:
             f.write(str(tag))
-        subprocess.check_call([git, 'add', 'absolute'], env=sys_git_env)
-        subprocess.check_call([git, 'commit', '-m', 'absolute{}'.format(tag)],
+        check_call_env([git, 'add', 'absolute'], env=sys_git_env)
+        check_call_env([git, 'commit', '-m', 'absolute{}'.format(tag)],
                                 env=sys_git_env)
 
         os.chdir(relative_sub)
         if tag == 0:
-            subprocess.check_call([git, 'init'], env=sys_git_env)
+            check_call_env([git, 'init'], env=sys_git_env)
         with open('relative', 'w') as f:
             f.write(str(tag))
-        subprocess.check_call([git, 'add', 'relative'], env=sys_git_env)
-        subprocess.check_call([git, 'commit', '-m', 'relative{}'.format(tag)],
+        check_call_env([git, 'add', 'relative'], env=sys_git_env)
+        check_call_env([git, 'commit', '-m', 'relative{}'.format(tag)],
                                 env=sys_git_env)
 
         os.chdir(toplevel)
         if tag == 0:
-            subprocess.check_call([git, 'init'], env=sys_git_env)
+            check_call_env([git, 'init'], env=sys_git_env)
         with open('toplevel', 'w') as f:
             f.write(str(tag))
-        subprocess.check_call([git, 'add', 'toplevel'], env=sys_git_env)
-        subprocess.check_call([git, 'commit', '-m', 'toplevel{}'.format(tag)],
+        check_call_env([git, 'add', 'toplevel'], env=sys_git_env)
+        check_call_env([git, 'commit', '-m', 'toplevel{}'.format(tag)],
                                 env=sys_git_env)
         if tag == 0:
-            subprocess.check_call([git, 'submodule', 'add',
+            check_call_env([git, 'submodule', 'add',
                                     convert_path_for_cygwin_or_msys2(git, absolute_sub), 'absolute'],
                                     env=sys_git_env)
-            subprocess.check_call([git, 'submodule', 'add', '../relative_sub', 'relative'],
+            check_call_env([git, 'submodule', 'add', '../relative_sub', 'relative'],
                                     env=sys_git_env)
         else:
             # Once we use a more recent Git for Windows than 2.6.4 on Windows or m2-git we
             # can change this to `git submodule update --recursive`.
-            subprocess.check_call([git, 'submodule', 'foreach', git, 'pull'], env=sys_git_env)
-        subprocess.check_call([git, 'commit', '-am', 'added submodules@{}'.format(tag)],
+            check_call_env([git, 'submodule', 'foreach', git, 'pull'], env=sys_git_env)
+        check_call_env([git, 'commit', '-am', 'added submodules@{}'.format(tag)],
                               env=sys_git_env)
-        subprocess.check_call([git, 'tag', '-a', str(tag), '-m', 'tag {}'.format(tag)],
+        check_call_env([git, 'tag', '-a', str(tag), '-m', 'tag {}'.format(tag)],
                                 env=sys_git_env)
 
         # It is possible to use `Git for Windows` here too, though you *must* not use a different

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -20,6 +20,7 @@ def test_convert_exe_raises():
         assert "cannot convert:" in str(exc)
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 def test_convert_platform_to_others(testing_workdir, base_platform):
     f = 'http://repo.continuum.io/pkgs/free/{}-64/itsdangerous-0.24-py27_0.tar.bz2'.format(base_platform)
@@ -31,6 +32,8 @@ def test_convert_platform_to_others(testing_workdir, base_platform):
         assert package_has_file(os.path.join(platform, fn),
                                 '{}/site-packages/itsdangerous.py'.format(python_folder))
 
+
+@pytest.mark.serial
 @pytest.mark.skipif(on_win, reason="we create the package to be converted in *nix, so don't run on win.")
 def test_convert_from_unix_to_win_creates_entry_points(test_config):
     recipe_dir = os.path.join(metadata_dir, "entry_points")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,8 @@ from conda_build.conda_interface import download
 from conda_build.tarcheck import TarCheck
 
 from conda_build import api
-from conda_build.utils import get_site_packages, on_win, get_build_folders, package_has_file
+from conda_build.utils import (get_site_packages, on_win, get_build_folders, package_has_file,
+                               check_call_env)
 from conda_build.conda_interface import TemporaryDirectory
 from .utils import (testing_workdir, metadata_dir, testing_env, test_config, test_metadata,
                     put_bad_conda_on_path)
@@ -41,8 +42,8 @@ def test_build_with_conda_not_on_path(testing_workdir):
     with put_bad_conda_on_path(testing_workdir):
         # using subprocess is not ideal, but it is the easiest way to ensure that PATH
         #    is altered the way we want here.
-        utils.check_call_env('conda-build {0}'.format(os.path.join(metadata_dir, "python_run")),
-                              env=os.environ, shell=True)
+        check_call_env('conda-build {0}'.format(os.path.join(metadata_dir, "python_run")).split(),
+                              env=os.environ)
 
 def test_build_add_channel():
     """This recipe requires the blinker package, which is only on conda-forge.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ def test_build_with_conda_not_on_path(testing_workdir):
     with put_bad_conda_on_path(testing_workdir):
         # using subprocess is not ideal, but it is the easiest way to ensure that PATH
         #    is altered the way we want here.
-        subprocess.check_call('conda-build {0}'.format(os.path.join(metadata_dir, "python_run")),
+        utils.check_call_env('conda-build {0}'.format(os.path.join(metadata_dir, "python_run")),
                               env=os.environ, shell=True)
 
 def test_build_add_channel():

--- a/tests/test_published_examples.py
+++ b/tests/test_published_examples.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 
 from conda_build import api
-from .utils import testing_workdir, test_config, metadata_dir, is_valid_dir
+from .utils import testing_workdir, test_config, metadata_dir, is_valid_dir, check_call_env
 
 published_examples = os.path.join(os.path.dirname(metadata_dir), 'published_code')
 
@@ -12,9 +12,9 @@ published_examples = os.path.join(os.path.dirname(metadata_dir), 'published_code
 def test_skeleton_pypi(testing_workdir):
     """published in docs at http://conda.pydata.org/docs/build_tutorials/pkgs.html"""
     cmd = 'conda skeleton pypi pyinstrument'
-    subprocess.check_call(cmd.split())
+    check_call_env(cmd.split())
     cmd = 'conda build pyinstrument'
-    subprocess.check_call(cmd.split())
+    check_call_env(cmd.split())
 
 @pytest.fixture(params=[dirname for dirname in os.listdir(published_examples)
                         if is_valid_dir(published_examples, dirname)])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ import pytest
 from conda_build.conda_interface import PY3
 from conda_build.config import Config
 from conda_build.metadata import MetaData
-from conda_build.utils import on_win, prepend_bin_path
+from conda_build.utils import on_win, prepend_bin_path, check_call_env
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 metadata_dir = os.path.join(thisdir, "test-recipes/metadata")
@@ -82,8 +82,8 @@ def test_metadata(request, test_config):
 def testing_env(testing_workdir, request):
     env_path = os.path.join(testing_workdir, 'env')
 
-    subprocess.check_call(['conda', 'create', '-yq', '-p', env_path,
-                           'python={0}'.format(".".join(sys.version.split('.')[:2]))])
+    check_call_env(['conda', 'create', '-yq', '-p', env_path,
+                    'python={0}'.format(".".join(sys.version.split('.')[:2]))])
     path_backup = os.environ['PATH']
     os.environ['PATH'] = prepend_bin_path(os.environ.copy(), env_path, prepend_prefix=True)['PATH']
 


### PR DESCRIPTION
This was some crufty code duplication, anyway.

Also, Python 2.7 using check_output has a trailing newline that python 3.x does not have.  This was causing an invalid rendered recipe to be written to packages.  This newline is rstripped by this commit.

Fixes #1642 
Fixes #1618 