### PR TITLE
skeleton(CRAN): Workaround no `Depends:`

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -293,6 +293,9 @@ def dict_from_cran_lines(lines):
     for line in lines:
         if not line:
             continue
+        if line == 'Depends:':
+            # The CRAN package 'leaps' has empty depends. Make it depend on CONDA_R instead.
+            line = 'Depends: R (>= %s)' % (Config().CONDA_R)
         try:
             (k, v) = line.split(': ', 1)
         except ValueError:

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -10,6 +10,9 @@ from .utils import testing_workdir, test_config
 thisdir = os.path.dirname(os.path.realpath(__file__))
 
 repo_packages = [('', 'pypi', 'pip', "8.1.2"),
+                 # has no deps
+                 ('r', 'cran', 'leaps', ""),
+                 # has deps
                  ('r', 'cran', 'nmf', ""),
                  ('perl', 'cpan', 'Shell-Cmd', ""),
                  # ('lua', luarocks', 'LuaSocket'),


### PR DESCRIPTION
The CRAN `leaps` package suffers from this.

Submitting here as I don't want to disrupt my own repo with the cross compile changes.