### PR TITLE
remove existing entry points (esp. links) before writing new ones

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -622,6 +622,8 @@ def create_entry_point(path, module, func, config):
             copy_into(join(dirname(__file__), 'cli-{}.exe'.format(config.arch)),
                     path + '.exe', config.timeout)
     else:
+        if os.path.islink(path):
+            os.remove(path)
         with open(path, 'w') as fo:
             if not config.noarch:
                 fo.write('#!%s\n' % config.build_python)


### PR DESCRIPTION
For conda especially, what was happening was that writing the new entry points was following the symlink through to the root environment, causing the root env conda to break.