### PR TITLE
Add meta.yaml lib test section

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -12,6 +12,7 @@ import sys
 
 from conda_build.utils import copy_into, get_ext_files, on_win, ensure_list, rm_rf
 from conda_build import source
+from conda_build.environ import get_shlib_ext
 
 
 def create_files(m):
@@ -85,6 +86,26 @@ def create_shell_files(m):
                 f.write('\n')
                 if sys.platform == 'win32':
                     f.write("if errorlevel 1 exit 1\n")
+                has_tests = True
+
+    libs = ensure_list(m.get_value('test/load_libs', []))
+    if libs:
+        if sys.platform.startswith('win'):
+            lib_path = os.path.join(m.config.test_prefix, 'Library', 'bin')
+        else:
+            lib_path = os.path.join(m.config.test_prefix, 'lib')
+
+        with open(join(m.config.test_dir, name), 'a') as f:
+            f.write('\n\n')
+            for lib in libs:
+                lib_loc = os.path.join(lib_path, lib + get_shlib_ext())
+                # test existence
+                if sys.platform.startswith('win'):
+                    f.write('if not exist ' + lib_loc + ' exit 1\n')
+                else:
+                    f.write('test -f ' + lib_loc + '\n')
+                # test loading
+                f.write('python -c "import ctypes; ctypes.cdll[\'' + lib_loc + '\']" || exit 1\n')
                 has_tests = True
 
     return has_tests

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -327,6 +327,7 @@ default_structs = {
     'test/source_files': list,
     'test/commands': list,
     'test/imports': list,
+    'test/load_libs' : list,
     'package/version': text_type,
     'build/string': text_type,
     'build/pin_depends': text_type,


### PR DESCRIPTION
This adds a testing section in meta.yaml for library loading test as in #2135:

```
test:
   libs:
    - libmuparser
```

This would test existence and loading of libmuparser shared libray.