### PR TITLE
use host_subdir instead of build_subdir when setting selectors

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -48,7 +48,7 @@ ARCH_MAP = {'32': 'x86',
 
 def ns_cfg(config):
     # Remember to update the docs of any of this changes
-    plat = config.build_subdir
+    plat = config.host_subdir
     d = dict(
         linux=plat.startswith('linux-'),
         linux32=bool(plat == 'linux-32'),


### PR DESCRIPTION
without this, running builds targeting win-32 on win-64 build workers will not evaluate x86_64 in selectors correctly.