### PR TITLE
add pythonw on osx for tests when osx_is_app is defined

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1321,6 +1321,10 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
             if utils.on_win:
                 tf.write("if errorlevel 1 exit 1\n")
         if py_files:
+            test_python = config.test_python
+            # use pythonw for import tests when osx_is_app is set
+            if metadata.get_value('build/osx_is_app') and sys.platform == 'darwin':
+                test_python = test_python + 'w'
             tf.write("{python} -s {test_file}\n".format(
                 python=config.test_python,
                 test_file=join(config.test_dir, 'run_test.py')))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -442,6 +442,16 @@ class MetaData(object):
                 self.meta['requirements']['run'] = run_requirements
 
         self.validate_features()
+        self.append_requirements()
+
+    def append_requirements(self):
+        """For dynamic determination of build or run reqs, based on configuration"""
+        reqs = self.meta.get('requirements', {})
+        run_reqs = reqs.get('run', [])
+        build_reqs = reqs.get('build', [])
+        if bool(self.get_value('build/osx_is_app', False)) and self.config.platform == 'osx':
+            run_reqs.append('python.app')
+        self.meta['requirements'] = reqs
 
     def parse_until_resolved(self, config):
         # undefined_jinja_vars is refreshed by self.parse again

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -71,7 +71,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
 
     encoding = sys.stdout.encoding or 'utf8'
 
-    py_exec = ('/bin/bash ' + prefix + '/bin/python.app'
+    py_exec = ('/bin/bash ' + prefix + '/bin/pythonw'
                if sys.platform == 'darwin' and osx_is_app else
                prefix + '/bin/' + basename(build_python))
     new_data = SHEBANG_PAT.sub(b'#!' + py_exec.encode(encoding), data, count=1)
@@ -430,7 +430,7 @@ def post_build(m, files, prefix, build_python, croot):
     binary_relocation = m.binary_relocation()
     if not binary_relocation:
         print("Skipping binary relocation logic")
-    osx_is_app = bool(m.get_value('build/osx_is_app', False))
+    osx_is_app = bool(m.get_value('build/osx_is_app', False)) and sys.platform == 'darwin'
 
     check_symlinks(files, prefix, croot)
 

--- a/tests/test-recipes/metadata/_nexpy/bld.bat
+++ b/tests/test-recipes/metadata/_nexpy/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/_nexpy/build.sh
+++ b/tests/test-recipes/metadata/_nexpy/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record installed_files.txt

--- a/tests/test-recipes/metadata/_nexpy/meta.yaml
+++ b/tests/test-recipes/metadata/_nexpy/meta.yaml
@@ -1,0 +1,56 @@
+package:
+  name: nexpy
+  version: "0.9.2"
+
+source:
+  git_url: https://github.com/nexpy/nexpy.git
+  git_tag: v0.9.2
+
+build:
+  entry_points:
+    - nexpy = nexpy.nexpygui:main
+  number: 0
+  osx_is_app: True
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - nexusformat >=0.4.5
+    - numpy >=1.6.0
+    - scipy
+    - h5py
+    - jupyter
+    - ipython >=4.0.0
+    - matplotlib >=1.4.0
+    - six
+
+  run:
+    - python
+    - nexusformat >=0.4.4
+    - numpy >=1.6.0
+    - scipy
+    - h5py
+    - jupyter
+    - ipython >=4.0.0
+    - matplotlib >=1.4.0
+
+test:
+  imports:
+    - nexpy
+    - nexpy.api
+    - nexpy.api.frills
+    - nexpy.api.frills.functions
+    - nexpy.api.nexus
+    - nexpy.definitions
+    - nexpy.gui
+    - nexpy.plugins
+    - nexpy.readers
+
+  commands:
+    - nexpy --help
+
+about:
+  home: http://nexpy.github.io/nexpy/
+  license: BSD License
+  summary: 'NeXpy: A Python GUI to analyze NeXus data'

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -826,3 +826,12 @@ def test_workdir_removal_warning_no_remove(test_config, caplog):
     recipe = os.path.join(metadata_dir, '_test_uses_src_dir')
     api.build(recipe, config=test_config, remove_work_dir=False)
     assert "Not removing work directory after build" in caplog.text()
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason="relevant to mac only")
+def test_append_python_app_osx(test_config):
+    """Recipes that use osx_is_app need to have python.app in their runtime requirements."""
+    recipe = os.path.join(metadata_dir, '_nexpy')
+    # tests will fail here if python.app is not added to the run reqs by conda-build, because
+    #    without it, pythonw will be missing.
+    api.build(recipe, config=test_config, channel_urls=('nexpy', ))


### PR DESCRIPTION
fixes #7 
fixes #1664

Would be nice to replace the _nexpy recipe with a simpler recipe that just has a known GUI entry point.  As it is, this test wastes some time downloading scipy.