### PR TITLE
Pass WINDIR env var through on win

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -392,6 +392,7 @@ def windows_vars(prefix):
         'R': join(prefix, 'Scripts', 'R.exe'),
         'CYGWIN_PREFIX': ''.join(('/cygdrive/', drive.lower(), tail.replace('\\', '/'))),
         'SYSTEMROOT': os.getenv('SYSTEMROOT'),
+        'WINDIR': os.getenv('WINDIR'),
     }
 
 


### PR DESCRIPTION
This issue was encountered when building a recipe for cx_Oracle. It was failing on the test stage because `import cx_Oracle` results in setuptools `pkg_resources.resource_filename` being called, which in turn has a call to `os.environ['windir']` on Windows.

I guess that the `WINDIR` environment variable is widely assumed to always be set on Windows, like `SYSTEMROOT`.