### PR TITLE
fix context conda_build attribute error with older conda

### DIFF
--- a/conda_build/_link.py
+++ b/conda_build/_link.py
@@ -77,6 +77,8 @@ def link_files(src_root, dst_root, files):
 # yanked from conda
 def replace_long_shebang(data):
     # this function only changes a shebang line if it exists and is greater than 127 characters
+    if hasattr(data, 'encode'):
+        data = data.encode()
     shebang_match = re.match(SHEBANG_REGEX, data, re.MULTILINE)
     if shebang_match:
         whole_shebang, executable, options = shebang_match.groups()
@@ -84,6 +86,8 @@ def replace_long_shebang(data):
             executable_name = executable.decode('utf-8').split('/')[-1]
             new_shebang = '#!/usr/bin/env %s%s' % (executable_name, options.decode('utf-8'))
             data = data.replace(whole_shebang, new_shebang.encode('utf-8'))
+    if hasattr(data, 'decode'):
+        data = data.decode()
     return data
 
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -814,6 +814,7 @@ def post_process_files(m, initial_prefix_files):
     get_build_metadata(m, config=m.config)
     create_post_scripts(m, config=m.config)
 
+    # this is new-style noarch, with a value of 'python'
     if not is_noarch_python(m):
         utils.create_entry_points(m.get_value('build/entry_points'), config=m.config)
     current_prefix_files = prefix_files(prefix=m.config.build_prefix)

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -151,7 +151,7 @@ if parse_version(CONDA_VERSION) >= parse_version("4.2"):
 
     get_rc_urls = lambda: list(context.channels)
     get_prefix = partial(context_get_prefix, context)
-    cc_conda_build = context.conda_build
+    cc_conda_build = context.conda_build if hasattr(context, 'conda_build') else {}
 
     # disallow softlinks.  This avoids a lot of dumb issues, at the potential cost of disk space.
     os.environ['CONDA_ALLOW_SOFTLINKS'] = 'false'

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -562,23 +562,19 @@ def iter_entry_points(items):
 
 def create_entry_point(path, module, func, config):
     pyscript = PY_TMPL % {'module': module, 'func': func}
-    if config.noarch:
-        with open(path, 'w') as fo:
+    if on_win:
+        with open(path + '-script.py', 'w') as fo:
+            if os.path.isfile(os.path.join(config.build_prefix, 'python_d.exe')):
+                fo.write('#!python_d\n')
             fo.write(pyscript)
-        os.chmod(path, 0o775)
-    else:
-        if sys.platform == 'win32':
-            with open(path + '-script.py', 'w') as fo:
-                if os.path.isfile(os.path.join(config.build_prefix, 'python_d.exe')):
-                    fo.write('#!python_d\n')
-                fo.write(pyscript)
             copy_into(join(dirname(__file__), 'cli-{}.exe'.format(config.arch)),
                     path + '.exe', config.timeout)
-        else:
-            with open(path, 'w') as fo:
+    else:
+        with open(path, 'w') as fo:
+            if not config.noarch:
                 fo.write('#!%s\n' % config.build_python)
-                fo.write(pyscript)
-            os.chmod(path, 0o775)
+            fo.write(pyscript)
+        os.chmod(path, 0o775)
 
 
 def create_entry_points(items, config):


### PR DESCRIPTION
fixes #1812 

conda only recently added this attribute.  This falls back to a safe default for older conda versions.