### PR TITLE
do not modify user-specified build/string with hash

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -89,7 +89,7 @@ def get_output_file_paths(recipe_path_or_metadata, no_download_source=False, con
     elif isinstance(recipe_path_or_metadata, string_types):
         # first, render the parent recipe (potentially multiple outputs, depending on variants).
         metadata = render(recipe_path_or_metadata, no_download_source=no_download_source,
-                            variants=variants, config=config, **kwargs)
+                            variants=variants, config=config, finalize=True, **kwargs)
     else:
         assert hasattr(recipe_path_or_metadata, 'config'), ("Expecting metadata object - got {}"
                                                             .format(recipe_path_or_metadata))

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -207,12 +207,18 @@ def copy_recipe(m):
                 utils.copy_into(src_path, dst_path, timeout=output_metadata.config.timeout,
                                 locking=output_metadata.config.locking, clobber=True)
 
+        # hard code the build string, so that tests don't get it mixed up
+        build = output_metadata.meta.get('build', {})
+        build['string'] = output_metadata.build_id()
+        output_metadata.meta['build'] = build
+
         # just for lack of confusion, don't show outputs in final rendered recipes
         if 'outputs' in output_metadata.meta:
             del output_metadata.meta['outputs']
 
         utils.sort_list_in_nested_structure(output_metadata.meta,
                                             ('build/script', 'test/commands'))
+
         rendered = output_yaml(output_metadata)
 
         if not original_recipe or not open(original_recipe).read() == rendered:
@@ -1492,6 +1498,9 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
                                             max_env_retry=metadata.config.max_env_retry,
                                             output_folder=metadata.config.output_folder,
                                             channel_urls=tuple(metadata.config.channel_urls))
+
+    # ensure that the test prefix isn't kept between variants
+    utils.rm_rf(metadata.config.test_prefix)
     environ.create_env(metadata.config.test_prefix, actions, config=metadata.config, env='host',
                         subdir=subdir, is_cross=metadata.is_cross)
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -411,6 +411,10 @@ def meta_vars(meta, config):
     d['PKG_BUILDNUM'] = str(meta.build_number() or 0)
     if meta.final:
         d['PKG_BUILD_STRING'] = str(meta.build_id())
+        d['PKG_HASH'] = meta.hash_dependencies()
+    else:
+        d['PKG_BUILD_STRING'] = 'placeholder'
+        d['PKG_HASH'] = '1234567'
     d['RECIPE_DIR'] = (meta.path if meta.path else
                        meta.meta.get('extra', {}).get('parent_recipe', {}).get('path', ''))
     return d

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -337,8 +337,6 @@ def finalize_metadata(m, permit_unsatisfiable_variants=False):
 
     if not rendered_metadata.meta.get('build'):
         rendered_metadata.meta['build'] = {}
-    # hard-code build string so that any future "renderings" can't go wrong based on user env
-    rendered_metadata.meta['build']['string'] = rendered_metadata.build_id()
 
     if build_unsat or host_unsat:
         rendered_metadata.final = False

--- a/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
+++ b/tests/test-recipes/metadata/source_git_jinja2/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER|int }}
-  string: py{{ CONDA_PY }}h1234567_{{ GIT_DESCRIBE_NUMBER|int }}_g{{ GIT_FULL_HASH[:7] }}
+  string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ GIT_DESCRIBE_NUMBER|int }}_g{{ GIT_FULL_HASH[:7] }}
 
 requirements:
   build:

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -129,9 +129,9 @@ def test_git_describe_info_on_branch(testing_config):
     recipe_path = os.path.join(metadata_dir, "_git_describe_number_branch")
     m = api.render(recipe_path, config=testing_config)[0][0]
     output = api.get_output_file_path(m)[0]
-    _hash = m._hash_dependencies()
+    # missing hash because we set custom build string in meta.yaml
     test_path = os.path.join(testing_config.croot, testing_config.host_subdir,
-                    "git_describe_number_branch-1.20.2.0-{}_1_g82c6ba6.tar.bz2".format(_hash))
+                    "git_describe_number_branch-1.20.2.0-1_g82c6ba6.tar.bz2")
     assert test_path == output
 
 
@@ -172,7 +172,7 @@ def test_output_build_path_git_source(testing_workdir, testing_config):
     recipe_path = os.path.join(metadata_dir, "source_git_jinja2")
     m = api.render(recipe_path, config=testing_config)[0][0]
     output = api.get_output_file_paths(m)[0]
-    _hash = m._hash_dependencies()
+    _hash = m.hash_dependencies()
     test_path = os.path.join(testing_config.croot, testing_config.host_subdir,
                     "conda-build-test-source-git-jinja2-1.20.2-py{}{}{}_0_g262d444.tar.bz2".format(
                         sys.version_info.major, sys.version_info.minor, _hash))
@@ -426,7 +426,7 @@ def test_build_metadata_object(testing_metadata):
 def test_numpy_setup_py_data(testing_config):
     recipe_path = os.path.join(metadata_dir, '_numpy_setup_py_data')
     m = api.render(recipe_path, config=testing_config, numpy="1.11")[0][0]
