### PR TITLE
Only write one build script to build file and warn when multiple scripts found

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1043,9 +1043,9 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
             else:
                 build_file = join(m.path, 'build.sh')
                 if isfile(build_file) and script:
-                    raise CondaBuildException("Found a build.sh script and a build script "
+                    raise CondaBuildException("Found a build.sh script and a build/script section"
                                               "inside meta.yaml. Either remove the build.sh "
-                                              "script or remove the build script in meta.yaml.")
+                                              "script or remove the build/script section in meta.yaml.")
                 # There is no sense in trying to run an empty build script.
                 if isfile(build_file) or script:
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1042,6 +1042,10 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                 windows.build(m, build_file)
             else:
                 build_file = join(m.path, 'build.sh')
+                if isfile(build_file) and script:
+                    utils.get_logger(__name__).warn("Found a build.sh script and a build script "
+                                      "inside meta.yaml. The build script in meta.yaml "
+                                      "will be used.")
                 # There is no sense in trying to run an empty build script.
                 if isfile(build_file) or script:
 
@@ -1075,7 +1079,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                                  m.config.host_prefix))
                         if script:
                                 bf.write(script)
-                        if isfile(build_file):
+                        if isfile(build_file) and not script:
                             bf.write(open(build_file).read())
 
                     os.chmod(work_file, 0o766)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -53,7 +53,7 @@ from conda_build.post import (post_process, post_build,
                               fix_permissions, get_build_metadata)
 
 from conda_build.index import update_index
-from conda_build.exceptions import indent, DependencyNeedsBuildingError
+from conda_build.exceptions import indent, DependencyNeedsBuildingError, CondaBuildException
 from conda_build.variants import (set_language_env_vars, dict_of_lists_to_list_of_dicts,
                                   get_package_variants)
 from conda_build.create_test import (create_files, create_shell_files, create_r_files,
@@ -1043,9 +1043,9 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
             else:
                 build_file = join(m.path, 'build.sh')
                 if isfile(build_file) and script:
-                    utils.get_logger(__name__).warn("Found a build.sh script and a build script "
-                                      "inside meta.yaml. The build script in meta.yaml "
-                                      "will be used.")
+                    raise CondaBuildException("Found a build.sh script and a build script "
+                                              "inside meta.yaml. Either remove the build.sh "
+                                              "script or remove the build script in meta.yaml.")
                 # There is no sense in trying to run an empty build script.
                 if isfile(build_file) or script:
 


### PR DESCRIPTION
fixes #2231

If a build.sh exists and a script value exists in meta.yaml's build field, conda build will build with the script found in meta.yaml. Also a warning will be raised to let the user know that two scripts exist.

I tried adding a test for the warning that used capfd to capture stderr, but there's too much output from the build process for capfd to capture.