### PR TITLE
WIP: provide default platform

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -40,6 +40,15 @@ def _ensure_dir(path):
 # we need this to be accessible to the CLI, so it needs to be more static.
 DEFAULT_PREFIX_LENGTH = 255
 
+# translate our internal more meaningful subdirs to the ones that conda understands
+SUBDIR_ALIASES = {
+    'linux-cos5-x86_64': 'linux-64',
+    'linux-cos5-x86': 'linux-32',
+    'osx-109-x86_64': 'osx-64,'
+    'win-x86_64': 'win-64,'
+    'win-x86': 'win-32,'
+}
+
 Setting = namedtuple("ConfigSetting", "name, default")
 DEFAULTS = [Setting('activate', True),
             Setting('anaconda_upload', binstar_upload),
@@ -197,10 +206,12 @@ class Config(object):
 
     @property
     def host_subdir(self):
-        return "-".join([self.host_platform, str(self.host_arch)])
+        subdir = "-".join([self.host_platform, str(self.host_arch)])
+        return SUBDIR_ALIASES.get(subdir, subdir)
 
     @host_subdir.setter
     def host_subdir(self, value):
+        value = SUBDIR_ALIASES.get(value, value)
         values = value.split('-')
         self.host_platform = values[0]
         if len(values) > 1:

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -44,9 +44,9 @@ DEFAULT_PREFIX_LENGTH = 255
 SUBDIR_ALIASES = {
     'linux-cos5-x86_64': 'linux-64',
     'linux-cos5-x86': 'linux-32',
-    'osx-109-x86_64': 'osx-64,'
-    'win-x86_64': 'win-64,'
-    'win-x86': 'win-32,'
+    'osx-109-x86_64': 'osx-64',
+    'win-x86_64': 'win-64',
+    'win-x86': 'win-32',
 }
 
 Setting = namedtuple("ConfigSetting", "name, default")

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -322,8 +322,7 @@ def compiler(language, config, permit_undefined_jinja=False):
         # support cross compilers.  A cross-compiler package will have a name such as
         #    gcc_target
         #    gcc_linux-cos5-64
-        if 'target_platform' in config.variant:
-            compiler = '_'.join((compiler, config.variant['target_platform']))
+        compiler = '_'.join([ compiler, config.variant['target_platform']])
     return compiler
 
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -22,6 +22,12 @@ DEFAULT_VARIANTS = {
     'exclude_from_build_hash': ['numpy', 'mkl'],
 }
 
+DEFAULT_PLATFORMS = {
+    'linux': 'linux-cos5-' + cc.arch_name,
+    'osx': 'osx-109-' + cc.arch_name,
+    'win': 'win-' + cc.arch_name,
+}
+
 
 SUFFIX_MAP = {'PY': 'python',
               'NPY': 'numpy',
@@ -142,6 +148,10 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts):
         specs = [DEFAULT_VARIANTS] + list(dict_or_list_of_dicts or [])
 
     combined, extend_keys = combine_specs(specs)
+
+    if not 'target_platform' in combined:
+        combined['target_platform'] = [DEFAULT_PLATFORMS[cc.platform] + str(cc.arch_name)]
+
     if 'extend_keys' in combined:
         del combined['extend_keys']
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -18,6 +18,7 @@ DEFAULT_VARIANTS = {
     'perl': ['5.22.2'],
     'lua': ['5.2'],
     'r_base': ['3.3.2'],
+    'cpu_optimization_target': ['nocona'],
     'pin_run_as_build': {'python': {'min_pin': 'p.p', 'max_pin': 'p.p'}},
     'exclude_from_build_hash': ['numpy', 'mkl'],
 }
@@ -150,7 +151,7 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts):
     combined, extend_keys = combine_specs(specs)
 
     if not 'target_platform' in combined:
-        combined['target_platform'] = [DEFAULT_PLATFORMS[cc.platform] + str(cc.arch_name)]
+        combined['target_platform'] = [DEFAULT_PLATFORMS[cc.platform]]
 
     if 'extend_keys' in combined:
         del combined['extend_keys']


### PR DESCRIPTION
This is so that we don't need to provide aliases to our cross-compiler packages.  Instead, we keep the default names of compilers the same, but append a default target_platform value.