### PR TITLE
WIP fixes setting target in outputs section

### DIFF
--- a/conda_build/tarcheck.py
+++ b/conda_build/tarcheck.py
@@ -82,7 +82,7 @@ class TarCheck(object):
 
     def correct_subdir(self):
         info = json.loads(self.t.extractfile('info/index.json').read().decode('utf-8'))
-        assert info['subdir'] in [self.config.host_subdir, 'noarch'], \
+        assert info['subdir'] in [self.config.host_subdir, 'noarch', self.config.target_subdir], \
             ("Inconsistent subdir in package - index.json expecting {0},"
              " got {1}".format(self.config.host_subdir, info['subdir']))
 


### PR DESCRIPTION
Resolves #2264 

## Problem

setting target in the outputs section would go through the whole build process and fail at the end with an error like this:
```
Inconsistent subdir in package - index.json expecting linux-64 got win-64
```

## Solution

Add target_subdir to the assert statements allowed values in tarcheck.py. This allows the value in the outputs section's target to be valid during this check. This also doesn't interfere with the other allowed values and shouldn't have any side effects.

## Testing

I have tested building a package on windows with the target hard coded to linux-64, it worked as expected. I also tested building a package which utilizes the ```conda_build_config.yaml``` for cross compiling and a normal package built and hosted on the same config. All worked as expected.