### PR TITLE
fix unbound local variables when --no-locking used.  Add test.

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -17,6 +17,7 @@ from .conda_interface import PY3, md5_file
 
 def read_index_tar(tar_path, config, lock):
     """ Returns the index.json dict inside the given package tarball. """
+    locks = []
     if config.locking:
         locks = [lock]
     with try_acquire_locks(locks, config.timeout):
@@ -38,6 +39,7 @@ def write_repodata(repodata, dir_path, lock, config=None):
     if not config:
         import conda_build.config
         config = conda_build.config.config
+    locks = []
     if config.locking:
         locks = [lock]
     with try_acquire_locks(locks, config.timeout):

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -919,3 +919,10 @@ def test_only_lua_env(test_config):
     test_config.prefix_length = 80
     test_config.set_build_id = False
     api.build(recipe, config=test_config)
+
+
+@pytest.mark.serial
+def test_no_locking(test_config):
+    recipe = os.path.join(metadata_dir, 'source_git_jinja2')
+    api.update_index(os.path.join(test_config.croot, test_config.subdir), config=test_config)
+    api.build(recipe, config=test_config, locking=False)


### PR DESCRIPTION
This is a partial fix for #1883 

It at least fixes errors associated with --no-locking.  The other errors are going to take more work, and unfortunately there's quite a lot ahead of them.