### PR TITLE
fix for conda's new MatchSpec implementation

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -621,7 +621,7 @@ class MetaData(object):
                 ms = MatchSpec(spec)
             except AssertionError:
                 raise RuntimeError("Invalid package specification: %r" % spec)
-            except AttributeError:
+            except (AttributeError, ValueError):
                 raise RuntimeError("Received dictionary as spec.  Note that pip requirements are "
                                    "not supported in conda-build meta.yaml.")
             if ms.name == self.name():


### PR DESCRIPTION
This fixes a changed exception type associated with conda/conda#4158