### PR TITLE
Removed subdir as cli platform default and now checking for length of platforms

### DIFF
--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -13,7 +13,6 @@ from conda_build.conda_interface import ArgumentParser
 
 from conda_build import api
 from conda_build.utils import PY3
-from conda_build.conda_interface import subdir
 
 logging.basicConfig(level=logging.INFO)
 

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -63,7 +63,7 @@ all.""",
         action="append",
         choices=['osx-64', 'linux-32', 'linux-64', 'win-32', 'win-64', 'all'],
         help="Platform to convert the packages to.",
-        default=[subdir]
+        default=None
     )
     p.add_argument(
         "--dependencies", "-d",

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -393,7 +393,7 @@ def get_pure_py_file_map(t, platform, dependencies):
 
 def conda_convert(file_path, output_dir=".", show_imports=False, platforms=None, force=False,
                   dependencies=None, verbose=False, quiet=True, dry_run=False):
-    if not show_imports and platforms is None:
+    if not show_imports and len(platforms) == 0:
         sys.exit('Error: --platform option required for conda package conversion')
 
     with tarfile.open(file_path) as t:


### PR DESCRIPTION
Using the subdir as the default platform on the subcommand parser causes two problems: 

When converting from one platform to the subdir platform, the platforms list will contain a duplicate of the subdir platform. This causes conda convert to convert the package to the subdir platform twice.

The other problem is that when converting from one platform to another platform and both platforms are not the subdir platform,  the package is needlessly converted to the subdir platform. This may be a bug in how conda.base.context handles subdir, but I think this fix is necessary in conda-build anyway.