### PR TITLE
Python 2 os.environ Windows compat. fix

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -165,7 +165,7 @@ if parse_version(CONDA_VERSION) >= parse_version("4.2"):
     cc_conda_build = context.conda_build if hasattr(context, 'conda_build') else {}
 
     # disallow softlinks.  This avoids a lot of dumb issues, at the potential cost of disk space.
-    os.environ['CONDA_ALLOW_SOFTLINKS'] = 'false'
+    os.environ[str('CONDA_ALLOW_SOFTLINKS')] = str('false')
     reset_context()
 
     from conda.models.channel import get_conda_build_local_url


### PR DESCRIPTION
The current release doesn't work on Python 2.7 with conda >= 4.2 without this unfortunately:

```TypeError: environment can only contain strings```
