### PR TITLE
allow un-finalizable recipes (things that are not installable)

### DIFF
--- a/ci/travis/run.sh
+++ b/ci/travis/run.sh
@@ -12,6 +12,7 @@ if [[ "$FLAKE8" == "true" ]]; then
     conda install $(conda render --output conda.recipe)
     conda build conda.recipe --no-anaconda-upload
 else
-    $HOME/miniconda/bin/py.test -v -n 0 --basetemp /tmp/cb --cov conda_build --cov-report xml -m "serial" tests
-    $HOME/miniconda/bin/py.test -v -n 2 --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --durations=15
+    # $HOME/miniconda/bin/py.test -v -n 0 --basetemp /tmp/cb --cov conda_build --cov-report xml -m "serial" tests
+    # $HOME/miniconda/bin/py.test -v -n 2 --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --durations=15
+    $HOME/miniconda/bin/py.test -v --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml tests --durations=15
 fi

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1334,12 +1334,10 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                 if clear_index:
                     config.index = None
                 metadata_tuples, index = render_recipe(recipe, config=config, variants=variants,
-                                                       permit_unsatisfiable_variants=False)
+                                                       permit_unsatisfiable_variants=True)
 
             with config:
                 for (metadata, need_source_download, need_reparse_in_env) in metadata_tuples:
-                    if not metadata.final:
-                        metadata = finalize_metadata(metadata, index)
                     packages_from_this = build(metadata, index=index, post=post,
                                                need_source_download=need_source_download,
                                                need_reparse_in_env=need_reparse_in_env)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1308,7 +1308,7 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                 #    before downloading happens - or else we lose where downloads are
                 if config.set_build_id:
                     config.compute_build_id(metadata.name(), reset=True)
-                recipe_parent_dir = ""
+                recipe_parent_dir = os.path.dirname(metadata.path)
                 to_build_recursive.append(metadata.name())
                 metadata_tuples = []
                 if clear_index:
