### PR TITLE
fix direct file links are treated as absolute links

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -471,7 +471,7 @@ def check_symlinks(files, prefix, croot):
             elif real_link_path.startswith(real_build_prefix):
                 # If the path is in the build prefix, this is fine, but
                 # the link needs to be relative
-                if not link_path.startswith('.'):
+                if not link_path.startswith('.') and not os.path.dirname(link_path) == '':
                     # Don't change the link structure if it is already a
                     # relative link. It's possible that ..'s later in the path
                     # can result in a broken link still, but we'll assume that


### PR DESCRIPTION
This causes errors if the link is in a directory that itself is linked to within the environment, consider this example build environment after installing mylib package:

    lib/
        mylib.so -> mylib.so.1
        mylib.so.1
    share/
        mypackage/
            lib -> ../../lib

so share/mypackage/lib -> lib
The problem is that during post (mylib.so -> mylib.so.1) is treated as absolute link and we get these messages:

Making absolute symlink lib/mylib.so -> mylib.so.1 relative
Making absolute symlink share/mypackage/lib/mylib.so -> mylib.so.1 relative

While the first does not cause any issues, the second actually does, since it changes the symbolic link (mylib.so -> mylib.so.1) to

    mylib.so -> ../../../lib/mylib.so.1

so we have

    lib/
        mylib.so -> ../../../lib/mylib.so.1
        mylib.so.1
    share/
        mypackage/
            lib -> ../../lib

and further on we get this error:

Error: lib/mylib.so is a symlink to a path that may not exist after the build is completed (../../../lib/mylib.so.1)