### PR TITLE
Rewrite skeleton template and match conda-forge standard

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -105,8 +105,9 @@ def ns_cfg(config):
 # Notes:
 # - [([^\[\]]+)\] means "find a pair of brackets containing any
 #                 NON-bracket chars, and capture the contents"
-# - (?(2).*)$ means "allow trailing characters iff group 2 (#.*) was found."
-sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2).*)$')
+# - (?(2)[^\(\)]*)$ means "allow trailing characters iff group 2 (#.*) was found."
+#                 Skip markdown link syntax.
+sel_pat = re.compile(r'(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2)[^\(\)]*)$')
 
 
 # this function extracts the variable name from a NameError exception, it has the form of:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -580,11 +580,13 @@ def render_recipe(recipe_path, config, no_download_source=False, variants=None,
 
     return rendered_metadata
 
+# Keep this out of the function below so it can be imported by other modules.
+FIELDS = ["package", "source", "build", "requirements", "test", "app", "outputs", "about", "extra"]
 
 # Next bit of stuff is to support YAML output in the order we expect.
 # http://stackoverflow.com/a/17310199/1170370
 class _MetaYaml(dict):
-    fields = ["package", "source", "build", "requirements", "test", "outputs", "about", "extra"]
+    fields = FIELDS
 
     def to_omap(self):
         return [(field, self[field]) for field in _MetaYaml.fields if field in self]

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -580,8 +580,10 @@ def render_recipe(recipe_path, config, no_download_source=False, variants=None,
 
     return rendered_metadata
 
+
 # Keep this out of the function below so it can be imported by other modules.
 FIELDS = ["package", "source", "build", "requirements", "test", "app", "outputs", "about", "extra"]
+
 
 # Next bit of stuff is to support YAML output in the order we expect.
 # http://stackoverflow.com/a/17310199/1170370

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -35,6 +35,7 @@ from conda_build.environ import create_env
 from conda_build.config import Config
 from conda_build.metadata import MetaData
 from conda_build.license_family import allowed_license_families, guess_license_family
+from conda_build.render import FIELDS as EXPECTED_SECTION_ORDER
 
 pypi_example = """
 Examples:
@@ -52,11 +53,8 @@ Use the --pypi-url flag to point to a PyPI mirror url:
     conda skeleton pypi --pypi-url <mirror-url> package_name
 """
 
-# Definitions of EXPECTED_SECTION_ORDER and REQUIREMENTS_ORDER below are from
+# Definition of REQUIREMENTS_ORDER below are from
 # https://github.com/conda-forge/conda-smithy/blob/master/conda_smithy/lint_recipe.py#L16
-EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
-                          'test', 'app', 'about', 'extra']
-
 REQUIREMENTS_ORDER = ['build', 'run']
 
 # Definition of ABOUT_ORDER reflects current practice
@@ -64,7 +62,7 @@ ABOUT_ORDER = ['home', 'license', 'license_family', 'license_file', 'summary',
                'description', 'doc_url', 'dev_url']
 
 # This may be overkill, but some day sha256 won't be enough. Might as well be
