### PR TITLE
Fix mixed-case license family names

### DIFF
--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -13,11 +13,11 @@ GPL2
 GPL
 BSD
 MIT
-Apache
+APACHE
 PSF
-Public-Domain
-Proprietary
-Other
+PUBLIC-DOMAIN
+PROPRIETARY
+OTHER
 NONE
 """.split()
 


### PR DESCRIPTION
The `ensure_valid_license_family` function in `license_family.py` calls `normalize()` before comparing to the list of `allowed_license_families`, which converts the license family to all-caps before comparing to the list. However, `allowed_license_families` contains some elements that are not upper-cased. This PR corrects `allowed_license_families` to only contain upper-case elements.

This bug can be reproduced with a `meta.yaml` file that has an `about` section which looks like this:
```
about:
  license_family: Proprietary
```