### PR TITLE
fix numpy x.x getting .* added to it

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -641,7 +641,8 @@ def _ensure_valid_spec(spec):
     if isinstance(spec, MatchSpec):
         if (hasattr(spec, 'version') and spec.version and
                 spec_ver_needing_star_re.match(str(spec.version))):
-            spec = MatchSpec("{} {}".format(str(spec.name), str(spec.version) + '.*'))
+            if str(spec.name) != 'numpy' or str(spec.version) != 'x.x':
+                spec = MatchSpec("{} {}".format(str(spec.name), str(spec.version) + '.*'))
     else:
         match = spec_needing_star_re.match(spec)
         # ignore exact pins (would be a 3rd group)

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -5,7 +5,7 @@ import tempfile
 import pytest
 
 from conda_build import environ, api
-from conda_build.conda_interface import PaddingError, LinkError, CondaError, subdir
+from conda_build.conda_interface import PaddingError, LinkError, CondaError, subdir, MatchSpec
 from conda_build.utils import on_win
 
 from .utils import metadata_dir
@@ -68,3 +68,4 @@ def test_ensure_valid_spec():
     assert environ._ensure_valid_spec('python 2.7.12 0') == 'python 2.7.12 0'
     assert environ._ensure_valid_spec('python >=2.7,<2.8') == 'python >=2.7,<2.8'
     assert environ._ensure_valid_spec('numpy x.x') == 'numpy x.x'
+    assert environ._ensure_valid_spec(MatchSpec('numpy x.x')) == MatchSpec('numpy x.x')


### PR DESCRIPTION
As reported by @nehaljwani on flowdock, ``numpy x.x`` specs were leading to this traceback:

```
(root) root@bff79ce8ddcb:~/astropy-feedstock/recipe# conda build . --numpy 1.12

Leaving build/test directories:
  Work:     ../../../conda/conda-bld/work 
  Test:     ../../../conda/conda-bld/test_tmp 
Leaving build/test environments:
  Test:    source activate  ../../../conda/conda-bld/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol 
  Build:    source activate  ../../../conda/conda-bld/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p 


Traceback (most recent call last):
  File "/conda/lib/python3.6/site-packages/conda_build/environ.py", line 699, in get_install_actions
    actions = install_actions(prefix, index, specs, force=True)
  File "/conda/lib/python3.6/site-packages/conda/plan.py", line 461, in install_actions
    update_deps, pinned)
  File "/conda/lib/python3.6/site-packages/conda/plan.py", line 634, in get_actions_for_dists
    pkgs = r.install(specs, installed, update_deps=update_deps)
  File "/conda/lib/python3.6/site-packages/conda/resolve.py", line 811, in install
    pkgs = self.solve(specs, returnall=returnall)
  File "/conda/lib/python3.6/site-packages/conda/resolve.py", line 850, in solve
    reduced_index = self.get_reduced_index(specs)
  File "/conda/lib/python3.6/site-packages/conda/resolve.py", line 376, in get_reduced_index
    specs, features = self.verify_specs(specs)
  File "/conda/lib/python3.6/site-packages/conda/resolve.py", line 302, in verify_specs
    raise NoPackagesFoundError(bad_deps)
conda.exceptions.NoPackagesFoundError: Package missing in current linux-64 channels: 
  - numpy x.x.*

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/conda/bin/conda-build", line 6, in <module>
    sys.exit(conda_build.cli.main_build.main())
  File "/conda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 342, in main
    execute(sys.argv[1:])
  File "/conda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 333, in execute
    noverify=args.no_verify)
  File "/conda/lib/python3.6/site-packages/conda_build/api.py", line 183, in build
    need_source_download=need_source_download, config=config, variants=variants)
  File "/conda/lib/python3.6/site-packages/conda_build/build.py", line 1615, in build_tree
    built_packages=built_packages,
  File "/conda/lib/python3.6/site-packages/conda_build/build.py", line 928, in build
    channel_urls=tuple(m.config.channel_urls))
  File "/conda/lib/python3.6/site-packages/conda_build/environ.py", line 701, in get_install_actions
    raise DependencyNeedsBuildingError(exc, subdir=subdir)
conda_build.exceptions.DependencyNeedsBuildingError: Unsatisfiable dependencies for platform linux-64: ['numpy']
```

Tests did not catch this because MatchSpec was a different code path, and only strings were tested.