### PR TITLE
build_prefix->host_prefix in write_pth

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -96,7 +96,7 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
 def write_pth(egg_path, config):
     fn = os.path.basename(egg_path)
     py_ver = '.'.join(config.variant['python'].split('.')[:2])
-    with open(os.path.join(utils.get_site_packages(config.build_prefix, py_ver),
+    with open(os.path.join(utils.get_site_packages(config.host_prefix, py_ver),
                            '%s.pth' % (fn.split('-')[0])), 'w') as fo:
         fo.write('./%s\n' % fn)
 

--- a/conda_build/tarcheck.py
+++ b/conda_build/tarcheck.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import json
 from os.path import basename
-import re
 import tarfile
 
 from conda_build.utils import codec


### PR DESCRIPTION
Fixes cross-compiling errors with python packages like:

```
Traceback (most recent call last):
  File "C:\ProgramData\Miniconda3\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\cli\main_build.py", line 388, in main
    execute(sys.argv[1:])
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\cli\main_build.py", line 379, in execute
    noverify=args.no_verify)
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\api.py", line 185, in build
    need_source_download=need_source_download, config=config, variants=variants)
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\build.py", line 1773, in build_tree
    notest=notest,
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\build.py", line 1241, in build
    built_package = bundlers[output_d.get('type', 'conda')](output_d, m, env)
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\build.py", line 720, in bundle_conda
    files = post_process_files(metadata, initial_files)
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\build.py", line 643, in post_process_files
    skip_compile_pyc=m.get_value('build/skip_compile_pyc'))
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\post.py", line 233, in post_process
    remove_easy_install_pth(files, prefix, config, preserve_egg_dir=preserve_egg_dir)
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\post.py", line 116, in remove_easy_install_pth
    write_pth(egg_path, config=config)
  File "C:\ProgramData\Miniconda3\lib\site-packages\conda_build\post.py", line 100, in write_pth
    '%s.pth' % (fn.split('-')[0])), 'w') as fo:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\ci\\conda_1505503384710\\_build_env\\Lib\\site-packages\\conda.pth'
```

Here, python is not installed in _build_env - it is in _h_env instead, so of course this fails.