### PR TITLE
Remove .a from files not considered for prefix replacement

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -108,7 +108,7 @@ def have_prefix_files(files, prefix):
         double_backslash_prefix_bytes = double_backslash_prefix.encode(utils.codec)
 
     for f in files:
-        if f.endswith(('.pyc', '.pyo', '.a')):
+        if f.endswith(('.pyc', '.pyo')):
             continue
         path = join(prefix, f)
         if not isfile(path):


### PR DESCRIPTION
There is no reason on earth for this exclusion.