### PR TITLE
Problem: Unknown selectors crash conda-build

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -106,6 +106,7 @@ def eval_selector(selector_string, namespace):
         return eval(selector_string, namespace, {})
     except NameError as e:
         missing_var = parseNameNotFound(e)
+        print("Warning: Treating unknown selector \'" + missing_var + "\' as if it was False.")
         next_string = selector_string.replace(missing_var, "False")
         return eval_selector(next_string, namespace)
 

--- a/tests/test-recipes/metadata/unknown_selector/meta.yaml
+++ b/tests/test-recipes/metadata/unknown_selector/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: unknown_selector_test
+  version: 1.0.0
+
+build:
+  skip: True #[unknown_selector]

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -894,3 +894,7 @@ def test_pin_depends(test_metadata):
 def test_croot_with_spaces(test_metadata, testing_workdir):
     test_metadata.config.croot = os.path.join(testing_workdir, "space path")
     api.build(test_metadata)
+
+def test_unknown_selectors(test_config):
+    recipe = os.path.join(metadata_dir, 'unknown_selector')
+    api.build(recipe, config=test_config)


### PR DESCRIPTION
Solution: evaluate them to false...

this is related to #1723 

It allows code like this, even if `linux-aarch64` is not known at the time of writing

```
build:
  skip: True #[linux-aarch64]
```