### PR TITLE
log info/debug to stdout.  Log warn/error to stderr.  dedupe better.

### DIFF
--- a/ci/travis/run.sh
+++ b/ci/travis/run.sh
@@ -9,7 +9,7 @@ if [[ "$FLAKE8" == "true" ]]; then
     conda build conda.recipe --no-anaconda-upload
     conda create -n _cbtest python=$TRAVIS_PYTHON_VERSION conda-build
     # because this is a file, conda is not going to process any of its dependencies.
-    conda install $(conda render --output conda.recipe) -n _cbtest
+    conda install -n _cbtest $(conda render --output conda.recipe)
     source activate _cbtest
     conda build conda.recipe --no-anaconda-upload
 else

--- a/conda_build/__init__.py
+++ b/conda_build/__init__.py
@@ -4,8 +4,6 @@
 # conda is distributed under the terms of the BSD 3-clause license.
 # Consult LICENSE.txt or http://opensource.org/licenses/BSD-3-Clause.
 
-import logging
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
@@ -22,20 +20,3 @@ sub_commands = [
     'render'
     'skeleton',
 ]
-
-
-# unclutter logs - show messages only once
-class DuplicateFilter(object):
-    def __init__(self):
-        self.msgs = set()
-
-    def filter(self, record):
-        rv = record.msg not in self.msgs
-        self.msgs.add(record.msg)
-        return rv
-
-
-dedupe_handler = logging.StreamHandler()
-filt = DuplicateFilter()
-dedupe_handler.addFilter(filt)
-logging.getLogger(__name__).addHandler(dedupe_handler)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1291,7 +1291,7 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
 
         print("TEST START:", test_package_name)
 
-        if metadata.config.remove_work_dir and os.listdir(metadata.config.work_dir):
+        if metadata.config.remove_work_dir:
             # Needs to come after create_files in case there's test/source_files
             print("Deleting work directory,", metadata.config.work_dir)
             utils.rm_rf(metadata.config.work_dir)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1598,6 +1598,13 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
             # add the failed one back in at the beginning - but its deps may come before it
             recipe_list.extendleft([metadata if metadata else recipe])
             for pkg in e.packages:
