### PR TITLE
Simplify handling of blank fields in CRAN metadata.

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -149,10 +149,6 @@ CRAN_KEYS = [
     'Maintainer',
 ]
 
-CRAN_KEYS_CAN_BE_BLANK = [
-    'Suggests'
-]
-
 # The following base/recommended package names are derived from R's source
 # tree (R-3.0.2/share/make/vars.mk).  Hopefully they don't change too much
 # between versions.
@@ -285,14 +281,16 @@ def dict_from_cran_lines(lines):
         if not line:
             continue
         try:
-            line = line.split(':')
-            if len(line) < 2 and line[0] in CRAN_KEYS_CAN_BE_BLANK:
-                continue
-            k = line[0]
-            v = ':'.join(line[1:])
+            if ': ' in line:
+                (k, v) = line.split(': ', 1)
+            else:
+                # Sometimes fields are included but left blank, e.g.:
+                #   - Enhances in data.tree
+                #   - Suggests in corpcor
+                (k, v) = line.split(':', 1)
         except ValueError:
             sys.exit("Error: Could not parse metadata (%s)" % line)
-        d[k.strip()] = v.strip()
+        d[k] = v
         # if k not in CRAN_KEYS:
         #     print("Warning: Unknown key %s" % k)
     d['orig_lines'] = lines


### PR DESCRIPTION
## Summary

This PR re-implements a past solution for `conda skeleton cran` that handles blank entries for any field in CRAN metadata.

## Background

Sometimes R packages on CRAN have blank metadata fields (e.g. Suggests is blank for [corpcor](https://cran.r-project.org/web/packages/corpcor/DESCRIPTION) and Enhances is blank for [data.tree](https://cran.r-project.org/web/packages/data.tree/DESCRIPTION)). In the past this caused problems when running `conda skeleton cran`, e.g.:

* Issue #1787 from March 2017 for data.tree using conda-build 2.1.5
* Issue https://github.com/conda/conda/issues/5624 from July 2017 for corpcor using conda-build 2.1.16

One solution to this problem was provided on July 5th by @nehaljwani in commit https://github.com/conda/conda-build/pull/2153/commits/4d90305bf675a6ebe49b3ead162820338f74413c in PR https://github.com/conda/conda-build/pull/2153. The implementation was to create a global variable `CRAN_KEYS_CAN_BE_BLANK` that stored metadata fields known to be blank. This fixed the issue with creating a recipe for corpcor.

```
CRAN_KEYS_CAN_BE_BLANK = [
    'Suggests'
]
```

When I saw that Issue #1787 was still open, I figured that I could fix the data.tree recipe by adding `'Enhances'` to `CRAN_KEYS_CAN_BE_BLANK`. However to my surprise, `conda skeleton cran` was already able to create a recipe for data.tree. The reason is because the line that evaluates blank columns always evaluates to `False` because `'Enhances:'.split(':')` returns `['Enhances', '']`:

```
if len(line) < 2 and line[0] in CRAN_KEYS_CAN_BE_BLANK:
    continue
```

In researching this, I discovered that there was a separate solution submitted shortly beforehand. On Jun 14th, @mingwandroid submitted commit https://github.com/conda/conda-build/pull/2088/commits/c1fcde94f0cb0b7d2e7cfe4266e72f2d530776e9 in PR https://github.com/conda/conda-build/pull/2088:

```
if ': ' in line:
    (k, v) = line.split(': ', 1)
else:
    # Sometimes (leaflet) you get lines such as 'Depends:'
    (k, v) = line.split(':', 1)
```

The advantage to this solution is that it works for any blank entry without having to pre-define them. This solution was overwritten in commit https://github.com/conda/conda-build/commit/59e7dbd4a9eb5ca8ab6d0c2a1b24a8cd42430855?diff=split when PR #2153 was merged.

In this PR, I re-implemented the solution from @mingwandroid. I tested that it works for both corpcor and data.tree. It should also work for any other packages that have blank entries in other fields. In my opinion, this solution is easier to maintain, since we don't have to edit the skeleton file each time a new blank field is observed in CRAN metadata. And if a package is missing critical metadata (e.g. License), this solution will fail just the same as one that pre-defines all the fields that are safe to be blank.