### PR TITLE
post: Fix $ORIGIN replacement

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -364,7 +364,7 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
     existing = existing.split(os.pathsep)
     new = []
     for old in existing:
-        if old.startswith('$ORIGIN/'):
+        if old.startswith('$ORIGIN'):
             new.append(old)
         elif old.startswith('/'):
             # Test if this absolute path is outside of prefix. That is fatal.


### PR DESCRIPTION
Literal RPATHs of '$ORIGIN' were falling through to the fixup code
when they should have been passed unmodified. A trailing slash was
the cause and this broke openjdk.