### PR TITLE
fix CONDA_PY env format (no period)

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -139,12 +139,19 @@ def combine_variants(*variants):
 
 
 def set_language_env_vars(variant):
-    """Given args passed into conda command, set language env vars to be made available"""
+    """Given args passed into conda command, set language env vars to be made available.
+
+    Search terms: CONDA_PY, CONDA_R, CONDA_PERL, CONDA_LUA, CONDA_NPY
+    """
     inverse_map = {v: k for k, v in SUFFIX_MAP.items()}
     env = {}
     for variant_name, env_var_name in inverse_map.items():
         if variant_name in variant:
-            env['CONDA_' + env_var_name] = str(variant[variant_name])
+            value = str(variant[variant_name])
+            # legacy compatibility: python should be just first
+            if env_var_name == 'PY':
+                value = ''.join(value.split('.')[:2])
+            env['CONDA_' + env_var_name] = value
     return env
 
 

--- a/tests/test-recipes/metadata/python_env_defined/run_test.py
+++ b/tests/test-recipes/metadata/python_env_defined/run_test.py
@@ -3,6 +3,7 @@ import os
 assert os.getenv('PYTHON')
 assert os.getenv('PY_VER')
 assert os.getenv('CONDA_PY')
+assert '.' not in os.getenv('CONDA_PY')
 assert os.getenv('STDLIB_DIR')
 assert os.getenv('SP_DIR')
 assert os.getenv('PY3K')


### PR DESCRIPTION
fixes #2302 

@dhirschfeld CONDA_PY will remain the same.  PY_VER will have the period.  It doesn't make sense to have them both be the same value, IMHO.  I'll try to update the docs if I get a minute.