### PR TITLE
Added a check to skip conversion if source platform equals target platform

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,11 +417,14 @@ def test_convert(testing_workdir, testing_config):
     platforms = ['osx-64', 'win-32', 'win-64', 'linux-64', 'linux-32']
     for platform in platforms:
         dirname = os.path.join('converted', platform)
-        assert os.path.isdir(dirname)
-        assert pkg_name in os.listdir(dirname)
-        testing_config.host_subdir = platform
-        with TarCheck(os.path.join(dirname, pkg_name), config=testing_config) as tar:
-            tar.correct_subdir()
+        if platform != 'win-64':
+            assert os.path.isdir(dirname)
+            assert pkg_name in os.listdir(dirname)
+            testing_config.host_subdir = platform
+            with TarCheck(os.path.join(dirname, pkg_name), config=testing_config) as tar:
+                tar.correct_subdir()
+        else:
+            assert not os.path.isdir(dirname)
 
 
 @pytest.mark.serial


### PR DESCRIPTION
Currently, conda convert will convert a package even if both platforms and architectures are the same.  This PR includes a check that will skip conversion if the source platform and architecture equals the target platform and architecture. 

Also included is a test to make sure that these packages are not built. 

Because this feature broke the current convert test suite, the test suite has been refactored to omit conversions between the same platform and architecture.