### PR TITLE
allow pin_run_as_build to be a single 'x.x' string

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -111,8 +111,11 @@ def get_pin_from_build(m, dep, build_dep_versions):
     if (version and dep_name in m.config.variant.get('pin_run_as_build', {}) and
             not (dep_name == 'python' and m.noarch) and
             dep_name in build_dep_versions):
-        pin = utils.apply_pin_expressions(version.split()[0],
-                                            **m.config.variant['pin_run_as_build'][dep_name])
+        pin_cfg = m.config.variant['pin_run_as_build'][dep_name]
+        if isinstance(pin_cfg, str):
+            # if pin arg is a single 'x.x', use the same value for min and max
+            pin_cfg = dict(min_pin=pin_cfg, max_pin=pin_cfg)
+        pin = utils.apply_pin_expressions(version.split()[0], **pin_cfg)
     elif dep.startswith('numpy') and 'x.x' in dep:
         if not build_dep_versions.get(dep_name):
             raise ValueError("numpy x.x specified, but numpy not in build requirements.")


### PR DESCRIPTION
[docs](https://github.com/conda/conda-docs/pull/414/files#diff-d1a5dbb2f223de4935d93990676c7074) suggest that pinning should be specified as

```yaml
pin_run_as_build:
  pkg: x.x
```

but the code required a dict:

```yaml
pin_run_as_build
  pkg:
    min_pin: x.x
    max_pin: x.x
```

This transforms `'x.x'` string from the docs example into the same value for min/max kwargs. I'm not sure if this is the right place to do the transform, or if it should be done when the config file is loaded.