### PR TITLE
Add long test prefix option

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -964,8 +964,12 @@ def bundle_wheel(output, metadata, config, env):
     with TemporaryDirectory() as tmpdir, utils.tmp_chdir(config.work_dir):
         pip.main(['wheel', '--wheel-dir', tmpdir, '--no-deps', '.'])
         wheel_file = glob(os.path.join(tmpdir, "*.whl"))[0]
-        utils.copy_into(wheel_file, config.bldpkgs_dir, locking=config.locking)
-    return os.path.join(config.bldpkgs_dir, os.path.basename(wheel_file))
+        if config.output_folder:
+            output_folder = os.path.join(config.output_folder, metadata.config.subdir)
+        else:
+            output_folder = metadata.config.bldpkgs_dir
+        utils.copy_into(wheel_file, output_folder, locking=config.locking)
+    return os.path.join(output_folder, os.path.basename(wheel_file))
 
 
 bundlers = {

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -141,7 +141,10 @@ def have_prefix_files(files, prefix):
             continue
 
         fi = open(path, 'rb+')
-        mm = mmap.mmap(fi.fileno(), 0)
+        try:
+            mm = mmap.mmap(fi.fileno(), 0)
+        except OSError:
+            mm = fi
 
         mode = 'binary' if mm.find(b'\x00') != -1 else 'text'
         if mode == 'text':

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -226,7 +226,19 @@ different sets of packages."""
               " you package may depend on files that are not included in the package, and may pass"
               "tests, but ultimately fail on installed systems.")
     )
-
+    p.add_argument(
+        "--long-test-prefix", default=False, action="store_true",
+        help=("Use a long prefix for the test prefix, as well as the build prefix.  Affects only "
+              "Linux and Mac.  Prefix length matches the --prefix-length flag.  This is off by "
+              "default in conda-build 2.x, but will be enabled by default in conda-build 3.0.")
+    )
+    p.add_argument(
+        "--no-long-test-prefix", dest="long_test_prefix", action="store_false",
+        help=("Do not use a long prefix for the test prefix, as well as the build prefix."
+              "  Affects only Linux and Mac.  Prefix length matches the --prefix-length flag.  "
+              "This is currently the default behavior, and does not need to be set.  This will"
+              " change in conda-build 3.0 (long-test-prefix enabled by default)")
+    )
     add_parser_channels(p)
 
     args = p.parse_args(args)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -109,6 +109,7 @@ class Config(object):
                   Setting('output_folder', None),
                   Setting('prefix_length_fallback', True),
                   Setting('_prefix_length', DEFAULT_PREFIX_LENGTH),
+                  Setting('long_test_prefix', False),
                   Setting('locking', True),
                   Setting('max_env_retry', 3),
                   Setting('remove_work_dir', True),
@@ -290,7 +291,7 @@ class Config(object):
     @property
     def test_prefix(self):
         """The temporary folder where the test environment is created"""
-        if on_win:
+        if on_win or not self.long_test_prefix:
             return self._short_test_prefix
         return self._long_prefix(self._short_test_prefix)
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -379,6 +379,7 @@ def windows_vars(prefix):
         'R': join(prefix, 'Scripts', 'R.exe'),
         'CYGWIN_PREFIX': ''.join(('/cygdrive/', drive.lower(), tail.replace('\\', '/'))),
         'SYSTEMROOT': os.getenv('SYSTEMROOT'),
+        'WINDIR': os.getenv('WINDIR'),
     }
 
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -57,12 +57,16 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
     with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
         try:
             data = fi.read(100)
+            fi.seek(0)
         except UnicodeDecodeError:  # file is binary
             return
 
         # regexp on the memory mapped file so we only read it into
         # memory if the regexp matches.
-        mm = mmap.mmap(fi.fileno(), 0)
+        try:
+            mm = mmap.mmap(fi.fileno(), 0)
+        except OSError:
+            mm = fi
         m = SHEBANG_PAT.match(mm)
 
         if not (m and b'python' in m.group()):

--- a/tests/test-recipes/metadata/_test_long_test_prefix/meta.yaml
+++ b/tests/test-recipes/metadata/_test_long_test_prefix/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: test_long_test_prefix
+  version: 1.0
+
+requirements:
+  run:
+    - python

--- a/tests/test-recipes/metadata/_test_long_test_prefix/run_test.py
+++ b/tests/test-recipes/metadata/_test_long_test_prefix/run_test.py
@@ -1,0 +1,4 @@
+import os
+prefix = os.getenv('PREFIX')
+
+assert '_plac' in prefix

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -18,6 +18,7 @@ from conda_build.conda_interface import PY3, url_path
 
 from binstar_client.commands import remove, show
 from binstar_client.errors import NotFound
+from pkg_resources import parse_version
 import pytest
 import yaml
 import tarfile
@@ -25,7 +26,7 @@ import tarfile
 from conda_build import api, exceptions, __version__
 from conda_build.build import VersionOrder
 from conda_build.utils import (copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2,
-                               package_has_file, check_output_env, conda_43)
+                               package_has_file, check_output_env)
 from conda_build.os_utils.external import find_executable
 
 from .utils import metadata_dir, fail_dir, is_valid_dir, add_mangling
@@ -640,7 +641,8 @@ def test_about_json_content(test_metadata):
     assert 'root_pkgs' in about and about['root_pkgs']
 
 
-@pytest.mark.xfail(not conda_43(), reason="new noarch supported starting with conda 4.3")
+@pytest.mark.xfail(parse_version(conda.__version__) < parse_version("4.3.14"),
+                   reason="new noarch supported starting with conda 4.3.14")
 def test_noarch_python_with_tests(test_config):
     recipe = os.path.join(metadata_dir, "_noarch_python_with_tests")
     api.build(recipe, config=test_config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import subprocess
 import sys
 import yaml
 
@@ -106,6 +107,16 @@ def test_build_output_build_path_multiple_recipes(testing_workdir, test_config, 
     output, error = capfd.readouterr()
     assert error == ""
     assert output.rstrip().splitlines() == test_paths, error
+
+
+@pytest.mark.skipif(on_win, reason="prefix is always short on win.")
+def test_build_long_test_prefix_default_disabled(mocker, testing_workdir, test_metadata):
+    recipe_path = os.path.join(metadata_dir, '_test_long_test_prefix')
+    args = [recipe_path, '--no-anaconda-upload']
+    with pytest.raises(SystemExit):
+        main_build.execute(args)
+    args.append('--long-test-prefix')
+    main_build.execute(args)
 
 
 def test_slash_in_recipe_arg_keeps_build_id(testing_workdir, test_config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,8 +34,18 @@ def test_long_build_prefix_length(config):
     assert len(config.build_prefix) == config.prefix_length
 
 
+@pytest.mark.skipif(on_win, reason="Windows uses only the short prefix")
+def test_long_test_prefix_length(config):
+    assert not config.long_test_prefix
+    assert '_plac' not in config.test_prefix
+    config.long_test_prefix = True
+    config.prefix_length = 80
+    assert len(config.test_prefix) == config.prefix_length
+    config.prefix_length = 255
+    assert len(config.test_prefix) == config.prefix_length
+
+
 def test_build_id_at_end_of_long_build_prefix(config):
-    config.use_long_build_prefix = True
     build_id = 'test123'
     config.build_id = build_id
     assert build_id in config.build_prefix


### PR DESCRIPTION
Fixes #1824 #1816 

Note that long-test prefix will be disabled by default in conda-build 2.1.7 and any future 2.1.x releases, but enabled in 3.0+.