### PR TITLE
Sort output metadata prior to writing to meta.yaml

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -211,6 +211,16 @@ def copy_recipe(m):
         if 'outputs' in output_metadata.meta:
             del output_metadata.meta['outputs']
 
+        # each metadata field has a dict as a value and each value may contain
+        # a list of strings that needs to be sorted alphabetically
+        for field, value in output_metadata.meta.items():
+            for key in value.keys():
+                if '{}/{}' .format(field, key) not in ('build/script', 'test/commands'):
+                    try:
+                        output_metadata.meta[field][key].sort()
+                    except AttributeError:
+                        pass
+
         rendered = output_yaml(output_metadata)
 
         if not original_recipe or not open(original_recipe).read() == rendered:


### PR DESCRIPTION
In relation to #2140:

The field values in the metadata are sorted alphabetically prior to outputting the meta.yaml file in the info/recipe directory. The build/script and test/commands values are omitted.