### PR TITLE
test failure using filename_hashing=False

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1239,8 +1239,9 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
                     subdir = json.load(f)['subdir']
                 if subdir != 'noarch':
                     config.host_subdir = subdir
-                with open(os.path.join(info_dir, 'hash_input.json')) as f:
-                    hash_input = json.load(f)
+                if config.filename_hashing:
+                    with open(os.path.join(info_dir, 'hash_input.json')) as f:
+                        hash_input = json.load(f)
 
             local_location = os.path.dirname(recipedir_or_package_or_metadata)
             # strip off extra subdir folders


### PR DESCRIPTION
v3.0.0
avoid failing test when using filename_hashing=False (reading non-existent .json file)