### PR TITLE
Fix bugs related to multiple sources

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -380,7 +380,8 @@ def meta_vars(meta, config):
 
     git_exe = external.find_executable('git', config.build_prefix)
     if git_exe and os.path.exists(git_dir):
-        git_url = meta.get_value('source/git_url')
+        # We set all 'source' metavars using the FIRST source entry in meta.yaml.
+        git_url = meta.get_value('source/0/git_url')
 
         if os.path.exists(git_url):
             if sys.platform == 'win32':
@@ -396,9 +397,9 @@ def meta_vars(meta, config):
                                  git_url,
                                  config.git_commits_since_tag,
                                  config.debug,
-                                 meta.get_value('source/git_rev', 'HEAD'))
+                                 meta.get_value('source/0/git_rev', 'HEAD'))
 
-        if _x or meta.get_value('source/path'):
+        if _x or meta.get_value('source/0/path'):
             d.update(get_git_info(git_exe, git_dir, config.debug))
 
     elif external.find_executable('hg', config.build_prefix) and os.path.exists(hg_dir):

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -605,7 +605,7 @@ def provide(metadata, patch=True):
                        verbose=metadata.config.verbose, timeout=metadata.config.timeout,
                        locking=metadata.config.locking)
         elif 'path' in source_dict:
-            path = normpath(abspath(join(metadata.path, metadata.get_value('source/path'))))
+            path = normpath(abspath(join(metadata.path, source_dict['path'])))
             if metadata.config.verbose:
                 print("Copying %s to %s" % (path, src_dir))
             # careful here: we set test path to be outside of conda-build root in setup.cfg.

--- a/tests/test-recipes/metadata/source_multiple/bld.bat
+++ b/tests/test-recipes/metadata/source_multiple/bld.bat
@@ -1,0 +1,25 @@
+rem Check that second source was fetched properly
+if not exist second-source exit 1
+cd second-source
+if not exist .git exit 1
+git config core.fileMode false
+if errorlevel 1 exit 1
+git describe --tags --dirty
+if errorlevel 1 exit 1
+for /f "delims=" %%i in ('git describe') do set gitdesc=%%i
+if errorlevel 1 exit 1
+echo "%gitdesc%"
+if not "%gitdesc%"=="1.20.2" exit 1
+git status
+if errorlevel 1 exit 1
+cd ..
+
+rem Check that GIT_* tags are present
+rem Note that these describe the first source, not the second one.
+for %%i in (GIT_DESCRIBE_TAG GIT_DESCRIBE_NUMBER GIT_DESCRIBE_HASH GIT_FULL_HASH) DO (
+  if defined %%i (
+      echo %%i
+  ) else (
+    exit 1
+  )
+)

--- a/tests/test-recipes/metadata/source_multiple/build.sh
+++ b/tests/test-recipes/metadata/source_multiple/build.sh
@@ -1,0 +1,18 @@
+# Check that second source was fetched properly
+[ -d second-source ]
+cd second-source
+[ -d .git ]
+git describe
+[ "$(git describe)" = 1.20.2 ]
+cd -
+
+# Check if GIT_* variables are defined
+# Note that these describe the first source, not the second one.
+for i in GIT_DESCRIBE_TAG GIT_DESCRIBE_NUMBER GIT_DESCRIBE_HASH GIT_FULL_HASH
+do
+  if [ -n "eval $i" ]; then
+    eval echo \$$i
+  else
+    exit 1
+  fi
+done

--- a/tests/test-recipes/metadata/source_multiple/meta.yaml
+++ b/tests/test-recipes/metadata/source_multiple/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: conda-build-test-source-multiple
+  version: 1.0
+
+source:
+  - path: ../../../../../conda_build_test_recipe
+
+  - git_url: https://github.com/conda/conda_build_test_recipe
+    git_tag: 1.20.2
+    folder: second-source


### PR DESCRIPTION
After #1929, a single recipe may specify multiple source repos (fixing #1466).  In that case, the metadata `source` section is written as a **list** of source dicts instead of a single dict:

```yaml
source:
  - git_url: https://github.com/foo/foo
    git_tag: 1.0

  - git_url: https://github.com/foo/bar
    git_tag: 1.1
    folder: bar
```

But that breaks an assumption in the convenience function `MetaData.get_value()` -- that every section is a `dict`.  Calls like `meta.get_value('source/git_url')` result in errors.  For example:

```pytb
  File "/miniforge/lib/python3.6/site-packages/conda_build/metadata.py", line 888, in get_value
    value = self.get_section(section).get(key, default)
AttributeError: 'list' object has no attribute 'get'
```

~~This PR "fixes" the problem by merely assuming the caller is interested in the FIRST source in the list.~~

If you don't like this proposal, here are some alternative solutions we could consider:
- ~~Add an assertion to forbid using `MetaData.get_value()` for the `source` section altogether, and require callers to check the type of `meta.get_section('source')` themselves.~~
- Extend `MetaData.get_value()` to support indexes, e.g. `meta.get_value('source/0/git_url')`.

cc: @msarahan (Since you authored #1929)