### PR TITLE
metadata: Raise an error if a field has the wrong type.

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -723,6 +723,10 @@ class MetaData(object):
             elif value.lower() in falses:
                 value = False
 
+        if default_structs.get(field, None) is list and type(value) is not list:
+            raise ValueError("Metadata field '{}' has wrong type: expected list, got '{}'"
+                             .format(field, type(value).__name__))
+
         return value
 
     def check_fields(self):


### PR DESCRIPTION
Consider the following `meta.yaml`, which has only one build dependency:

```yaml
package:
  name: foopkg
  version: "0.1"

requirements:
  build:
    python
```

The user has made a typo in the `requirements` section, but that isn't detected by conda-build.  Instead, the string `python` is treated like a list `['p', 'y', 't', 'h', 'o', 'n']`:

```
$ conda build /tmp/foopkg
BUILD START: foopkg-0.1-0
updating index in: /miniconda2/conda-bld/osx-64
updating index in: /miniconda2/conda-bld/noarch
Can't build /tmp/foopkg due to unsatisfiable dependencies:
Packages missing in current osx-64 channels:
  - p
  - y
  - t
  - h
  - o
  - n
```

Something similar happens if the typo is in the `run` requirements:

```yaml
package:
  name: foopkg
  version: "0.1"

requirements:
  run:
    python
```

Conda-build creates the package without complaint, but then conda raises a cryptic error message at install-time:

```
$ conda create -n foo --use-local foopkg
Fetching package metadata ...............
Solving package specifications:


PackageNotFoundError: Package not found: Conda could not find '
```

This PR adds a simple check to verify that fields in `meta.yaml` are of the expected type.  Now such typos result in a reasonable error message:

```pytb
$ PYTHONPATH=. conda build /tmp/foopkg
Traceback (most recent call last):
  File "/miniconda2/bin/conda-build", line 6, in <module>
    sys.exit(conda_build.cli.main_build.main())
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/cli/main_build.py", line 322, in main
    execute(sys.argv[1:])
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/cli/main_build.py", line 313, in execute
    noverify=args.no_verify)
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/api.py", line 170, in build
    need_source_download=need_source_download, config=config, variants=variants)
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/build.py", line 1363, in build_tree
    permit_unsatisfiable_variants=False)
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/render.py", line 468, in render_recipe
    m = MetaData(recipe_dir, config=config)
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/metadata.py", line 527, in __init__
    self.parse_again(permit_undefined_jinja=True, stub_subpackages=True)
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/metadata.py", line 632, in parse_again
    self.ensure_no_pip_requirements()
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/metadata.py", line 637, in ensure_no_pip_requirements
    if any(hasattr(item, 'keys') for item in self.get_value(key)):
  File "/Users/bergs/Documents/workspace/conda-build/conda_build/metadata.py", line 730, in get_value
    .format(field, expected_type.__name__, type(value).__name__))
ValueError: Metadata field 'requirements/build' has wrong type: expected 'list', got 'unicode'
```