### PR TITLE
fix preferred_env in index.json in 2.1.x

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -698,6 +698,10 @@ class MetaData(object):
             if value:
                 d[key] = value
 
+        preferred_env = self.get_value('build/preferred_env')
+        if preferred_env:
+            d['preferred_env'] = preferred_env
+
         if self.get_value('build/features'):
             d['features'] = ' '.join(self.get_value('build/features'))
         if self.get_value('build/track_features'):


### PR DESCRIPTION
This patch is in conda-build 3, but I guess it didn't make it into the 2.1.x branch.

I'm running into some problems right now building conda with conda-build 3, so really need this in conda-build 2 to get the alpha release out today.  (Also looking into why conda won't build with conda-build 3.)