### PR TITLE
set default repo for twine to pypitest.  

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -82,6 +82,10 @@ test:
   source_files:
     - tests
 
+outputs:
+  - type: wheel
+  - name: {{ PKG_NAME }}
+
 about:
   home: https://github.com/conda/conda-build
   license: BSD 3-clause

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1623,12 +1623,18 @@ def handle_pypi_upload(wheels, config):
 
     wheels = utils.ensure_list(wheels)
 
-    for f in wheels:
-        try:
-            utils.check_call_env(args + [f])
-        except:
-            logging.getLogger(__name__).warn("wheel upload failed - is twine installed?"
-                                            "  Is this package registered?")
+    if config.anaconda_upload:
+        for f in wheels:
+            print("Uploading {}".format(f))
+            try:
+                utils.check_call_env(args + [f])
+            except:
+                logging.getLogger(__name__).warn("wheel upload failed - is twine installed?"
+                                                "  Is this package registered?")
+                logging.getLogger(__name__).warn("Wheel file left in {}".format(f))
+
+    else:
+        print("anaconda_upload is not set.  Not uploading wheels: {}".format(wheels))
 
 
 def print_build_intermediate_warning(config):

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -157,7 +157,7 @@ different sets of packages."""
         help="path to .pypirc file to use when uploading to pypi"
     )
     pypi_grp.add_argument(
-        '--repository', default='pypi',
+        '--repository', '-r', default='pypitest',
         help="PyPI repository to upload to"
     )
     p.add_argument(

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -120,7 +120,7 @@ class Config(object):
                   Setting('sign_with', 'gpg'),
                   Setting('identity', None),
                   Setting('config_file', None),
-                  Setting('repository', 'pypi'),
+                  Setting('repository', 'pypitest'),
 
                   Setting('ignore_recipe_verify_scripts',
                           cc.rc.get('conda-build', {}).get('ignore_recipe_verify_scripts', [])),

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -953,7 +953,12 @@ class MetaData(object):
                     outputs.append({'name': self.name(), 'requirements': requirements,
                                     'pin_downstream':
                                         self.meta.get('build', {}).get('pin_downstream')})
-                metadata = [self.get_output_metadata(output) for output in outputs]
+                for out in outputs:
+                    if (self.name() == out.get('name', '') and not (out.get('files') or
+                                                                    out.get('script'))):
+                        out['files'] = files
+                        requirements = requirements
+                    metadata = [self.get_output_metadata(output) for output in outputs]
         except SystemExit:
             if not permit_undefined_jinja:
                 raise


### PR DESCRIPTION
also, Allow default conda package by making name match pkg_name (uses default packaging logic, but allows both conda package output and wheel output without specifying files or script for main output).