### PR TITLE
Fix encoding error while creating executables on Windows

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -43,15 +43,16 @@ def fix_staged_scripts(scripts_dir):
         if not isfile(join(scripts_dir, fn)) or '.' in fn:
             continue
 
-        with open(join(scripts_dir, fn)) as f:
-            line = bs4.UnicodeDammit(f.readline()).unicode_markup.lower()
+        # read as binary file to ensure we don't run into encoding errors, see #1632
+        with open(join(scripts_dir, fn), 'rb') as f:
+            line = f.readline()
             # If it's a #!python script
-            if not (line.startswith('#!') and 'python' in line.lower()):
+            if not (line.startswith(b'#!') and b'python' in line.lower()):
                 continue
             print('Adjusting unix-style #! script %s, '
                   'and adding a .bat file for it' % fn)
             # copy it with a .py extension (skipping that first #! line)
-            with open(join(scripts_dir, fn + '-script.py'), 'w') as fo:
+            with open(join(scripts_dir, fn + '-script.py'), 'wb') as fo:
                 fo.write(f.read())
             # now create the .exe file
             copy_into(join(dirname(__file__), 'cli-%d.exe' % bits),

--- a/tests/test-recipes/metadata/_script_win_creates_exe_garbled/meta.yaml
+++ b/tests/test-recipes/metadata/_script_win_creates_exe_garbled/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: script_win_creates_exe
+  version: 1.0
+
+source:
+  path: .
+
+build:
+  script: python setup.py install
+
+requirements:
+  build:
+    - python

--- a/tests/test-recipes/metadata/_script_win_creates_exe_garbled/setup.py
+++ b/tests/test-recipes/metadata/_script_win_creates_exe_garbled/setup.py
@@ -1,0 +1,5 @@
+from distutils.core import setup
+setup(name='foobar',
+      version='1.0',
+      scripts=['test-script']
+      )

--- a/tests/test-recipes/metadata/_script_win_creates_exe_garbled/test-script
+++ b/tests/test-recipes/metadata/_script_win_creates_exe_garbled/test-script
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+print(sys.version)
+
+
+# binary data which might be present in a test script, to ensure we don't get encoding errors
+# while generating an executable on Windows.
+# This particular chunk was extracted from bottom of the "waf-script" file generated during build, see #1632
+#==>
+#BZh91AY&SYî?llvþÿ°#.Óÿÿÿÿÿÿÿÿÿÿÿ??Y@Â?%H4à?b<g^è?#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.ù??d\?mÏ?
+
+

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -743,8 +743,9 @@ def test_fix_permissions(test_config):
 
 
 @pytest.mark.skipif(not on_win, reason="windows-only functionality")
-def test_script_win_creates_exe(test_config):
-    recipe = os.path.join(metadata_dir, "_script_win_creates_exe")
+@pytest.mark.parametrize('recipe_name', ["_script_win_creates_exe", "_script_win_creates_exe_garbled"])
+def test_script_win_creates_exe(test_config, recipe_name):
+    recipe = os.path.join(metadata_dir, recipe_name)
     outputs = api.build(recipe, config=test_config)
     assert package_has_file(outputs[0], 'Scripts/test-script.exe')
     assert package_has_file(outputs[0], 'Scripts/test-script-script.py')


### PR DESCRIPTION
As [commented](https://github.com/conda/conda-build/issues/1632#issuecomment-273949364) in #1632, the `waf` build still fails in the latest version.

I tried the PR locally on my machine and I can confirm that the recipe for `waf` now builds correctly.

For the record, here's a snipped of the bottom of the `waf-script.py` file which causes the problem:

```
wafdir = find_lib()
sys.path.insert(0, wafdir)

if __name__ == '__main__':

	from waflib import Scripting
	Scripting.waf_entry_point(cwd, VERSION, wafdir)

#==>
#BZh91AY&SYî?llvþÿ°#.Óÿÿÿÿÿÿÿÿÿÿÿ??Y@Â?%H4à?b<g^è?#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.#.ù??d\?mÏ??[*DUï?]??Ü2\??uöº??#1µ?vÝå?{µuÛí??R{?#/?ìb?ïG??íÕ??9M=p?#.4ò{?ÐkAìôz?m?nwzmïzô?µÓ]mô{Á??]îìç?ÝÛÞìåºÜzë?4?ûîç{yöàú#.?<mî?îí;Ý??{íßo?wÝ7=Û?µï?#.#.Ð?qtÐÁÈû?#.FT??À{çË?:
```

I don't know about `waf` (internals or otherwise), but I guess the scripts reads that binary data from itself during runtime for some purpose. 

cc @tarcisiofischer @jakirkham @msarahan 

Fix #1632