### PR TITLE
source: Catch CondaHTTPError so mutliple urls get checked

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -59,6 +59,7 @@ if parse_version(conda.__version__) >= parse_version("4.2"):
     NoPackagesFoundError = conda.exceptions.NoPackagesFoundError
     CondaValueError = conda.exceptions.CondaValueError
     LockError = conda.exceptions.LockError
+    CondaHTTPError = conda.exceptions.CondaHTTPError
 
     # disallow softlinks.  This avoids a lot of dumb issues, at the potential cost of disk space.
     conda.base.context.context.allow_softlinks = False
@@ -101,6 +102,9 @@ else:
         pass
 
     class CondaValueError(Exception):
+        pass
+
+    class CondaHTTPError(Exception):
         pass
 
     env_path_backup_var_exists = os.environ.get('CONDA_PATH_BACKUP', None)

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -13,7 +13,7 @@ from .conda_interface import download, TemporaryDirectory
 from .conda_interface import hashsum_file
 
 from conda_build.os_utils import external
-from conda_build.conda_interface import url_path
+from conda_build.conda_interface import url_path, CondaHTTPError
 from conda_build.utils import (tar_xf, unzip, safe_print_unicode, copy_into, on_win, ensure_list,
                                check_output_env, check_call_env, convert_path_for_cygwin_or_msys2)
 
@@ -59,6 +59,8 @@ def download_to_cache(metadata, config):
             try:
                 print("Downloading %s" % url)
                 download(url, path)
+            except CondaHTTPError as e:
+                print("Error: %s" % str(e).strip(), file=sys.stderr)
             except RuntimeError as e:
                 print("Error: %s" % str(e).strip(), file=sys.stderr)
             else:


### PR DESCRIPTION
@msarahan, @kalefranz, please review. I'm not sure I need the old:

```
             except RuntimeError as e:
                 print("Error: %s" % str(e).strip(), file=sys.stderr)
```

.. still, but I kept it anyway.

This is needed for R packages where each meta.yaml lists two URLs:

```
  url:
    - http://cran.r-project.org/src/contrib/backports_1.0.4.tar.gz
    - http://cran.r-project.org/src/contrib/Archive/backports/backports_1.0.4.tar.gz
```
