### PR TITLE
[WIP] Avoid encoding/decoding on line-endings processing on patch files

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -434,10 +434,10 @@ def get_repository_info(recipe_path):
 def _ensure_unix_line_endings(path):
     """Replace windows line endings with Unix.  Return path to modified file."""
     out_path = path + "_unix"
-    with open(path) as inputfile:
-        with open(out_path, "w") as outputfile:
+    with open(path, "rb") as inputfile:
+        with open(out_path, "wb") as outputfile:
             for line in inputfile:
-                outputfile.write(line.replace("\r\n", "\n"))
+                outputfile.write(line.replace(b"\r\n", b"\n"))
     return out_path
 
 

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -516,6 +516,7 @@ def apply_patch(src_dir, path, config, git=None):
         patch_strip_level = _guess_patch_strip_level(files, src_dir)
         patch_args = ['-p%d' % patch_strip_level, '-i', path]
         if sys.platform == 'win32':
+            patch_args.insert(0, '--binary')
             patch_args[-1] = _ensure_unix_line_endings(path)
         check_call_env([patch] + patch_args, cwd=src_dir)
         if sys.platform == 'win32' and os.path.exists(patch_args[-1]):

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,6 +1,9 @@
 import os
+import tempfile
 
-from conda_build.source import _guess_patch_strip_level, apply_patch
+from conda_build.source import (
+    _ensure_unix_line_endings, _guess_patch_strip_level, apply_patch,
+)
 
 
 def test_patch_strip_level(testing_workdir, monkeypatch):
@@ -54,3 +57,16 @@ def test_patch(testing_workdir, testing_config):
         with open('file-modification.txt', 'r') as modified:
             lines = modified.readlines()
         assert lines[0] == '43770\n'
+
+
+def test_ensure_unix_line_endings_with_nonutf8_characters():
+    in_path = tempfile.mktemp()
+    with open(in_path, "wb") as fp:
+        fp.write(b"\xf1\r\n")  # tilde-n encoded in latin1
+
+    out_path = _ensure_unix_line_endings(in_path)
+    with open(out_path, "rb") as fp:
+        assert fp.read() == b"\xf1\n"
+
+    os.remove(in_path)
+    os.remove(out_path)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 
 import pytest
 


### PR DESCRIPTION
When a patch contains non-utf8 or when the system encoding doesn't match the file encoding the line endings processing fails because it attempts to decode the content.

Fixes #2032 