+                pkg_name = pkg.split(' ')[0]
+                # if we hit missing dependencies at test time, the error we get says that our
+                #    package that we just built needs to be built.  Very confusing.  Bomb out
+                #    if any of our output metadatas are in the exception list of pkgs.
+                if metadata and any(pkg_name == output_meta.name() for (_, output_meta) in
+                       metadata.get_output_metadata_set(permit_undefined_jinja=True)):
+                    raise
                 if pkg in to_build_recursive:
                     config.clean(remove_folders=False)
                     raise RuntimeError("Can't build {0} due to environment creation error:\n"

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1292,12 +1292,14 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
         print("TEST START:", test_package_name)
 
         if metadata.config.remove_work_dir:
+            dest = os.path.join(os.path.dirname(metadata.config.work_dir),
+                                'work_moved_' + metadata.dist())
             # Needs to come after create_files in case there's test/source_files
-            print("Deleting work directory,", metadata.config.work_dir)
-            utils.rm_rf(metadata.config.work_dir)
+            print("Renaming work directory, ", metadata.config.work_dir, " to ", dest)
+            os.rename(config.work_dir, dest)
         else:
-            log.warn("Not removing work directory after build.  Your package may depend on files "
-                    "in the work directory that are not included with your package")
+            log.warn("Not moving work directory after build.  Your package may depend on files "
+                     "in the work directory that are not included with your package")
 
         get_build_metadata(metadata)
         specs = ['%s %s %s' % (metadata.name(), metadata.version(), metadata.build_id())]

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -72,14 +72,12 @@ def get_lua_include_dir(config):
 def verify_git_repo(git_dir, git_url, git_commits_since_tag, debug=False, expected_rev='HEAD'):
     env = os.environ.copy()
     log = utils.get_logger(__name__)
-    base_log_level = log.getEffectiveLevel()
 
     if debug:
         stderr = None
     else:
         FNULL = open(os.devnull, 'w')
         stderr = FNULL
-        log.setLevel(logging.ERROR)
 
     if not expected_rev:
         return False
@@ -145,11 +143,10 @@ def verify_git_repo(git_dir, git_url, git_commits_since_tag, debug=False, expect
             log.debug("git_url: " + git_url.lower())
             OK = False
     except subprocess.CalledProcessError as error:
-        log.warn("Error obtaining git information in verify_git_repo.  Error was: ")
-        log.warn(str(error))
+        log.debug("Error obtaining git information in verify_git_repo.  Error was: ")
+        log.debug(str(error))
         OK = False
     finally:
-        log.setLevel(base_log_level)
         if not debug:
             FNULL.close()
     return OK
@@ -169,14 +166,12 @@ def get_git_info(repo, debug):
     """
     d = {}
     log = utils.get_logger(__name__)
-    base_log_level = log.getEffectiveLevel()
 
     if debug:
         stderr = None
     else:
         FNULL = open(os.devnull, 'w')
         stderr = FNULL
-        log.setLevel(logging.ERROR)
 
     # grab information from describe
     env = os.environ.copy()
@@ -192,7 +187,7 @@ def get_git_info(repo, debug):
         if len(parts) == 3:
             d.update(dict(zip(keys, parts)))
     except subprocess.CalledProcessError:
-        log.warn("Failed to obtain git tag information.  Are you using annotated tags?")
+        log.debug("Failed to obtain git tag information.  Are you using annotated tags?")
 
     try:
         # get the _full_ hash of the current HEAD
@@ -203,15 +198,14 @@ def get_git_info(repo, debug):
 
         d['GIT_FULL_HASH'] = output
     except subprocess.CalledProcessError as error:
-        log.warn("Error obtaining git commit information.  Error was: ")
-        log.warn(str(error))
+        log.debug("Error obtaining git commit information.  Error was: ")
+        log.debug(str(error))
 
     # set up the build string
     if "GIT_DESCRIBE_NUMBER" in d and "GIT_DESCRIBE_HASH" in d:
         d['GIT_BUILD_STR'] = '{}_{}'.format(d["GIT_DESCRIBE_NUMBER"],
                                             d["GIT_DESCRIBE_HASH"])
 
-    log.setLevel(base_log_level)
     # issues on Windows with the next line of the command prompt being recorded here.
     assert not any("\n" in value for value in d.values())
     return d
@@ -742,10 +736,8 @@ def create_env(prefix, specs_or_actions, env, config, subdir, clear_cache=True, 
     Create a conda envrionment for the given prefix and specs.
     '''
     if config.debug:
-        utils.get_logger("conda_build").setLevel(logging.DEBUG)
         external_logger_context = utils.LoggingContext(logging.DEBUG)
     else:
-        utils.get_logger("conda_build").setLevel(logging.INFO)
         external_logger_context = utils.LoggingContext(logging.ERROR)
 
     with external_logger_context:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -101,8 +101,6 @@ def update_index(dir_path, force=False, check_md5=False, remove=True, lock=None,
             except (IOError, ValueError):
                 index = {}
 
-        subdir = None
-
         files = set(fn for fn in os.listdir(dir_path) if fn.endswith('.tar.bz2'))
         for fn in files:
             path = join(dir_path, fn)
@@ -117,9 +115,6 @@ def update_index(dir_path, force=False, check_md5=False, remove=True, lock=None,
             d = read_index_tar(path, lock=lock, locking=locking, timeout=timeout)
             d.update(file_info(path))
             index[fn] = d
-            # there's only one subdir for a given folder, so only read these contents once
-            if not subdir:
-                subdir = d['subdir']
 
         for fn in files:
             index[fn]['sig'] = '.' if isfile(join(dir_path, fn + '.sig')) else None

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -18,7 +18,7 @@ from .conda_interface import specs_from_url
 from .conda_interface import envs_dirs
 from .conda_interface import string_types
 
-from conda_build import exceptions, filt, utils, variants
+from conda_build import exceptions, utils, variants
 from conda_build.features import feature_list
 from conda_build.config import Config, get_or_merge_config
 from conda_build.utils import (ensure_list, find_recipe, expand_globs, get_installed_packages,
@@ -597,6 +597,8 @@ def finalize_outputs_pass(base_metadata, render_order, pass_no, outputs=None,
             log = utils.get_logger(__name__)
             # We should reparse the top-level recipe to get all of our dependencies fixed up.
             # we base things on base_metadata because it has the record of the full origin recipe
+            if base_metadata.config.verbose:
+                log.info("Attempting to finalize metadata for {}".format(metadata.name()))
             om = base_metadata.copy()
             # match up the old variant with the current one from this output
             om.config.variant = metadata.config.variant
@@ -733,7 +735,6 @@ class MetaData(object):
         assert not self.final, "modifying metadata after finalization"
 
         log = utils.get_logger(__name__)
-        log.addFilter(filt)
 
         if isfile(self.requirements_path) and not self.get_value('requirements/run'):
             self.meta.setdefault('requirements', {})

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -990,7 +990,6 @@ def rm_rf(path, config=None):
         _rm_rf(path)
 
 
-
 # https://stackoverflow.com/a/31459386/1170370
 class LessThanFilter(logging.Filter):
     def __init__(self, exclusive_maximum, name=""):

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -8,6 +8,7 @@ from glob import glob
 import json
 from locale import getpreferredencoding
 import logging
+import logging.config
 import mmap
 import operator
 import os
@@ -20,6 +21,7 @@ import shutil
 import tarfile
 import tempfile
 import time
+import yaml
 import zipfile
 
 from distutils.version import LooseVersion
@@ -34,9 +36,9 @@ from .conda_interface import string_types, url_path, get_rc_urls
 from .conda_interface import memoized
 from .conda_interface import StringIO
 from .conda_interface import VersionOrder
+from .conda_interface import cc_conda_build
 # NOQA because it is not used in this file.
 from conda_build.conda_interface import rm_rf as _rm_rf # NOQA
-import conda_build
 from conda_build.os_utils import external
 
 if PY3:
@@ -988,13 +990,68 @@ def rm_rf(path, config=None):
         _rm_rf(path)
 
 
-def get_logger(name, dedupe=True):
-    log = logging.getLogger(name)
-    if dedupe:
-        dedupe_handler = logging.StreamHandler()
-        dedupe_handler.addFilter(conda_build.filt)
-        log.addHandler(dedupe_handler)
 
+# https://stackoverflow.com/a/31459386/1170370
+class LessThanFilter(logging.Filter):
+    def __init__(self, exclusive_maximum, name=""):
+        super(LessThanFilter, self).__init__(name)
+        self.max_level = exclusive_maximum
+
+    def filter(self, record):
+        # non-zero return means we log this message
+        return 1 if record.levelno < self.max_level else 0
+
+
+class GreaterThanFilter(logging.Filter):
+    def __init__(self, exclusive_minimum, name=""):
+        super(GreaterThanFilter, self).__init__(name)
+        self.min_level = exclusive_minimum
+
+    def filter(self, record):
+        # non-zero return means we log this message
+        return 1 if record.levelno > self.min_level else 0
+
+
+# unclutter logs - show messages only once
+class DuplicateFilter(logging.Filter):
+    def __init__(self):
+        self.msgs = set()
+
+    def filter(self, record):
+        log = record.msg not in self.msgs
+        self.msgs.add(record.msg)
+        return int(log)
+
+
+dedupe_filter = DuplicateFilter()
+info_debug_stdout_filter = LessThanFilter(logging.WARNING)
+warning_error_stderr_filter = GreaterThanFilter(logging.INFO)
+
+
+def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers=True):
+    config_file = cc_conda_build.get('log_config_file')
+    # by loading config file here, and then only adding handlers later, people
+    # should be able to override conda-build's logger settings here.
+    if config_file:
+        with open(config_file) as f:
+            config_dict = yaml.load(f)
+        logging.config.dictConfig(config_dict)
+        level = config_dict.get('loggers', {}).get(name, {}).get('level', level)
+    log = logging.getLogger(name)
+    log.setLevel(level)
+    if dedupe:
+        log.addFilter(dedupe_filter)
+
+    # these are defaults.  They can be overridden by configuring a log config yaml file.
+    if not log.handlers and add_stdout_stderr_handlers:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stdout_handler.addFilter(info_debug_stdout_filter)
+        stderr_handler.addFilter(warning_error_stderr_filter)
+        stdout_handler.setLevel(level)
+        stderr_handler.setLevel(level)
+        log.addHandler(stdout_handler)
+        log.addHandler(stderr_handler)
     return log
 
 

--- a/tests/test-recipes/metadata/_checkout_tool_as_dependency/meta.yaml
+++ b/tests/test-recipes/metadata/_checkout_tool_as_dependency/meta.yaml
@@ -12,4 +12,5 @@ requirements:
   build:
     # To test the conda_build version
     - svn
-    - vc 9   # [win]
+    - vc 9   # [win and py2k]
+    - vc 14   # [win and py3k]

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -404,7 +404,6 @@ def test_compileall_compiles_all_good_files(testing_workdir, testing_config):
 
 
 def test_render_setup_py_old_funcname(testing_workdir, testing_config, caplog):
-    logging.basicConfig(level=logging.INFO)
     api.build(os.path.join(metadata_dir, "_source_setuptools"), config=testing_config)
     assert "Deprecation notice: the load_setuptools function has been renamed to " in caplog.text
 
@@ -803,7 +802,7 @@ def test_remove_workdir_default(testing_config, caplog):
 
 
 @pytest.mark.serial
-def test_keep_workdir_and_dirty_reuse(testing_config, caplog):
+def test_keep_workdir_and_dirty_reuse(testing_config, capfd):
     recipe = os.path.join(metadata_dir, '_keep_work_dir')
     # make a metadata object - otherwise the build folder is computed within the build, but does
     #    not alter the config object that is passed in.  This is by design - we always make copies
@@ -813,7 +812,7 @@ def test_keep_workdir_and_dirty_reuse(testing_config, caplog):
     metadata = api.render(recipe, config=testing_config, dirty=True, remove_work_dir=False)[0][0]
     workdir = metadata.config.work_dir
     api.build(metadata)
-    assert "Not removing work directory after build" in caplog.text
+    out, err = capfd.readouterr()
     assert glob(os.path.join(metadata.config.work_dir, '*'))
 
     # test that --dirty reuses the same old folder
@@ -827,7 +826,6 @@ def test_keep_workdir_and_dirty_reuse(testing_config, caplog):
     testing_config.clean()
 
 
-@pytest.mark.serial
 def test_workdir_removal_warning(testing_config, caplog):
     recipe = os.path.join(metadata_dir, '_test_uses_src_dir')
     with pytest.raises(ValueError) as exc:
@@ -835,18 +833,18 @@ def test_workdir_removal_warning(testing_config, caplog):
         assert "work dir is removed" in str(exc)
 
 
-@pytest.mark.serial
-def test_workdir_removal_warning_no_remove(testing_config, caplog):
+def test_workdir_removal_warning_no_remove(testing_config, capfd):
     recipe = os.path.join(metadata_dir, '_test_uses_src_dir')
     api.build(recipe, config=testing_config, remove_work_dir=False)
-    assert "Not removing work directory after build" in caplog.text
+    out, err = capfd.readouterr()
+    assert "Not removing work directory after build" in err
 
 
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason="cross compiler packages created only on Linux right now")
 @pytest.mark.xfail(VersionOrder(conda.__version__) < VersionOrder('4.3.2'),
                    reason="not completely implemented yet")
-def test_cross_compiler(testing_workdir, testing_config, caplog):
+def test_cross_compiler(testing_workdir, testing_config, capfd):
     # TODO: testing purposes.  Package from @mingwandroid's channel, copied to conda_build_test
     testing_config.channel_urls = ('conda_build_test', )
     # activation is necessary to set the appropriate toolchain env vars

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -833,13 +833,6 @@ def test_workdir_removal_warning(testing_config, caplog):
         assert "work dir is removed" in str(exc)
 
 
-def test_workdir_removal_warning_no_remove(testing_config, capfd):
-    recipe = os.path.join(metadata_dir, '_test_uses_src_dir')
-    api.build(recipe, config=testing_config, remove_work_dir=False)
-    out, err = capfd.readouterr()
-    assert "Not removing work directory after build" in err
-
-
 @pytest.mark.skipif(not sys.platform.startswith('linux'),
                     reason="cross compiler packages created only on Linux right now")
 @pytest.mark.xfail(VersionOrder(conda.__version__) < VersionOrder('4.3.2'),


### PR DESCRIPTION
fixes #1827 

This also adds configurability to conda-build's logger usage.  Users may configure the logging using the YAML syntax presented at the bottom of the section at https://docs.python.org/3.6/howto/logging.html#configuring-logging

and by putting an entry into their .condarc files:

```
conda-build:
    log_config_file: (path to config file)
```