### PR TITLE
Add source cache to config and remove conda legacy imports

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -259,8 +259,8 @@ different sets of packages."""
               "failure.")
     )
     p.add_argument(
-        '--cache',
-        help=('Path to store the source files during the build.'),
+        '--cache-dir',
+        help=('Path to store the source files (archives, git clones, etc.) during the build.'),
     )
     add_parser_channels(p)
 

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -258,6 +258,10 @@ different sets of packages."""
         help=("When running tests, keep going after each failure.  Default is to stop on the first "
               "failure.")
     )
+    p.add_argument(
+        '--cache',
+        help=('Path to store the source files during the build.'),
+    )
     add_parser_channels(p)
 
     args = p.parse_args(args)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -66,6 +66,7 @@ DEFAULTS = [Setting('activate', True),
             Setting('token', None),
             Setting('user', None),
             Setting('verbose', True),
+            
             Setting('debug', False),
             Setting('timeout', 90),
             Setting('set_build_id', True),
@@ -81,6 +82,7 @@ DEFAULTS = [Setting('activate', True),
             Setting('_host_arch', None),
             Setting('filename_hashing', True),
             Setting('keep_old_work', False),
+            Setting('_src_cache_root', None),
 
             Setting('index', None),
 
@@ -170,7 +172,11 @@ class Config(object):
             set_lang(self.variant, lang)
 
         self._build_id = kwargs.get('build_id', getattr(self, '_build_id', ""))
+        source_cache = kwargs.get('cache')
         croot = kwargs.get('croot')
+
+        if source_cache:
+            self._src_cache_root = os.path.abspath(os.path.normpath(source_cache))
         if croot:
             self._croot = os.path.abspath(os.path.normpath(croot))
         else:
@@ -276,6 +282,14 @@ class Config(object):
     @target_subdir.setter
     def target_subdir(self, value):
         self._target_subdir = value
+
+    @property
+    def src_cache_root(self):
+        return self._src_cache_root if self._src_cache_root else self.croot
+
+    @src_cache_root.setter
+    def src_cache_root(self, value):
+        self._src_cache_root = value
 
     @property
     def croot(self):
@@ -503,28 +517,28 @@ class Config(object):
     @property
     def src_cache(self):
         """Where tarballs and zip files are downloaded and stored"""
-        path = join(self.croot, 'src_cache')
+        path = join(self.src_cache_root, 'src_cache')
         _ensure_dir(path)
         return path
 
     @property
     def git_cache(self):
         """Where local clones of git sources are stored"""
-        path = join(self.croot, 'git_cache')
+        path = join(self.src_cache_root, 'git_cache')
         _ensure_dir(path)
         return path
 
     @property
     def hg_cache(self):
         """Where local clones of hg sources are stored"""
-        path = join(self.croot, 'hg_cache')
+        path = join(self.src_cache_root, 'hg_cache')
         _ensure_dir(path)
         return path
 
     @property
     def svn_cache(self):
         """Where local checkouts of svn sources are stored"""
-        path = join(self.croot, 'svn_cache')
+        path = join(self.src_cache_root, 'svn_cache')
         _ensure_dir(path)
         return path
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -66,7 +66,7 @@ DEFAULTS = [Setting('activate', True),
             Setting('token', None),
             Setting('user', None),
             Setting('verbose', True),
-            
+
             Setting('debug', False),
             Setting('timeout', 90),
             Setting('set_build_id', True),
@@ -172,7 +172,7 @@ class Config(object):
             set_lang(self.variant, lang)
 
         self._build_id = kwargs.get('build_id', getattr(self, '_build_id', ""))
-        source_cache = kwargs.get('cache')
+        source_cache = kwargs.get('cache_dir')
         croot = kwargs.get('croot')
 
         if source_cache:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -19,12 +19,6 @@ from conda_build.utils import (tar_xf, unzip, safe_print_unicode, copy_into, on_
                                check_output_env, check_call_env, convert_path_for_cygwin_or_msys2,
                                get_logger, rm_rf, LoggingContext)
 
-# legacy exports for conda
-from .config import Config as _Config
-SRC_CACHE = _Config().src_cache
-GIT_CACHE = _Config().git_cache
-SVN_CACHE = _Config().svn_cache
-HG_CACHE = _Config().hg_cache
 
 if on_win:
     from conda_build.utils import convert_unix_path_to_win

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1106,3 +1106,17 @@ def test_dependencies_with_notest(testing_workdir, testing_config):
 
     assert 'Unsatisfiable dependencies for platform' in str(excinfo.value)
     assert 'somenonexistentpackage1' in str(excinfo.value)
+
+
+def test_source_cache_build(testing_workdir):
+    recipe = os.path.join(metadata_dir, 'source_git_jinja2')
+    config = api.Config(src_cache_root=testing_workdir)
+    api.build(recipe, notest=True, config=config)
+
+    git_cache_directory = '{}/git_cache' .format(testing_workdir)
+    assert os.path.isdir(git_cache_directory)
+
+    files = [filename for _, _, filenames in os.walk(git_cache_directory)
+             for filename in filenames]
+
+    assert len(files) > 0


### PR DESCRIPTION
Add src_cache_root to Config objects and allow setting via --cache command line flag.