### PR TITLE
WIP: fix PROCESSOR_ARCHITECTURE coming out as None on win

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -237,6 +237,7 @@ def build(m, bld_bat):
             fo.write(data)
 
         cmd = ['cmd.exe', '/c', 'bld.bat']
-        check_call_env(cmd, cwd=src_dir)
+        import ipdb; ipdb.set_trace()
+        check_call_env(cmd, cwd=src_dir, env=env)
 
     fix_staged_scripts(join(m.config.build_prefix, 'Scripts'))

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1142,3 +1142,12 @@ def test_copy_test_source_files(testing_config):
         else:
             assert not copy, "'info/test/' not found in tar.bz2 but copying test source files"
     assert len(filenames) == 2, "copy_test_source_files does not modify the build hash but should"
+
+
+@pytest.mark.skipif(not on_win, reason="windows-only variables tested here")
+def test_cpu_vars_win(testing_metadata):
+    testing_metadata.meta['build']['script'] = ['echo %PROCESSOR_ARCHITECTURE%',
+            ("python -c \"import os; "
+             "assert os.environ['PROCESSOR_ARCHITECTURE'] == 'AMD64', "
+             "'PROCESSOR_ARCHITECTURE is {}'.format(os.environ['PROCESSOR_ARCHITECTURE'])\"")]
+    api.build(testing_metadata)


### PR DESCRIPTION
fixes #2257 

Right now, this is only a test that reproduces the issue.  I need to work more on figuring out why this comes out wrong.