### PR TITLE
create strong run_exports delineation.  Default weak

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -462,10 +462,15 @@ def get_entry_point_script_names(entry_point_scripts):
 
 
 def write_run_exports(m):
-    if m.meta.get('build', {}).get('run_exports'):
-        with open(os.path.join(m.config.info_dir, 'run_exports'), 'w') as f:
-            for pin in utils.ensure_list(m.meta['build']['run_exports']):
-                f.write(pin + "\n")
+    run_exports = m.meta.get('build', {}).get('run_exports', {})
+    if run_exports:
+        with open(os.path.join(m.config.info_dir, 'run_exports.yaml'), 'w') as f:
+            if not hasattr(run_exports, 'keys'):
+                run_exports = {'weak': run_exports}
+            for k in ('weak', 'strong'):
+                if k in run_exports:
+                    run_exports[k] = utils.ensure_list(run_exports[k])
+            yaml.dump(run_exports, f)
 
 
 def create_info_files(m, files, prefix):

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -920,7 +920,7 @@ def get_pkginfo(package, filename, pypiurl, digest, python_version, extra_specs,
                     setup_options=setup_options)
         try:
             with open(join(tempdir, 'pkginfo.yaml')) as fn:
-                pkg_info = yaml.load(fn)
+                pkg_info = yaml.safe_load(fn)
         except IOError:
             pkg_info = pkginfo.SDist(download_path).__dict__
         if new_hash_value:
