### PR TITLE
Add SSL_CERT_FILE and REQUESTS_CA_BUNDLE to build environment

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -289,6 +289,7 @@ def conda_build_vars(prefix, config):
         'SRC_DIR': src_dir,
         'HTTPS_PROXY': os.getenv('HTTPS_PROXY', ''),
         'HTTP_PROXY': os.getenv('HTTP_PROXY', ''),
+        'REQUESTS_CA_BUNDLE': os.getenv('REQUESTS_CA_BUNDLE', ''),
         'DIRTY': '1' if config.dirty else '',
         'ROOT': root_dir,
     }
@@ -485,6 +486,7 @@ def unix_vars(prefix):
         'HOME': os.getenv('HOME', 'UNKNOWN'),
         'PKG_CONFIG_PATH': join(prefix, 'lib', 'pkgconfig'),
         'CMAKE_GENERATOR': 'Unix Makefiles',
+        'SSL_CERT_FILE': os.getenv('SSL_CERT_FILE', ''),
     }
 
 


### PR DESCRIPTION
Just like the HTTP proxies, these are part of the system configuration that the build might rely on if it uses requests to fetch an HTTPS resource. An example would be building sphinx-based documentation with the intersphinx extension enabled attempting to download the inventory from `docs.python.org`.