### PR TITLE
add .* to specs that are underspecified (variants in run/test esp)

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -327,6 +327,7 @@ def finalize_metadata(m, permit_unsatisfiable_variants=False):
     full_build_dep_versions = {dep.split()[0]: " ".join(dep.split()[1:]) for dep in full_build_deps}
     versioned_run_deps = [get_pin_from_build(m, dep, full_build_dep_versions) for dep in run_deps]
     versioned_run_deps.extend(extra_run_specs)
+    versioned_run_deps = [utils.ensure_valid_spec(spec, warn=True) for spec in versioned_run_deps]
 
     for _env, values in (('build', build_deps), ('host', host_deps), ('run', versioned_run_deps)):
         if values:
@@ -340,6 +341,8 @@ def finalize_metadata(m, permit_unsatisfiable_variants=False):
     if test_deps:
         versioned_test_deps = list({get_pin_from_build(m, dep, full_build_dep_versions)
                                     for dep in test_deps})
+        versioned_test_deps = [utils.ensure_valid_spec(spec, warn=True)
+                               for spec in versioned_test_deps]
         rendered_metadata.meta['test']['requires'] = versioned_test_deps
     rendered_metadata.meta['extra']['copy_test_source_files'] = m.config.copy_test_source_files
 

--- a/tests/test-recipes/variants/14_variant_in_run_and_test/conda_build_config.yaml
+++ b/tests/test-recipes/variants/14_variant_in_run_and_test/conda_build_config.yaml
@@ -1,0 +1,8 @@
+click:
+  - 6
+pytest:
+  - 3.2
+pytest_cov:
+  - 2.3
+pytest_mock:
+  - 1.6

--- a/tests/test-recipes/variants/14_variant_in_run_and_test/meta.yaml
+++ b/tests/test-recipes/variants/14_variant_in_run_and_test/meta.yaml
@@ -1,0 +1,21 @@
+# in this recipe, both the click variant and the pytest variant are underspecified for conda.
+#   In conda-build <3.0.15, this recipe will fail, with unsatisfiable dependencies.  In 3.0.15,
+#   we add .* to underspecified variant versions in run and test deps, but we also warn people
+#   that it would be better if they used better specs (provide .* themselves, or use >/< expressions
+
+package:
+  name: test_variant_in_run_and_test
+  version: 1.0
+
+requirements:
+  build:
+    - python
+  run:
+    - click  {{ click }}
+
+test:
+  requires:
+    - pytest  {{ pytest }}
+    # neither of these two should have warning messages
+    - pytest-cov  {{ pytest_cov }}.*
+    - pytest-mock  >={{ pytest_mock }}

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -892,8 +892,8 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     testing_metadata.meta['requirements']['build'] = ['test_has_run_exports']
     api.output_yaml(testing_metadata, 'meta.yaml')
     m = api.render(testing_workdir, config=testing_config)[0][0]
-    assert 'strong_pinned_package 1.0' in m.meta['requirements']['run']
-    assert 'weak_pinned_package 1.0' in m.meta['requirements']['run']
+    assert 'strong_pinned_package 1.0.*' in m.meta['requirements']['run']
+    assert 'weak_pinned_package 1.0.*' in m.meta['requirements']['run']
 
     #    2. host present.  Use run_exports from host, ignore 'weak' ones from build.  All are
     #           weak by default.
@@ -901,7 +901,7 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     testing_metadata.meta['requirements']['host'] = ['python']
     api.output_yaml(testing_metadata, 'meta.yaml')
     m = api.render(testing_workdir, config=testing_config)[0][0]
-    assert 'weak_pinned_package 2.0' not in m.meta['requirements']['run']
+    assert 'weak_pinned_package 2.0.*' not in m.meta['requirements']['run']
 
     #    3. host present, and deps in build have "strong" run_exports section.  use host, add
     #           in "strong" from build.
@@ -909,10 +909,11 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     testing_metadata.meta['requirements']['host'] = ['test_has_run_exports_implicit_weak']
     api.output_yaml(testing_metadata, 'meta.yaml')
     m = api.render(testing_workdir, config=testing_config)[0][0]
-    assert 'strong_pinned_package 1.0' in m.meta['requirements']['run']
+    assert 'strong_pinned_package 1.0.*' in m.meta['requirements']['run']
     # weak one from test_has_run_exports should be excluded, since it is a build dep
-    assert 'weak_pinned_package 1.0' not in m.meta['requirements']['run']
-    assert 'weak_pinned_package 2.0' in m.meta['requirements']['run']
+    assert 'weak_pinned_package 1.0.*' not in m.meta['requirements']['run']
+    assert 'weak_pinned_package 2.0.*' in m.meta['requirements']['run']
+
 
 @pytest.mark.serial
 def test_ignore_run_exports(testing_metadata, testing_config):

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -73,7 +73,7 @@ def test_run_exports_in_subpackage(testing_metadata):
     p2.meta['requirements']['build'] = ['has_run_exports']
     p2.original_meta = p2.meta.copy()
     p2_final = finalize_metadata(p2)
-    assert 'bzip2 1.0' in p2_final.meta['requirements']['run']
+    assert 'bzip2 1.0.*' in p2_final.meta['requirements']['run']
 
 
 # @pytest.mark.serial
@@ -241,9 +241,10 @@ def test_subpackage_hash_inputs(testing_config):
             assert utils.package_has_file(out, 'info/recipe/build.sh')
 
 
+@pytest.mark.serial
 def test_overlapping_files(testing_config, caplog):
     recipe_dir = os.path.join(subpackage_dir, '_overlapping_files')
+    utils.reset_deduplicator()
     outputs = api.build(recipe_dir, config=testing_config)
     assert len(outputs) == 3
-    # would be nice if this worked, but broken on Travis.  Works locally.  Catchlog 1.2.2
-    # assert caplog.text().count('Exact overlap') == 2
+    assert sum(int("Exact overlap" in rec.message) for rec in caplog.records) == 1

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -178,3 +178,15 @@ def test_variant_input_with_zip_keys_keeps_zip_keys_list():
                  'MACOSX_DEPLOYMENT_TARGET': '10.9', 'CONDA_BUILD_SYSROOT': '/opt/MacOSX10.9.sdk'}]
     variant_list = variants.dict_of_lists_to_list_of_dicts(variants_)
     assert len(variant_list) == 1
+
+
+@pytest.mark.serial
+def test_ensure_valid_spec_on_run_and_test(testing_workdir, testing_config, caplog):
+    recipe = os.path.join(recipe_dir, '14_variant_in_run_and_test')
+    api.render(recipe, config=testing_config)
+
+    text = caplog.text
+    assert "Adding .* to spec 'click  6'" in text
+    assert "Adding .* to spec 'pytest  3.2'" in text
+    assert "Adding .* to spec 'pytest-cov  2.3'" not in text
+    assert "Adding .* to spec 'pytest-mock  1.6'" not in text


### PR DESCRIPTION
fixes #2317 