### PR TITLE
Added test actions so that conda build errors out earlier if test dependencies not found

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -925,20 +925,27 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                                     output_folder=m.config.output_folder,
                                                     channel_urls=tuple(m.config.channel_urls))
 
-        # make sure test deps are available before taking time to create build env
-        environ.get_install_actions(m.config.test_prefix,
-                                    tuple(test_run_ms_deps), 'test',
-                                    subdir=m.config.build_subdir,
-                                    debug=m.config.debug,
-                                    verbose=m.config.verbose,
-                                    locking=m.config.locking,
-                                    bldpkgs_dirs=tuple(m.config.bldpkgs_dirs),
-                                    timeout=m.config.timeout,
-                                    disable_pip=m.config.disable_pip,
-                                    max_env_retry=m.config.max_env_retry,
-                                    output_folder=m.config.output_folder,
-                                    channel_urls=tuple(m.config.channel_urls))
-
+        try:
+            # make sure test deps are available before taking time to create build env
+            environ.get_install_actions(m.config.test_prefix,
+                                        tuple(test_run_ms_deps), 'test',
+                                        subdir=m.config.build_subdir,
+                                        debug=m.config.debug,
+                                        verbose=m.config.verbose,
+                                        locking=m.config.locking,
+                                        bldpkgs_dirs=tuple(m.config.bldpkgs_dirs),
+                                        timeout=m.config.timeout,
+                                        disable_pip=m.config.disable_pip,
+                                        max_env_retry=m.config.max_env_retry,
+                                        output_folder=m.config.output_folder,
+                                        channel_urls=tuple(m.config.channel_urls))
+        except DependencyNeedsBuildingError as e:
+            # subpackages are not actually missing.  We just haven't built them yet.
+            missing_deps = set(e.packages) - set(out.name()
+                        for _, out in m.get_output_metadata_set(permit_undefined_jinja=True))
+            if missing_deps:
+                e.packages = missing_deps
+                raise e
         if (not m.config.dirty or not os.path.isdir(m.config.build_prefix) or
                 not os.listdir(m.config.build_prefix)):
             environ.create_env(m.config.build_prefix, build_actions, env='build', config=m.config,
@@ -1097,6 +1104,20 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                                                            output_d.get('script'))):
                     output_d['files'] = (utils.prefix_files(prefix=m.config.host_prefix) -
                                          initial_files)
+
+                meta_dir = (m.meta_path or
+                            m.meta.get('extra', {}).get('parent_recipe', {}).get('path'))
+                if meta_dir and meta_dir.endswith('.yaml'):
+                    meta_dir = os.path.dirname(meta_dir)
+                # ensure that packaging scripts are copied over into the workdir
+                if 'script' in output_d and meta_dir:
+                    utils.copy_into(os.path.join(meta_dir, output_d['script']), m.config.work_dir)
+
+                # same thing, for test scripts
+                test_script = output_d.get('test', {}).get('script')
+                if test_script and meta_dir:
+                    utils.copy_into(os.path.join(meta_dir, test_script),
+                                    os.path.join(m.config.work_dir, test_script))
 
                 assert output_d.get('type') != 'conda' or m.final, (
                     "output metadata for {} is not finalized".format(m.dist()))

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -888,7 +888,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         # installed files at packaging-time.
         host_ms_deps = None
         build_ms_deps = None
-        test_ms_deps = m.get_value('test/requires', [])
+        test_run_ms_deps = m.get_value('test/requires', []) + m.get_value('requirements/run', [])
 
         if m.config.host_subdir != m.config.build_subdir:
             if VersionOrder(conda_version) < VersionOrder('4.3.2'):
@@ -927,7 +927,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
 
         # make sure test deps are available before taking time to create build env
         environ.get_install_actions(m.config.test_prefix,
-                                    tuple(test_ms_deps), 'test',
+                                    tuple(test_run_ms_deps), 'test',
                                     subdir=m.config.build_subdir,
                                     debug=m.config.debug,
                                     verbose=m.config.verbose,

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -888,6 +888,8 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         # installed files at packaging-time.
         host_ms_deps = None
         build_ms_deps = None
+        test_ms_deps = m.get_value('test/requires', [])
+
         if m.config.host_subdir != m.config.build_subdir:
             if VersionOrder(conda_version) < VersionOrder('4.3.2'):
                 raise RuntimeError("Non-native subdir support only in conda >= 4.3.2")
@@ -922,6 +924,21 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                                     max_env_retry=m.config.max_env_retry,
                                                     output_folder=m.config.output_folder,
                                                     channel_urls=tuple(m.config.channel_urls))
