### PR TITLE
rename pin_downstream to run_exports

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -445,10 +445,10 @@ def get_entry_point_script_names(entry_point_scripts):
     return scripts
 
 
-def write_pin_downstream(m):
-    if 'pin_downstream' in m.meta.get('build', {}):
-        with open(os.path.join(m.config.info_dir, 'pin_downstream'), 'w') as f:
-            for pin in utils.ensure_list(m.meta['build']['pin_downstream']):
+def write_run_exports(m):
+    if 'run_exports' in m.meta.get('build', {}):
+        with open(os.path.join(m.config.info_dir, 'run_exports'), 'w') as f:
+            for pin in utils.ensure_list(m.meta['build']['run_exports']):
                 f.write(pin + "\n")
 
 
@@ -469,7 +469,7 @@ def create_info_files(m, files, prefix):
     write_info_json(m)  # actually index.json
     write_about_json(m)
     write_link_json(m)
-    write_pin_downstream(m)
+    write_run_exports(m)
 
     copy_recipe(m)
     copy_readme(m)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -817,7 +817,7 @@ class MetaData(object):
         # filter build requirements for ones that should not be in the hash
         requirements = composite.get('requirements', {})
         build_reqs = requirements.get('build', [])
-        excludes = self.config.variant.get('exclude_from_build_hash', [])
+        excludes = self.config.variant.get('ignore_version', [])
         if excludes:
             exclude_pattern = re.compile('|'.join('{}[\s$]?.*'.format(exc) for exc in excludes))
             build_reqs = [req for req in build_reqs if not exclude_pattern.match(req)]

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -489,7 +489,7 @@ def toposort(outputs):
 def output_dict_from_top_level_meta(m, files=None):
     requirements = m.meta.get('requirements', {})
     output_d = {'name': m.name(), 'requirements': requirements,
-                'pin_downstream': m.meta.get('build', {}).get('pin_downstream'),
+                'run_exports': m.meta.get('build', {}).get('run_exports'),
                 'noarch_python': m.get_value('build/noarch_python'),
                 'noarch': m.get_value('build/noarch'),
                 'type': 'conda',
@@ -1287,9 +1287,9 @@ class MetaData(object):
             if (not (output_metadata.noarch or output_metadata.noarch_python) and
                     self.config.platform != output_metadata.config.platform):
                 output_metadata.config.platform = self.config.platform
-            if 'pin_downstream' in output:
+            if 'run_exports' in output:
                 build = output_metadata.meta.get('build', {})
-                build['pin_downstream'] = output['pin_downstream']
+                build['run_exports'] = output['run_exports']
                 output_metadata.meta['build'] = build
             if 'outputs' in output_metadata.meta:
                 del output_metadata.meta['outputs']

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -81,7 +81,7 @@ def get_env_dependencies(m, env, variant, index=None, exclude_pattern=None):
                 if dash_or_under.sub("", key) == dash_or_under.sub("", spec_name):
                     dependencies.append(" ".join((spec_name, value)))
         elif exclude_pattern.match(spec):
-            pass_through_deps.append(spec)
+            pass_through_deps.append(spec.split(' ')[0])
     random_string = ''.join(random.choice(string.ascii_uppercase + string.digits)
                             for _ in range(10))
     dependencies = list(set(dependencies))
@@ -188,7 +188,7 @@ def finalize_metadata(m, index=None, finalized_outputs=None):
         index = get_build_index(m.config, m.config.build_subdir)
 
     exclude_pattern = None
-    excludes = set(m.config.variant.get('exclude_from_build_hash', []))
+    excludes = set(m.config.variant.get('ignore_version', []))
 
     for key in m.config.variant.get('pin_run_as_build', {}).keys():
         if key in excludes:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -148,12 +148,12 @@ def get_upstream_pins(m, actions, index):
                 pkg_dir = os.path.join(pkgs_dir, pkg_dist)
                 pkg_file = os.path.join(pkgs_dir, pkg_dist + '.tar.bz2')
                 if os.path.isdir(pkg_dir):
-                    downstream_file = os.path.join(pkg_dir, 'info/pin_downstream')
+                    downstream_file = os.path.join(pkg_dir, 'info/run_exports')
                     if os.path.isfile(downstream_file):
                         additional_specs.extend(open(downstream_file).read().splitlines())
                     break
                 elif os.path.isfile(pkg_file):
-                    extra_specs = utils.package_has_file(pkg_file, 'info/pin_downstream')
+                    extra_specs = utils.package_has_file(pkg_file, 'info/run_exports')
                     if extra_specs:
                         additional_specs.extend(extra_specs.splitlines())
                     break
@@ -168,7 +168,7 @@ def get_upstream_pins(m, actions, index):
                             pkg_file = os.path.join(pkgs_dir, pkg.dist_name + '.tar.bz2')
                             if os.path.isfile(pkg_file):
                                 extra_specs = utils.package_has_file(pkg_file,
-                                                                    'info/pin_downstream')
+                                                                    'info/run_exports')
                                 if extra_specs:
                                     additional_specs.extend(extra_specs.splitlines())
                                 break

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -14,7 +14,7 @@ from conda_build.conda_interface import arch_name
 from conda_build.conda_interface import cc_conda_build
 from conda_build.conda_interface import cc_platform
 
