### PR TITLE
update variants notebook for cb3 blog post

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -203,7 +203,8 @@ def pin_compatible(m, package_name, lower_bound=None, upper_bound=None, min_pin=
                     else:
                         version = str(version)
                     if upper_bound:
-                        compatibility = ">=" + str(version) + ","
+                        if min_pin or lower_bound:
+                            compatibility = ">=" + str(version) + ","
                         compatibility += '<{upper_bound}'.format(upper_bound=upper_bound)
                     else:
                         compatibility = apply_pin_expressions(version, min_pin, max_pin)

--- a/tests/test-recipes/variants/06_compatible_custom/compatible/meta.yaml
+++ b/tests/test-recipes/variants/06_compatible_custom/compatible/meta.yaml
@@ -1,9 +1,0 @@
-package:
-  name: compatible
-  version: 1.0
-
-requirements:
-  build:
-    - libpng
-  run:
-    - libpng  {{ pin_compatible('libpng') }}

--- a/tests/test-recipes/variants/07_compatible_custom_lower_upper/compatible/meta.yaml
+++ b/tests/test-recipes/variants/07_compatible_custom_lower_upper/compatible/meta.yaml
@@ -1,9 +1,0 @@
-package:
-  name: compatible
-  version: 1.0
-
-requirements:
-  build:
-    - libpng
-  run:
-    - libpng  {{ pin_compatible('libpng') }}

--- a/tests/test-recipes/variants/07_compatible_custom_lower_upper/meta.yaml
+++ b/tests/test-recipes/variants/07_compatible_custom_lower_upper/meta.yaml
@@ -6,4 +6,4 @@ requirements:
   build:
     - libpng
   run:
-    - {{ pin_compatible('libpng', max_pin='x.x', min_pin=None) }}
+    - {{ pin_compatible('libpng', min_pin=None, upper_bound='5.0') }}

--- a/tests/test-recipes/variants/10_runtimes/uses_run_exports/meta.yaml
+++ b/tests/test-recipes/variants/10_runtimes/uses_run_exports/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   run_exports:
-    - bzip2  {{ pin_compatible('bzip2') }}
+    - {{ pin_compatible('bzip2') }}
 
 requirements:
   build:

--- a/tests/test-recipes/variants/conda-build-demo.ipynb
+++ b/tests/test-recipes/variants/conda-build-demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Conda Build 3 new features demo"
+    "# Package Better with Conda Build 3"
    ]
   },
   {
@@ -20,9 +20,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This document is intended as a quick overview of new features in conda-build 3.  For more information, see the docs PR at https://github.com/conda/conda-docs/pull/414\n",
+    "This document is intended as a quick overview of new features in conda-build 3.  For more information, see the docs PR at https://conda.io/docs/building/variants.html\n",
     "\n",
-    "These demos use conda-build's python API to render and build recipes.  That API currently does not have a docs page, but is pretty self explanatory.  See the source at https://github.com/conda/conda-build/blob/master/conda_build/api.py"
+    "These demos use conda-build's python API to render and build recipes.  That API currently does not have a docs page, but is pretty self explanatory.  See the source at https://github.com/conda/conda-build/blob/master/conda_build/api.py\n",
+    "\n",
+    "This jupyter notebook itself is included in conda-build's tests folder.  If you're interested in running this notebook yourself, see the tests/test-recipes/variants folder in a git checkout of the conda-build source.  Tests are not included with conda packages of conda-build."
    ]
   },
   {
@@ -57,7 +59,8 @@
     "    yamls = [api.output_yaml(m[0]) \n",
     "             for m in api.render(recipe, verbose=False, permit_unsatisfiable_variants=True, **kwargs)]\n",
     "    for yaml in yamls:\n",
-    "        print(yaml)"
+    "        print(yaml)\n",
+    "        print('-' * 50)"
    ]
   },
   {
@@ -137,7 +140,7 @@
    "source": [
     "OK, that's fun already.  But wait, there's more!\n",
     "\n",
-    "People are used to not needing to explicitly pin numpy.  Conda-build 3 supports that, as well as explicit pinning."
+    "We saw a warning about \"finalization.\"  That's conda-build trying to figure out exactly what packages are going to be installed for the build process.  This is all determined before the build.  Doing so allows us to tell you the actual output filenames before you build anything.  Conda-build will still render recipes if some dependencies are unavailable, but you obviously won't be able to actually build that recipe."
    ]
   },
   {
@@ -174,6 +177,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here you see that we have many more dependencies than we specified, and we have much more detailed pinning.  This is a finalized recipe.  It represents exactly the state that would be present for building (at least on the current platform).\n",
+    "\n",
+    "So, this new way to pass versions is very fun, but there's a lot of code out there that uses the older way of doing things - environment variables and CLI arguments.  Those still work.  They override any conda_build_config.yaml settings."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -207,7 +219,7 @@
     "\n",
     "Conda-build 3 aims to generalize pinning/constraints.  Such constraints differentiate a package.  For example, in the past, we have had things like py27np111 in filenames.  This is the same idea, just generalized.  Since we can't readily put every possible constraint into the filename, we have kept the old ones, but added the hash as a general solution.\n",
     "\n",
-    "There's more information about what goes into a hash at https://github.com/conda/conda-docs/pull/414/files#diff-d1a5dbb2f223de4935d93990676c7074R919\n",
+    "There's more information about what goes into a hash at https://conda.io/docs/building/variants.html#differentiating-packages-built-with-different-variants\n",
     "\n",
     "Let's take a look at how to inspect the hash contents of a built package."
    ]
