### PR TITLE
Add missing six dependency

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - pycrypto
     - python
     - pyyaml
+    - six
 
 test:
   requires:


### PR DESCRIPTION
In the master branch this has been fixed in https://github.com/conda/conda-build/commit/a31774d8b9c8d9954dc2b14be6e955ef8ec70d1b, but 2.1.15 also uses six, e.g. it is imported in [conda_build/metadata.py](https://github.com/conda/conda-build/blob/2.1.x/conda_build/metadata.py).