### PR TITLE
ensure bundle_conda cleanup is acting on absolute paths

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -881,6 +881,8 @@ def bundle_conda(output, metadata, config, env, **kw):
     # remove files from build prefix.  This is so that they can be included in other packages.  If
     #     we were to leave them in place, then later scripts meant to also include them may not.
     for f in files:
+        if not os.path.isabs(f):
+            f = os.path.abspath(os.path.normpath(os.path.join(metadata.config.build_prefix, f)))
         utils.rm_rf(f)
     return final_output
 

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -21,12 +21,14 @@ def test_autodetect_raises_on_invalid_extension(test_config):
         api.build(os.path.join(subpackage_dir, '_invalid_script_extension'), config=test_config)
 
 
-def test_rm_rf_does_not_follow_links(test_config):
+# regression test for https://github.com/conda/conda-build/issues/1661
+def test_rm_rf_does_not_remove_relative_source_package_files(test_config, monkeypatch):
     recipe_dir = os.path.join(subpackage_dir, '_rm_rf_stays_within_prefix')
-    bin_file_that_disappears = os.path.join(recipe_dir, 'bin', 'lsfm')
+    monkeypatch.chdir(recipe_dir)
+    bin_file_that_disappears = os.path.join('bin', 'lsfm')
     if not os.path.isfile(bin_file_that_disappears):
         with open(bin_file_that_disappears, 'w') as f:
             f.write('weee')
     assert os.path.isfile(bin_file_that_disappears)
-    api.build(os.path.join(recipe_dir, 'conda'), config=test_config)
+    api.build('conda', config=test_config)
     assert os.path.isfile(bin_file_that_disappears)


### PR DESCRIPTION
Do not delete project files - which was possible if file paths were relative
paths.  Whoops.

Closes #1661 #1693 

CC @hainm @patricksnape @jabooth