### PR TITLE
metadata: Fix mistake in get_value() (bug from #2247)

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -924,7 +924,7 @@ class MetaData(object):
             if len(section_data) == 0:
                 section_data = {}
             else:
-                section_data = section_data[0]
+                section_data = section_data[index]
                 assert isinstance(section_data, dict), \
                     "Expected {}/{} to be a dict".format(section, index)
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -63,6 +63,11 @@ def test_multiple_different_sources(testing_metadata):
     assert os.path.exists(os.path.join(testing_metadata.config.work_dir, 'f1', 'a'))
     assert os.path.exists(os.path.join(testing_metadata.config.work_dir, 'f2', 'README.md'))
 
+    # Test get_value() indexing syntax.
+    assert testing_metadata.get_value('source/url') == testing_metadata.meta['source'][0]['url']
+    assert testing_metadata.get_value('source/0/url') == testing_metadata.meta['source'][0]['url']
+    assert (testing_metadata.get_value('source/1/git_url')
+            == testing_metadata.meta['source'][1]['git_url'])
 
 def test_git_into_existing_populated_folder_raises(testing_metadata):
     """Git will not clone into a non-empty folder.  This should raise an exception."""


### PR DESCRIPTION
Well, this is embarrassing.  Last week I submitted a PR (#2247) which had a small bug in it.  If someone uses the new "index" syntax for `get_value()` with a non-zero index (e.g. `meta.get_value('source/2/git_url')`), it won't work.  Oops.

This isn't affecting anyone right now, because at the moment no part of conda-build calls `get_value()` with a non-zero index.  But here's a fix nonetheless.  (With a test case!)