-# ready...list this in order of decreasing preference.
+# ready...list these in order of decreasing preference.
 POSSIBLE_DIGESTS = ['sha256', 'md5']
 
 PYPI_META_HEADER = """{{% set name = "{packagename}" %}}
@@ -547,7 +545,7 @@ def get_download_data(pypi_data, package, version, is_url, all_urls, noprompt, m
         else:
             # That didn't work, even though as of 7/17/2017 some packages
             # have a 'digests' entry.
-            # As a last-ditch effort, try for this entry
+            # As a last-ditch effort, try for the md5_digest entry
             try:
                 digest = ('md5', url['md5_digest'])
             except KeyError:

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -395,6 +395,7 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
         print("Writing recipe for %s" % package.lower())
         with open(join(output_dir, name, 'meta.yaml'), 'w') as f:
             rendered_recipe = PYPI_META_HEADER.format(**d)
+
             ordered_recipe = ruamel_yaml.comments.CommentedMap()
             # Create all keys in expected ordered
             for key in EXPECTED_SECTION_ORDER:
@@ -439,7 +440,8 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
 
             content = ruamel_yaml.dump(ordered_recipe,
                                        Dumper=ruamel_yaml.RoundTripDumper,
-                                       default_flow_style=False)
+                                       default_flow_style=False,
+                                       width=200)
 
             rendered_recipe += content
             f.write(rendered_recipe)
@@ -781,14 +783,12 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
             d['home'] = "The package home page"
 
     if pkginfo.get('summary'):
-        d['summary'] = repr(pkginfo['summary'])
+        d['summary'] = pkginfo['summary']
     else:
         if data:
-            d['summary'] = repr(data['summary'])
+            d['summary'] = data['summary']
         else:
             d['summary'] = "Summary of the package"
-    if d['summary'].startswith("u'") or d['summary'].startswith('u"'):
-        d['summary'] = d['summary'][1:]
 
     license_classifier = "License :: OSI Approved :: "
     if pkginfo.get('classifiers'):

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -307,17 +307,8 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
                 'run_depends': '',
                 'build_depends': '',
                 'entry_points': '',
-                'build_comment': '# ',
-                'noarch_python_comment': '# ',
                 'test_commands': '',
-                'requires_comment': '#',
                 'tests_require': '',
-                'usemd5': '',
-                'test_comment': '',
-                'entry_comment': '# ',
-                'egg_comment': '# ',
-                'summary_comment': '',
-                'home_comment': '',
             })
         if is_url:
             del d['packagename']
@@ -374,30 +365,12 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
                                                                         is_url, all_urls,
                                                                         noprompt, manual_url)
 
-        if d['md5'] == '':
-            d['usemd5'] = '# '
-        else:
-            d['usemd5'] = ''
-
         d['import_tests'] = ''
 
         get_package_metadata(package, d, data, output_dir, python_version,
                              all_extras, recursive, created_recipes, noarch_python,
                              noprompt, packages, extra_specs, config=config,
                              setup_options=setup_options)
-
-        if d['import_tests'] == '':
-            d['import_comment'] = '# '
-        else:
-            d['import_comment'] = ''
-
-        if d['tests_require'] == '':
-            d['requires_comment'] = '# '
-        else:
-            d['requires_comment'] = ''
-
-        if d['entry_comment'] == d['import_comment'] == '# ':
-            d['test_comment'] = '# '
 
         d['recipe_setup_options'] = ' '.join(setup_options)
 
@@ -428,15 +401,16 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
                 try:
                     ordered_recipe[key] = PYPI_META_STATIC[key]
                 except KeyError:
-                    ordered_recipe[key] = {} # OrderedDict()
+                    ordered_recipe[key] = {}
 
             if d['entry_points']:
                 ordered_recipe['build']['entry_points'] = d['entry_points']
 
             if noarch_python:
                 ordered_recipe['build']['noarch'] = 'python'
+
             # Always require python as a dependency
-            ordered_recipe['requirements'] = {} # OrderedDict()
+            ordered_recipe['requirements'] = {}
             ordered_recipe['requirements']['build'] = ['python'] + d['build_depends']
             ordered_recipe['requirements']['run'] = ['python'] + d['run_depends']
 
@@ -449,7 +423,7 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
             if d['tests_require']:
                 ordered_recipe['test']['requires'] = d['tests_require']
 
-            ordered_recipe['about'] = {} # OrderedDict()
+            ordered_recipe['about'] = {}
             # Yuck. But don't want to change homeurl to home everywhere today, just
             # want this to work.
             d['home'] = d['homeurl']
@@ -465,7 +439,6 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
                 if not ordered_recipe[key]:
                     del ordered_recipe[key]
 
-            #ordered_recipe = ruamel_yaml.comments.CommentedMap(ordered_recipe)
             content = ruamel_yaml.dump(ordered_recipe,
                                        Dumper=ruamel_yaml.RoundTripDumper,
                                        default_flow_style=False)
@@ -747,8 +720,6 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
             entry_list = (cs + gs)
             if len(cs + gs) != 0:
                 d['entry_points'] = entry_list
-                d['entry_comment'] = ''
-                d['build_comment'] = ''
                 d['test_commands'] = make_entry_tests(entry_list)
 
     requires = get_requirements(package, pkginfo, all_extras=all_extras)
@@ -774,8 +745,6 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
         if 'setuptools' in deps:
             setuptools_build = False
             setuptools_run = False
-            d['egg_comment'] = ''
-            d['build_comment'] = ''
         d['build_depends'] = ['setuptools'] * setuptools_build + deps
         d['run_depends'] = ['setuptools'] * setuptools_run + deps
 
@@ -785,10 +754,6 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                 if not exists(join(output_dir, dep)):
                     if dep not in created_recipes:
                         packages.append(dep)
-
-    if noarch_python:
-        d['build_comment'] = ''
-        d['noarch_python_comment'] = ''
 
     if 'packagename' not in d:
         d['packagename'] = pkginfo['name'].lower()
@@ -805,7 +770,6 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                         if x != '-']
             deps = set(olddeps) | deps
         d['import_tests'] = sorted(deps)
-        d['import_comment'] = ''
 
         d['tests_require'] = sorted([spec_from_line(pkg) for pkg
                                      in ensure_list(pkginfo['tests_require'])])
@@ -817,7 +781,6 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
             d['homeurl'] = data['homeurl']
         else:
             d['homeurl'] = "The package home page"
-            d['home_comment'] = '#'
 
     if pkginfo.get('summary'):
         d['summary'] = repr(pkginfo['summary'])
@@ -826,7 +789,6 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
             d['summary'] = repr(data['summary'])
         else:
             d['summary'] = "Summary of the package"
-            d['summary_comment'] = '#'
     if d['summary'].startswith("u'") or d['summary'].startswith('u"'):
         d['summary'] = d['summary'][1:]
 

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -237,7 +237,7 @@ diff core.py core.py
 +    data['packages'] = kwargs.get('packages', [])
 +    data['setuptools'] = 'setuptools' in sys.modules
 +    data['summary'] = kwargs.get('description', None)
-+    data['homeurl'] = kwargs.get('url', None)
++    data['home'] = kwargs.get('url', None)
 +    data['license'] = kwargs.get('license', None)
 +    data['name'] = kwargs.get('name', '??PACKAGE-NAME-UNKNOWN??')
 +    data['classifiers'] = kwargs.get('classifiers', None)
@@ -424,9 +424,7 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
                 ordered_recipe['test']['requires'] = d['tests_require']
 
             ordered_recipe['about'] = {}
-            # Yuck. But don't want to change homeurl to home everywhere today, just
-            # want this to work.
-            d['home'] = d['homeurl']
+
             for key in ABOUT_ORDER:
                 try:
                     ordered_recipe['about'][key] = d[key]
@@ -774,13 +772,13 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
         d['tests_require'] = sorted([spec_from_line(pkg) for pkg
                                      in ensure_list(pkginfo['tests_require'])])
 
-    if pkginfo.get('homeurl'):
-        d['homeurl'] = pkginfo['homeurl']
+    if pkginfo.get('home'):
+        d['home'] = pkginfo['home']
     else:
-        if data and 'homeurl' in data:
-            d['homeurl'] = data['homeurl']
+        if data and 'home' in data:
+            d['home'] = data['home']
         else:
-            d['homeurl'] = "The package home page"
+            d['home'] = "The package home page"
 
     if pkginfo.get('summary'):
         d['summary'] = repr(pkginfo['summary'])

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -24,8 +24,7 @@ import ruamel_yaml
 
 from conda_build.conda_interface import spec_from_line
 from conda_build.conda_interface import input, configparser, StringIO, string_types, PY3
-from conda_build.conda_interface import CondaSession
-from conda_build.conda_interface import download, handle_proxy_407
+from conda_build.conda_interface import download
 from conda_build.conda_interface import normalized_version
 from conda_build.conda_interface import human_bytes, hashsum_file
 from conda_build.conda_interface import default_python

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -874,10 +874,10 @@ def get_pkginfo(package, filename, pypiurl, digest, python_version, extra_specs,
         if not isfile(download_path) or \
                 hashsum_file(download_path, hash_type) != hash_value:
             download(pypiurl, join(config.src_cache, filename))
-            if not hashsum_file(download_path, hash_type) != hash_value:
+            if not hashsum_file(download_path, hash_type) == hash_value:
                 raise RuntimeError(' Download of {} failed'
-                                   ' checksum matching. Please'
-                                   ' try again.'.format(package))
+                                   ' checksum type {} expected value {}. Please'
+                                   ' try again.'.format(package, hash_type, hash_value))
         else:
             print("Using cached download")
         # Calculate the preferred hash type here if necessary.

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -185,7 +185,6 @@ PYPI_META_STATIC = {
     },
 }
 
-
 # Note the {} formatting bits here
 DISTUTILS_PATCH = '''\
 diff core.py core.py
@@ -424,6 +423,26 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
                     rendered_recipe += '\n'
             # make sure that recipe ends with one newline, by god.
             rendered_recipe.rstrip()
+
+            # This hackery is necessary because
+            #  - the default indentation of lists is not what we would like.
+            #    Ideally we'd contact the ruamel.yaml auther to find the right
+            #    way to do this. See this PR thread for more:
+            #    https://github.com/conda/conda-build/pull/2205#issuecomment-315803714
+            #    Brute force fix below.
+
+            # Fix the indents
+            recipe_lines = []
+            for line in rendered_recipe.splitlines():
+                match = re.search('^\s+(-) ', line,
+                                  flags=re.MULTILINE)
+                if match:
+                    pre, sep, post = line.partition('-')
+                    sep = '  ' + sep
+                    line = pre + sep + post
+                recipe_lines.append(line)
+            rendered_recipe = '\n'.join(recipe_lines)
+
             f.write(rendered_recipe)
 
 

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -393,8 +393,8 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
 
             # Always require python as a dependency
             ordered_recipe['requirements'] = {}
-            ordered_recipe['requirements']['build'] = ['python'] + d['build_depends']
-            ordered_recipe['requirements']['run'] = ['python'] + d['run_depends']
+            ordered_recipe['requirements']['build'] = ['python'] + ensure_list(d['build_depends'])
+            ordered_recipe['requirements']['run'] = ['python'] + ensure_list(d['run_depends'])
 
             if d['import_tests']:
                 ordered_recipe['test']['imports'] = d['import_tests']

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -151,7 +151,7 @@ EXPECTED_SECTION_ORDER = ['package', 'source', 'build', 'requirements',
 
 REQUIREMENTS_ORDER = ['build', 'run']
 
-# Definition of ABOUT_ORDER reflect current practice
+# Definition of ABOUT_ORDER reflects current practice
 ABOUT_ORDER = ['home', 'license', 'license_family', 'license_file', 'summary',
                'description', 'doc_url', 'dev_url']
 

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -233,6 +233,12 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
 
         d['import_tests'] = ''
 
+        # Get summary and description directly from the metadata returned
+        # from PyPI. summary will be pulled from package information in
+        # get_package_metadata or a default value set if it turns out that
+        # data['summary'] is empty.
+        d['summary'] = data['summary']
+        d['description'] = data['description']
         get_package_metadata(package, d, data, output_dir, python_version,
                              all_extras, recursive, created_recipes, noarch_python,
                              noprompt, packages, extra_specs, config=config,
@@ -545,7 +551,7 @@ def get_download_data(pypi_data, package, version, is_url, all_urls, noprompt, m
         else:
             # That didn't work, even though as of 7/17/2017 some packages
             # have a 'digests' entry.
-            # As a last-ditch effort, try for the md5_digest entry
+            # As a last-ditch effort, try for the md5_digest entry.
             try:
                 digest = ('md5', url['md5_digest'])
             except KeyError:
@@ -719,12 +725,11 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
             d['home'] = "The package home page"
 
     if pkginfo.get('summary'):
-        d['summary'] = pkginfo['summary']
+        if 'summary' in d and not d['summary']:
+            # Need something here, use what the package had
+            d['summary'] = pkginfo['summary']
     else:
-        if data:
-            d['summary'] = data['summary']
-        else:
-            d['summary'] = "Summary of the package"
+        d['summary'] = "Summary of the package"
 
     license_classifier = "License :: OSI Approved :: "
     if pkginfo.get('classifiers'):

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -3,9 +3,9 @@ import sys
 
 from pkg_resources import parse_version
 import pytest
-import yaml
 
 from conda_build import api
+from conda_build.exceptions import DependencyNeedsBuildingError
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 
@@ -18,6 +18,7 @@ repo_packages = [('', 'pypi', 'pip', '8.1.2'),
                  ]
 
 
+@pytest.mark.serial
 @pytest.mark.parametrize("prefix, repo, package, version", repo_packages)
 def test_repo(prefix, repo, package, version, testing_workdir, testing_config):
     api.skeletonize(package, repo, version=version, output_dir=testing_workdir,
@@ -34,26 +35,23 @@ def test_repo(prefix, repo, package, version, testing_workdir, testing_config):
         raise
 
 
+@pytest.mark.serial
 def test_name_with_version_specified(testing_workdir, testing_config):
     api.skeletonize(packages='sympy', repo='pypi', version='0.7.5', config=testing_config)
-    with open('{}/test-skeleton/sympy-0.7.5/meta.yaml'.format(thisdir)) as f:
-        expected = yaml.load(f)
-    with open('sympy/meta.yaml') as f:
-        actual = yaml.load(f)
-    assert expected == actual, (expected, actual)
+    m = api.render('sympy/meta.yaml')[0][0]
+    assert m.version() == "0.7.5"
 
 
+@pytest.mark.serial
 def test_pypi_url(testing_workdir, testing_config):
     api.skeletonize('https://pypi.python.org/packages/source/s/sympy/'
                     'sympy-0.7.5.tar.gz#md5=7de1adb49972a15a3dd975e879a2bea9',
                     repo='pypi', config=testing_config)
-    with open('{}/test-skeleton/sympy-0.7.5-url/meta.yaml'.format(thisdir)) as f:
-        expected = yaml.load(f)
-    with open('sympy/meta.yaml') as f:
-        actual = yaml.load(f)
-    assert expected == actual, (expected, actual)
+    m = api.render('sympy/meta.yaml')[0][0]
+    assert m.version() == "0.7.5"
 
 
+@pytest.mark.serial
 def test_pypi_with_setup_options(testing_workdir, testing_config):
     # Use photutils package below because skeleton will fail unless the setup.py is given
     # the flag --offline because of a bootstrapping a helper file that
@@ -64,33 +62,29 @@ def test_pypi_with_setup_options(testing_workdir, testing_config):
                     config=testing_config)
 
     # Check that the setup option occurs in bld.bat and build.sh.
-    for script in ['bld.bat', 'build.sh']:
-        with open('photutils/{}'.format(script)) as f:
-            content = f.read()
-            assert '--offline' in content
+    m = api.render('photutils')[0][0]
+    assert '--offline' in m.meta['build']['script']
 
 
+@pytest.mark.serial
 def test_pypi_pin_numpy(testing_workdir, testing_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
     api.skeletonize(packages='msumastro', repo='pypi', version='0.9.0', config=testing_config,
                     pin_numpy=True)
-
-    with open('msumastro/meta.yaml') as f:
-        actual = yaml.load(f)
-
-    assert 'numpy x.x' in actual['requirements']['run']
-    assert 'numpy x.x' in actual['requirements']['build']
+    with open(os.path.join('msumastro', 'meta.yaml')) as f:
+        assert f.read().count('numpy x.x') == 2
+    with pytest.raises(DependencyNeedsBuildingError):
+        api.build('msumastro')
 
 
+@pytest.mark.serial
 def test_pypi_version_sorting(testing_workdir, testing_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
     api.skeletonize(packages='impyla', repo='pypi', config=testing_config)
-
-    with open('impyla/meta.yaml') as f:
-        actual = yaml.load(f)
-        assert parse_version(actual['package']['version']) >= parse_version("0.13.8")
+    m = api.render('impyla')[0][0]
+    assert parse_version(m.version()) >= parse_version("0.13.8")
 
 
 def test_list_skeletons():
@@ -98,61 +92,63 @@ def test_list_skeletons():
     assert set(skeletons) == set(['pypi', 'cran', 'cpan', 'luarocks', 'rpm'])
 
 
+@pytest.mark.serial
 def test_pypi_with_entry_points(testing_workdir):
     api.skeletonize('planemo', repo='pypi', python_version="2.7")
     assert os.path.isdir('planemo')
 
 
+@pytest.mark.serial
 def test_pypi_with_version_arg(testing_workdir):
     # regression test for https://github.com/conda/conda-build/issues/1442
     api.skeletonize('PrettyTable', 'pypi', version='0.7.2')
-    with open('prettytable/meta.yaml') as f:
-        actual = yaml.load(f)
-        assert parse_version(actual['package']['version']) == parse_version("0.7.2")
+    m = api.render('prettytable')[0][0]
+    assert parse_version(m.version()) == parse_version("0.7.2")
 
 
+@pytest.mark.serial
 def test_pypi_with_extra_specs(testing_workdir):
     # regression test for https://github.com/conda/conda-build/issues/1697
     api.skeletonize('bigfile', 'pypi', extra_specs=["cython", "mpi4py"], version='0.1.24')
-    with open('bigfile/meta.yaml') as f:
-        actual = yaml.load(f)
-        assert parse_version(actual['package']['version']) == parse_version("0.1.24")
+    m = api.render('bigfile')[0][0]
+    assert parse_version(m.version()) == parse_version("0.1.24")
+    assert any('cython' in req for req in m.meta['requirements']['build'])
+    assert any('mpi4py' in req for req in m.meta['requirements']['build'])
 
 
+@pytest.mark.serial
 def test_pypi_with_version_inconsistency(testing_workdir):
     # regression test for https://github.com/conda/conda-build/issues/189
     api.skeletonize('mpi4py_test', 'pypi', extra_specs=["mpi4py"], version='0.0.10')
-    with open('mpi4py_test/meta.yaml') as f:
-        actual = yaml.load(f)
-        assert parse_version(actual['package']['version']) == parse_version("0.0.10")
+    m = api.render('mpi4py_test')[0][0]
+    assert parse_version(m.version()) == parse_version("0.0.10")
 
 
+@pytest.mark.serial
 def test_pypi_with_basic_environment_markers(testing_workdir):
     # regression test for https://github.com/conda/conda-build/issues/1974
     api.skeletonize('coconut', 'pypi', version='1.2.2')
-    with open('coconut/meta.yaml') as f:
-        actual = yaml.load(f)
-        build_reqs = str(actual['requirements']['build'])
-        run_reqs = str(actual['requirements']['run'])
-        # should include the right dependencies for the right version
-        if sys.version_info < (3,):
-            assert "futures" in build_reqs
-            assert "futures" in run_reqs
-        else:
-            assert "futures" not in build_reqs
-            assert "futures" not in run_reqs
-        if sys.version_info >= (2, 7):
-            assert "pygments" in build_reqs
-            assert "pygments" in run_reqs
-        else:
-            assert "pygments" not in build_reqs
-            assert "pygments" not in run_reqs
+    m = api.render('coconut')[0][0]
+
+    build_reqs = str(m.meta['requirements']['build'])
+    run_reqs = str(m.meta['requirements']['run'])
+    # should include the right dependencies for the right version
+    if sys.version_info < (3,):
+        assert "futures" in build_reqs
+        assert "futures" in run_reqs
+    else:
+        assert "futures" not in build_reqs
+        assert "futures" not in run_reqs
+    if sys.version_info >= (2, 7):
+        assert "pygments" in build_reqs
+        assert "pygments" in run_reqs
+    else:
+        assert "pygments" not in build_reqs
+        assert "pygments" not in run_reqs
 
 
+@pytest.mark.serial
 def test_setuptools_test_requirements(testing_workdir):
     api.skeletonize(packages='hdf5storage', repo='pypi')
-
-    with open('hdf5storage/meta.yaml') as f:
-        actual = yaml.load(f)
-
-    assert actual['test']['requires'] == ['nose >=1.0']
+    m = api.render('hdf5storage')[0][0]
+    assert m.meta['test']['requires'] == ['nose >=1.0']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,24 +252,17 @@ def test_skeleton_pypi_arguments_work(testing_workdir):
 
     # Deliberately bypass metadata reading in conda build to get as
     # close to the "ground truth" as possible.
-    with open('msumastro/meta.yaml') as f:
-        actual = yaml.load(f)
-
-    assert 'numpy x.x' in actual['requirements']['run']
-    assert 'numpy x.x' in actual['requirements']['build']
+    with open(os.path.join('msumastro', 'meta.yaml')) as f:
+        assert f.read().count('numpy x.x') == 2
 
     args = ['pypi', 'photutils', '--version=0.2.2', '--setup-options=--offline']
     main_skeleton.execute(args)
     assert os.path.isdir('photutils')
     # Check that the setup option occurs in bld.bat and build.sh.
-    for script in ['bld.bat', 'build.sh']:
-        with open('photutils/{}'.format(script)) as f:
-            content = f.read()
-            assert '--offline' in content
 
-    with open(os.path.join('photutils', 'meta.yaml')) as f:
-        content = f.read()
-        assert 'version: "0.2.2"' in content
+    m = api.render('photutils')[0][0]
+    assert '--offline' in m.meta['build']['script']
+    assert m.version() == '0.2.2'
 
 
 def test_metapackage(testing_config, testing_workdir):

--- a/tests/test_published_examples.py
+++ b/tests/test_published_examples.py
@@ -9,6 +9,7 @@ from .utils import metadata_dir, is_valid_dir
 published_examples = os.path.join(os.path.dirname(metadata_dir), 'published_code')
 
 
+@pytest.mark.serial
 def test_skeleton_pypi(testing_workdir):
     """published in docs at http://conda.pydata.org/docs/build_tutorials/pkgs.html"""
     cmd = 'conda skeleton pypi pyinstrument'


### PR DESCRIPTION
This replaces the string template with what is essentially a nested ordered dict (`ruamel_yaml.comments.CommentedMap`) and writes the recipe out in conda-forge order. 

This needs a bit of cleanup still (feel free to do that, I won't be able to come back around to it until later on Sunday).

A few thoughts that I won't remember in the morning:

+ It would be nice to put the "standard order" variables (`EXPECTED_SECTION_ORDER`, `REQUIREMENTS_ORDER`, maybe `ABOUT_ORDER`) some place "standard" and have `conda skeleton` and `conda-smithy` import from that place rather than trying to keep the values synced across packages.
+ With a little refactoring I think the recipe generation conda build pulled out into a function that can take in either the dictionary `d` generated in `skeletonize` or metadata pulled from an existing recipe. With that change, with same function could be used to "conda forge-ify" existing recipes.