+
+        # make sure test deps are available before taking time to create build env
+        environ.get_install_actions(m.config.test_prefix,
+                                    tuple(test_ms_deps), 'test',
+                                    subdir=m.config.build_subdir,
+                                    debug=m.config.debug,
+                                    verbose=m.config.verbose,
+                                    locking=m.config.locking,
+                                    bldpkgs_dirs=tuple(m.config.bldpkgs_dirs),
+                                    timeout=m.config.timeout,
+                                    disable_pip=m.config.disable_pip,
+                                    max_env_retry=m.config.max_env_retry,
+                                    output_folder=m.config.output_folder,
+                                    channel_urls=tuple(m.config.channel_urls))
+
         if (not m.config.dirty or not os.path.isdir(m.config.build_prefix) or
                 not os.listdir(m.config.build_prefix)):
             environ.create_env(m.config.build_prefix, build_actions, env='build', config=m.config,

--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -1,5 +1,4 @@
 import textwrap
-from conda_build import conda_interface
 SEPARATOR = "-" * 70
 
 indent = lambda s: textwrap.fill(textwrap.dedent(s))
@@ -61,8 +60,8 @@ class VerifyError(CondaBuildException):
 
 class DependencyNeedsBuildingError(CondaBuildException):
     def __init__(self, conda_exception=None, packages=None, subdir=None, *args, **kwargs):
+        self.subdir = subdir
         if packages:
-            self.message = "Unsatisfiable dependencies: {}".format(packages)
             self.packages = packages
         else:
             self.packages = packages or []
@@ -72,16 +71,16 @@ class DependencyNeedsBuildingError(CondaBuildException):
                 pkg = line.lstrip('  - ').split(' -> ')[-1]
                 pkg = pkg.strip().split(' ')[0]
                 self.packages.append(pkg)
-            conda_exception_text = str(conda_exception)
-            if subdir:
-                conda_exception_text = conda_exception_text.replace(conda_interface.subdir, subdir)
-            self.message = conda_exception_text
         if not self.packages:
             raise RuntimeError("failed to parse packages from exception:"
                                " {}".format(str(conda_exception)))
 
     def __str__(self):
         return self.message
+
+    @property
+    def message(self):
+        return "Unsatisfiable dependencies for platform {}: {}".format(self.subdir, self.packages)
 
 
 class RecipeError(CondaBuildException):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1535,16 +1535,6 @@ class MetaData(object):
             build['run_exports'] = output['run_exports']
             output_metadata.meta['build'] = build
 
-        # ensure that packaging scripts are copied over into the workdir
-        if 'script' in output:
-            utils.copy_into(os.path.join(self.path, output['script']), self.config.work_dir)
-
-        # same thing, for test scripts
-        test_script = output.get('test', {}).get('script')
-        if test_script:
-            utils.copy_into(os.path.join(self.path, test_script),
-                            os.path.join(self.config.work_dir, test_script))
-
         return output_metadata
 
     def get_output_metadata_set(self, permit_undefined_jinja=False,

--- a/tests/test-recipes/fail/check_runtime_dependencies/meta.yaml
+++ b/tests/test-recipes/fail/check_runtime_dependencies/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: conda-build-test-depedencies
+  version: 1.0
+
+build:
+  string: abc
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - some-nonexistent-package1
+
+test:
+  requires:
+    - pytest
+    - pytest-cov

--- a/tests/test-recipes/fail/check_test_dependencies/meta.yaml
+++ b/tests/test-recipes/fail/check_test_dependencies/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: conda-build-test-depedencies
+  version: 1.0
+
+build:
+  string: abc
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+    - pytest-cov
+    - pytest-package-does-not-exist

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1030,3 +1030,13 @@ def test_no_locking(testing_config):
     api.update_index(os.path.join(testing_config.croot, testing_config.subdir),
                      config=testing_config)
     api.build(recipe, config=testing_config, locking=False)
+
+
+def test_test_dependencies(testing_workdir, testing_config):
+    recipe = os.path.join(fail_dir, 'check_test_dependencies')
+
+    with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
+        api.build(recipe, config=testing_config)
+
+    assert ('Package missing in current osx-64 channels: \n  '
+            '- pytest-package-does-not-exist' in str(e.value))

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1038,8 +1038,8 @@ def test_test_dependencies(testing_workdir, testing_config):
     with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
         api.build(recipe, config=testing_config)
 
-    assert 'Package missing in current' in str(e.value)
-    assert '- pytest-package-does-not-exist' in str(e.value)
+    assert 'Unsatisfiable dependencies for platform ' in str(e.value)
+    assert 'pytest-package-does-not-exist' in str(e.value)
 
 
 def test_runtime_dependencies(testing_workdir, testing_config):
@@ -1048,5 +1048,5 @@ def test_runtime_dependencies(testing_workdir, testing_config):
     with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
         api.build(recipe, config=testing_config)
 
-    assert 'Package missing in current' in str(e.value)
-    assert '- some-nonexistent-package1' in str(e.value)
+    assert 'Unsatisfiable dependencies for platform ' in str(e.value)
+    assert 'some-nonexistent-package1' in str(e.value)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1040,3 +1040,13 @@ def test_test_dependencies(testing_workdir, testing_config):
 
     assert ('Package missing in current osx-64 channels: \n  '
             '- pytest-package-does-not-exist' in str(e.value))
+
+
+def test_runtime_dependencies(testing_workdir, testing_config):
+    recipe = os.path.join(fail_dir, 'check_runtime_dependencies')
+
+    with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
+        api.build(recipe, config=testing_config)
+
+    assert ('Package missing in current osx-64 channels: \n  '
+            '- some-nonexistent-package1' in str(e.value))

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1038,8 +1038,8 @@ def test_test_dependencies(testing_workdir, testing_config):
     with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
         api.build(recipe, config=testing_config)
 
-    assert ('Package missing in current osx-64 channels: \n  '
-            '- pytest-package-does-not-exist' in str(e.value))
+    assert 'Package missing in current' in str(e.value)
+    assert '- pytest-package-does-not-exist' in str(e.value)
 
 
 def test_runtime_dependencies(testing_workdir, testing_config):
@@ -1048,5 +1048,5 @@ def test_runtime_dependencies(testing_workdir, testing_config):
     with pytest.raises(exceptions.DependencyNeedsBuildingError) as e:
         api.build(recipe, config=testing_config)
 
-    assert ('Package missing in current osx-64 channels: \n  '
-            '- some-nonexistent-package1' in str(e.value))
+    assert 'Package missing in current' in str(e.value)
+    assert '- some-nonexistent-package1' in str(e.value)


### PR DESCRIPTION
fixes #671

Used get_install_actions from environ.py to check if the test dependencies listed in meta.yaml could be found. This fix also includes a test to make sure that a DependencyNeedsBuildingError is raised when a test dependency can't be found.