### PR TITLE
fix strong run_export from build to host being applied too late

### DIFF
--- a/tests/test-recipes/metadata/_run_exports/meta.yaml
+++ b/tests/test-recipes/metadata/_run_exports/meta.yaml
@@ -8,3 +8,8 @@ build:
       - strong_pinned_package 1.0
     weak:
       - weak_pinned_package 1.0
+
+outputs:
+  - name: test_has_run_exports
+  - name: strong_pinned_package
+  - name: weak_pinned_package

--- a/tests/test-recipes/metadata/_run_exports_implicit_weak/meta.yaml
+++ b/tests/test-recipes/metadata/_run_exports_implicit_weak/meta.yaml
@@ -5,3 +5,8 @@ package:
 build:
   run_exports:
     - weak_pinned_package 2.0
+
+outputs:
+  - name: test_has_run_exports_implicit_weak
+  - name: weak_pinned_package
+    version: 2.0

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -909,6 +909,7 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     testing_metadata.meta['requirements']['host'] = ['test_has_run_exports_implicit_weak']
     api.output_yaml(testing_metadata, 'meta.yaml')
     m = api.render(testing_workdir, config=testing_config)[0][0]
+    assert any('strong_pinned_package 1.0' in req for req in m.meta['requirements']['host'])
     assert 'strong_pinned_package 1.0.*' in m.meta['requirements']['run']
     # weak one from test_has_run_exports should be excluded, since it is a build dep
     assert 'weak_pinned_package 1.0.*' not in m.meta['requirements']['run']


### PR DESCRIPTION
This was allowing incorrect things to happen because the actual pin was applied after we may have already obtained pins.  The end result was conflicting specs.