### PR TITLE
Use glob2 to resolve recursive pattern /**/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
         conda info;
     fi
   - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION
-  - conda install -q pyflakes conda-verify beautifulsoup4 chardet pycrypto
+  - conda install -q pyflakes conda-verify beautifulsoup4 chardet pycrypto glob2
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2
   - conda install -q pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4
   - conda install -c conda-forge -q perl
   # this is to ensure dependencies

--- a/ci/travis/run.sh
+++ b/ci/travis/run.sh
@@ -7,7 +7,7 @@ if [[ "$FLAKE8" == "true" ]]; then
     conda build --help
     conda build --version
     conda build conda.recipe --no-anaconda-upload
-    conda create -n _cbtest python=$TRAVIS_PYTHON_VERSION conda-build
+    conda create -n _cbtest python=$TRAVIS_PYTHON_VERSION conda-build glob2
     # because this is a file, conda is not going to process any of its dependencies.
     conda install -n _cbtest $(conda render --output conda.recipe)
     source activate _cbtest

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - python
     - pyyaml
     - six
+    - glob2
 
 test:
   requires:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -273,7 +273,7 @@ def get_files_with_prefix(m, files, prefix):
         ignore_files = []
     if not m.get_value('build/detect_binary_files_with_prefix', True):
         ignore_types.update((FileMode.binary.name,))
-    # files_with_prefix is a list of tuples containing (prefix_placeholder, file_mode)
+    # files_with_prefix is a list of tuples containing (prefix_placeholder, file_type, file_path)
     ignore_files.extend(
         f[2] for f in files_with_prefix if f[1] in ignore_types and f[2] not in ignore_files)
     files_with_prefix = [f for f in files_with_prefix if f[2] not in ignore_files]

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -756,11 +756,12 @@ def expand_globs(path_list, root_dir):
             files.append(path.replace(root_dir + os.path.sep, ''))
         else:
             # File compared to the globs use / as separator indenpendently of the os
-            glob_files = [f.replace(root_dir + os.path.sep, '').replace(os.path.sep, '/')
+            glob_files = [f.replace(root_dir + os.path.sep, '')
                           for f in glob(path)]
             if not glob_files:
                 log.error('invalid recipe path: {}'.format(path))
             files.extend(glob_files)
+    files = [f.replace(os.path.sep, '/') for f in files]
     return files
 
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -4,7 +4,7 @@ import base64
 from collections import defaultdict
 import contextlib
 import fnmatch
-from glob import glob
+from glob2 import glob
 import json
 from locale import getpreferredencoding
 import logging
@@ -755,7 +755,9 @@ def expand_globs(path_list, root_dir):
         elif os.path.isfile(path):
             files.append(path.replace(root_dir + os.path.sep, ''))
         else:
-            glob_files = [f.replace(root_dir + os.path.sep, '') for f in glob(path)]
+            # File compared to the globs use / as separator indenpendently of the os
+            glob_files = [f.replace(root_dir + os.path.sep, '').replace(os.path.sep, '/')
+                          for f in glob(path)]
             if not glob_files:
                 log.error('invalid recipe path: {}'.format(path))
             files.extend(glob_files)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
                             'conda-render = conda_build.cli.main_render:main',
                             'conda-skeleton = conda_build.cli.main_skeleton:main',
                             ]},
-    install_requires=['conda', 'requests', 'filelock', 'pyyaml', 'conda-verify', 'pkginfo'],
+    install_requires=['conda', 'requests', 'filelock', 'pyyaml', 'conda-verify',
+                      'pkginfo', 'glob2'],
     package_data={'conda_build': ['templates/*', 'cli-*.exe']},
     zip_safe=False,
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -179,12 +179,30 @@ class TestUtils(unittest.TestCase):
 
 
 def test_expand_globs(testing_workdir):
-    files = ['abc', 'acb']
+    sub_dir = os.path.join(testing_workdir, 'sub1')
+    os.mkdir(sub_dir)
+    ssub_dir = os.path.join(sub_dir, 'ssub1')
+    os.mkdir(ssub_dir)
+    files = ['abc', 'acb',
+             os.path.join(sub_dir, 'def'),
+             os.path.join(sub_dir, 'abc'),
+             os.path.join(ssub_dir, 'ghi'),
+             os.path.join(ssub_dir, 'abc')]
     for f in files:
         with open(f, 'w') as _f:
             _f.write('weee')
-    assert utils.expand_globs(files, testing_workdir) == files
-    assert utils.expand_globs(['a*'], testing_workdir) == files
+
+    # Test dirs
+    exp = utils.expand_globs([os.path.join('sub1', 'ssub1')], testing_workdir)
+    assert sorted(exp) == sorted(['sub1/ssub1/ghi', 'sub1/ssub1/abc'])
+
+    # Test files
+    exp = sorted(utils.expand_globs(['abc', files[2]], testing_workdir))
+    assert exp == sorted(['abc', 'sub1/def'])
+
+    # Test globs
+    exp = sorted(utils.expand_globs(['a*', '*/*f', '**/*i'], testing_workdir))
+    assert exp == sorted(['abc', 'acb', 'sub1/def', 'sub1/ssub1/ghi'])
 
 
 def test_filter_files():


### PR DESCRIPTION
This adds glob2 as a dependency to the project to support patterns such as:
```
**/my_project/**/.txt
```
in all entries using expand_globs. 

Furthermore the output of expand_globs is modified to replace os.path.sep by / as conda manipulate paths containing only / (this is for example the case for ignore_prefix_files, with the modification the filtering fails on Windows). I am not sure this is the proper fix.

If you are favorable to such changes, I will add tests and update the docs on conda-docs. One open question is that glob2 is not available on conda and so it needs to be added as otherwise the conda recipe will not valid.