### PR TITLE
fix windows test failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,13 +80,20 @@ test_script:
   - set "PATH=%CONDA_ROOT%;%CONDA_ROOT%\Scripts;%CONDA_ROOT%\Library\bin;%PATH%"
   - set PATH
   - mkdir C:\cbtmp
+  # unset other language env vars - we only want to test if conda-build sets them itself
+  - set PERL=
+  - set PYTHON=
+  - set LUA=
+  - set R=
   - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
   - rd /S /Q C:\cbtmp
   - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial" --durations=15
 
-on_failure:
-  - 7z.exe a cbtmp.7z C:\cbtmp
-  - appveyor PushArtifact cbtmp.7z
+# For debugging, this is helpful - zip up the test environment and make it available for later download.
+#    However, it eats up a fair amount of time.  Better to disable until you need it.
+# on_failure:
+#   - 7z.exe a cbtmp.7z C:\cbtmp
+#   - appveyor PushArtifact cbtmp.7z
 
 on_success:
   - pip install codecov

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from conda_build.metadata import select_lines, MetaData
-from conda_build import api
+from conda_build import api, conda_interface
 from .utils import thisdir, metadata_dir
 
 
@@ -153,18 +153,20 @@ def test_native_compiler_metadata_linux(testing_config, mocker):
     testing_config.platform = 'linux'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config)[0][0]
-    assert 'gcc_linux-cos5-x86_64' in metadata.meta['requirements']['build']
-    assert 'gxx_linux-cos5-x86_64' in metadata.meta['requirements']['build']
-    assert 'gfortran_linux-cos5-x86_64' in metadata.meta['requirements']['build']
+    _64 = '_64' if conda_interface.bits == 64 else ''
+    assert 'gcc_linux-cos5-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'gxx_linux-cos5-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'gfortran_linux-cos5-x86' + _64 in metadata.meta['requirements']['build']
 
 
 def test_native_compiler_metadata_osx(testing_config, mocker):
     testing_config.platform = 'osx'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config)[0][0]
-    assert 'clang_osx-109-x86_64' in metadata.meta['requirements']['build']
-    assert 'clangxx_osx-109-x86_64' in metadata.meta['requirements']['build']
-    assert 'gfortran_osx-109-x86_64' in metadata.meta['requirements']['build']
+    _64 = '_64' if conda_interface.bits == 64 else ''
+    assert 'clang_osx-109-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'clangxx_osx-109-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'gfortran_osx-109-x86' + _64 in metadata.meta['requirements']['build']
 
 
 def test_compiler_metadata_cross_compiler():


### PR DESCRIPTION
Appveyor seems to set several variables that conda-build expects to be unset.  Also adress a 32-bit oopsie in a couple of tests.