### PR TITLE
Match package_name plus delimiter exactly to avoid spurious matches...

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -327,7 +327,7 @@ class Config(object):
             assert not os.path.isabs(package_name), ("package name should not be a absolute path, "
                                                      "to preserve croot during path joins")
             build_folders = sorted([build_folder for build_folder in get_build_folders(self.croot)
-                                if package_name + "_" in build_folder])
+                                if build_folder.startswith(package_name + "_")])
 
             if self.dirty and build_folders:
                 # Use the most recent build with matching recipe name


### PR DESCRIPTION
...of prefix strings. I.e if package names "package" and "ABCpackage" exist, previous fix would still return list containing both. Covers cases missed by #1931.