### PR TITLE
Selector improvements with variants

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -74,7 +74,8 @@ class FilteredLoader(jinja2.BaseLoader):
         from .metadata import select_lines, ns_cfg
         contents, filename, uptodate = self._unfiltered_loader.get_source(environment,
                                                                           template)
-        return select_lines(contents, ns_cfg(self.config)), filename, uptodate
+        return (select_lines(contents, ns_cfg(self.config),
+                             variants_in_place=bool(self.config.variant)), filename, uptodate)
 
 
 def load_setup_py_data(config, setup_file='setup.py', from_recipe_dir=False, recipe_dir=None,

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -8,7 +8,7 @@ import sys
 import six
 import yaml
 
-from conda_build.utils import ensure_list, HashableDict
+from conda_build.utils import ensure_list, HashableDict, trim_empty_keys
 from conda_build.conda_interface import string_types
 from conda_build.conda_interface import subdir
 from conda_build.conda_interface import cc_conda_build
@@ -257,6 +257,9 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts, platform=cc_platform):
     # here's where we add in the zipped dimensions
     for group in _get_zip_groups(combined):
         dimensions.update(group)
+
+    # in case selectors nullify any groups - or else zip reduces whole set to nil
+    trim_empty_keys(dimensions)
 
     for x in product(*dimensions.values()):
         remapped = dict(six.moves.zip(dimensions, x))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -46,7 +46,7 @@ test {{ JINJA_VAR[:2] }} # [abc] stuff yes
 {{ environ["test"] }}  # [abc]
 """
 
-    assert select_lines(lines, {'abc': True}) == """
+    assert select_lines(lines, {'abc': True}, variants_in_place=True) == """
 test
 test [abc] no
 test [abc] # no
@@ -61,7 +61,7 @@ test {{ JINJA_VAR[:2] }}
 test {{ JINJA_VAR[:2] }}
 {{ environ["test"] }}
 """
-    assert select_lines(lines, {'abc': False}) == """
+    assert select_lines(lines, {'abc': False}, variants_in_place=True) == """
 test
 test [abc] no
 test [abc] # no


### PR DESCRIPTION
- Fix empty dimensions resulting from selectors operating on conda_build_config.yaml
- Allow variables provided in conda_build_config.yaml to be used in selector expressions