-DEFAULT_EXTEND_KEYS = ['pin_run_as_build', 'exclude_from_build_hash']
+DEFAULT_EXTEND_KEYS = ['pin_run_as_build', 'ignore_version']
 DEFAULT_VARIANTS = {
     'python': ['{0}.{1}'.format(sys.version_info.major, sys.version_info.minor)],
     'numpy': ['1.11'],
@@ -23,7 +23,7 @@ DEFAULT_VARIANTS = {
     'r_base': ['3.3.2'],
     'cpu_optimization_target': ['nocona'],
     'pin_run_as_build': {'python': {'min_pin': 'x.x', 'max_pin': 'x.x'}},
-    'exclude_from_build_hash': ['numpy'],
+    'ignore_version': [],
 }
 
 DEFAULT_PLATFORMS = {

--- a/tests/test-recipes/metadata/_pin_downstream/meta.yaml
+++ b/tests/test-recipes/metadata/_pin_downstream/meta.yaml
@@ -1,7 +1,7 @@
 package:
-  name: test_has_pin_downstream
+  name: test_has_run_exports
   version: 1.0
 
 build:
-  pin_downstream:
+  run_exports:
     - downstream_pinned_package 1.0

--- a/tests/test-recipes/metadata/_pin_downstream/meta.yaml
+++ b/tests/test-recipes/metadata/_pin_downstream/meta.yaml
@@ -1,7 +1,0 @@
-package:
-  name: test_has_run_exports
-  version: 1.0
-
-build:
-  run_exports:
-    - downstream_pinned_package 1.0

--- a/tests/test-recipes/metadata/_pin_subpackage_exact/meta.yaml
+++ b/tests/test-recipes/metadata/_pin_subpackage_exact/meta.yaml
@@ -1,10 +1,10 @@
 package:
-  name: test_has_pin_downstream
+  name: test_has_run_exports
   version: 1.0
 
 requirements:
   run:
-    - {{ pin_subpackage('pin_downstream_subpkg', exact=True) }}
+    - {{ pin_subpackage('run_exports_subpkg', exact=True) }}
 
 outputs:
-  - name: pin_downstream_subpkg
+  - name: run_exports_subpkg

--- a/tests/test-recipes/metadata/_run_exports/meta.yaml
+++ b/tests/test-recipes/metadata/_run_exports/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: test_has_run_exports
+  version: 1.0
+
+build:
+  run_exports:
+    - downstream_pinned_package 1.0

--- a/tests/test-recipes/variants/03_numpy_matrix/conda_build_config.yaml
+++ b/tests/test-recipes/variants/03_numpy_matrix/conda_build_config.yaml
@@ -4,3 +4,5 @@ python:
 numpy:
   - 1.10
   - 1.11
+ignore_version:
+  - numpy

--- a/tests/test-recipes/variants/10_runtimes/pins_downstream/meta.yaml
+++ b/tests/test-recipes/variants/10_runtimes/pins_downstream/meta.yaml
@@ -1,9 +1,9 @@
 package:
-  name: pins_downstream
+  name: package_has_run_exports
   version: 1.0
 
 build:
-  pin_downstream:
+  run_exports:
     - bzip2  {{ pin_compatible('bzip2') }}
 
 requirements:

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -891,9 +891,9 @@ def test_append_python_app_osx(testing_config):
 #         api.build(metadata)
 
 
-def test_pin_downstream(testing_metadata, testing_config):
-    api.build(os.path.join(metadata_dir, '_pin_downstream'), config=testing_config)
-    testing_metadata.meta['requirements']['build'] = ['test_has_pin_downstream']
+def test_run_exports(testing_metadata, testing_config):
+    api.build(os.path.join(metadata_dir, '_run_exports'), config=testing_config)
+    testing_metadata.meta['requirements']['build'] = ['test_has_run_exports']
     testing_metadata.config.index = None
     m = finalize_metadata(testing_metadata)
     assert 'downstream_pinned_package 1.0' in m.meta['requirements']['run']
@@ -902,7 +902,7 @@ def test_pin_downstream(testing_metadata, testing_config):
 def test_pin_subpackage_exact(testing_config):
     recipe = os.path.join(metadata_dir, '_pin_subpackage_exact')
     ms = api.render(recipe, config=testing_config)
-    assert any(re.match(r'pin_downstream_subpkg 1.0 h[a-f0-9]{%s}_0' % testing_config.hash_length,
+    assert any(re.match(r'run_exports_subpkg 1.0 h[a-f0-9]{%s}_0' % testing_config.hash_length,
                         req)
               for (m, _, _) in ms for req in m.meta['requirements']['run'])
     api.build(recipe, config=testing_config)

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -63,13 +63,13 @@ def test_subpackage_independent_hash(testing_metadata):
     assert outputs[0][-15:] != outputs[1][-15:]
 
 
-def test_pin_downstream_in_subpackage(testing_metadata, testing_index):
+def test_run_exports_in_subpackage(testing_metadata, testing_index):
     p1 = testing_metadata.copy()
-    p1.meta['outputs'] = [{'name': 'has_pin_downstream', 'pin_downstream': 'bzip2 1.0'}]
+    p1.meta['outputs'] = [{'name': 'has_run_exports', 'run_exports': 'bzip2 1.0'}]
     output = api.build(p1)[0]
     api.update_index(os.path.dirname(output), config=testing_metadata.config)
     p2 = testing_metadata.copy()
-    p2.meta['requirements']['build'] = ['has_pin_downstream']
+    p2.meta['requirements']['build'] = ['has_run_exports']
     p2.config.index = None
     p2_final = finalize_metadata(p2, None)
     assert 'bzip2 1.0' in p2_final.meta['requirements']['run']

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -22,7 +22,7 @@ def test_later_spec_priority():
     combined_spec, extend_keys = variants.combine_specs([global_specs, single_version])
     assert len(combined_spec) == 2
     assert combined_spec["python"] == ["2.7.*"]
-    assert extend_keys == {'exclude_from_build_hash', 'pin_run_as_build'}
+    assert extend_keys == {'ignore_version', 'pin_run_as_build'}
 
     # keep keys that are not overwritten
     combined_spec, extend_keys = variants.combine_specs([single_version, no_numpy_version])
@@ -31,8 +31,10 @@ def test_later_spec_priority():
 
 
 def test_get_package_variants_from_file(testing_workdir, testing_config):
+    variants = global_specs.copy()
+    variants['ignore_version'] = ['numpy']
     with open('variant_example.yaml', 'w') as f:
-        yaml.dump(global_specs, f)
+        yaml.dump(variants, f)
     testing_config.variant_config_files = [os.path.join(testing_workdir, 'variant_example.yaml')]
     testing_config.ignore_system_config = True
     metadata = api.render(os.path.join(thisdir, "variant_recipe"),
@@ -47,10 +49,12 @@ def test_get_package_variants_from_file(testing_workdir, testing_config):
 
 def test_get_package_variants_from_dictionary_of_lists(testing_config):
     testing_config.ignore_system_config = True
+    variants = global_specs.copy()
+    variants['ignore_version'] = ['numpy']
     # Note: variant is coming from up above: global_specs
     metadata = api.render(os.path.join(thisdir, "variant_recipe"),
                           no_download_source=False, config=testing_config,
-                          variants=global_specs)
+                          variants=variants)
     # one for each Python version.  Numpy is not strictly pinned and should present only 1 dimension
     assert len(metadata) == 2
     assert sum('python >=2.7,<2.8' in req for (m, _, _) in metadata


### PR DESCRIPTION
after internal discussion, we decided that pin_downstream just isn't clear wording for what this feature is doing.  We believe "run_exports" is more intuitive - package requirements that are exported as runtime requirements to downstream packages.

CC @pzwang 