### PR TITLE
Don't set build_id in test phase if --no-build-id is given

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1276,7 +1276,8 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
 
     warn_on_use_of_SRC_DIR(metadata)
 
-    config.compute_build_id(metadata.name())
+    if config.set_build_id:
+        config.compute_build_id(metadata.name())
 
     clean_pkg_cache(metadata.dist(), config)
 


### PR DESCRIPTION
Build work directory is deleted in test phase and it tries to
delete the work dir with id. As a consequence, the test phase
keeps the real work dir and then the next package build breaks
because it tries to apply a patch it was already applied.

cc @gqmelo 

xref: https://github.com/conda-forge/conda-smithy/pull/526#issuecomment-309106967