### PR TITLE
Remove user specific information from about.json

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -382,30 +382,6 @@ def write_about_json(m):
             if value:
                 d[key] = value
 
-        # for sake of reproducibility, record some conda info
-        d['conda_version'] = conda_version
-        d['conda_build_version'] = conda_build_version
-        # conda env will be in most, but not necessarily all installations.
-        #    Don't die if we don't see it.
-        stripped_channels = []
-        for channel in get_rc_urls() + list(m.config.channel_urls):
-            stripped_channels.append(sanitize_channel(channel))
-        d['channels'] = stripped_channels
-        evars = ['PATH', 'PYTHONPATH', 'PYTHONHOME', 'CONDA_DEFAULT_ENV',
-                 'CIO_TEST', 'CONDA_ENVS_PATH']
-
-        if cc_platform == 'linux':
-            evars.append('LD_LIBRARY_PATH')
-        elif cc_platform == 'osx':
-            evars.append('DYLD_LIBRARY_PATH')
-        d['env_vars'] = {ev: os.getenv(ev, '<not set>') for ev in evars}
-        # this information will only be present in conda 4.2.10+
-        try:
-            d['conda_private'] = conda_private
-        except (KeyError, AttributeError):
-            pass
-        env = environ.Environment(root_dir)
-        d['root_pkgs'] = env.package_specs()
         json.dump(d, fo, indent=2, sort_keys=True)
 
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -620,19 +620,10 @@ def test_noarch_foo_value(testing_config):
 def test_about_json_content(testing_metadata):
     outputs = api.build(testing_metadata)
     about = json.loads(package_has_file(outputs[0], 'info/about.json').decode())
-    assert 'conda_version' in about and about['conda_version'] == conda.__version__
-    assert 'conda_build_version' in about and about['conda_build_version'] == __version__
-    assert 'channels' in about and about['channels']
-    try:
-        assert 'env_vars' in about and about['env_vars']
-    except AssertionError:
-        # new versions of conda support this, so we should raise errors.
-        if VersionOrder(conda.__version__) >= VersionOrder('4.2.10'):
-            raise
-        else:
-            pass
 
-    assert 'root_pkgs' in about and about['root_pkgs']
+    assert 'sweet home' in about['home']
+    assert 'contract in blood' in about['license']
+    assert 'a test package' in about['summary']
 
 
 @pytest.mark.xfail(parse_version(conda.__version__) < parse_version("4.3.14"),


### PR DESCRIPTION
In relation to #2140, this PR removes the writing of user specific information to about.json. I spoke with @kalefranz and @abarto and neither conda nor Anaconda.org uses the metadata from about.json. I wasn't sure if it was safe to remove the about.json file completely so I limited the content to package information.