### PR TITLE
pass tests and build section through wholesale from any output

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1621,9 +1621,6 @@ class MetaData(object):
             host_reqs = [req for req in host_reqs if not subpackage_pattern.match(req)]
             run_reqs = [req for req in run_reqs if not subpackage_pattern.match(req)]
 
-        if 'about' in output:
-            output_metadata.meta['about'] = output['about']
-
         requirements = {'build': build_reqs, 'host': host_reqs, 'run': run_reqs}
         if constrain_reqs:
             requirements['run_constrained'] = constrain_reqs
@@ -1650,6 +1647,7 @@ class MetaData(object):
             output_metadata.config.platform = self.config.platform
 
         build = output_metadata.meta.get('build', {})
+        # legacy (conda build 2.1.x - 3.0.25)
         if 'number' in output:
             build['number'] = output['number']
         if 'string' in output:
@@ -1660,7 +1658,15 @@ class MetaData(object):
             build['track_features'] = output['track_features']
         if 'features' in output and output['features']:
             build['features'] = output['features']
+        # 3.0.26+ - just pass through the whole build section from the output.
+        #    It clobbers everything else.
+        if 'build' in output:
+            build = output['build']
         output_metadata.meta['build'] = build
+        if 'test' in output:
+            output_metadata.meta['test'] = output['test']
+        if 'about' in output:
+            output_metadata.meta['about'] = output['about']
 
         return output_metadata
 

--- a/tests/test-recipes/split-packages/_per_output_tests/meta.yaml
+++ b/tests/test-recipes/split-packages/_per_output_tests/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: test_per_output_tests
+  version: 1.0
+
+test:
+  commands:
+    - echo "top-level test"
+
+outputs:
+  # top-level recipe - ensure that its tests also get run
+  - name: test_per_output_tests
+  - name: output_1
+    test:
+      commands:
+        - echo "output-level test"

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -248,3 +248,11 @@ def test_overlapping_files(testing_config, caplog):
     outputs = api.build(recipe_dir, config=testing_config)
     assert len(outputs) == 3
     assert sum(int("Exact overlap" in rec.message) for rec in caplog.records) == 1
+
+
+def test_per_output_tests(testing_config, capfd):
+    recipe_dir = os.path.join(subpackage_dir, '_per_output_tests')
+    api.build(recipe_dir, config=testing_config)
+    out, err = capfd.readouterr()
+    assert out.count("output-level test") == 1
+    assert out.count("top-level test") == 1


### PR DESCRIPTION
outputs can now be like this:

```
outputs:
  - name: steve
    build:
       features:
         - vc9
       number: 4
    test:
      commands:
        - echo "yes this works"
```

This is important for 2 reasons: it allows more of the build section to pass-through than before; and it allows per-output tests to be defined.