### PR TITLE
prepare 2.1.x tests for enhanced package cache structure

### DIFF
--- a/tests/test-recipes/metadata/_legacy_noarch_python/run_test.py
+++ b/tests/test-recipes/metadata/_legacy_noarch_python/run_test.py
@@ -4,7 +4,16 @@ import subprocess
 import noarch_test_package
 
 pkgs_dir = os.path.abspath(os.path.join(os.environ["ROOT"], 'pkgs'))
-pkg_dir = os.path.join(pkgs_dir, 'noarch_test_package-1.0-py_0')
+package_dir_name = 'noarch_test_package-1.0-py_0'
+pkg_dir = os.path.join(pkgs_dir, package_dir_name)
+
+if not os.path.isdir(pkg_dir):
+    channel_name = os.path.basename(os.path.dirname(os.path.dirname(os.environ["PREFIX"])))
+    print("channel_name: %s" % channel_name)
+    pkg_dir = os.path.join(pkgs_dir, channel_name, 'noarch', package_dir_name)
+    print(pkg_dir)
+    if not os.path.isdir(pkg_dir):
+        raise RuntimeError("No pkg_dir found: %s" % pkg_dir)
 
 assert os.path.isdir(pkg_dir)
 

--- a/tests/test-recipes/metadata/_noarch_python_with_tests/run_test.py
+++ b/tests/test-recipes/metadata/_noarch_python_with_tests/run_test.py
@@ -4,7 +4,16 @@ import subprocess
 import noarch_python_test_package
 
 pkgs_dir = os.path.abspath(os.path.join(os.environ["ROOT"], 'pkgs'))
-pkg_dir = os.path.join(pkgs_dir, 'noarch_python_test_package-1.0-py_0')
+package_dir_name = 'noarch_python_test_package-1.0-py_0'
+pkg_dir = os.path.join(pkgs_dir, package_dir_name)
+
+if not os.path.isdir(pkg_dir):
+    channel_name = os.path.basename(os.path.dirname(os.path.dirname(os.environ["PREFIX"])))
+    print("channel_name: %s" % channel_name)
+    pkg_dir = os.path.join(pkgs_dir, channel_name, 'noarch', package_dir_name)
+    print(pkg_dir)
+    if not os.path.isdir(pkg_dir):
+        raise RuntimeError("No pkg_dir found: %s" % pkg_dir)
 
 assert os.path.isdir(pkg_dir)
 

--- a/tests/test-recipes/metadata/ignore_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/ignore_prefix_files/run_test.py
@@ -1,6 +1,16 @@
 import os
 
 pkgs = os.path.join(os.environ["ROOT"], "pkgs")
-info_dir = os.path.join(pkgs, "conda-build-test-ignore-prefix-files-1.0-0", "info")
+package_dir_name = "conda-build-test-ignore-prefix-files-1.0-0"
+info_dir = os.path.join(pkgs, package_dir_name, "info")
+
+if not os.path.isdir(info_dir):
+    channel_name = os.path.basename(os.path.dirname(os.path.dirname(os.environ["PREFIX"])))
+    print("channel_name: %s" % channel_name)
+    info_dir = os.path.join(pkgs, channel_name, os.environ["SUBDIR"], package_dir_name, "info")
+    print(info_dir)
+    if not os.path.isdir(info_dir):
+        raise RuntimeError("No info_dir found: %s" % info_dir)
+
 assert os.path.isdir(info_dir)
 assert not os.path.isfile(os.path.join(info_dir, "has_prefix"))

--- a/tests/test-recipes/metadata/ignore_some_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/ignore_some_prefix_files/run_test.py
@@ -1,9 +1,19 @@
 import os
 
 pkgs = os.path.join(os.environ["ROOT"], "pkgs")
-info_dir = os.path.join(pkgs, "conda-build-test-ignore-some-prefix-files-1.0-0", "info")
-has_prefix_file = os.path.join(info_dir, "has_prefix")
+package_dir_name = "conda-build-test-ignore-some-prefix-files-1.0-0"
+info_dir = os.path.join(pkgs, package_dir_name, "info")
 print(info_dir)
+
+if not os.path.isdir(info_dir):
+    channel_name = os.path.basename(os.path.dirname(os.path.dirname(os.environ["PREFIX"])))
+    print("channel_name: %s" % channel_name)
+    info_dir = os.path.join(pkgs, channel_name, os.environ["SUBDIR"], package_dir_name, "info")
+    print(info_dir)
+    if not os.path.isdir(info_dir):
+        raise RuntimeError("No info_dir found: %s" % info_dir)
+
+has_prefix_file = os.path.join(info_dir, "has_prefix")
 assert os.path.isfile(has_prefix_file)
 with open(has_prefix_file) as f:
     assert "test2" not in f.read()


### PR DESCRIPTION
Some minimal changes to tests to prepare them for compatibility with the enhanced package cache structure that might make it into conda 4.4.  Changes are only to tests that verify files in specific locations in the package cache.  No changes needed to main code.

This PR would be needed for test compatibility with https://github.com/conda/conda/pull/5937