### PR TITLE
Fix some small issues with pytest configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
     else
       conda install -c conda-forge -q perl;
       conda install -q pytest pip pytest-cov numpy mock;
-      $HOME/miniconda/bin/pip install pytest-xdist pytest-capturelog pytest-mock;
+      $HOME/miniconda/bin/pip install pytest-xdist pytest-catchlog pytest-mock;
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
     fi
   - pip install --no-deps .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,9 +75,9 @@ test_script:
   - set "PATH=%CONDA_ROOT%;%CONDA_ROOT%\Scripts;%CONDA_ROOT%\Library\bin;%PATH%"
   - set PATH
   - mkdir C:\cbtmp
-  - py.test -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
+  - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
   - rd /S /Q C:\cbtmp
-  - py.test -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial"
+  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial"
 
 on_failure:
   - 7z.exe a cbtmp.7z C:\cbtmp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - pip install --no-deps .
-  - pip install pytest-xdist pytest-capturelog pytest-env pytest-mock filelock pkginfo
+  - pip install pytest-xdist pytest-catchlog pytest-env pytest-mock filelock pkginfo
   - set PATH
   - conda build --version
   - call appveyor\setup_x64.bat

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 100
 ignore = E122,E123,E126,E127,E128,E731
 exclude = build,conda_build/_version.py,tests,conda.recipe,.git
 
-[pytest]
+[tool:pytest]
 norecursedirs= tests/test-recipes .* *.egg* build dist conda.recipe
 addopts =
     --junitxml=junit.xml

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -409,7 +409,7 @@ def test_compileall_compiles_all_good_files(testing_workdir, test_config):
 def test_render_setup_py_old_funcname(testing_workdir, test_config, caplog):
     logging.basicConfig(level=logging.INFO)
     api.build(os.path.join(metadata_dir, "_source_setuptools"), config=test_config)
-    assert "Deprecation notice: the load_setuptools function has been renamed to " in caplog.text()
+    assert "Deprecation notice: the load_setuptools function has been renamed to " in caplog.text
 
 
 def test_debug_build_option(test_metadata, caplog, capfd):
@@ -418,16 +418,16 @@ def test_debug_build_option(test_metadata, caplog, capfd):
     debug_message = "DEBUG"
     api.build(test_metadata)
     # this comes from an info message
-    assert info_message in caplog.text()
+    assert info_message in caplog.text
     # this comes from a debug message
-    assert debug_message not in caplog.text()
+    assert debug_message not in caplog.text
 
     test_metadata.config.debug = True
     api.build(test_metadata)
     # this comes from an info message
-    assert info_message in caplog.text()
+    assert info_message in caplog.text
     # this comes from a debug message
-    assert debug_message in caplog.text()
+    assert debug_message in caplog.text
 
 
 @pytest.mark.skipif(not on_win, reason="only Windows is insane enough to have backslashes in paths")
@@ -809,7 +809,7 @@ def test_remove_workdir_default(test_config, caplog):
 def test_keep_workdir(test_config, caplog):
     recipe = os.path.join(metadata_dir, '_keep_work_dir')
     api.build(recipe, config=test_config, dirty=True, remove_work_dir=False, debug=True)
-    assert "Not removing work directory after build" in caplog.text()
+    assert "Not removing work directory after build" in caplog.text
     assert glob(os.path.join(test_config.work_dir, '*'))
     test_config.clean()
 
@@ -826,7 +826,7 @@ def test_workdir_removal_warning(test_config, caplog):
 def test_workdir_removal_warning_no_remove(test_config, caplog):
     recipe = os.path.join(metadata_dir, '_test_uses_src_dir')
     api.build(recipe, config=test_config, remove_work_dir=False)
-    assert "Not removing work directory after build" in caplog.text()
+    assert "Not removing work directory after build" in caplog.text
 
 
 @pytest.mark.skipif(sys.platform != 'darwin', reason="relevant to mac only")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -81,7 +81,7 @@ def test_env_creation_with_short_prefix_does_not_deadlock(caplog):
         raise
     finally:
         rm_rf(test_base)
-    assert 'One or more of your package dependencies needs to be rebuilt' in caplog.text()
+    assert 'One or more of your package dependencies needs to be rebuilt' in caplog.text
 
 
 @pytest.mark.serial
@@ -125,7 +125,7 @@ with open(fn, 'wb') as f:
     test_metadata.meta['build']['script'] = 'python -c "{0}"'.format(cmd)
 
     api.build(test_metadata)
-    assert "Falling back to legacy prefix" in caplog.text()
+    assert "Falling back to legacy prefix" in caplog.text
 
 
 def test_warn_on_old_conda_build(test_config, capfd):


### PR DESCRIPTION
I noticed that the current pytest configuration is emitting some warnings which are easily fixable:

```
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
WI1 /home/travis/miniconda/lib/python3.5/site-packages/pytest_capturelog.py:171 'pytest_runtest_makereport' hook uses deprecated __multicall__ argument
WC1 None pytest_funcarg__caplog: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
WC1 None pytest_funcarg__capturelog: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
```

* `[pytest]` should be renamed to `[tool:pytest]` in `setup.cfg` to avoid conflicts with other distutils commands (see pytest-dev/pytest#567 for details);
* The warnings about `pytest_funcarg` functions are due to deprecated hooks used by the [`pytest-capturelog`](https://pypi.python.org/pypi/pytest-capturelog) plugin, which is considered abandoned by the community; this PR replaces it with [`pytest-catchlog`](https://pypi.python.org/pypi/pytest-catchlog) which is a maintained fork and has the exact same functionality.