@@ -944,7 +944,7 @@ def run_setuppy(src_dir, temp_dir, python_version, extra_specs, config, setup_op
     #    needs it in recent versions.  At time of writing, it is not a package in defaults, so this
     #    actually breaks conda-build right now.  Omit it until packaging is on defaults.
     # specs = ['python %s*' % python_version, 'pyyaml', 'setuptools', 'six', 'packaging', 'appdirs']
-    specs = ['python %s*' % python_version, 'pyyaml']
+    specs = ['python %s*' % python_version, 'pyyaml', 'setuptools']
     with open(os.path.join(src_dir, "setup.py")) as setup:
         text = setup.read()
         if 'import numpy' in text or 'from numpy' in text:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1069,7 +1069,7 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
     # should be able to override conda-build's logger settings here.
     if config_file:
         with open(config_file) as f:
-            config_dict = yaml.load(f)
+            config_dict = yaml.safe_load(f)
         logging.config.dictConfig(config_dict)
         level = config_dict.get('loggers', {}).get(name, {}).get('level', level)
     log = logging.getLogger(name)

--- a/tests/test-recipes/metadata/_osx_is_app_missing_python_app/meta.yaml
+++ b/tests/test-recipes/metadata/_osx_is_app_missing_python_app/meta.yaml
@@ -14,5 +14,8 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
+    # pkg_resources used; needs setuptools
+    - setuptools

--- a/tests/test-recipes/metadata/_run_exports/meta.yaml
+++ b/tests/test-recipes/metadata/_run_exports/meta.yaml
@@ -4,4 +4,7 @@ package:
 
 build:
   run_exports:
-    - downstream_pinned_package 1.0
+    strong:
+      - strong_pinned_package 1.0
+    weak:
+      - weak_pinned_package 1.0

--- a/tests/test-recipes/metadata/_run_exports_implicit_weak/meta.yaml
+++ b/tests/test-recipes/metadata/_run_exports_implicit_weak/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: test_has_run_exports_implicit_weak
+  version: 1.0
+
+build:
+  run_exports:
+    - weak_pinned_package 2.0

--- a/tests/test-recipes/metadata/entry_points/meta.yaml
+++ b/tests/test-recipes/metadata/entry_points/meta.yaml
@@ -17,5 +17,6 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python

--- a/tests/test-recipes/metadata/extra_freeform_metadata/run_test.py
+++ b/tests/test-recipes/metadata/extra_freeform_metadata/run_test.py
@@ -13,7 +13,7 @@ def main():
     source_file = os.path.join(info['link']['source'],
                                'info', 'recipe', 'meta.yaml')
     with open(source_file, 'r') as fh:
-        source = yaml.load(fh)
+        source = yaml.safe_load(fh)
 
     assert 'custom' in source['extra']
     assert 'however' in source['extra']

--- a/tests/test-recipes/metadata/jinja_load_setuptools/meta.yaml
+++ b/tests/test-recipes/metadata/jinja_load_setuptools/meta.yaml
@@ -10,6 +10,7 @@ source:
 requirements:
   build:
     - python
+    - setuptools
     {% for req in data.get('install_requires', []) -%}
     - {{req}}
     {% endfor %}

--- a/tests/test-recipes/metadata/osx_is_app/meta.yaml
+++ b/tests/test-recipes/metadata/osx_is_app/meta.yaml
@@ -14,6 +14,9 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
     - python.app
+    # pkg_resources used; needs setuptools
+    - setuptools

--- a/tests/test-recipes/metadata/preserve_egg_dir/meta.yaml
+++ b/tests/test-recipes/metadata/preserve_egg_dir/meta.yaml
@@ -12,5 +12,6 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -182,8 +182,7 @@ def test_pypi_section_order_preserved(testing_workdir):
         lines = [l for l in file.readlines() if not l.startswith("{%")]
 
     # The loader below preserves the order of entries...
-    recipe = ruamel_yaml.load('\n'.join(lines),
-                              Loader=ruamel_yaml.RoundTripLoader)
+    recipe = ruamel_yaml.load('\n'.join(lines), Loader=ruamel_yaml.RoundTripLoader)
 
     major_sections = list(recipe.keys())
     # Blank fields are omitted when skeletonizing, so prune any missing ones

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,7 @@ def test_render_add_channel():
         rendered_filename = os.path.join(tmpdir, 'out.yaml')
         args = ['-c', 'conda_build_test', os.path.join(metadata_dir, "_recipe_requiring_external_channel"), '--file', rendered_filename]
         main_render.execute(args)
-        rendered_meta = yaml.load(open(rendered_filename, 'r'))
+        rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
         required_package_string = [pkg for pkg in rendered_meta['requirements']['build'] if 'conda_build_test_requirement' in pkg][0]
         required_package_details = required_package_string.split(' ')
         assert len(required_package_details) > 1, "Expected version number on successful rendering, but got only {}".format(required_package_details)
@@ -85,7 +85,7 @@ def test_render_without_channel_fails():
         rendered_filename = os.path.join(tmpdir, 'out.yaml')
         args = ['--override-channels', '-c', 'conda', os.path.join(metadata_dir, "_recipe_requiring_external_channel"), '--file', rendered_filename]
         main_render.execute(args)
-        rendered_meta = yaml.load(open(rendered_filename, 'r'))
+        rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
         required_package_string = [pkg for pkg in rendered_meta['requirements']['build'] if 'conda_build_test_requirement' in pkg][0]
         assert required_package_string == 'conda_build_test_requirement', \
                "Expected to get only base package name because it should not be found, but got :{}".format(required_package_string)

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -67,7 +67,7 @@ def test_subpackage_independent_hash(testing_metadata):
 def test_run_exports_in_subpackage(testing_metadata):
     p1 = testing_metadata.copy()
     p1.meta['outputs'] = [{'name': 'has_run_exports', 'run_exports': 'bzip2 1.0'}]
-    api.build(p1)[0]
+    api.build(p1, config=testing_metadata.config)[0]
     # api.update_index(os.path.dirname(output), config=testing_metadata.config)
     p2 = testing_metadata.copy()
     p2.meta['requirements']['build'] = ['has_run_exports']


### PR DESCRIPTION
There are some run_exports that should cross the build/host boundary.  For example, the runtime deps imposed by compilers specified in build should affect the end run dependencies.  However, for other build-time dependencies that exist only for utility (such as xz for unarchiving), things in build should be ignored.

This PR creates the "strong" or "weak" distinction.  It is completely optional.  Everything is "weak" by default, and the old syntax works.  The new syntax for strong run_exports is:

```
build:
  run_exports:
    strong:
      - some_dep
    weak:
      - something_else
```

When run_exports has a value that is a list, all of the list items are "weak".