### PR TITLE
Inspect linkages logs when mult pkgs provide lib

### DIFF
--- a/conda_build/inspect.py
+++ b/conda_build/inspect.py
@@ -230,8 +230,9 @@ def inspect_linkages(packages, prefix=sys.prefix, untracked=False,
                 if path.startswith(prefix):
                     deps = list(which_package(path))
                     if len(deps) > 1:
+                        deps_str = [str(dep) for dep in deps]
                         get_logger(__name__).warn("Warning: %s comes from multiple "
-                                                  "packages: %s", path, comma_join(deps))
+                                                  "packages: %s", path, comma_join(deps_str))
                     if not deps:
                         if exists(path):
                             depmap['untracked'].append((lib, path.split(prefix +


### PR DESCRIPTION
The conda inspect linkages command now logs as a warning when multiple
packages contain a library.

closes #1882