### PR TITLE
make strong run_exports apply to host section as well as run section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;
     else
-      conda install -c conda-forge -q perl;
+      conda install -c c3i_test -q perl;
       conda install -q pytest pip pytest-cov numpy mock;
       $HOME/miniconda/bin/pip install pytest-xdist==1.16.0 pytest-catchlog pytest-mock;
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -302,6 +302,10 @@ def finalize_metadata(m, permit_unsatisfiable_variants=False):
         host_deps, host_actions, host_unsat = get_env_dependencies(m, 'host', m.config.variant,
                                         exclude_pattern,
                                         permit_unsatisfiable_variants=permit_unsatisfiable_variants)
+        # extend host deps with strong build run exports.  This is important for things like
+        #    vc feature activation to work correctly in the host env.
+        if host_deps:
+            host_deps.extend(extra_run_specs_from_build.get('strong', []))
         extra_run_specs_from_host = get_upstream_pins(m, host_actions, 'host')
         extra_run_specs = set(extra_run_specs_from_host.get('strong', []) +
                               extra_run_specs_from_host.get('weak', []) +

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1025,7 +1025,7 @@ def test_only_r_env_vars_defined(testing_config):
 
 def test_only_perl_env_vars_defined(testing_config):
     recipe = os.path.join(metadata_dir, '_perl_env_defined')
-    testing_config.channel_urls = ('conda-forge', )
+    testing_config.channel_urls = ('c3i_test', )
     api.build(recipe, config=testing_config)
 
 


### PR DESCRIPTION
The problem that highlighted the need for this was libtiff:

```
requirements:
  build:
    - {{ compiler('c') }}
    - {{ compiler('cxx') }}
    - cmake   # [win]
  host:
    - zlib
    - jpeg
    - xz    # [not win]
```

On Windows, the C and CXX compilers will activate the correct feature, but that's only for build section.  It left the host section ambiguous, and so we ended up with conflicts when creating the host env.

This PR addresses the issue by applying the strong run_exports from the build section to the host section.  Strong run_exports are ones that cross from build to run, as opposed to weak run_exports which pass only from host to run.  Generally, strong run_exports should only be part of (cross) compiler packages, which can target a platform other than their native one.