### PR TITLE
try to encode/decode delimiter for py_file_map

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -267,6 +267,10 @@ def get_pure_py_file_map(t, platform):
         fieldnames = ['prefix', 'type', 'path']
         csv_dialect = csv.Sniffer().sniff(has_prefix_files)
         csv_dialect.lineterminator = '\n'
+        if PY3 and hasattr(csv_dialect.delimiter, 'decode'):
+            csv_dialect.delimiter = csv_dialect.decode()
+        elif not PY3 and hasattr(csv_dialect.delimiter, 'encode'):
+            csv_dialect.delimiter = csv_dialect.encode()
         has_prefix_files = csv.DictReader(has_prefix_files.splitlines(), fieldnames=fieldnames,
                                           dialect=csv_dialect)
         # convenience: store list of dictionaries as map by path


### PR DESCRIPTION
fixes #1784

@H0R5E please test.  I could not reproduce your error locally on a Win-64 system, converting a win-32 package to win-64.  I used a package for ``wheel`` that I had lying around.  It may be something particular about your package - especially if your default system encoding is affecting things.  If this PR doesn't fix things for you, I need to ask for more info about your system, and possibly a dummy package, if you don't mind creating one (just build some arbitrary publicly available recipe and post your package somewhere).