### PR TITLE
fix error unpacking tarball containing unicode filenames

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -321,7 +321,10 @@ unxz is required to unarchive .xz source files.
         check_call_env([unxz, '-f', '-k', tarball])
         tarball = tarball[:-3]
     t = tarfile.open(tarball, mode)
-    t.extractall(path=dir_path)
+    if not PY3 and on_win:
+        t.extractall(path=dir_path.encode(codec))
+    else:
+        t.extractall(path=dir_path)
     t.close()
 
 

--- a/tests/test-recipes/metadata/_unicode_in_tarball/meta.yaml
+++ b/tests/test-recipes/metadata/_unicode_in_tarball/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "pyslet" %}
+{% set version = "0.5.20140801" %}
+{% set sha256 = "89538ad432d8c51b7d4b419817526f864697580d5eb1471784d15f6c056a88b6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  skip: True  # [py3k]
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+ 
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - pyslet
+    - pyslet.http
+    - pyslet.odata2
+    - pyslet.qtiv1
+    - pyslet.qtiv2
+    - pyslet.xml20081126
+
+about:
+  home: http://www.pyslet.org/
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: 'Pyslet: Python package for Standards in Learning, Education and Training'
+  description: |
+    Pyslet is a Python package for Standards in Learning Education and Training
+    (LET). It implements a number of LET-specific standards, including IMS QTI,
+    Content Packaging and Basic LTI. It also includes support for some general
+    standards, including the data access standard OData (see
+    http://www.odata.org).
+
+    Pyslet was originally written to be the engine behind the QTI migration
+    tool but it can be used independently as a support module for your own
+    Python applications.
+
+    Pyslet currently supports Python 2.6 and 2.7, see docs for details.
+  doc_url: http://pyslet.readthedocs.org
+  dev_url: https://github.com/swl10/pyslet
+
+extra:
+  recipe-maintainers:
+    - stuertz

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -887,6 +887,13 @@ def test_croot_with_spaces(test_metadata, testing_workdir):
     test_metadata.config.croot = os.path.join(testing_workdir, "space path")
     api.build(test_metadata)
 
+
 def test_unknown_selectors(test_config):
     recipe = os.path.join(metadata_dir, 'unknown_selector')
+    api.build(recipe, config=test_config)
+
+
+def test_extract_tarball_with_unicode_filename(test_config):
+    """See https://github.com/conda/conda-build/pull/1779"""
+    recipe = os.path.join(metadata_dir, '_unicode_in_tarball')
     api.build(recipe, config=test_config)


### PR DESCRIPTION
The problem may occur only on windows and only with py2.