### PR TITLE
wrap copy of test/source_files so that errors don't prevent a build

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -5,6 +5,7 @@ Module to handle generating test files.
 from __future__ import absolute_import, division, print_function
 
 import glob
+import logging
 import os
 from os.path import join, exists, isdir
 import sys
@@ -63,8 +64,12 @@ def create_files(dir_path, m, config):
         if not files:
             raise RuntimeError("Did not find any source_files for test with pattern %s", pattern)
         for f in files:
-            copy_into(f, f.replace(config.work_dir, config.test_dir), config.timeout,
-                      locking=config.locking)
+            try:
+                copy_into(f, f.replace(config.work_dir, config.test_dir), config.timeout,
+                        locking=config.locking)
+            except OSError as e:
+                log = logging.getLogger(__name__)
+                log.warn("Failed to copy {0} into test files.  Error was: {1}".format(f, str(e)))
         for ext in '.pyc', '.pyo':
             for f in get_ext_files(config.test_dir, ext):
                 os.remove(f)


### PR DESCRIPTION
CC @stuartarchibald

I don't think this is a proper fix, but absent a reproducer, this should at least be a good enough band-aid to make conda-build get out of your way.