### PR TITLE
Fix pin compatible dependencies by removing tilde from dependency

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -619,7 +619,7 @@ def convert_version(version):
     version_parts = version.split('.')
     suffixes = ('post', 'pre')
     if any(suffix in version_parts[-1] for suffix in suffixes):
-        version_parts.remove(version_parts[-1])
+        version_parts.pop()
     # the max pin length is n-1, but in terms of index this is n-2
     max_ver_len = len(version_parts) - 2
     version_parts[max_ver_len] = int(version_parts[max_ver_len]) + 1

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -700,8 +700,12 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                     spec = spec_from_line(dep)
                     if '~' in spec:
                         version = spec.split()[-1]
+                        version_parts = version.split('.')
                         tilde_version = '~ {}' .format(version)
-                        max_pin = int(version.split('.')[0]) + 1
+                        # the max pin length is n-1, but in terms of index this is n-2
+                        max_ver_len = len(version_parts)-2
+                        version_parts[max_ver_len] = int(version_parts[max_ver_len]) + 1
+                        max_pin = '.'.join(str(v) for v in version_parts[:max_ver_len+1])
                         pin_compatible = ' >={},<{}' .format(version, max_pin)
                         spec = spec.replace(tilde_version, pin_compatible)
                     if spec is None:

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -698,6 +698,12 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                 dep = dep.split('#')[0].strip()
                 if dep:  # ... and empty (or comment only) lines
                     spec = spec_from_line(dep)
+                    if '~' in spec:
+                        version = spec.split()[-1]
+                        tilde_version = '~ {}' .format(version)
+                        max_pin = int(version.split('.')[0]) + 1
+                        pin_compatible = ' >={},<{}' .format(version, max_pin)
+                        spec = spec.replace(tilde_version, pin_compatible)
                     if spec is None:
                         sys.exit("Error: Could not parse: %s" % dep)
                     deps.append(spec)

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -614,6 +614,20 @@ def version_compare(package, versions):
         sys.exit()
 
 
+def convert_version(version):
+    """Convert version into a pin-compatible format according to PEP440."""
+    version_parts = version.split('.')
+    suffixes = ('post', 'pre')
+    if any(suffix in version_parts[-1] for suffix in suffixes):
+        version_parts.remove(version_parts[-1])
+    # the max pin length is n-1, but in terms of index this is n-2
+    max_ver_len = len(version_parts)-2
+    version_parts[max_ver_len] = int(version_parts[max_ver_len]) + 1
+    max_pin = '.'.join(str(v) for v in version_parts[:max_ver_len+1])
+    pin_compatible = ' >={},<{}' .format(version, max_pin)
+    return pin_compatible
+
+
 def get_package_metadata(package, d, data, output_dir, python_version, all_extras,
                          recursive, created_recipes, noarch_python, noprompt, packages,
                          extra_specs, config, setup_options):
@@ -700,13 +714,8 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                     spec = spec_from_line(dep)
                     if '~' in spec:
                         version = spec.split()[-1]
-                        version_parts = version.split('.')
                         tilde_version = '~ {}' .format(version)
-                        # the max pin length is n-1, but in terms of index this is n-2
-                        max_ver_len = len(version_parts)-2
-                        version_parts[max_ver_len] = int(version_parts[max_ver_len]) + 1
-                        max_pin = '.'.join(str(v) for v in version_parts[:max_ver_len+1])
-                        pin_compatible = ' >={},<{}' .format(version, max_pin)
+                        pin_compatible = convert_version(version)
                         spec = spec.replace(tilde_version, pin_compatible)
                     if spec is None:
                         sys.exit("Error: Could not parse: %s" % dep)

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -621,9 +621,9 @@ def convert_version(version):
     if any(suffix in version_parts[-1] for suffix in suffixes):
         version_parts.remove(version_parts[-1])
     # the max pin length is n-1, but in terms of index this is n-2
-    max_ver_len = len(version_parts)-2
+    max_ver_len = len(version_parts) - 2
     version_parts[max_ver_len] = int(version_parts[max_ver_len]) + 1
-    max_pin = '.'.join(str(v) for v in version_parts[:max_ver_len+1])
+    max_pin = '.'.join(str(v) for v in version_parts[:max_ver_len + 1])
     pin_compatible = ' >={},<{}' .format(version, max_pin)
     return pin_compatible
 

--- a/tests/test_pypi_skeleton.py
+++ b/tests/test_pypi_skeleton.py
@@ -1,0 +1,23 @@
+from conda_build.skeletons import pypi
+
+
+def test_version_compare():
+    short_version = '2.2'
+    long_version = '1.4.5'
+    post_version = '2.2.post3'
+    pre_version = '2.2.pre3'
+    alpha_version = '1.4.5a4'
+    beta_version = '1.4.5b4'
+    rc_version = '1.4.5rc4'
+    padding_version_short = '2.2.0'
+    padding_version_long = '1.4.5.0'
+
+    assert pypi.convert_version(short_version) == ' >=2.2,<3'
+    assert pypi.convert_version(long_version) == ' >=1.4.5,<1.5'
+    assert pypi.convert_version(post_version) == ' >=2.2.post3,<3'
+    assert pypi.convert_version(pre_version) == ' >=2.2.pre3,<3'
+    assert pypi.convert_version(alpha_version) == ' >=1.4.5a4,<1.5'
+    assert pypi.convert_version(beta_version) == ' >=1.4.5b4,<1.5'
+    assert pypi.convert_version(rc_version) == ' >=1.4.5rc4,<1.5'
+    assert pypi.convert_version(padding_version_short) == ' >=2.2.0,<2.3'
+    assert pypi.convert_version(padding_version_long) == ' >=1.4.5.0,<1.4.6'


### PR DESCRIPTION
fixes #2351 

This PR adds pin compatible versioning functionality to the PyPI skeleton. For example, a version listed as ``package ~= 1.4.3`` will be converted to ``package >=1.4.3,<2``.

The error stems from https://github.com/conda/conda/blob/master/conda/cli/common.py#L106 so I'll be submitting a PR there as well. 

Tests look fine locally. 