### PR TITLE
Fix variable name in `bldpkgs_dirs` comment

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -475,7 +475,7 @@ class Config(object):
     def bldpkgs_dirs(self):
         """ Dirs where previous build packages might be. """
         # The first two *might* be the same, but might not, depending on if this is a cross-compile.
-        #     cc.subdir should be the native platform, while self.subdir would be the host platform.
+        #     subdir should be the native platform, while self.subdir would be the host platform.
         return {join(self.croot, self.host_subdir), join(self.croot, subdir),
                 join(self.croot, "noarch"), }
 


### PR DESCRIPTION
The variable `cc.subdir` was renamed to the property `subdir` in a previous commit (referenced below). However the comment above was not. This corrects the comment to clarify what this now represents.

ref: https://github.com/conda/conda-build/commit/f99776f9a0f25e6cd2aa363ef036b8b7bbece7a6