### PR TITLE
allow per-output specification of host subdir (target)

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1287,6 +1287,7 @@ class MetaData(object):
                 subpackage_pattern = re.compile(r'(?:^{}(?:\s|$|\Z))'.format(output['name']))
                 build_reqs = [req for req in build_reqs if not subpackage_pattern.match(req)]
                 run_reqs = [req for req in run_reqs if not subpackage_pattern.match(req)]
+            output_metadata.config.host_subdir = output.get('target', self.config.host_subdir)
 
             requirements['build'] = build_reqs
             requirements['run'] = run_reqs

--- a/tests/test-recipes/split-packages/_output_specific_subdir/meta.yaml
+++ b/tests/test-recipes/split-packages/_output_specific_subdir/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: test_output_specific_subdir
+  version: 1.0
+
+outputs:
+  - name: default_subdir
+  - name: custom_subdir
+    target: linux-aarch64
+  # one package after to show that the customization is local to the one package
+  - name: default_subdir_2

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -5,6 +5,7 @@ import sys
 
 from conda_build import api
 from conda_build.render import finalize_metadata
+from conda_build.conda_interface import subdir
 
 from .utils import subpackage_dir, is_valid_dir
 
@@ -140,3 +141,17 @@ def test_intradep_with_templated_output_name(testing_config):
     expected_names = {'test_templated_subpackage_name', 'templated_subpackage_nameabc',
                       'depends_on_templated'}
     assert set((m.name() for (m, _, _) in metadata)) == expected_names
+
+
+def test_output_specific_subdir(testing_config):
+    recipe = os.path.join(subpackage_dir, '_output_specific_subdir')
+    metadata = api.render(recipe, config=testing_config)
+    assert len(metadata) == 3
+    for (m, _, _) in metadata:
+        if m.name() in ('default_subdir', 'default_subdir_2'):
+            assert m.config.host_subdir == subdir
+        elif m.name() == 'custom_subdir':
+            assert m.config.host_subdir == 'linux-aarch64'
+        else:
+            raise AssertionError("Test for output_specific_subdir written incorrectly - "
+                                 "package name not recognized")


### PR DESCRIPTION
This is essential for packages that create both cross-compilers and their runtime libraries.  The compilers themselves have the native platform as the host, but the runtime libraries need the target platform as their host.

cc @mingwandroid 