### PR TITLE
Sort files before they're written to the files file

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -330,7 +330,7 @@ def write_info_files_file(m, files):
         if m.get_value('build/noarch_python'):
             fo.write('\n')
         elif m.noarch == 'python':
-            for f in files:
+            for f in sorted(files):
                 if f.find("site-packages") >= 0:
                     fo.write(f[f.find("site-packages"):] + '\n')
                 elif f.startswith("bin") and (f not in entry_point_script_names):
@@ -340,7 +340,7 @@ def write_info_files_file(m, files):
                 else:
                     fo.write(f + '\n')
         else:
-            for f in files:
+            for f in sorted(files):
                 fo.write(f + '\n')
 
 

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -500,15 +500,20 @@ def update_files_file(temp_dir, verbose):
     files_file = os.path.join(temp_dir, 'info/files')
 
     with open(files_file, 'w+') as files:
+        file_paths = []
         for dirpath, dirnames, filenames in os.walk(temp_dir):
             for filename in filenames:
                 package_file_path = os.path.join(
                     dirpath, filename).replace(temp_dir, '').lstrip(os.sep)
                 if not package_file_path.startswith('info'):
-                    files.write(package_file_path + '\n')
+                    # files.write(package_file_path + '\n')
+                    file_paths.append(package_file_path)
 
                     if verbose:
                         print('Updating {}' .format(package_file_path))
+
+        for file_path in sorted(file_paths):
+            files.write(file_path + '\n')
 
 
 def create_target_archive(file_path, temp_dir, platform, output_dir):


### PR DESCRIPTION
In reference sorted files in issue #2140 

For build.py I merely added a sorted() call around the files argument. Even though the if statements are not calling paths in alphabetical order, the sorted files argument seems to be enough.

For convert.py I decided to append all filepaths to a list then write that sorted list into the files file. 