### PR TITLE
Fix cran skeleton so that fields are not truncated by a semicolon.

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -288,7 +288,8 @@ def dict_from_cran_lines(lines):
             line = line.split(':')
             if len(line) < 2 and line[0] in CRAN_KEYS_CAN_BE_BLANK:
                 continue
-            (k, v) = line[:2]
+            k = line[0]
+            v = ':'.join(line[1:])
         except ValueError:
             sys.exit("Error: Could not parse metadata (%s)" % line)
         d[k.strip()] = v.strip()


### PR DESCRIPTION
When using `conda skeleton cran` to create recipes for R packages, I noticed that the URL for the home field was always truncated. By testing this on previous versions of conda-build, I determined this bug was introduced in PR https://github.com/conda/conda-build/pull/2153 to fix https://github.com/conda/conda/issues/5624 and released in version [3.0.2](https://github.com/conda/conda-build/tree/3.0.2).

This is how the home and summary fields look in the recipe for r-corpcor created by the most recent release of conda-build (3.0.9):

```
$ conda install conda-build=3.0.9
$ conda skeleton cran corpcor
$ grep home r-corpcor/meta.yaml 
  home: http
$ grep -A 3 summary r-corpcor/meta.yaml 
  summary: Implements a James-Stein-type shrinkage estimator for  the covariance matrix, with
    separate shrinkage for variances and correlations.   The details of the method are
    explained in Schafer and Strimmer (2005)  <DOI
  license_family: GPL3
```

This is how the home and summary fields look in the recipe for r-corpcor created by conda-build after applying my fix:

```
$ cd conda-build/
$ conda build conda.recipe/
$ conda install --use-local --yes conda-build
$ conda skeleton cran corpcor
$ grep home r-corpcor/meta.yaml
  home: http://strimmerlab.org/software/corpcor/
$ grep -A 12 summary r-corpcor/meta.yaml
  summary: Implements a James-Stein-type shrinkage estimator for  the covariance matrix, with
    separate shrinkage for variances and correlations.   The details of the method are
    explained in Schafer and Strimmer (2005)  <DOI:10.2202/1544-6115.1175> and Opgen-Rhein
    and Strimmer (2007)  <DOI:10.2202/1544-6115.1252>.  The approach is both computationally
    as well as statistically very efficient, it is applicable to "small n, large p"
    data,  and always returns a positive definite and well-conditioned covariance matrix.   In
    addition to inferring the covariance matrix the package also provides  shrinkage
    estimators for partial correlations and partial variances.   The inverse of the
    covariance and correlation matrix  can be efficiently computed, as well as any arbitrary
    power of the  shrinkage correlation matrix.  Furthermore, functions are available
    for fast  singular value decomposition, for computing the pseudoinverse, and for  checking
    the rank and positive definiteness of a matrix.
  license_family: GPL3
```