-    _hash = m._hash_dependencies()
+    _hash = m.hash_dependencies()
     assert os.path.basename(api.get_output_file_path(m)[0]) == \
                             "load_setup_py_test-1.0a1-np111py{0}{1}{2}_1.tar.bz2".format(
                                 sys.version_info.major, sys.version_info.minor, _hash)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,7 +85,7 @@ def test_render_output_build_path(testing_workdir, testing_metadata, capfd, capl
     metadata = api.render(testing_workdir, debug=False, verbose=False)[0][0]
     args = ['--output', os.path.join(testing_workdir)]
     main_render.execute(args)
-    _hash = metadata._hash_dependencies()
+    _hash = metadata.hash_dependencies()
     test_path = os.path.join(sys.prefix, "conda-bld", testing_metadata.config.host_subdir,
                              "test_render_output_build_path-1.0-py{}{}{}_1.tar.bz2".format(
                                  sys.version_info.major, sys.version_info.minor, _hash))
@@ -101,7 +101,7 @@ def test_build_output_build_path(testing_workdir, testing_metadata, testing_conf
     metadata = api.render(testing_workdir, config=testing_config)[0][0]
     args = ['--output', os.path.join(testing_workdir)]
     main_build.execute(args)
-    _hash = metadata._hash_dependencies()
+    _hash = metadata.hash_dependencies()
     test_path = os.path.join(sys.prefix, "conda-bld", testing_config.host_subdir,
                                   "test_build_output_build_path-1.0-py{}{}{}_1.tar.bz2".format(
                                       sys.version_info.major, sys.version_info.minor, _hash))
@@ -120,7 +120,7 @@ def test_build_output_build_path_multiple_recipes(testing_workdir, testing_metad
 
     main_build.execute(args)
 
-    _hash = metadata._hash_dependencies()
+    _hash = metadata.hash_dependencies()
     test_path = lambda pkg: os.path.join(sys.prefix, "conda-bld", testing_config.host_subdir, pkg)
     test_paths = [test_path(
         "test_build_output_build_path_multiple_recipes-1.0-py{}{}{}_1.tar.bz2".format(
@@ -216,7 +216,7 @@ def test_render_output_build_path_set_python(testing_workdir, testing_metadata, 
     args = ['--output', testing_workdir, '--python', version]
     main_render.execute(args)
 
-    _hash = metadata._hash_dependencies()
+    _hash = metadata.hash_dependencies()
     test_path = "test_render_output_build_path_set_python-1.0-py{}{}{}_1.tar.bz2".format(
                                       version.split('.')[0], version.split('.')[1], _hash)
     output, error = capfd.readouterr()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -184,29 +184,11 @@ def test_compiler_metadata_cross_compiler():
     assert 'fortran-compiler-linux_osx-109-x86_64' in metadata.meta['requirements']['build']
 
 
-req = 'zlib 1.2.8 '
-if sys.platform == 'win32':
-    vc_ver = '9' if sys.version_info[0] == 2 else '14'
-    req += 'vc{}_'.format(vc_ver)
-req += '3'
-test_reqs = [req]
-if sys.platform == 'win32':
-    test_reqs.append('vc {}'.format(vc_ver))
-
-
 def test_hash_build_id(testing_metadata):
-    testing_metadata.meta['requirements']['build'] = test_reqs
-    testing_metadata = render.finalize_metadata(testing_metadata)
-    if sys.platform == 'win32':
-        if sys.version_info[0] == 2:
-            assert testing_metadata._hash_dependencies() == 'h5e09b76'
-            assert testing_metadata.build_id() == 'h5e09b76_1'
-        else:
-            assert testing_metadata._hash_dependencies() == 'h32e72be'
-            assert testing_metadata.build_id() == 'h32e72be_1'
-    else:
-        assert testing_metadata._hash_dependencies() == 'hed137b3'
-        assert testing_metadata.build_id() == 'hed137b3_1'
+    testing_metadata.meta['requirements']['build'] = ['zlib 1.2.8']
+    testing_metadata.final = True
+    assert testing_metadata.hash_dependencies() == 'h90ec539'
+    assert testing_metadata.build_id() == 'h90ec539_1'
 
 
 def test_hash_build_id_key_order(testing_metadata):
@@ -216,29 +198,16 @@ def test_hash_build_id_key_order(testing_metadata):
     newdeps = deps[:]
     newdeps.insert(0, 'steve')
     testing_metadata.meta['requirements']['build'] = newdeps
-    hash_pre = testing_metadata._hash_dependencies()
+    hash_pre = testing_metadata.hash_dependencies()
 
     # next, append
     newdeps = deps[:]
     newdeps.append('steve')
     testing_metadata.meta['requirements']['build'] = newdeps
-    hash_post = testing_metadata._hash_dependencies()
+    hash_post = testing_metadata.hash_dependencies()
 
     # make sure they match
     assert hash_pre == hash_post
-
-
-def test_hash_applies_to_custom_build_string(testing_metadata):
-    testing_metadata.meta['build']['string'] = 'steve'
-    testing_metadata.meta['requirements']['build'] = test_reqs
-    testing_metadata = render.finalize_metadata(testing_metadata)
-    if sys.platform == 'win32':
-        if sys.version_info[0] == 2:
-            assert testing_metadata.build_id() == 'steveh5e09b76'
-        else:
-            assert testing_metadata.build_id() == 'steveh32e72be'
-    else:
-        assert testing_metadata.build_id() == 'stevehbcfeb9f'
 
 
 def test_config_member_decoupling(testing_metadata):


### PR DESCRIPTION
fixes #2245 

This also makes the hash available as the PKG_HASH env var, usable in build scripts and in meta.yaml, should the user want to put it in themselves.  It does not include the leading h.