### PR TITLE
load conda_build_config.yaml for test packages to set variables

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -602,8 +602,12 @@ def render_recipe(recipe_path, config, no_download_source=False, variants=None,
         try_download(m, no_download_source=no_download_source)
 
     if m.final:
-        if not hasattr(m.config, 'variants'):
-            m.config.variants = [m.config.variant]
+        if not hasattr(m.config, 'variants') or not m.config.variant:
+            m.config.ignore_system_variants = True
+            if os.path.isfile(os.path.join(m.path, 'conda_build_config.yaml')):
+                m.config.variant_config_files = [os.path.join(m.path, 'conda_build_config.yaml')]
+            m.config.variants = get_package_variants(m)
+            m.config.variant = m.config.variants[0]
         rendered_metadata = [(m, False, False), ]
     else:
         index, index_ts = get_build_index(m.config.build_subdir,

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -70,9 +70,9 @@ def find_config_files(metadata_or_path, additional_files=None, ignore_system_con
         if os.path.isfile(system_path):
             files.append(system_path)
 
-    cwd = os.path.join(os.getcwd(), 'conda_build_config.yaml')
-    if os.path.isfile(cwd):
-        files.append(cwd)
+        cwd = os.path.join(os.getcwd(), 'conda_build_config.yaml')
+        if os.path.isfile(cwd):
+            files.append(cwd)
 
     if hasattr(metadata_or_path, 'path'):
         recipe_config = os.path.join(metadata_or_path.path, "conda_build_config.yaml")


### PR DESCRIPTION
This loads conda_build_config.yaml from the package's info/recipe dir if available.  This facilitates testing, when testing depends on variables that may have been present at build time, are present in the variant, but otherwise not present in the test scripts.