### PR TITLE
add test for rm_rf invasively removing relative paths

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -62,6 +62,9 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
     from conda_build.conda_interface import string_types
     from conda_build.utils import find_recipe
 
+    assert post in (None, True, False), ("post must be boolean or None.  Remember, you must pass "
+                                         "other arguments (config) by keyword.")
+
     config = get_or_merge_config(config, **kwargs)
 
     recipe_paths_or_metadata = _ensure_list(recipe_paths_or_metadata)
@@ -80,10 +83,14 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
     recipes.extend(metadata)
     absolute_recipes = []
     for recipe in recipes:
-        if hasattr(recipe, "config") or os.path.isabs(recipe):
+        if hasattr(recipe, "config"):
             absolute_recipes.append(recipe)
         else:
-            absolute_recipes.append(os.path.normpath(os.path.join(os.getcwd(), recipe)))
+            if not os.path.isabs(recipe):
+                recipe = os.path.normpath(os.path.join(os.getcwd(), recipe))
+            if not os.path.exists(recipe):
+                raise ValueError("Path to recipe did not exist: {}".format(recipe))
+            absolute_recipes.append(recipe)
 
     return build_tree(absolute_recipes, build_only=build_only, post=post, notest=notest,
                       need_source_download=need_source_download, config=config)

--- a/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/bin/lsfm
+++ b/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/bin/lsfm
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+print("yeehaw")

--- a/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/conda/meta.yaml
+++ b/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/conda/meta.yaml
@@ -1,0 +1,16 @@
+# regression test for https://github.com/conda/conda-build/issues/1661
+
+package:
+  name: test_rm_rf_does_not_follow_links
+  version: 1.0
+
+source:
+  path: ../
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools

--- a/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/conda/run_test.py
+++ b/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/conda/run_test.py
@@ -1,0 +1,3 @@
+import os
+
+assert os.path.isfile(os.path.join(os.getenv("PREFIX"), 'bin', 'lsfm'))

--- a/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/setup.py
+++ b/tests/test-recipes/split-packages/_rm_rf_stays_within_prefix/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+from os.path import join
+
+setup(name='lsfm',
+      version="1.0",
+      modules=['lsfm'],
+      scripts=[join('bin', 'lsfm')],
+      )

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -19,6 +19,12 @@ def test_autodetect_raises_on_invalid_extension(test_config):
     with pytest.raises(NotImplementedError):
         api.build(os.path.join(subpackage_dir, '_invalid_script_extension'), config=test_config)
 
-
-# def test_all_subpackages_uploaded():
-#     raise NotImplementedError
+def test_rm_rf_does_not_follow_links(test_config):
+    recipe_dir = os.path.join(subpackage_dir, '_rm_rf_stays_within_prefix')
+    bin_file_that_disappears = os.path.join(recipe_dir, 'bin', 'lsfm')
+    if not os.path.isfile(bin_file_that_disappears):
+        with open(bin_file_that_disappears, 'w') as f:
+            f.write('weee')
+    assert os.path.isfile(bin_file_that_disappears)
+    api.build(os.path.join(recipe_dir, 'conda'), config=test_config)
+    assert os.path.isfile(bin_file_that_disappears)


### PR DESCRIPTION
closes #1661 

@patricksnape this test is meant to diagnose your reported rm_rf issue.  I did duplicate the behavior once, but in the process of shooting myself in the foot with wrong config arguments (config not passed as a keyword, which is why I added https://github.com/conda/conda-build/compare/master...msarahan:test_rm_rf?expand=1#diff-e2183a8fc8686417bd5c8f72d886e4ffR65), I can no longer repeat the behavior.  Would you please look over this test and ensure that it is repeating enough of the lsfm behavior to be an adequate test?