### PR TITLE
Use symlinks while copying from file sources to improve perf.

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -531,7 +531,8 @@ def provide(metadata, config, patch=True):
             print("Copying %s to %s" % (path, config.work_dir))
         # careful here: we set test path to be outside of conda-build root in setup.cfg.
         #    If you don't do that, this is a recursive function
-        copy_into(path, config.work_dir, config.timeout, locking=config.locking)
+        copy_into(path, config.work_dir, config.timeout, symlinks=True,
+                  locking=config.locking)
     else:  # no source
         if not isdir(config.work_dir):
             os.makedirs(config.work_dir)


### PR DESCRIPTION
I wondered why using file sources, no symlinks were used. Seems to be forgotten.

I tried running the very long running mentioned tests, but they fail before and after my change :-( 

Running my local build worked fine for me with this change.