### PR TITLE
force conda 4.2.x for 2.7 and 3.5 builds (for speed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: python
 matrix:
   include:
     - python: '2.7'
-      os: linux
-    - python: '3.5'
+      env: $CONDA_VERSION=4.2.x
       os: linux
     - python: '3.5'
       env: $CONDA_VERSION=4.2.x

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,7 @@ install:
   - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet
   - conda install -q pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4
   - conda install -c conda-forge -q perl
+  - conda install -q conda=4.2
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"


### PR DESCRIPTION
Conda 4.3 is currently about 3x slower than conda 4.2.  Now that conda 4.3 is the default conda, our tests got slower.  This makes conda 4.2.x the used version instead.