### PR TITLE
Fix FEATURE_* environment variables

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -646,6 +646,7 @@ def get_install_actions(prefix, specs, env, retries=0, subdir=None,
     actions = {}
     log = utils.get_logger(__name__)
     conda_log_level = logging.WARN
+    specs = list(specs)
     if verbose:
         capture = contextlib.contextmanager(lambda: (yield))
     elif debug:


### PR DESCRIPTION
The `specs` parameter is passed as a tuple to `environ.get_install_actions`
in various places, which makes appending due to FEATURE_* environment
variables (e.g. FEATURE_NOMKL=1) fail. Therefore, explicitly convert
`specs` to a list.