### PR TITLE
Added ensure_list to line 803 in order to parse string literal test requirements

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -29,7 +29,7 @@ from conda_build.conda_interface import normalized_version
 from conda_build.conda_interface import human_bytes, hashsum_file
 from conda_build.conda_interface import default_python
 
-from conda_build.utils import tar_xf, unzip, rm_rf, check_call_env
+from conda_build.utils import tar_xf, unzip, rm_rf, check_call_env, ensure_list
 from conda_build.source import apply_patch
 from conda_build.build import create_env
 from conda_build.config import Config
@@ -800,7 +800,7 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
         d['import_comment'] = ''
 
         d['tests_require'] = INDENT.join(sorted([spec_from_line(pkg) for pkg
-                                                    in pkginfo['tests_require']]))
+                                                 in ensure_list(pkginfo['tests_require'])]))
 
     if pkginfo.get('homeurl'):
         d['homeurl'] = pkginfo['homeurl']

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -119,3 +119,12 @@ def test_pypi_with_version_inconsistency(testing_workdir):
     with open('mpi4py_test/meta.yaml') as f:
         actual = yaml.load(f)
         assert parse_version(actual['package']['version']) == parse_version("0.0.10")
+
+
+def test_setuptools_test_requirements(testing_workdir):
+    api.skeletonize(packages='hdf5storage', repo='pypi')
+
+    with open('hdf5storage/meta.yaml') as f:
+        actual = yaml.load(f)
+
+    assert actual['test']['requires'] == ['nose >=1.0']


### PR DESCRIPTION
fixes #2103 

Test requirements are now parsed as a list when given a string literal. This fix includes a test using a package that uses a string in setup.py's test_requires.