### PR TITLE
Conda Convert - Update the info/paths.json file

### DIFF
--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -21,18 +21,18 @@ def test_convert_exe_raises():
         api.convert("some_wheel.exe")
         assert "cannot convert:" in str(exc)
 
-def package_paths_matches_files(package_path):
+def assert_package_paths_matches_files(package_path):
     """Ensure that info/paths.json matches info/files"""
     with tarfile.open(package_path) as t:
-        files_content = t.extractfile('info/files')
-        files_set = set(line.strip() for line in files_content)
+        files_content = t.extractfile('info/files').read().decode('utf-8')
+        files_set = set(line for line in files_content.split('\n') if line)
         paths_content = json.loads(t.extractfile('info/paths.json').read().decode('utf-8'))
 
     for path_entry in paths_content['paths']:
         assert path_entry['_path'] in files_set
         files_set.remove(path_entry['_path'])
 
-    return not files_set # Check that we've seen all the entries in files
+    assert not files_set # Check that we've seen all the entries in files
 
 @pytest.mark.serial
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
@@ -53,7 +53,7 @@ def test_convert_platform_to_others(testing_workdir, base_platform, package):
 
         if expected_paths_json:
             assert package_has_file(package, 'info/paths.json')
-            assert package_paths_matches_files(package)
+            assert_package_paths_matches_files(package)
 
 @pytest.mark.serial
 @pytest.mark.skipif(on_win, reason="we create the package to be converted in *nix, so don't run on win.")

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -1,4 +1,6 @@
 import os
+import json
+import tarfile
 
 import pytest
 
@@ -19,19 +21,40 @@ def test_convert_exe_raises():
         api.convert("some_wheel.exe")
         assert "cannot convert:" in str(exc)
 
+def package_paths_matches_files(package_path):
+    """Ensure that info/paths.json matches info/files"""
+    with tarfile.open(package_path) as t:
+        files_content = t.extractfile('info/files')
+        files_set = set(line.strip() for line in files_content)
+        paths_content = json.loads(t.extractfile('info/paths.json').read().decode('utf-8'))
+
+    for path_entry in paths_content['paths']:
+        assert path_entry['_path'] in files_set
+        files_set.remove(path_entry['_path'])
+
+    return not files_set # Check that we've seen all the entries in files
 
 @pytest.mark.serial
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
-def test_convert_platform_to_others(testing_workdir, base_platform):
-    f = 'http://repo.continuum.io/pkgs/free/{}-64/itsdangerous-0.24-py27_0.tar.bz2'.format(base_platform)
-    fn = "itsdangerous-0.24-py27_0.tar.bz2"
+@pytest.mark.parametrize('package', [('itsdangerous-0.24', 'itsdangerous.py'),
+                                     ('py-1.4.32', 'py/__init__.py')])
+def test_convert_platform_to_others(testing_workdir, base_platform, package):
+    package_name, example_file = package
+    f = 'http://repo.continuum.io/pkgs/free/{}-64/{}-py27_0.tar.bz2'.format(base_platform, package_name)
+    fn = "{}-py27_0.tar.bz2".format(package_name)
     download(f, fn)
-    api.convert(fn, platforms='all', quiet=False, verbose=True)
+    expected_paths_json = package_has_file(fn, 'info/paths.json')
+    api.convert(fn, platforms='all', quiet=False, verbose=False)
+    print testing_workdir
     for platform in ['osx-64', 'win-64', 'win-32', 'linux-64', 'linux-32']:
         python_folder = 'lib/python2.7' if not platform.startswith('win') else 'Lib'
-        assert package_has_file(os.path.join(platform, fn),
-                                '{}/site-packages/itsdangerous.py'.format(python_folder))
+        package = os.path.join(platform, fn)
+        assert package_has_file(package,
+                                '{}/site-packages/{}'.format(python_folder, example_file))
 
+        if expected_paths_json:
+            assert package_has_file(package, 'info/paths.json')
+            assert package_paths_matches_files(package)
 
 @pytest.mark.serial
 @pytest.mark.skipif(on_win, reason="we create the package to be converted in *nix, so don't run on win.")

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -45,7 +45,6 @@ def test_convert_platform_to_others(testing_workdir, base_platform, package):
     download(f, fn)
     expected_paths_json = package_has_file(fn, 'info/paths.json')
     api.convert(fn, platforms='all', quiet=False, verbose=False)
-    print testing_workdir
     for platform in ['osx-64', 'win-64', 'win-32', 'linux-64', 'linux-32']:
         python_folder = 'lib/python2.7' if not platform.startswith('win') else 'Lib'
         package = os.path.join(platform, fn)


### PR DESCRIPTION
This file is now used in Conda 4.3 to identify files to be hardlinked.

Fixes #1678