### PR TITLE
TST: Add skip to test_unzip unit test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,6 +68,7 @@ def test_disallow_merge_conflicts(namespace_setup, testing_config):
                                                  'package'))
 
 
+@pytest.mark.skipif(utils.on_win, reason="only unix has full os.chmod capabilities")
 def test_unzip(testing_workdir):
     with open('file_with_execute_permission', 'w') as f:
         f.write("test")


### PR DESCRIPTION
test_unzip should only be run on Unix system where os.chmod works on all file permissions.