### PR TITLE
Add new functionality to --keep-work-dir flag

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -108,8 +108,9 @@ different sets of packages."""
     p.add_argument(
         '--keep-old-work',
         action='store_true',
-        dest='dirty',
-        help="Deprecated.  Same as --dirty."
+        dest='keep_old_work',
+        help="Do not remove anything from environment, even after successful"
+             "build and test."
     )
     p.add_argument(
         '--dirty',

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -423,6 +423,14 @@ class Config(object):
                         rm_rf(path)
             if os.path.isfile(os.path.join(self.build_folder, 'prefix_files')):
                 rm_rf(os.path.join(self.build_folder, 'prefix_files'))
+        else:
+            print("\nLeaving build/test directories:"
+                  "\n  Work:\t", os.path.relpath(self.work_dir),
+                  "\n  Test:\t", os.path.relpath(self.test_dir),
+                  "\nLeaving build/test environments:"
+                  "\n  Test:\tsource activate ", os.path.relpath(self.test_prefix),
+                  "\n  Build:\tsource activate ",os.path.relpath(self.build_prefix),
+                  "\n\n")
 
         for lock in get_conda_operation_locks(self):
             rm_rf(lock.lock_file)
@@ -437,9 +445,12 @@ class Config(object):
 
     def __exit__(self, e_type, e_value, traceback):
         if not getattr(self, 'dirty') and e_type is None:
-            logging.getLogger(__name__).info("--dirty flag not specified.  Removing build"
-                                             " folder after successful build/test.\n")
-            self.clean()
+            if not getattr(self, 'keep_old_work'):
+                logging.getLogger(__name__).info("--dirty flag and --keep-old-work not specified."
+                                                 "Removing build/test folder after successful build/test.\n")
+                self.clean()
+            else:
+                self.clean(remove_folders=False)
 
     def copy(self):
         new = copy.copy(self)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -114,6 +114,7 @@ class Config(object):
                   Setting('locking', True),
                   Setting('max_env_retry', 3),
                   Setting('remove_work_dir', True),
+                  Setting('keep_old_work', False),
 
                   # pypi upload settings (twine)
                   Setting('password', None),
@@ -429,7 +430,7 @@ class Config(object):
                   "\n  Test:\t", os.path.relpath(self.test_dir),
                   "\nLeaving build/test environments:"
                   "\n  Test:\tsource activate ", os.path.relpath(self.test_prefix),
-                  "\n  Build:\tsource activate ",os.path.relpath(self.build_prefix),
+                  "\n  Build:\tsource activate ", os.path.relpath(self.build_prefix),
                   "\n\n")
 
         for lock in get_conda_operation_locks(self):
@@ -447,7 +448,7 @@ class Config(object):
         if not getattr(self, 'dirty') and e_type is None:
             if not getattr(self, 'keep_old_work'):
                 logging.getLogger(__name__).info("--dirty flag and --keep-old-work not specified."
-                                                 "Removing build/test folder after successful build/test.\n")
+                                        "Removing build/test folder after successful build/test.\n")
                 self.clean()
             else:
                 self.clean(remove_folders=False)

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -473,6 +473,7 @@ def linux_vars(compiler_vars, prefix, config):
         'DISPLAY': os.getenv('DISPLAY'),
     }
 
+
 def system_vars(env_dict, prefix, config):
     d = dict()
     compiler_vars = defaultdict(text_type)


### PR DESCRIPTION
The --keep-old-work flag was deprecated and ended up having the same functionality as the --dirty flag. However, there are times when a developer would want to have the work directory remain intact even after a successful build/test. Rather than create a new flag, the --keep-work-dir flag will be used for this particular case.

@msarahan 