### PR TITLE
remove several relpath uses due to Windows drive mixing errors

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -579,11 +579,11 @@ class Config(object):
                 rm_rf(os.path.join(self.build_folder, 'prefix_files'))
         else:
             print("\nLeaving build/test directories:"
-                  "\n  Work:\t", os.path.relpath(self.work_dir),
-                  "\n  Test:\t", os.path.relpath(self.test_dir),
+                  "\n  Work:\t", self.work_dir,
+                  "\n  Test:\t", self.test_dir,
                   "\nLeaving build/test environments:"
-                  "\n  Test:\tsource activate ", os.path.relpath(self.test_prefix),
-                  "\n  Build:\tsource activate ", os.path.relpath(self.build_prefix),
+                  "\n  Test:\tsource activate ", self.test_prefix,
+                  "\n  Build:\tsource activate ", self.build_prefix,
                   "\n\n")
 
         for lock in get_conda_operation_locks(self.locking, self.bldpkgs_dirs):


### PR DESCRIPTION
Errors happen when recipe is on different drive than workdir (for example, recipe on shared drive mapped in, workdir on C:)

```
builder@DESKTOP-CB8H04D  /z/msarahan/code/aggregate
$ conda build curl-feedstock/
Attempting to finalize metadata for curl
INFO:conda_build.metadata:Attempting to finalize metadata for curl
Traceback (most recent call last):
  File "C:\Users\builder\Miniconda2\Scripts\conda-build-script.py", line 11, in <module>
    load_entry_point('conda-build', 'console_scripts', 'conda-build')()
  File "z:\msarahan\code\conda-build\conda_build\cli\main_build.py", line 388, in main
    execute(sys.argv[1:])
  File "z:\msarahan\code\conda-build\conda_build\cli\main_build.py", line 379, in execute
    noverify=args.no_verify)
  File "z:\msarahan\code\conda-build\conda_build\api.py", line 185, in build
    need_source_download=need_source_download, config=config, variants=variants)
  File "z:\msarahan\code\conda-build\conda_build\build.py", line 1825, in build_tree
    config.clean(remove_folders=False)
  File "z:\msarahan\code\conda-build\conda_build\config.py", line 582, in clean
    "\n  Work:\t", os.path.relpath(self.work_dir),
  File "C:\Users\builder\Miniconda2\lib\ntpath.py", line 529, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive C:, start on drive Z:
```