### PR TITLE
Add filename to order function so that filenames with identical filesizes are sorted alphabetically

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -752,7 +752,7 @@ def bundle_conda(output, metadata, env, **kw):
             fsize = os.stat(join(metadata.config.host_prefix, f)).st_size or 100000
             # info/* records will be False == 0, others will be 1.
             info_order = int(os.path.dirname(f) != 'info')
-            return info_order, fsize
+            return info_order, fsize, f
 
         # add files in order of a) in info directory, b) increasing size so
         # we can access small manifest or json files without decompressing

--- a/tests/test-recipes/metadata/_conda_build/bld.bat
+++ b/tests/test-recipes/metadata/_conda_build/bld.bat
@@ -1,0 +1,8 @@
+python setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1
+
+del %SCRIPTS%\conda-init
+if errorlevel 1 exit 1
+
+copy bdist_conda.py %PREFIX%\Lib\distutils\command\
+if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/_conda_build/build.sh
+++ b/tests/test-recipes/metadata/_conda_build/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python setup.py install --single-version-externally-managed --record=record.txt
+
+cp bdist_conda.py ${PREFIX}/lib/python${PY_VER}/distutils/command

--- a/tests/test-recipes/metadata/_conda_build/meta.yaml
+++ b/tests/test-recipes/metadata/_conda_build/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: conda-build
+  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+
+source:
+  git_url: https://github.com/conda/conda-build.git
+
+build:
+  number: 0
+  entry_points:
+    - conda-build = conda_build.cli.main_build:main
+    - conda-convert = conda_build.cli.main_convert:main
+    - conda-develop = conda_build.cli.main_develop:main
+    - conda-index = conda_build.cli.main_index:main
+    - conda-inspect = conda_build.cli.main_inspect:main
+    - conda-metapackage = conda_build.cli.main_metapackage:main
+    - conda-render = conda_build.cli.main_render:main
+    - conda-skeleton = conda_build.cli.main_skeleton:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - beautifulsoup4
+    - chardet
+    - conda  >=4.3
+    - conda-verify
+    - contextlib2   # [py<34]
+    - enum34        # [py<34]
+    - filelock
+    - futures       # [py<3]
+    - jinja2
+    - patchelf      # [linux]
+    - pkginfo
+    - python
+    - pyyaml
+    - six
+    - glob2
+
+
+about:
+  home: https://github.com/conda/conda-build
+  license: BSD 3-clause

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1184,10 +1184,11 @@ def test_archive_ordering(testing_workdir):
 
     archive = tarfile.open(outputs[0])
 
-    # the last three files in 'archive' have identical file sizes
-    # so we will test them for ordering
-    archive_names = [tarinfo.name for tarinfo in archive]
-    archive_sizes = [tarinfo.size for tarinfo in archive]
+    member_information = [(tarinfo.name, tarinfo.size) for tarinfo in archive]
 
-    assert archive_names[-3:] == sorted(archive_names[-3:])
-    assert archive_sizes[-3:] == sorted(archive_sizes[-3:])
+    # if two consecutive files have the same filesize, we need to check
+    # that their filenames are sorted correctly
+    for i in range(len(member_information) - 1):
+        if member_information[i][1] == member_information[i + 1][1]:
+            same_sized_files = [member_information[i][0], member_information[i + 1][0]]
+            assert same_sized_files == sorted(same_sized_files)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1176,3 +1176,18 @@ def test_pin_depends(testing_config):
     if PY3 and hasattr(requires, 'decode'):
         requires = requires.decode()
     assert re.search('python\=[23]\.', requires), "didn't find pinned python in info/requires"
+
+
+def test_archive_ordering(testing_workdir):
+    recipe = os.path.join(metadata_dir, '_conda_build')
+    outputs = api.build(recipe)
+
+    archive = tarfile.open(outputs[0])
+
+    # the last three files in 'archive' have identical file sizes
+    # so we will test them for ordering
+    archive_names = [tarinfo.name for tarinfo in archive]
+    archive_sizes = [tarinfo.size for tarinfo in archive]
+
+    assert archive_names[-3:] == sorted(archive_names[-3:])
+    assert archive_sizes[-3:] == sorted(archive_sizes[-3:])


### PR DESCRIPTION
In relation to reproducibility (issue #2140), this PR adds the filename of the file as a last resort when ordering. Now, two files with identical filesizes will be sorted alphabetically.