### PR TITLE
remove strict need to always use jinja2 for variants

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1634,7 +1634,7 @@ class MetaData(object):
         return final_conda_packages + non_conda_packages
 
     def get_loop_vars(self):
-        return variants.get_loop_vars(self.config.variants)
+        return variants.get_loop_vars(self.config.input_variants)
 
     def clean(self):
         """This ensures that clean is called with the correct build id"""

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,5 +1,6 @@
 import os
 from conda_build import api
+from conda_build import render
 
 
 def test_output_with_noarch_says_noarch(testing_metadata):
@@ -14,5 +15,13 @@ def test_output_with_noarch_python_says_noarch(testing_metadata):
     assert os.path.sep + "noarch" + os.path.sep in output[0]
 
 
-# no tests here - this is tested at a high level in test_cli.py and in test_api_render.py.
-#   tests here should be lower-level unit tests of the render.py functionality.
+def test_insert_variant_versions(testing_metadata):
+    testing_metadata.meta['requirements']['build'] = ['python', 'numpy 1.13']
+    testing_metadata.config.variant = {'python': '2.7', 'numpy': '1.11'}
+    render.insert_variant_versions(testing_metadata, 'build')
+    # this one gets inserted
+    assert 'python 2.7' in testing_metadata.meta['requirements']['build']
+    # this one should not be altered
+    assert 'numpy 1.13' in testing_metadata.meta['requirements']['build']
+    # the overall length does not change
+    assert len(testing_metadata.meta['requirements']['build']) == 2


### PR DESCRIPTION
prior to this, python was special-cased, and you could write

```
requirements:
  build:
    - python
```

and expect conda-build to loop over all python versions defined in conda_build_config.yaml.  For anything else, you'd need to define Jinja2 placeholders:

```
requirements:
  build:
    - python
    - numpy   {{ numpy }}
```

where the ``{{ numpy }}`` will use the numpy value from the variant.

This PR matches package names up with variant keys, and obviates the need for the explicit syntax.  The explicit syntax still works, though.