@@ -1387,8 +1387,7 @@ for Python 3.5 and needs to be rebuilt."""
                                 "{0} first").format(pkg))
                         add_recipes.append(recipe_dir)
                 else:
-                    raise RuntimeError("Can't build {0} due to unsatisfiable dependencies:\n{1}"
-                                       .format(recipe, e.packages) + "\n\n" + extra_help)
+                    raise
             # if we failed to render due to unsatisfiable dependencies, we should only bail out
             #    if we've already retried this recipe.
             if (not metadata and retried_recipes.count(recipe) and

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -164,13 +164,31 @@ class Config(object):
 
     @property
     def arch(self):
-        """Always the native (build system) arch"""
+        """Always the native (build system) arch, except when pretending to be some
+        other platform"""
         return self._arch or cc.subdir.split('-')[-1]
+
+    @arch.setter
+    def arch(self, value):
+        log = get_logger(__name__)
+        log.warn("setting build arch.  This is only useful when pretending to be on another "
+                 "arch, such as for rendering necessary dependencies on a non-native arch."
+                 "  I trust that you know what you're doing.")
+        self._arch = str(value)
 
     @property
     def platform(self):
-        """Always the native (build system) OS"""
+        """Always the native (build system) OS, except when pretending to be some
+        other platform"""
         return self._platform or cc.platform
+
+    @platform.setter
+    def platform(self, value):
+        log = get_logger(__name__)
+        log.warn("setting build platform.  This is only useful when pretending to be on another "
+                 "platform, such as for rendering necessary dependencies on a non-native platform."
+                 "  I trust that you know what you're doing.")
+        self._platform = value
 
     @property
     def build_subdir(self):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -214,7 +214,8 @@ def get_build_index(config, subdir, clear_cache=False, omit_defaults=False):
                                 platform=subdir)
             # HACK: defaults does not have the many subfolders we support.  Omit it and try again.
             except CondaHTTPError:
-                urls.remove('defaults')
+                if 'defaults' in urls:
+                    urls.remove('defaults')
                 index = get_index(channel_urls=urls,
                                 prepend=omit_defaults,
                                 use_local=True,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -509,6 +509,8 @@ class MetaData(object):
         # In the second pass, we'll be more strict. See build.build()
         # Primarily for debugging.  Ensure that metadata is not altered after "finalizing"
         self.parse_again(permit_undefined_jinja=True)
+        if 'host' in self.get_section('requirements'):
+            self.config.has_separate_host_prefix = True
         self.config.disable_pip = self.disable_pip
 
     @property

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -134,6 +134,7 @@ def set_language_env_vars(variant):
 
 def all_unique(_list):
     seen = set()
+    item = None
     unique = not any(item in seen or seen.add(item) for _set in _list for item in _set)
     return unique or item
 
@@ -162,7 +163,7 @@ def _get_zip_key_set(combined_variant):
             # make sure that each key only occurs in one set
             key_sets = [set(group) for group in zip_keys]
             _all_unique = all_unique(key_sets)
-            if _all_unique != True:
+            if _all_unique is not True:
                 raise ValueError("All package in zip keys must belong to only one group.  "
                                 "'{}' is in more than one group.".format(_all_unique))
             for ks in key_sets:
@@ -231,19 +232,15 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts):
             v = combined.get(col)
             if v:
                 remapped[col] = v if hasattr(v, 'keys') else list(set(v))
-        del_keys = []
         # split out zipped keys
-        for k, v in remapped.items():
+        for k, v in remapped.copy().items():
             if isinstance(k, string_types) and isinstance(v, string_types):
                 keys = k.split(',')
                 values = v.split(',')
                 for (_k, _v) in zip(keys, values):
                     remapped[_k] = _v
                 if ',' in k:
-                    del_keys.append(k)
-        for k in del_keys:
-            del remapped[k]
-
+                    del remapped[k]
         dicts.append(remapped)
     return dicts
 

--- a/tests/test-recipes/metadata/_post_link_exits_after_retry/meta.yaml
+++ b/tests/test-recipes/metadata/_post_link_exits_after_retry/meta.yaml
@@ -4,4 +4,4 @@ package:
 
 requirements:
   build:
-    - post-link-fails
+    - _post-link-fails

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -415,9 +415,9 @@ def test_purge(testing_workdir, testing_metadata):
     outputs = api.build(testing_metadata)
     args = ['purge']
     main_build.execute(args)
-    dirs = os.listdir(get_build_folders(testing_metadata.config.croot)[0])
-    folder_re = re.compile('[a-zA-Z_]+[0-9]+')
-    assert not any(folder_re.match(folder) for folder in dirs)
+    dirs = get_build_folders(testing_metadata.config.croot)
+    assert not dirs
+    # make sure artifacts are kept - only temporary folders get nuked
     assert all(os.path.isfile(fn) for fn in outputs)
 
 

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -87,15 +87,15 @@ def test_pinning_in_build_requirements():
     assert all(len(req.split(' ')) == 3 for req in build_requirements)
 
 
-def test_no_satisfiable_variants_raises_error():
+def test_no_satisfiable_variants_raises_error(caplog):
     recipe = os.path.join(recipe_dir, '01_basic_templating')
-    with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
+    with pytest.raises(exceptions.DependencyNeedsBuildingError):
         api.render(recipe, permit_unsatisfiable_variants=False)
 
-    # the packages are not installable anyway, so this should raise a valueerror when
-    #    permitting unsatisfiable variants (no satisfiable variants)
-    with pytest.raises(ValueError) as e:
-        api.render(recipe, permit_unsatisfiable_variants=True)
+    # the packages are not installable anyway, so this should show a warning that recipe can't
+    #   be finalized
+    api.render(recipe, permit_unsatisfiable_variants=True)
+    assert "Could not finalize metadata due to missing dependencies" in caplog.text
 
 
 def test_zip_fields():
@@ -126,5 +126,5 @@ def test_zip_fields():
     v = {'python': ['2.7', '3.5'], 'zip_keys': [('python', 'vc')]}
     ld = variants.dict_of_lists_to_list_of_dicts(v)
     assert len(ld) == 2
-    assert not 'vc' in ld[0].keys()
-    assert not 'vc' in ld[1].keys()
+    assert 'vc' not in ld[0].keys()
+    assert 'vc' not in ld[1].keys()


### PR DESCRIPTION
This is especially necessary for concourse's test modules, where they are just never meant to actually install/build packages.  The net result of this PR is that with api.render, you can now allow it to return un-finalized metadata.  For building, metadata will still be finalized, or will raise errors when it is not able to be finalized.