### PR TITLE
add support for selectors in conda_build_config.yaml files

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -40,9 +40,12 @@ SUFFIX_MAP = {'PY': 'python',
               'R': 'r_base'}
 
 
-def parse_config_file(path):
+def parse_config_file(path, config):
+    from conda_build.metadata import select_lines, ns_cfg
     with open(path) as f:
-        content = yaml.load(f, Loader=yaml.loader.BaseLoader)
+        contents = f.read()
+    contents = select_lines(contents, ns_cfg(config))
+    content = yaml.load(contents, Loader=yaml.loader.BaseLoader)
     return content
 
 
@@ -278,7 +281,7 @@ def get_package_variants(recipedir_or_metadata, config=None):
     files = find_config_files(recipedir_or_metadata, ensure_list(config.variant_config_files),
                               ignore_system_config=config.ignore_system_variants)
 
-    specs = get_default_variants(config.platform) + [parse_config_file(f) for f in files]
+    specs = get_default_variants(config.platform) + [parse_config_file(f, config) for f in files]
 
     # this is the override of the variants from files and args with values from CLI or env vars
     if config.variant:

--- a/tests/test-recipes/variants/selector_conda_build_config.yaml
+++ b/tests/test-recipes/variants/selector_conda_build_config.yaml
@@ -1,0 +1,3 @@
+value:
+  - abc
+  - def    # [py > 99]

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -34,7 +34,7 @@ def test_get_package_variants_from_file(testing_workdir, testing_config):
     variants = global_specs.copy()
     variants['ignore_version'] = ['numpy']
     with open('variant_example.yaml', 'w') as f:
-        yaml.dump(variants, f)
+        yaml.dump(variants, f, default_flow_style=False)
     testing_config.variant_config_files = [os.path.join(testing_workdir, 'variant_example.yaml')]
     testing_config.ignore_system_config = True
     metadata = api.render(os.path.join(thisdir, "variant_recipe"),
@@ -45,6 +45,12 @@ def test_get_package_variants_from_file(testing_workdir, testing_config):
                for req in m.meta['requirements']['run']) == 1
     assert sum('python >=3.5,<3.6' in req for (m, _, _) in metadata
                for req in m.meta['requirements']['run']) == 1
+
+
+def test_use_selectors_in_variants(testing_workdir, testing_config):
+    testing_config.variant_config_files = [os.path.join(recipe_dir,
+                                                        'selector_conda_build_config.yaml')]
+    variants.get_package_variants(testing_workdir, testing_config)
 
 
 def test_get_package_variants_from_dictionary_of_lists(testing_config):


### PR DESCRIPTION
example:

```
python:
  - 2.7
  - 3.5  # [unix]
```