### PR TITLE
try to encode/decode delimiter for py_file_map

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -56,7 +56,6 @@ from conda_build.render import (parse_or_try_download, output_yaml, bldpkg_path,
 import conda_build.os_utils.external as external
 from conda_build.post import (post_process, post_build,
                               fix_permissions, get_build_metadata)
-from conda_build.metadata import build_string_from_metadata
 from conda_build.index import update_index
 from conda_build.create_test import (create_files, create_shell_files,
                                      create_py_files, create_pl_files)
@@ -881,15 +880,11 @@ def bundle_conda(output, metadata, config, env, **kw):
 
     files = post_process_files(metadata, initial_files)
 
-    tmp_metadata = copy.deepcopy(metadata)
-    tmp_metadata.meta['package']['name'] = output['name']
-    tmp_metadata.meta['requirements'] = {'run': output.get('requirements', [])}
-
     output_filename = ('-'.join([output['name'], metadata.version(),
-                                 build_string_from_metadata(tmp_metadata)]) + '.tar.bz2')
+                                 metadata.build_id()]) + '.tar.bz2')
     # first filter is so that info_files does not pick up ignored files
     files = filter_files(files, prefix=config.build_prefix)
-    create_info_files(tmp_metadata, files, config=config, prefix=config.build_prefix)
+    create_info_files(metadata, files, config=config, prefix=config.build_prefix)
     test_dest_path = os.path.join(config.info_dir, 'recipe', 'run_test.py')
     if output.get('test', {}).get('script'):
         utils.copy_into(os.path.join(metadata.path, output['test']['script']),

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -267,6 +267,11 @@ def get_pure_py_file_map(t, platform):
         fieldnames = ['prefix', 'type', 'path']
         csv_dialect = csv.Sniffer().sniff(has_prefix_files)
         csv_dialect.lineterminator = '\n'
+        for attr in ('delimiter', 'quotechar'):
+            if PY3 and hasattr(getattr(csv_dialect, attr), 'decode'):
+                setattr(csv_dialect, attr, getattr(csv_dialect, attr).decode())
+            elif not PY3 and hasattr(getattr(csv_dialect, attr), 'encode'):
+                setattr(csv_dialect, attr, getattr(csv_dialect, attr).encode())
         has_prefix_files = csv.DictReader(has_prefix_files.splitlines(), fieldnames=fieldnames,
                                           dialect=csv_dialect)
         # convenience: store list of dictionaries as map by path

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -379,7 +379,7 @@ def build_string_from_metadata(metadata):
                     ('perl', 'pl'), ('lua', 'lua'),
                     ('r', 'r'), ('r-base', 'r')):
         for ms in metadata.ms_depends():
-            if ms.name == name:
+            if ms.name.split(' ')[0] == name:
                 try:
                     v = ms.spec.split()[1]
                 except IndexError:
@@ -966,8 +966,9 @@ class MetaData(object):
                 for out in outputs:
                     if (self.name() == out.get('name', '') and not (out.get('files') or
                                                                     out.get('script'))):
-                        out['files'] = files
-                        requirements = requirements
+                        if files:
+                            out['files'] = files
+                        out['requirements'] = requirements
                     metadata = [self.get_output_metadata(output) for output in outputs]
         except SystemExit:
             if not permit_undefined_jinja:


### PR DESCRIPTION
Replaces #1788 - meant to do this against 2.1.x.

fixes #1784

@H0R5E please test. I could not reproduce your error locally on a Win-64 system, converting a win-32 package to win-64. I used a package for wheel that I had lying around. It may be something particular about your package - especially if your default system encoding is affecting things. If this PR doesn't fix things for you, I need to ask for more info about your system, and possibly a dummy package, if you don't mind creating one (just build some arbitrary publicly available recipe and post your package somewhere).