### PR TITLE
3.0.0 fixes

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1593,7 +1593,9 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                         built_packages.update({pkg: dict_and_meta})
                 else:
                     built_packages.update(packages_from_this)
-            config.clean()
+            # each metadata element here comes from one recipe, thus it will share one build id
+            #    cleaning on the last metadata in the loop should take care of all of the stuff.
+            metadata.clean()
         except DependencyNeedsBuildingError as e:
             skip_names = ['python', 'r', 'r-base', 'perl', 'lua']
             add_recipes = []

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1015,7 +1015,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                             bf.write('export {0}="{1}"\n'.format(k, v))
 
                         if m.config.activate:
-                            bf.write('source "{0}activate" "{1}" &> /dev/null\n'
+                            bf.write('source "{0}activate" "{1}"\n'
                                      .format(utils.root_script_dir + os.path.sep,
                                              m.config.build_prefix))
                             if m.is_cross:
@@ -1030,7 +1030,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                 #
                                 # Conda 4.4 may break this by reworking the activate scripts.
                                 bf.write('unset CONDA_PATH_BACKUP\n')
-                                bf.write('source "{0}activate" "{1}" &> /dev/null\n'
+                                bf.write('source "{0}activate" "{1}"\n'
                                          .format(utils.root_script_dir + os.path.sep,
                                                  m.config.host_prefix))
                         if script:
@@ -1392,12 +1392,11 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
                 tf.write('set -x -e\n')
             if config.activate:
                 ext = ".bat" if utils.on_win else ""
-                tf.write('{source} "{conda_root}activate{ext}" "{test_env}" {squelch}\n'.format(
+                tf.write('{source} "{conda_root}activate{ext}" "{test_env}"\n'.format(
                     conda_root=utils.root_script_dir + os.path.sep,
                     source="call" if utils.on_win else "source",
                     ext=ext,
-                    test_env=config.test_prefix,
-                    squelch=">nul 2>&1" if utils.on_win else "&> /dev/null"))
+                    test_env=config.test_prefix))
                 if utils.on_win:
                     tf.write("if errorlevel 1 exit 1\n")
             if py_files:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1631,3 +1631,7 @@ class MetaData(object):
 
     def get_loop_vars(self):
         return variants.get_loop_vars(self.config.variants)
+
+    def clean(self):
+        """This ensures that clean is called with the correct build id"""
+        self.config.clean()

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -10,7 +10,7 @@ import yaml
 
 from conda_build.utils import ensure_list, HashableDict
 from conda_build.conda_interface import string_types
-from conda_build.conda_interface import arch_name
+from conda_build.conda_interface import subdir
 from conda_build.conda_interface import cc_conda_build
 from conda_build.conda_interface import cc_platform
 
@@ -26,9 +26,11 @@ DEFAULT_VARIANTS = {
     'ignore_version': [],
 }
 
+arch_name = subdir.rsplit('-', 1)[-1]
+
 DEFAULT_PLATFORMS = {
-    'linux': 'linux-cos5-' + arch_name,
-    'osx': 'osx-109-' + arch_name,
+    'linux': 'linux-' + arch_name,
+    'osx': 'osx-' + arch_name,
     'win': 'win-' + arch_name,
 }
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -156,10 +156,10 @@ def test_native_compiler_metadata_linux(testing_config, mocker):
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config, permit_unsatisfiable_variants=True,
                           finalize=False)[0][0]
-    _64 = '_64' if conda_interface.bits == 64 else ''
-    assert any(dep.startswith('gcc_linux-cos5-x86' + _64) for dep in metadata.meta['requirements']['build'])
-    assert any(dep.startswith('gxx_linux-cos5-x86' + _64) for dep in metadata.meta['requirements']['build'])
-    assert any(dep.startswith('gfortran_linux-cos5-x86' + _64) for dep in metadata.meta['requirements']['build'])
+    _64 = '64' if conda_interface.bits == 64 else '32'
+    assert any(dep.startswith('gcc_linux-' + _64) for dep in metadata.meta['requirements']['build'])
+    assert any(dep.startswith('gxx_linux-' + _64) for dep in metadata.meta['requirements']['build'])
+    assert any(dep.startswith('gfortran_linux-' + _64) for dep in metadata.meta['requirements']['build'])
 
 
 def test_native_compiler_metadata_osx(testing_config, mocker):
@@ -167,10 +167,10 @@ def test_native_compiler_metadata_osx(testing_config, mocker):
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config, permit_unsatisfiable_variants=True,
                           finalize=False)[0][0]
-    _64 = '_64' if conda_interface.bits == 64 else ''
-    assert any(dep.startswith('clang_osx-109-x86' + _64) for dep in metadata.meta['requirements']['build'])
-    assert any(dep.startswith('clangxx_osx-109-x86' + _64) for dep in metadata.meta['requirements']['build'])
-    assert any(dep.startswith('gfortran_osx-109-x86' + _64) for dep in metadata.meta['requirements']['build'])
+    _64 = '64' if conda_interface.bits == 64 else '32'
+    assert any(dep.startswith('clang_osx-' + _64) for dep in metadata.meta['requirements']['build'])
+    assert any(dep.startswith('clangxx_osx-' + _64) for dep in metadata.meta['requirements']['build'])
+    assert any(dep.startswith('gfortran_osx-' + _64) for dep in metadata.meta['requirements']['build'])
 
 
 def test_compiler_metadata_cross_compiler():


### PR DESCRIPTION
- show more output from source activate (especially important for seeing variables changed by activate.d scripts)
- fix cleanup not knowing about build id and doing a bad job (fixes #2104)
- Change default platform to not include things like cos5 or 109 - let the user define those.