### PR TITLE
fix run_exports getting picked up transitively

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1017,8 +1017,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
 
         with utils.path_prepended(m.config.build_prefix):
             try_download(m, no_download_source=False)
-        if need_source_download:
-            m.final = False
+        if need_source_download and not m.final:
             m.parse_until_resolved(allow_no_other_outputs=True)
 
         elif need_reparse_in_env:

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -508,7 +508,7 @@ def unix_vars(prefix):
 def osx_vars(compiler_vars, config):
     OSX_ARCH = 'i386' if config.arch == 32 else 'x86_64'
     MACOSX_DEPLOYMENT_TARGET = os.environ.get('MACOSX_DEPLOYMENT_TARGET',
-                                              config.variant.get('MACOSX_DEPLOYMENT_TARGET', '10.9'))
+                                       config.variant.get('MACOSX_DEPLOYMENT_TARGET', '10.9'))
     compiler_vars['CFLAGS'] += ' -arch {0}'.format(OSX_ARCH)
     compiler_vars['CXXFLAGS'] += ' -arch {0}'.format(OSX_ARCH)
     compiler_vars['LDFLAGS'] += ' -arch {0}'.format(OSX_ARCH)

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -30,13 +30,6 @@ DEFAULT_VARIANTS = {
 
 arch_name = subdir.rsplit('-', 1)[-1]
 
-DEFAULT_PLATFORMS = {
-    'linux': 'linux-' + arch_name,
-    'osx': 'osx-' + arch_name,
-    'win': 'win-' + arch_name,
-}
-
-
 SUFFIX_MAP = {'PY': 'python',
               'NPY': 'numpy',
               'LUA': 'lua',
@@ -241,11 +234,10 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts, platform=cc_platform):
 
     combined, extend_keys = combine_specs(specs)
 
-    if 'target_platform' not in combined or not combined['target_platform']:
-        try:
-            combined['target_platform'] = [DEFAULT_PLATFORMS[platform]]
-        except KeyError:
-            combined['target_platform'] = [DEFAULT_PLATFORMS[platform.split('-')[0]]]
+    # default target platform is native subdir
+    # if 'target_platform' not in combined:
+    #     from conda_build.config import Config
+    #     combined['target_platform'] = [Config().subdir]
 
     if 'extend_keys' in combined:
         del combined['extend_keys']
@@ -342,12 +334,14 @@ def get_package_variants(recipedir_or_metadata, config=None):
 
     specs = get_default_variants(config.platform) + [parse_config_file(f, config) for f in files]
 
+    target_platform_default = [{'target_platform': config.subdir}]
     # this is the override of the variants from files and args with values from CLI or env vars
     if config.variant:
-        combined_spec, extend_keys = combine_specs(specs + [config.variant])
+        combined_spec, extend_keys = combine_specs(target_platform_default + specs +
+                                                   [config.variant])
     else:
         # this tweaks behavior from clobbering to appending/extending
-        combined_spec, extend_keys = combine_specs(specs)
+        combined_spec, extend_keys = combine_specs(target_platform_default + specs)
 
     # clobber the variant with anything in the config (stuff set via CLI flags or env vars)
     for k, v in config.variant.items():

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -882,11 +882,11 @@ def test_append_python_app_osx(testing_config):
 
 
 @pytest.mark.serial
-def test_run_exports(testing_metadata, testing_config):
+def test_run_exports(testing_metadata, testing_config, testing_workdir):
     api.build(os.path.join(metadata_dir, '_run_exports'), config=testing_config)
     testing_metadata.meta['requirements']['build'] = ['test_has_run_exports']
-    testing_metadata.config.index = None
-    m = finalize_metadata(testing_metadata)
+    api.output_yaml(testing_metadata, 'meta.yaml')
+    m = api.render(testing_workdir, config=testing_config)[0][0]
     assert 'downstream_pinned_package 1.0' in m.meta['requirements']['run']
 
 

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -51,7 +51,7 @@ def test_get_output_file_path(testing_workdir, testing_metadata):
     testing_metadata = render.finalize_metadata(testing_metadata)
     api.output_yaml(testing_metadata, 'recipe/meta.yaml')
 
-    build_path = api.get_output_file_path(os.path.join(testing_workdir, 'recipe'),
+    build_path = api.get_output_file_paths(os.path.join(testing_workdir, 'recipe'),
                                           config=testing_metadata.config,
                                           no_download_source=True)[0]
     _hash = testing_metadata.hash_dependencies()
@@ -64,7 +64,7 @@ def test_get_output_file_path(testing_workdir, testing_metadata):
 
 def test_get_output_file_path_metadata_object(testing_metadata):
     testing_metadata.final = True
-    build_path = api.get_output_file_path(testing_metadata)[0]
+    build_path = api.get_output_file_paths(testing_metadata)[0]
     _hash = testing_metadata.hash_dependencies()
     python = ''.join(testing_metadata.config.variant['python'].split('.')[:2])
     assert build_path == os.path.join(testing_metadata.config.croot,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,8 +100,8 @@ def test_no_filename_hash(testing_workdir, testing_metadata, capfd):
     args = ['--no-anaconda-upload', '--no-activate', testing_workdir, '--old-build-string']
     main_build.execute(args)
     output, error = capfd.readouterr()
-    assert not re.search('h[0-9a-f]{%d}' % testing_metadata.config.hash_length, output)
-    assert not re.search('h[0-9a-f]{%d}' % testing_metadata.config.hash_length, error)
+    assert not re.search('test_no_filename_hash.*h[0-9a-f]{%d}' % testing_metadata.config.hash_length, output)
+    assert not re.search('test_no_filename_hash.*h[0-9a-f]{%d}' % testing_metadata.config.hash_length, error)
 
 
 def test_render_output_build_path(testing_workdir, testing_metadata, capfd, caplog):

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -67,11 +67,11 @@ def test_subpackage_independent_hash(testing_metadata):
 def test_run_exports_in_subpackage(testing_metadata):
     p1 = testing_metadata.copy()
     p1.meta['outputs'] = [{'name': 'has_run_exports', 'run_exports': 'bzip2 1.0'}]
-    output = api.build(p1)[0]
-    api.update_index(os.path.dirname(output), config=testing_metadata.config)
+    api.build(p1)[0]
+    # api.update_index(os.path.dirname(output), config=testing_metadata.config)
     p2 = testing_metadata.copy()
     p2.meta['requirements']['build'] = ['has_run_exports']
-    p2.config.index = None
+    p2.original_meta = p2.meta.copy()
     p2_final = finalize_metadata(p2)
     assert 'bzip2 1.0' in p2_final.meta['requirements']['run']
 


### PR DESCRIPTION
This fixes the problem where indirect dependencies would impose run dependencies.  For example, python uses xz.  Packages depending on python should not necessarily have a dependency on xz imposed.