### PR TITLE
reset build folder for each built package

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1494,6 +1494,9 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                 config.run_recipe_verify_scripts else None
             verifier.verify_recipe(ignore_scripts=ignore_scripts, run_scripts=run_scripts,
                                    rendered_meta=metadata.meta, recipe_dir=metadata.path)
+
+        if metadata.name() not in metadata.config.build_folder:
+            metadata.config.compute_build_id(metadata.name(), reset=True)
         try:
             with config:
                 packages_from_this = build(metadata, post=post,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,22 @@ def test_build_no_build_id(testing_workdir, test_config):
     assert 'has_prefix_files_1' not in data
 
 
+@pytest.mark.serial
+def test_build_multiple_recipes(test_metadata, testing_workdir, test_config):
+    """Test that building two recipes in one CLI call separates the build environment for each"""
+    os.makedirs('recipe1')
+    os.makedirs('recipe2')
+    api.output_yaml(test_metadata, 'recipe1/meta.yaml')
+    with open('recipe1/run_test.py', 'w') as f:
+        f.write("import os; assert 'test_build_multiple_recipes' in os.getenv('PREFIX')")
+    test_metadata.meta['package']['name'] = 'package2'
+    api.output_yaml(test_metadata, 'recipe2/meta.yaml')
+    with open('recipe2/run_test.py', 'w') as f:
+        f.write("import os; assert 'package2' in os.getenv('PREFIX')")
+    args = ['--no-anaconda-upload', 'recipe1', 'recipe2']
+    main_build.execute(args)
+
+
 def test_build_output_folder(testing_workdir, test_metadata, capfd):
     api.output_yaml(test_metadata, 'meta.yaml')
     with TemporaryDirectory() as tmp:


### PR DESCRIPTION
Fixes an issue reported on the conda mailing list, where specifying two or more recipes on the CLI would fail to create independent build folders.