### PR TITLE
conda_build/windows.py: avoid trailing semicolon in %MSYS2_ARG_CONV_EXCL%

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -131,7 +131,7 @@ def msvc_env_cmd(bits, config, override=None):
                                                             {64: ' Win64', 32: ''}[bits]))
     # tell msys2 to ignore path conversions for issue-causing windows-style flags in build
     #   See https://github.com/conda-forge/icu-feedstock/pull/5
-    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out;%MSYS2_ARG_CONV_EXCL%"')
+    msvc_env_lines.append('set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"')
     msvc_env_lines.append('set "MSYS2_ENV_CONV_EXCL=CL"')
     if version == '10.0':
         try:


### PR DESCRIPTION
The previous method of setting the `%MSYS2_ARG_CONV_EXCL%` environment variable tried to preserve any preexisting value of the variable. Not only does this make the build process depend on the initial environment more, it generally leads to a trailing semicolon in the variable value. This seems to cause MSYS2 to parse the variable as having an empty value that prevents *all* argument conversions, as investigated in the conda-forge `cairo` package: [see here](https://github.com/conda-forge/cairo-feedstock/pull/18).

I do not know what fallout this change will have for existing build scripts, but the current behavior cannot be what was intended.