### PR TITLE
add preferred_env to index.json

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -916,6 +916,10 @@ class MetaData(object):
             if value:
                 d[key] = value
 
+        preferred_env = self.get_value('build/preferred_env')
+        if preferred_env:
+            d['preferred_env'] = preferred_env
+
         if self.get_value('build/features'):
             d['features'] = ' '.join(self.get_value('build/features'))
         if self.get_value('build/track_features'):

--- a/tests/test-recipes/metadata/_preferred_env/run_test.py
+++ b/tests/test-recipes/metadata/_preferred_env/run_test.py
@@ -1,0 +1,9 @@
+import json
+import os
+
+pkgs_dir = os.path.abspath(os.path.join(os.environ["ROOT"], 'pkgs'))
+pkg_dir = os.path.join(pkgs_dir, 'preferred_env_test_package-1.0-0')
+
+with open(os.path.join(pkg_dir, 'info', 'index.json')) as fh:
+    index_json = json.loads(fh.read())
+assert index_json['preferred_env'] == "_env_"


### PR DESCRIPTION
The `preferred_env` field needs to be part of index.json for conda to properly plan installations.  That it hasn't been was an oversight that I just discovered as I'm now going back and writing extra integration tests for this feature.