### PR TITLE
fix quoting for test paths.  test croot with spaces.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1348,19 +1348,19 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
             # use pythonw for import tests when osx_is_app is set
             if metadata.get_value('build/osx_is_app') and sys.platform == 'darwin':
                 test_python = test_python + 'w'
-            tf.write("{python} -s {test_file}\n".format(
+            tf.write('"{python}" -s "{test_file}"\n'.format(
                 python=config.test_python,
                 test_file=join(config.test_dir, 'run_test.py')))
             if utils.on_win:
                 tf.write("if errorlevel 1 exit 1\n")
         if pl_files:
-            tf.write("{perl} {test_file}\n".format(
+            tf.write('"{perl}" "{test_file}"\n'.format(
                 perl=config.test_perl,
                 test_file=join(config.test_dir, 'run_test.pl')))
             if utils.on_win:
                 tf.write("if errorlevel 1 exit 1\n")
         if lua_files:
-            tf.write("{lua} {test_file}\n".format(
+            tf.write('"{lua}" "{test_file}"\n'.format(
                 lua=config.test_lua,
                 test_file=join(config.test_dir, 'run_test.lua')))
             if utils.on_win:
@@ -1368,13 +1368,13 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
         if shell_files:
             test_file = join(config.test_dir, 'run_test.' + suffix)
             if utils.on_win:
-                tf.write("call {test_file}\n".format(test_file=test_file))
+                tf.write('call "{test_file}"\n'.format(test_file=test_file))
                 if utils.on_win:
                     tf.write("if errorlevel 1 exit 1\n")
             else:
                 # TODO: Run the test/commands here instead of in run_test.py
-                tf.write("{shell_path} -x -e {test_file}\n".format(shell_path=shell_path,
-                                                                    test_file=test_file))
+                tf.write('"{shell_path}" -x -e "{test_file}"\n'.format(shell_path=shell_path,
+                                                                       test_file=test_file))
 
     if utils.on_win:
         cmd = ['cmd.exe', "/d", "/c", test_script]

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -887,3 +887,10 @@ def test_recursion_layers(test_config):
 def test_pin_depends(test_metadata):
     test_metadata.meta['build']['pin_depends'] = 'record'
     api.build(test_metadata)
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason=("spaces break openssl prefix "
+                                                     "replacement on *nix"))
+def test_croot_with_spaces(test_metadata, testing_workdir):
+    test_metadata.config.croot = os.path.join(testing_workdir, "space path")
+    api.build(test_metadata)


### PR DESCRIPTION
fixes #1742 

On Windows, test script execution paths were not correctly quoted to allow spaces.

On linux and mac, spaces in paths still don't work, but it's because conda and openssl's custom prefix replacement don't work.