### PR TITLE
Fix detection of patch strip level when maxlevel = 0.

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -419,7 +419,7 @@ def _guess_patch_strip_level(filesstr, src_dir):
     src_dir = src_dir.encode(errors='ignore')
     for file in files:
         numslash = file.count(b'/')
-        maxlevel = numslash if not maxlevel else min(maxlevel, numslash)
+        maxlevel = numslash if maxlevel is None else min(maxlevel, numslash)
     if maxlevel == 0:
         patchlevel = 0
     else:


### PR DESCRIPTION
The _guess_patch_strip_level() function autodetects a value for the `-p` option to `patch` based on the file names present in the patch file. It had a bug, though, when the ideal strip level was zero: the code that found the value of `maxlevel` (a bit confusingly named) found its minimum value over each filename but checked for the initialization case with `if not maxlevel`. This condition holds if `maxlevel` is equal to its initial value, `None`, but also if `maxlevel` is zero. In that case, `maxlevel` could have been erroneously set to be too large, leading to patch failure, depending on the ordering of iteration through the `files` set.

This was observed in the wild:
https://circleci.com/gh/conda-forge/gobject-introspection-feedstock/2 .