### PR TITLE
add track_features and features to output options

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1666,6 +1666,10 @@ class MetaData(object):
             build['string'] = output['string']
         if 'run_exports' in output and output['run_exports']:
             build['run_exports'] = output['run_exports']
+        if 'track_features' in output and output['track_features']:
+            build['track_features'] = output['track_features']
+        if 'features' in output and output['features']:
+            build['features'] = output['features']
         output_metadata.meta['build'] = build
 
         return output_metadata


### PR DESCRIPTION
discovered this while trying to consolidate vs2008, vs2008_runtime, and vc 9 recipes into one recipe with split packages.  Split packages need to be able to set track_features independently of one another.