### PR TITLE
Drop extra space in build:script

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -301,7 +301,7 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
 
             ordered_recipe['build']['script'] = 'python setup.py install ' + ' '.join(setup_options)
             if any(re.match(r'^setuptools(?:\s|$)', req) for req in d['build_depends']):
-                ordered_recipe['build']['script'] += (' --single-version-externally-managed '
+                ordered_recipe['build']['script'] += ('--single-version-externally-managed '
                                                       '--record=record.txt')
 
             # Always require python as a dependency


### PR DESCRIPTION
There is already a space after `python setup.py install`