@@ -235,133 +247,16 @@
    "outputs": [],
    "source": [
     "# using command line here just to show you that this command exists.\n",
-    "!conda inspect hash-inputs ~/miniconda3/conda-bld/osx-64/abc-1.0-py36ha934722_0.tar.bz2"
+    "!conda inspect hash-inputs ~/miniconda3/conda-bld/osx-64/abc-1.0-py36hd0a5620_0.tar.bz2"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When numpy gets involved, things get more fun.  The simplest use of numpy is just for its python interface - not using its C header.  For such usage, we don't need to pin numpy in the output packages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "!cat 03_numpy_matrix/meta.yaml"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "!cat 03_numpy_matrix/conda_build_config.yaml"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "OK, so I'm hoping that we get only two packages here - one for each Python version, but not one for each numpy version."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "pprint(api.get_output_file_paths('03_numpy_matrix/', verbose=False))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "print_yamls('03_numpy_matrix/')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "What about when we do use numpy's C API, and we do need to pin it so that a particular version is available at runtime?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "!cat 04_numpy_matrix_pinned/meta.yaml"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "!cat 04_numpy_matrix_pinned/conda_build_config.yaml"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "pin_run_as_build is a special extra key in the config file.  It is a generalization of the ``x.x`` concept that existed for numpy since 2015.  There's more information at https://github.com/conda/conda-docs/pull/414/files#diff-d1a5dbb2f223de4935d93990676c7074R757\n",
+    "pin_run_as_build is a special extra key in the config file.  It is a generalization of the ``x.x`` concept that existed for numpy since 2015.  There's more information at https://conda.io/docs/building/variants.html#customizing-compatibility\n",
     "\n",
-    "Each x indicates another level of pinning in the output recipe."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "print_outputs('04_numpy_matrix_pinned/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "print_yamls('04_numpy_matrix_pinned/')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "OK, you've now seen several examples of \"pinning expressions\" - things like x.x that apply pins more or less stringently.  Let's take a look at how we can control the relationship of these constraints.  Before now you could certainly accomplish pinning, it just took more work.  Now you can define your pinning expressions, and then change your target versions only in one config file."
+    "Each x indicates another level of pinning in the output recipe.  Let's take a look at how we can control the relationship of these constraints. Before now you could certainly accomplish pinning, it just took more work. Now you can define your pinning expressions, and then change your target versions only in one config file."
    ]
   },
   {
@@ -381,7 +276,7 @@
    "source": [
     "This is effectively saying \"add a runtime libpng constraint that follows conda-build's default behavior, relative to the version of libpng that was used at build time\"\n",
     "\n",
-    "The default behavior is: exact version match lower bound (\"x.x.x.x.x.x.x\"), next major version upper bound (\"x\")"
+    "pin_compatible is a new helper function available to you in meta.yaml.  The default behavior is: exact version match lower bound (\"x.x.x.x.x.x.x\"), next major version upper bound (\"x\")"
    ]
   },
   {
@@ -477,25 +372,7 @@
    "source": [
     "By replacing any actual compiler with this jinja2 function, we're free to swap in different compilers based on the contents of the conda_build_config.yaml file (or other variant configuration).  Rather than saying \"I need gcc,\" we are saying \"I need a C compiler.\"\n",
     "\n",
-    "By doing so, recipes are much more dynamic, and conda-build also helps to keep your recipes in line with respect to runtimes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "print_yamls('08_compiler/')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Conda-build 3 is very good at allowing cross compiling.  For example, we have the same placeholder compiler recipe:"
+    "By doing so, recipes are much more dynamic, and conda-build also helps to keep your recipes in line with respect to runtimes.  We're also free to keep compilation and linking flags associated with specific \"compiler\" packages - allowing us to build against potentially multiple configurations (Release, Debug?).  With cross compilers, we could also build for other platforms."
    ]
   },
   {
@@ -596,7 +473,7 @@
     "collapsed": true
    },
    "source": [
-    "In the above recipe, note that bzip2 has been added as a runtime dependency, and is pinned according to conda-build's default pin_compatible scheme."
+    "In the above recipe, note that bzip2 has been added as a runtime dependency, and is pinned according to conda-build's default pin_compatible scheme.  This behavior can be overridden in recipes if necessary, but we hope it will prove useful."
    ]
   }
  ],


### PR DESCRIPTION
Update links to point to real docs now (they're live), fix one bounds issue in pin_compatible, and shorten it a bit.