### PR TITLE
Fix mmap/file problems on VirtualBox shared folders

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -124,9 +124,9 @@ def have_prefix_files(files, prefix):
 
         fi = open(path, 'rb+')
         try:
-            mm = mmap.mmap(fi.fileno(), 0)
+            mm = mmap.mmap(fi.fileno(), 0, flags=mmap.MAP_PRIVATE)
         except OSError:
-            mm = fi
+            mm = fi.read()
 
         mode = 'binary' if mm.find(b'\x00') != -1 else 'text'
         if mode == 'text':
@@ -138,7 +138,7 @@ def have_prefix_files(files, prefix):
                 mm.close()
                 fi.close()
                 fi = open(path, 'rb+')
-                mm = mmap.mmap(fi.fileno(), 0)
+                mm = mmap.mmap(fi.fileno(), 0, flags=mmap.MAP_PRIVATE)
         if mm.find(prefix_bytes) != -1:
             yield (prefix, mode, f)
         if utils.on_win and mm.find(forward_slash_prefix_bytes) != -1:

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -51,7 +51,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
     if os.stat(path).st_size == 0:
         return
 
-    with io.open(path, encoding=locale.getpreferredencoding(), mode='r') as fi:
+    with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
         try:
             data = fi.read(100)
             fi.seek(0)
@@ -61,7 +61,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
         # regexp on the memory mapped file so we only read it into
         # memory if the regexp matches.
         try:
-            mm = mmap.mmap(fi.fileno(), 0)
+            mm = mmap.mmap(fi.fileno(), 0, flags=mmap.MAP_PRIVATE)
         except OSError:
             mm = fi.read()
         m = SHEBANG_PAT.match(mm)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -51,7 +51,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
     if os.stat(path).st_size == 0:
         return
 
-    with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
+    with io.open(path, encoding=locale.getpreferredencoding(), mode='r') as fi:
         try:
             data = fi.read(100)
             fi.seek(0)
@@ -63,7 +63,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
         try:
             mm = mmap.mmap(fi.fileno(), 0)
         except OSError:
-            mm = fi
+            mm = fi.read()
         m = SHEBANG_PAT.match(mm)
 
         if not (m and b'python' in m.group()):


### PR DESCRIPTION
In one case, we can open the file as read-only before mmapping it to
prevent OSError 22.

When that fallback fails, set mm to the file contents not the file
handle when mmap fails to prevent:

    m = SHEBANG_PAT.match(mm)
TypeError: expected string or bytes-like object

In the other case, the file is written to via the memory mapping so
there use flags=mmap.MAP_PRIVATE instead.