### PR TITLE
Don’t strip generic files in noarch: python

### DIFF
--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -85,10 +85,11 @@ def handle_file(f, d, prefix):
     # Include examples in the metadata doc
     elif f.startswith(('Examples/', 'Examples\\')):
         d['Examples'].append(f[9:])
+    # No special treatment for other files
+    # leave them as-is
     else:
         log = logging.getLogger(__name__)
-        log.warn("Don't know how to handle file: %s.  Omitting it from package." % f)
-        os.unlink(path)
+        log.debug("Don't know how to handle file: %s.  Including it as-is." % f)
 
 
 def populate_files(m, files, prefix, entry_point_scripts=None):


### PR DESCRIPTION
This appears to have been simpler than I thought. Stripping unrecognized files prevents `noarch: python` packages from including data_files, such as those in `$PREFIX/share`. Simply removing the stripping appears to cause the correct behavior of including these files relative to $PREFIX as in a non-noarch package.

closes #2419