### PR TITLE
fix upper bound increment to account for prerelease versions

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -633,7 +633,7 @@ class Environment(object):
         return specs
 
 
-spec_needing_star_re = re.compile("([0-9a-zA-Z\.]+\s+)([0-9a-zA-Z\.]+)(\s+[0-9a-zA-Z\.]+)?")
+spec_needing_star_re = re.compile("([0-9a-zA-Z\.]+\s+)([0-9a-zA-Z\.\+]+)(\s+[0-9a-zA-Z\.\_]+)?")
 spec_ver_needing_star_re = re.compile("^([0-9a-zA-Z\.]+)$")
 
 

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -105,7 +105,7 @@ def test_output_without_jinja_does_not_download(mock_source, testing_workdir, te
 def test_pin_compatible_semver(testing_config):
     recipe_dir = os.path.join(metadata_dir, '_pin_compatible')
     metadata = api.render(recipe_dir, config=testing_config)[0][0]
-    assert 'numpy  >=1.11.2,<2' in metadata.get_value('requirements/run')
+    assert 'numpy  >=1.11.2,<2.0a0' in metadata.get_value('requirements/run')
     # not terribly important, but might be nice for continuity's sake
     #    This is broken right now, because compound pins like we do here have never been supported
     #    in the build string.

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -8,7 +8,7 @@ def test_pin_default(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['test 1.2.3'], [], None
     pin = jinja_context.pin_compatible(testing_metadata, 'test')
-    assert pin == 'test  >=1.2.3,<2'
+    assert pin == 'test  >=1.2.3,<2.0a0'
 
 
 def test_pin_compatible_exact(testing_metadata, mocker):
@@ -22,7 +22,7 @@ def test_pin_jpeg_style_default(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['jpeg 9d 0'], [], None
     pin = jinja_context.pin_compatible(testing_metadata, 'jpeg')
-    assert pin == 'jpeg  >=9d,<10'
+    assert pin == 'jpeg  >=9d,<10a'
 
 
 def test_pin_jpeg_style_minor(testing_metadata, mocker):
@@ -36,7 +36,7 @@ def test_pin_openssl_style_bugfix(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['openssl 1.0.2j 0'], [], None
     pin = jinja_context.pin_compatible(testing_metadata, 'openssl', max_pin='x.x.x')
-    assert pin == 'openssl  >=1.0.2j,<1.0.3'
+    assert pin == 'openssl  >=1.0.2j,<1.0.3a'
     pin = jinja_context.pin_compatible(testing_metadata, 'openssl', max_pin='x.x.x.x')
     assert pin == 'openssl  >=1.0.2j,<1.0.2k'
 
@@ -45,7 +45,7 @@ def test_pin_major_minor(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['test 1.2.3'], [], None
     pin = jinja_context.pin_compatible(testing_metadata, 'test', max_pin='x.x')
-    assert pin == 'test  >=1.2.3,<1.3'
+    assert pin == 'test  >=1.2.3,<1.3.0a0'
 
 
 def test_pin_upper_bound(testing_metadata, mocker):
@@ -58,15 +58,15 @@ def test_pin_upper_bound(testing_metadata, mocker):
 def test_pin_lower_bound(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['test 1.2.3'], [], None
-    pin = jinja_context.pin_compatible(testing_metadata, 'test', lower_bound=1.0, upper_bound="3.0")
-    assert pin == 'test  >=1.0,<3.0'
+    pin = jinja_context.pin_compatible(testing_metadata, 'test', lower_bound=1.0)
+    assert pin == 'test  >=1.0,<2.0a0'
 
 
 def test_pin_none_min(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['test 1.2.3'], [], None
     pin = jinja_context.pin_compatible(testing_metadata, 'test', min_pin=None)
-    assert pin == 'test  <2'
+    assert pin == 'test  <2.0a0'
 
 
 def test_pin_none_max(testing_metadata, mocker):


### PR DESCRIPTION
When pre-release versions of things were present, conda-build's upper bounds didn't work very well.  ```python >=3.5,<3.6``` would allow python 3.6.0rc4, for example.

Here we add .0a0 to semver-style constraints, and for openssl and jpeg style, we go to the next major version, plus 'a' (presumably the first version for the next major series.)

fixes #2181 #2169 