### PR TITLE
simplify build index as global. remove duplicate creations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,6 @@ install:
     fi
   - pip install --no-deps .
   - conda info -a
-  # HACK: seem to be having issues getting MKL downloaded.  Force it to be there.
-  - curl -L https://repo.continuum.io/pkgs/free/linux-64/mkl-11.3.3-0.tar.bz2 -o ~/miniconda/pkgs/mkl-11.3.3-0.tar.bz2
-  - conda index ~/miniconda/pkgs
 
 script: ./ci/travis/run.sh
 

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -35,7 +35,7 @@ def render(recipe_path, config=None, variants=None, permit_unsatisfiable_variant
     from collections import OrderedDict
     config = get_or_merge_config(config, **kwargs)
 
-    metadata_tuples, index = render_recipe(recipe_path,
+    metadata_tuples = render_recipe(recipe_path,
                                     no_download_source=config.no_download_source,
                                     config=config, variants=variants,
                                     permit_unsatisfiable_variants=permit_unsatisfiable_variants)

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -27,12 +27,12 @@ conda_44 = parse_version(CONDA_VERSION) >= parse_version("4.4")
 display_actions, execute_actions, execute_plan = display_actions, execute_actions, execute_plan
 install_actions = install_actions
 
-if conda_44:
+try:
+    # Conda 4.4+
     from conda.exports import _toposort
-    _toposort = _toposort
-else:
+except ImportError:
     from conda.toposort import _toposort
-    _toposort = _toposort
+_toposort = _toposort
 
 if conda_43:
     from conda.exports import TmpDownload, download, handle_proxy_407  # NOQA

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -10,7 +10,6 @@ import jinja2
 
 from .conda_interface import PY3, memoized
 from .environ import get_dict as get_environ
-from .index import get_build_index
 from .utils import (get_installed_packages, apply_pin_expressions, get_logger, HashableDict,
                     string_types)
 from .render import get_env_dependencies
@@ -230,14 +229,12 @@ def pin_compatible(m, package_name, lower_bound=None, upper_bound=None, min_pin=
         by ``.``.
     """
     compatibility = None
-    if not m.config.index:
-        m.config.index = get_build_index(m.config, subdir=m.config.build_subdir)
 
     # this is the version split up into its component bits.
     # There are two cases considered here (so far):
     # 1. Good packages that follow semver style (if not philosophy).  For example, 1.2.3
     # 2. Evil packages that cram everything alongside a single major version.  For example, 9b
-    pins, _ = get_env_dependencies(m, 'build', m.config.variant, m.config.index)
+    pins, _ = get_env_dependencies(m, 'build', m.config.variant)
     versions = {p.split(' ')[0]: p.split(' ')[1:] for p in pins}
     if versions:
         if exact and versions.get(package_name):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1383,7 +1383,7 @@ class MetaData(object):
 
                     try:
                         # we'll still filter out subpackages in finalize_metadata
-                        fm = finalize_metadata(fm, fm.config.index)
+                        fm = finalize_metadata(fm)
                         if not output_d.get('type') or output_d.get('type') == 'conda':
                             outputs[(fm.name(), HashableDict(variant))] = (output_d, fm)
                         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,8 @@ def testing_workdir(tmpdir, request):
 @pytest.fixture(scope='function')
 def testing_index(request):
     with capture():
-        index = get_build_index(config=Config(debug=False, verbose=False), subdir=subdir,
-                                clear_cache=True)
+        index, index_ts = get_build_index(config=Config(debug=False, verbose=False), subdir=subdir,
+                                          clear_cache=True)
     return index
 
 

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -47,7 +47,7 @@ def test_render_yaml_output(testing_workdir, testing_config):
 
 
 def test_get_output_file_path(testing_workdir, testing_metadata):
-    testing_metadata = render.finalize_metadata(testing_metadata, testing_metadata.config.index)
+    testing_metadata = render.finalize_metadata(testing_metadata)
     api.output_yaml(testing_metadata, 'recipe/meta.yaml')
 
     build_path = api.get_output_file_path(os.path.join(testing_workdir, 'recipe'),

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -13,7 +13,7 @@ import pytest
 from conda_build import build, api
 from conda_build.utils import on_win
 
-from .utils import metadata_dir, put_bad_conda_on_path, get_noarch_python_meta, put_bad_conda_on_path
+from .utils import metadata_dir, put_bad_conda_on_path, get_noarch_python_meta
 
 prefix_tests = {"normal": os.path.sep}
 if sys.platform == "win32":
@@ -45,7 +45,7 @@ def test_find_prefix_files(testing_workdir):
 def test_build_preserves_PATH(testing_workdir, testing_config, testing_index):
     m = api.render(os.path.join(metadata_dir, 'source_git'), config=testing_config)[0][0]
     ref_path = os.environ['PATH']
-    build.build(m, index=testing_index)
+    build.build(m)
     assert os.environ['PATH'] == ref_path
 
 


### PR DESCRIPTION
This looks to me like about a 10-20% speed increase.  Further speed increases might require digging into conda (minimizing the number of re-creations of Resolve objects)