### PR TITLE
ignore feature records in index for 'conda inspect'

### DIFF
--- a/conda_build/inspect.py
+++ b/conda_build/inspect.py
@@ -164,6 +164,10 @@ def test_installable(channel='defaults'):
             if name in {'conda', 'conda-build'}:
                 # conda can only be installed in the root environment
                 continue
+            if name.endswith('@'):
+                # this is a 'virtual' feature record that conda adds to the index for the solver
+                # and should be ignored here
+                continue
             # Don't fail just because the package is a different version of Python
             # than the default.  We should probably check depends rather than the
             # build string.


### PR DESCRIPTION
This problem surfaced via https://github.com/conda/conda/pull/5645.  Conda has always added "virtual" feature records to the `index`.  It was never a problem here because there were so few of them in the past.  Now there are a few more, and specifically feature records for python, which is the source of the particular collision here.

The way feature records for the solver are identified in `index` is that the name field ends with an `@` character.