### PR TITLE
Moved try block in copy_recipe further up in order to catch values that are lists

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -214,12 +214,13 @@ def copy_recipe(m):
         # each metadata field has a dict as a value and each value may contain
         # a list of strings that needs to be sorted alphabetically
         for field, value in output_metadata.meta.items():
-            for key in value.keys():
-                if '{}/{}' .format(field, key) not in ('build/script', 'test/commands'):
-                    try:
+            try:
+                for key in value.keys():
+                    section = '{}/{}' .format(field, key)
+                    if section not in ('build/script', 'test/commands'):
                         output_metadata.meta[field][key].sort()
-                    except AttributeError:
-                        pass
+            except AttributeError:
+                pass
 
         rendered = output_yaml(output_metadata)
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -211,8 +211,8 @@ def copy_recipe(m):
         if 'outputs' in output_metadata.meta:
             del output_metadata.meta['outputs']
 
-        utils.sort_list_in_nested_dictionary(output_metadata.meta,
-                                             ('build/script', 'test/commands'))
+        utils.sort_list_in_nested_structure(output_metadata.meta,
+                                            ('build/script', 'test/commands'))
         rendered = output_yaml(output_metadata)
 
         if not original_recipe or not open(original_recipe).read() == rendered:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -211,17 +211,8 @@ def copy_recipe(m):
         if 'outputs' in output_metadata.meta:
             del output_metadata.meta['outputs']
 
-        # each metadata field has a dict as a value and each value may contain
-        # a list of strings that needs to be sorted alphabetically
-        for field, value in output_metadata.meta.items():
-            try:
-                for key in value.keys():
-                    section = '{}/{}' .format(field, key)
-                    if section not in ('build/script', 'test/commands'):
-                        output_metadata.meta[field][key].sort()
-            except AttributeError:
-                pass
-
+        utils.sort_list_in_nested_dictionary(output_metadata.meta,
+                                             ('build/script', 'test/commands'))
         rendered = output_yaml(output_metadata)
 
         if not original_recipe or not open(original_recipe).read() == rendered:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1145,7 +1145,7 @@ def remove_pycache_from_scripts(build_prefix):
             os.remove(entry_path)
 
 
-def sort_list_in_nested_dictionary(dictionary, omissions=''):
+def sort_list_in_nested_structure(dictionary, omissions=''):
     """Recurse through a nested dictionary and sort any lists that are found.
 
     If the list that is found contains anything but strings, it is skipped
@@ -1157,12 +1157,21 @@ def sort_list_in_nested_dictionary(dictionary, omissions=''):
             for key in value.keys():
                 section = dictionary[field][key]
                 if isinstance(section, dict):
-                    sort_list_in_nested_dictionary(section)
+                    sort_list_in_nested_structure(section)
                 elif (isinstance(section, list) and
                     '{}/{}' .format(field, key) not in omissions and
                         all(isinstance(item, str) for item in section)):
                     section.sort()
+
+        # there's a possibility for nested lists containing dictionaries
+        # in this case we recurse until we find a list to sort
+        elif isinstance(value, list):
+            for element in value:
+                if isinstance(element, dict):
+                    sort_list_in_nested_structure(element)
+            value.sort()
+
+        # since each field contains subfields, we don't need to worry
+        # about sorting anything that may come up here
         else:
-            # since each field contains subfields, we don't need to worry
-            # about sorting anything that may come up here
             continue

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1143,3 +1143,26 @@ def remove_pycache_from_scripts(build_prefix):
 
         elif os.path.isfile(entry_path) and entry_path.endswith('.pyc'):
             os.remove(entry_path)
+
+
+def sort_list_in_nested_dictionary(dictionary, omissions=''):
+    """Recurse through a nested dictionary and sort any lists that are found.
+
+    If the list that is found contains anything but strings, it is skipped
+    as we can't compare lists containing different types. The omissions argument
+    allows for certain sections of the dictionary to be omitted from sorting.
+    """
+    for field, value in dictionary.items():
+        if isinstance(value, dict):
+            for key in value.keys():
+                section = dictionary[field][key]
+                if isinstance(section, dict):
+                    sort_list_in_nested_dictionary(section)
+                elif (isinstance(section, list) and
+                    '{}/{}' .format(field, key) not in omissions and
+                        all(isinstance(item, str) for item in section)):
+                    section.sort()
+        else:
+            # since each field contains subfields, we don't need to worry
+            # about sorting anything that may come up here
+            continue


### PR DESCRIPTION
@mingwandroid brought up the issue that PR #2149 may result in an AttributeError traceback when a section contains a list as its value instead of a dictionary. This PR will fix that issue.