### PR TITLE
Expose DISPLAY variable on Linux (2.1.x)

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -469,8 +469,9 @@ def linux_vars(compiler_vars, prefix, config):
     if config.arch == 32:
         compiler_vars['CFLAGS'] += ' -m32'
         compiler_vars['CXXFLAGS'] += ' -m32'
-    return {}
-
+    return {
+        'DISPLAY': os.getenv('DISPLAY'),
+    }
 
 def system_vars(env_dict, prefix, config):
     d = dict()


### PR DESCRIPTION
This is needed when testing some packages involving GUI.