### PR TITLE
Use monkeypatch fixture in a few places of the test suite

### DIFF
--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -5,7 +5,7 @@ from conda_build.source import _guess_patch_strip_level, apply_patch
 from .utils import testing_workdir, test_config
 
 
-def test_patch_strip_level(testing_workdir):
+def test_patch_strip_level(testing_workdir, monkeypatch):
     patchfiles = set(('some/common/prefix/one.txt',
                       'some/common/prefix/two.txt',
                       'some/common/prefix/three.txt'))
@@ -16,13 +16,13 @@ def test_patch_strip_level(testing_workdir):
         with open(os.path.join(os.path.join(*folders), file), 'w') as f:
             f.write('hello\n')
     assert _guess_patch_strip_level(patchfiles, os.getcwd()) == 0
-    os.chdir(folders[0])
+    monkeypatch.chdir(folders[0])
     assert _guess_patch_strip_level(patchfiles, os.getcwd()) == 1
-    os.chdir(folders[1])
+    monkeypatch.chdir(folders[1])
     assert _guess_patch_strip_level(patchfiles, os.getcwd()) == 2
-    os.chdir(folders[2])
+    monkeypatch.chdir(folders[2])
     assert _guess_patch_strip_level(patchfiles, os.getcwd()) == 3
-    os.chdir(testing_workdir)
+    monkeypatch.chdir(testing_workdir)
 
 
 def test_patch(testing_workdir, test_config):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -79,19 +79,13 @@ def test_metadata(request, test_config):
 
 
 @pytest.fixture(scope='function')
-def testing_env(testing_workdir, request):
+def testing_env(testing_workdir, request, monkeypatch):
     env_path = os.path.join(testing_workdir, 'env')
 
     check_call_env(['conda', 'create', '-yq', '-p', env_path,
                     'python={0}'.format(".".join(sys.version.split('.')[:2]))])
-    path_backup = os.environ['PATH']
-    os.environ['PATH'] = prepend_bin_path(os.environ.copy(), env_path, prepend_prefix=True)['PATH']
-
+    monkeypatch.setenv('PATH', prepend_bin_path(os.environ.copy(), env_path, prepend_prefix=True)['PATH'])
     # cleanup is done by just cleaning up the testing_workdir
-    def reset_path():
-        os.environ['PATH'] = path_backup
-
-    request.addfinalizer(reset_path)
     return env_path
 
 


### PR DESCRIPTION
The [monkeypatch](http://doc.pytest.org/en/latest/monkeypatch.html) fixture automatically reverts environment variables and cwd to their previous values.

I did not run the tests locally and the changes should be harmless, but if something fails I will take a look later. 😁 