### PR TITLE
Correct rendering with --dirty flag if recipe name appears as a substring of another's name

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -327,7 +327,7 @@ class Config(object):
             assert not os.path.isabs(package_name), ("package name should not be a absolute path, "
                                                      "to preserve croot during path joins")
             build_folders = sorted([build_folder for build_folder in get_build_folders(self.croot)
-                                if package_name in build_folder])
+                                if package_name + "_" in build_folder])
 
             if self.dirty and build_folders:
                 # Use the most recent build with matching recipe name


### PR DESCRIPTION
Delimit package_name to prevent list from being loaded with other build folder names that contain the package name as a substring.

This allows recipes that call for the population of git-related environment variables to be rendered correctly when the `--dirty` flag is used.