### PR TITLE
Do not add setuptools to runtime dependencies

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -700,7 +700,8 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
             setuptools_build = False
             setuptools_run = False
         d['build_depends'] = ['setuptools'] * setuptools_build + deps
-        d['run_depends'] = ['setuptools'] * setuptools_run + deps
+        # Never add setuptools to runtime dependencies.
+        d['run_depends'] = deps
 
         if recursive:
             for dep in deps:


### PR DESCRIPTION
`skeleton pypi` currently adds `setuptools` to both `build` and `run` dependencies if it is not already present in the dependencies extracted from `setup.py`. My understanding is that `setuptools` should not be needed at run time, only at build time. 

This PR drops the addition of `setuptools` to the `run` requirements; if the package explicitly lists `setuptools` as a requirement in `setup.py` then it remains in the list of dependencies.