### PR TITLE
Relax entry_points syntax

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -436,7 +436,7 @@ def write_no_link(m, files):
 def get_entry_point_script_names(entry_point_scripts):
     scripts = []
     for entry_point in entry_point_scripts:
-        cmd = entry_point[:entry_point.find("= ")].strip()
+        cmd = entry_point[:entry_point.find("=")].strip()
         if utils.on_win:
             scripts.append("Scripts\\%s-script.py" % cmd)
             scripts.append("Scripts\\%s.exe" % cmd)


### PR DESCRIPTION
Allows elements of the build/entry_points section of a recipe to contain Python
entry points without spaces between the name of the console script and the
module path and function.  For example, foo=foo_module.func.

This syntax was previously allowed for some recipe but not noarch: python
recipe.

closes #1893