### PR TITLE
skeleton generation: replace legacy syntax for noarch pkgs

### DIFF
--- a/conda_build/skeletons/luarocks.py
+++ b/conda_build/skeletons/luarocks.py
@@ -68,7 +68,7 @@ source:
    # - fix.patch
 
 build:
-  {noarch_python_comment}noarch_python: True
+  {noarch_python_comment}noarch: generic
   # Useful to leave this on by default, will allow relocating
   # packages that have hard-coded paths in them
   detect_binary_files_with_prefix: true

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -169,7 +169,7 @@ source:
    # - fix.patch
 
 {build_comment}build:
-  {noarch_python_comment}noarch_python: True
+  {noarch_python_comment}noarch: python
   {egg_comment}preserve_egg_dir: True
   {entry_comment}entry_points:
     # Put any entry points (scripts to be generated automatically) here. The


### PR DESCRIPTION
`noarch_python` is legacy syntax

This patch modifies the skeleton generation for pypi and luarocks pkgs.