### PR TITLE
fix double activation on windows for cross-compiling

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -57,7 +57,8 @@ def render(recipe_path, config=None, variants=None, permit_unsatisfiable_variant
                     except (DependencyNeedsBuildingError, NoPackagesFoundError):
                         if not permit_unsatisfiable_variants:
                             raise
-                output_metas[om.dist()] = ((om, download, render_in_env))
+                output_metas[om.dist(), om.config.variant.get('target_platform')] = \
+                    ((om, download, render_in_env))
     return list(output_metas.values())
 
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1089,9 +1089,8 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                 open(history_file, 'a').close()
 
                             if m.is_cross:
-                                # HACK: we need both build and host envs
-                                #     "active" - i.e. on PATH, and with their
-                                #     activate.d scripts sourced. Conda only
+                                # HACK: we need both build and host envs "active" - i.e. on PATH,
+                                #     and with their activate.d scripts sourced. Conda only
                                 #     lets us activate one, though. This is a
                                 #     vile hack to trick conda into "stacking"
                                 #     two environments.
@@ -1110,6 +1109,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                         os.makedirs(dirname(history_file))
                                     open(history_file, 'a').close()
                                 bf.write('unset CONDA_PATH_BACKUP\n')
+                                bf.write('export CONDA_MAX_SHLVL=2\n')
                                 bf.write('source "{0}activate" "{1}"\n'
                                          .format(utils.root_script_dir + os.path.sep,
                                                  m.config.host_prefix))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1747,6 +1747,9 @@ class MetaData(object):
                     self.config.variants)
         return variants.get_loop_vars(_variants)
 
+    def get_variants_as_dict_of_lists(self):
+        return variants.list_of_dicts_to_dict_of_lists(self.config.variants)
+
     def clean(self):
         """This ensures that clean is called with the correct build id"""
         self.config.clean()

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -449,7 +449,10 @@ def distribute_variants(metadata, variants, permit_unsatisfiable_variants=False,
                 compiler_key = '{}_compiler'.format(match)
                 conform_dict[compiler_key] = variant.get(compiler_key,
                                         native_compiler(match, mv.config))
-                conform_dict['target_platform'] = variant['target_platform']
+
+        # target_platform is *always* a locked dimension, because top-level recipe is always
+        #    particular to a platform.
+        conform_dict['target_platform'] = variant['target_platform']
 
         build_reqs = mv.meta.get('requirements', {}).get('build', [])
         host_reqs = mv.meta.get('requirements', {}).get('host', [])
@@ -486,7 +489,8 @@ def distribute_variants(metadata, variants, permit_unsatisfiable_variants=False,
         #     on the current meta.yaml.  The accuracy doesn't matter, all that matters is
         #     our ability to differentiate configurations
         fm.final = True
-        rendered_metadata[fm.dist()] = (mv, need_source_download, None)
+        rendered_metadata[(fm.dist(), fm.config.variant['target_platform'])] = \
+                          (mv, need_source_download, None)
 
     # list of tuples.
     # each tuple item is a tuple of 3 items:

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -290,6 +290,7 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
         return
     squished = {}
     all_zip_keys = set()
+    groups = None
     if 'zip_keys' in list_of_dicts[0]:
         if ('zip_keys' in list_of_dicts[0]['zip_keys'] and
                 isinstance(list_of_dicts[0]['zip_keys'][0], list)):
@@ -311,6 +312,12 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
                 squished[k] = squished.get(k, []) + ensure_list(v)
                 if k not in all_zip_keys:
                     squished[k] = list(set(squished[k]))
+    # reduce the combinatoric space of the zipped keys, too:
+    if groups:
+        for group in groups:
+            values = list(zip(*set(zip(*(squished[key] for key in group)))))
+            for idx, key in enumerate(group):
+                squished[key] = values[idx]
     return squished
 
 
@@ -364,5 +371,6 @@ def get_loop_vars(variants):
     """For purposes of naming/identifying, provide a way of identifying which variables contribute
     to the matrix dimensionality"""
     special_keys = ('pin_run_as_build', 'zip_keys', 'ignore_version')
-    return [k for k in variants[0] if k not in special_keys and
+    loop_vars = [k for k in variants[0] if k not in special_keys and
             any(variant[k] != variants[0][k] for variant in variants[1:])]
+    return loop_vars


### PR DESCRIPTION
Also collapses zipped fields better, so there aren't any duplicate garbage entries in the output conda_build_config.yml when saving out recipes.

fixes #2276 