### PR TITLE
don't always remove test folder at end of test

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1490,7 +1490,6 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
             raise
         if need_cleanup:
             utils.rm_rf(recipe_dir)
-        utils.rm_rf(metadata.config.test_prefix)
         print("TEST END:", test_package_name)
 
     return True


### PR DESCRIPTION
This cleanup happens elsewhere.  This was removing test env too aggressively (--dirty was not keeping it around)

Fixes #2166 