### PR TITLE
remove meaningless error with glob_files during env creation

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -996,8 +996,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         if (not m.config.dirty or not os.path.isdir(m.config.build_prefix) or
                 not os.listdir(m.config.build_prefix)):
             environ.create_env(m.config.build_prefix, build_actions, env='build', config=m.config,
-                               subdir=m.config.build_subdir, is_cross=m.is_cross,
-                               always_include_files=m.always_include_files())
+                               subdir=m.config.build_subdir, is_cross=m.is_cross)
 
         # this check happens for the sake of tests, but let's do it before the build so we don't
         #     make people wait longer only to see an error

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -723,7 +723,7 @@ def get_install_actions(prefix, specs, env, retries=0, subdir=None,
 
 
 def create_env(prefix, specs_or_actions, env, config, subdir, clear_cache=True, retry=0,
-               locks=None, is_cross=False, always_include_files=[]):
+               locks=None, is_cross=False):
     '''
     Create a conda envrionment for the given prefix and specs.
     '''


### PR DESCRIPTION
fixes #2318 

@gabm, I am able to build conda perfectly fine with conda-build master and this recipe: https://github.com/AnacondaRecipes/conda-feedstock/blob/master/recipe/meta.yaml

I have inspected the built package, and it contains proper activate/deactivate/conda scripts, so I think the symlinking stuff (or rather, not symlinking, so that these files are real) is working OK.  We had an issue a little while ago where the symlinks were not being broken, and so we ended up writing through from the build env into the user's root env.  That should be fixed as of https://github.com/conda/conda-build/pull/2209

The error messages you posted in #2318 were annoying, but seemed ultimately harmless.  Just messy code from too many changes.  This PR cleans it up.  always_include_files when creating the environments was not actually used in that function.  Must have been some earlier notion.