### PR TITLE
fix_staged_scripts needs to use host_prefix

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -267,4 +267,4 @@ def build(m, bld_bat):
         cmd = ['cmd.exe', '/c', 'bld.bat']
         check_call_env(cmd, cwd=src_dir)
 
-    fix_staged_scripts(join(m.config.build_prefix, 'Scripts'))
+    fix_staged_scripts(join(m.config.host_prefix, 'Scripts'))


### PR DESCRIPTION
With this change and our previous one I can now build win-32 python.