### PR TITLE
Add libgcc to run dependencies.

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -689,6 +689,8 @@ def skeletonize(packages, output_dir=".", version=None, git_tag=None,
                     deps.append('{indent}posix                # [win]'.format(indent=INDENT))
                     deps.append('{indent}{{{{native}}}}toolchain  # [win]'.format(indent=INDENT))
                     deps.append('{indent}gcc                  # [not win]'.format(indent=INDENT))
+                else:
+                    deps.append('{indent}libgcc  # [not win]')
             d['%s_depends' % dep_type] = ''.join(deps)
 
     for package in package_dicts:


### PR DESCRIPTION
This PR adds libgcc to the runtime dependencies when the recipe needs compilation.