### PR TITLE
don't expose language versions from variant as env vars

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,6 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda3-x64"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Miniconda36"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %HOME%
 
@@ -80,13 +72,20 @@ test_script:
   - set "PATH=%CONDA_ROOT%;%CONDA_ROOT%\Scripts;%CONDA_ROOT%\Library\bin;%PATH%"
   - set PATH
   - mkdir C:\cbtmp
+  # unset other language env vars - we only want to test if conda-build sets them itself
+  - set PERL=
+  - set PYTHON=
+  - set LUA=
+  - set R=
   - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
   - rd /S /Q C:\cbtmp
   - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial" --durations=15
 
-on_failure:
-  - 7z.exe a cbtmp.7z C:\cbtmp
-  - appveyor PushArtifact cbtmp.7z
+# For debugging, this is helpful - zip up the test environment and make it available for later download.
+#    However, it eats up a fair amount of time.  Better to disable until you need it.
+# on_failure:
+#   - 7z.exe a cbtmp.7z C:\cbtmp
+#   - appveyor PushArtifact cbtmp.7z
 
 on_success:
   - pip install codecov

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -301,7 +301,7 @@ class Config(object):
 
     def _get_perl(self, prefix):
         if sys.platform == 'win32':
-            res = join(prefix, 'perl.exe')
+            res = join(prefix, 'Library', 'bin', 'perl.exe')
         else:
             res = join(prefix, 'bin/perl')
         return res
@@ -310,7 +310,7 @@ class Config(object):
         lua_ver = self.variant.get('lua', get_default_variants()[0]['lua'])
         binary_name = "luajit" if (lua_ver and lua_ver[0] == "2") else "lua"
         if sys.platform == 'win32':
-            res = join(prefix, '{}.exe'.format(binary_name))
+            res = join(prefix, 'Library', 'bin', '{}.exe'.format(binary_name))
         else:
             res = join(prefix, 'bin/{}'.format(binary_name))
         return res

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -32,6 +32,11 @@ from conda_build.exceptions import DependencyNeedsBuildingError
 from conda_build.variants import get_default_variants
 
 
+# these are things that we provide env vars for more explicitly.  This list disables the
+#    pass-through of variant values to env vars for these keys.
+LANGUAGES = ('PERL', 'LUA', 'R', "NUMPY", 'PYTHON')
+
+
 def get_perl_ver(config):
     return '.'.join(config.variant.get('perl', get_default_variants()[0]['perl']).split('.')[:2])
 
@@ -254,7 +259,7 @@ def get_dict(config, m=None, prefix=None, for_env=True):
               feature_list})
 
     for k, v in config.variant.items():
-        if not for_env or k.upper() not in d:
+        if not for_env or (k.upper() not in d and k.upper() not in LANGUAGES):
             d[k] = v
         else:
             log.debug("Omitting variable %s from env dictionary (already exists)", k)
@@ -315,6 +320,7 @@ def python_vars(config, prefix):
 def perl_vars(config, prefix):
     vars_ = {
             'PERL_VER': get_perl_ver(config),
+            'CONDA_PERL': get_perl_ver(config),
              }
     if os.path.isfile(config.perl_bin(prefix)):
         vars_.update({

--- a/tests/test-recipes/metadata/_perl_env_defined/run_test.py
+++ b/tests/test-recipes/metadata/_perl_env_defined/run_test.py
@@ -4,6 +4,6 @@ assert os.getenv('PERL')
 assert os.getenv('PERL_VER')
 assert os.getenv('CONDA_PERL')
 assert not os.getenv('R')
-assert not os.getenv('LUA')
+assert not os.getenv('LUA'), os.getenv('LUA')
 # python is allowed, because it's present to run this script.
 # assert not os.getenv('PYTHON')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from conda_build.metadata import select_lines, MetaData
-from conda_build import api
+from conda_build import api, conda_interface
 from .utils import thisdir, metadata_dir
 
 
@@ -153,18 +153,20 @@ def test_native_compiler_metadata_linux(testing_config, mocker):
     testing_config.platform = 'linux'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config)[0][0]
-    assert 'gcc_linux-cos5-x86_64' in metadata.meta['requirements']['build']
-    assert 'gxx_linux-cos5-x86_64' in metadata.meta['requirements']['build']
-    assert 'gfortran_linux-cos5-x86_64' in metadata.meta['requirements']['build']
+    _64 = '_64' if conda_interface.bits == 64 else ''
+    assert 'gcc_linux-cos5-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'gxx_linux-cos5-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'gfortran_linux-cos5-x86' + _64 in metadata.meta['requirements']['build']
 
 
 def test_native_compiler_metadata_osx(testing_config, mocker):
     testing_config.platform = 'osx'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config)[0][0]
-    assert 'clang_osx-109-x86_64' in metadata.meta['requirements']['build']
-    assert 'clangxx_osx-109-x86_64' in metadata.meta['requirements']['build']
-    assert 'gfortran_osx-109-x86_64' in metadata.meta['requirements']['build']
+    _64 = '_64' if conda_interface.bits == 64 else ''
+    assert 'clang_osx-109-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'clangxx_osx-109-x86' + _64 in metadata.meta['requirements']['build']
+    assert 'gfortran_osx-109-x86' + _64 in metadata.meta['requirements']['build']
 
 
 def test_compiler_metadata_cross_compiler():


### PR DESCRIPTION
This fixes several failing windows tests, because windows is case insensitive.