### PR TITLE
fix perl only creating run test py #1967

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -137,8 +137,7 @@ def create_py_files(m):
             # add any imports specifically marked as python
             if (hasattr(import_item, 'keys') and 'lang' in import_item and
                     import_item['lang'] == 'python'):
-                imports = import_item['imports']
-                break
+                imports.extend(import_item['imports'])
     else:
         imports = ensure_list(m.get_value('test/imports', []))
         imports = [item for item in imports if (not hasattr(item, 'keys') or

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -132,8 +132,8 @@ def create_py_files(m):
     likely_non_python_pkg = likely_r_pkg or likely_lua_pkg or likely_perl_pkg
 
     if likely_non_python_pkg:
-        imports = ensure_list(m.get_value('test/imports', []))
-        for import_item in imports:
+        imports = []
+        for import_item in ensure_list(m.get_value('test/imports', [])):
             # add any imports specifically marked as python
             if (hasattr(import_item, 'keys') and 'lang' in import_item and
                     import_item['lang'] == 'python'):

--- a/tests/test_create_test.py
+++ b/tests/test_create_test.py
@@ -61,6 +61,12 @@ def test_create_pl_files(testing_workdir, testing_metadata):
     assert 'use perl-base;\n' in data
     assert 'use perl-matrix;\n' in data
 
+def test_non_py_does_not_create_py_files(testing_workdir, testing_metadata):
+    testing_metadata.meta['test']['imports'] = ['perl-base', 'perl-matrix']
+    testing_metadata.meta['package']['name'] = 'perl-conda-test'
+    ct.create_py_files(testing_metadata)
+    py_test_file = os.path.join(testing_metadata.config.test_dir, 'run_test.py')
+    assert not os.path.isfile(py_test_file), "non-python package should not create run_test.py"
 
 def test_create_pl_files_lang_spec(testing_workdir, testing_metadata):
     testing_metadata.meta['test']['imports'] = [{'lang': 'perl', 'imports': ['perl-base',

--- a/tests/test_create_test.py
+++ b/tests/test_create_test.py
@@ -25,6 +25,19 @@ def test_create_py_files_in_other_language(testing_workdir, testing_metadata):
     assert 'import time\n' in data
     assert 'import datetime\n' in data
 
+def test_create_py_files_in_other_language_multiple_python_dicts(testing_workdir, testing_metadata):
+    testing_metadata.meta['test']['imports'] = [{'lang': 'python', 'imports': ['time', 'datetime']}]
+    testing_metadata.meta['test']['imports'].append({'lang': 'python', 'imports': ['bokeh', 'holoviews']})
+    testing_metadata.meta['package']['name'] = 'perl-conda-test'
+    ct.create_py_files(testing_metadata)
+    test_file = os.path.join(testing_metadata.config.test_dir, 'run_test.py')
+    assert os.path.isfile(test_file)
+    with open(test_file) as f:
+        data = f.readlines()
+    assert 'import time\n' in data
+    assert 'import datetime\n' in data
+    assert 'import bokeh\n' in data
+    assert 'import holoviews\n' in data
 
 def test_create_r_files(testing_workdir, testing_metadata):
     testing_metadata.meta['test']['imports'] = ['r-base', 'r-matrix']


### PR DESCRIPTION
- [ ] fixes #1967 

This PR has 4 commits:

1. create a test to demonstrate what I ran into in #1967 
1. fix the test from 1
1. create another test for a case that I'm not sure conda-build will allow.  If test/imports takes a list of dicts, does anything prevent two of the dicts in the list from having `lang` python?
1. fix the test from 3.