### PR TITLE
read metadata / options from setup.cfg in load_setup_py_data

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -134,6 +134,17 @@ def load_setup_py_data(config, setup_file='setup.py', from_recipe_dir=False, rec
         '__file__': setup_file,
     }
     if os.path.isfile(setup_file):
+        try:
+            from setuptools.config import read_configuration
+        except ImportError:
+            pass  # setuptools <30.3.0 cannot read metadata / options from 'setup.cfg'
+        else:
+            setup_cfg = os.path.join(os.path.dirname(setup_file), 'setup.cfg')
+            if os.path.isfile(setup_cfg):
+                # read_configuration returns a dict of dicts. Each dict (keys: 'metadata',
+                # 'options'), if present, provides keyword arguments for the setup function.
+                for kwargs in read_configuration(setup_cfg).values():
+                    _setuptools_data.update(kwargs)
         code = compile(open(setup_file).read(), setup_file, 'exec', dont_inherit=1)
         exec(code, ns, ns)
     else:

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -1,3 +1,5 @@
+import pytest
+
 from conda_build import jinja_context
 from conda_build.utils import HashableDict
 
@@ -85,3 +87,35 @@ def test_pin_subpackage_expression(testing_metadata):
                                       (output_dict, fm)}
     pin = jinja_context.pin_subpackage(testing_metadata, 'a')
     assert len(pin.split()) == 2
+
+
+try:
+    from setuptools.config import read_configuration
+    del read_configuration
+except ImportError:
+    _has_read_configuration = False
+else:
+    _has_read_configuration = True
+
+
+@pytest.mark.skipif(not _has_read_configuration,
+                    reason="setuptools <30.3.0 cannot read metadata / options from 'setup.cfg'")
+def test_load_setup_py_data_from_setup_cfg(testing_config, tmpdir):
+    setup_py = tmpdir.join('setup.py')
+    setup_cfg = tmpdir.join('setup.cfg')
+    setup_py.write(
+        'from setuptools import setup\n'
+        'setup(name="name_from_setup_py")\n'
+    )
+    setup_cfg.write(
+        '[metadata]\n'
+        'name = name_from_setup_cfg\n'
+        'version = version_from_setup_cfg\n'
+        '[options.extras_require]\n'
+        'extra = extra_package\n'
+    )
+    setup_file = str(setup_py)
+    setuptools_data = jinja_context.load_setup_py_data(testing_config, setup_file)
+    assert setuptools_data['name'] == 'name_from_setup_py'
+    assert setuptools_data['version'] == 'version_from_setup_cfg'
+    assert setuptools_data['extras_require'] == {'extra': ['extra_package']}


### PR DESCRIPTION
`setuptools 30.3.0` added the ability to read metadata / options, i.e. keyword arguments for `setuptools.setup`, from configuration files. See https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files.
This PR makes this functionality available in `conda_build.jinja_context.load_setup_py_data`.

I assumed that _setup.cfg_ resides next to _setup.py_ in the same directory. According to the doc-string of `distutils.dist.Distribution.find_config_files` (which is the function that provides the configuration filenames for `setup`) _setup.cfg_ is to be found "in the current directory". Thus maybe L142 should simply be `setup_cfg = 'setup.cfg'`. I am not sure whether the current working directory in `load_setup_py_data` would be the one `setuptools` / `distutils` assumes.
That aside, the reason for hard-coding the filename `'setup.cfg'` instead of making it an additional parameter to the function is that `find_config_files` uses this same hard-coded name.

Notice that the corresponding test is skipped for older versions of `setuptools`, e.g. the one available at https://repo.continuum.io/pkgs/free/. Conda-forge provides a more recent version of `setuptools`, though.
