### PR TITLE
add several variables that can be set in condarc

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -16,7 +16,8 @@ import filelock
 import conda_build.api as api
 import conda_build.build as build
 import conda_build.utils as utils
-from conda_build.conda_interface import add_parser_channels, url_path, binstar_upload
+from conda_build.conda_interface import (add_parser_channels, url_path, binstar_upload,
+                                         cc_conda_build)
 from conda_build.cli.main_render import get_render_parser
 import conda_build.source as source
 from conda_build.utils import LoggingContext
@@ -59,7 +60,7 @@ different sets of packages."""
         action="store_false",
         help="Don't include the recipe inside the built package.",
         dest='include_recipe',
-        default=True,
+        default=cc_conda_build.get('include_recipe', 'true').lower() == 'true',
     )
     p.add_argument(
         '-s', "--source",
@@ -100,8 +101,9 @@ different sets of packages."""
     p.add_argument(
         '--skip-existing',
         action='store_true',
-        help="""Skip recipes for which there already exists an existing build
-        (locally or in the channels). """
+        help=("Skip recipes for which there already exists an existing build"
+              "(locally or in the channels)."),
+        default=cc_conda_build.get('skip_existing', 'false').lower() == 'true',
     )
     p.add_argument(
         '--keep-old-work',
@@ -119,6 +121,7 @@ different sets of packages."""
         '-q', "--quiet",
         action="store_true",
         help="do not display progress bar",
+        default=cc_conda_build.get('quiet', 'false').lower() == 'true',
     )
     p.add_argument(
         '--debug',
@@ -127,16 +130,18 @@ different sets of packages."""
     )
     p.add_argument(
         '--token',
-        help="Token to pass through to anaconda upload"
+        help="Token to pass through to anaconda upload",
+        default=cc_conda_build.get('anaconda_token'),
     )
     p.add_argument(
         '--user',
-        help="User/organization to upload packages to on anaconda.org or pypi"
+        help="User/organization to upload packages to on anaconda.org or pypi",
+        default=cc_conda_build.get('user'),
     )
     pypi_grp = p.add_argument_group("PyPI upload parameters (twine)")
     pypi_grp.add_argument(
         '--password',
-        help="password to use when uploading packages to pypi"
+        help="password to use when uploading packages to pypi",
     )
     pypi_grp.add_argument(
         '--sign', default=False,
@@ -152,17 +157,19 @@ different sets of packages."""
     )
     pypi_grp.add_argument(
         '--config-file',
-        help="path to .pypirc file to use when uploading to pypi"
+        help="path to .pypirc file to use when uploading to pypi",
+        default=cc_conda_build.get('pypirc'),
     )
     pypi_grp.add_argument(
-        '--repository', '-r', default='pypitest',
-        help="PyPI repository to upload to"
+        '--repository', '-r', help="PyPI repository to upload to",
+        default=cc_conda_build.get('pypi_repository', 'pypitest'),
     )
     p.add_argument(
         "--no-activate",
         action="store_false",
         help="do not activate the build and test envs; just prepend to PATH",
         dest='activate',
+        default=cc_conda_build.get('activate', 'true').lower() == 'true',
     )
     p.add_argument(
         "--no-build-id",
@@ -170,6 +177,8 @@ different sets of packages."""
         help=("do not generate unique build folder names.  Use if having issues with "
               "paths being too long."),
         dest='set_build_id',
+        # note: inverted - dest stores positive logic
+        default=cc_conda_build.get('set_build_id', 'true').lower() == 'true',
     )
     p.add_argument(
         "--croot",
@@ -179,7 +188,8 @@ different sets of packages."""
     p.add_argument(
         "--no-verify",
         action="store_true",
-        help=("do not run verification on recipes or packages when building")
+        help="do not run verification on recipes or packages when building",
+        default=cc_conda_build.get('no_verify', 'false').lower() == 'true',
     )
     p.add_argument(
         "--output-folder",

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 import sys
 
-from conda_build.conda_interface import ArgumentParser, add_parser_channels
+from conda_build.conda_interface import ArgumentParser, add_parser_channels, cc_conda_build
 
 from conda_build import __version__, api
 
@@ -101,10 +101,11 @@ source to try fill in related template variables.",
     )
     p.add_argument(
         "--old-build-string", dest="filename_hashing", action="store_false",
-        default=True, help=("Disable hash additions to filenames to distinguish package "
-                            "variants from one another.  NOTE: any filename collisions are "
-                            "yours to handle.  Any variants with overlapping names within a "
-                            "build will clobber each other.")
+        default=cc_conda_build.get('filename_hashing', 'true').lower() == 'true',
+        help=("Disable hash additions to filenames to distinguish package "
+              "variants from one another. NOTE: any filename collisions are "
+              "yours to handle. Any variants with overlapping names within a "
+              "build will clobber each other.")
     )
 
     add_parser_channels(p)

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -60,8 +60,8 @@ def download_to_cache(cache_folder, recipe_path, source_dict):
                     url = os.path.normpath(os.path.join(recipe_path, url))
                 url = url_path(url)
             else:
-                if url.startswith('file://~'):
-                    url = 'file://' + expanduser(url[7:]).replace('\\', '/')
+                if url.startswith('file:///~'):
+                    url = 'file:///' + expanduser(url[8:]).replace('\\', '/')
             try:
                 print("Downloading %s" % url)
                 with LoggingContext():

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -91,7 +91,7 @@ def test_source_user_expand(testing_workdir):
             tbz_name = os.path.join(tmp, "cb-test.tar.bz2")
             with tarfile.open(tbz_name, "w:bz2") as tar:
                 tar.add(tbz_srcdir, arcname=os.path.sep)
-            for prefix in ('~', 'file://~'):
+            for prefix in ('~', 'file:///~'):
                 source_dict = {"url": os.path.join(prefix, os.path.basename(tmp), "cb-test.tar.bz2")}
                 with TemporaryDirectory() as tmp2:
                     download_to_cache(tmp2, '', source_dict)


### PR DESCRIPTION
fixes #1512 

New things:

* filename_hashing: defaults to True.  If False, disables new conda-build 3 hashes in filenames.
* no_verify: defaults to False.  If True, does not run conda-verify checks on recipe or packages.
* set_build_id: defaults to True.  If False, does not create separate build folders for each build.
* activate: defaults to True.  If False, environments are added to PATH, but activate scripts are not run.  Not recommended.
* pypi_repository: unset by default.  PyPI repository to upload wheels to.
* pypirc: unset by default.  Path to pypirc file to be used for uploading wheels to pypi
* user: unset by default.  Username to use for uploading packages to anaconda.org or wheels to PyPI.
* anaconda_token: unset by default.  Token used to authenticate with anaconda.org for uploading packages.
* quiet: defaults to False.  Limits verbosity of various steps
* skip_existing: defaults to False.  Skips package building when packages are already available in configured channels
* include_recipe: defaults to True.  If False, does not include recipe in final package.  If this is set, you cannot split your test phase from your build phase.