### PR TITLE
fix misleading error when download_url is present but empty

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -516,7 +516,7 @@ def get_download_data(pypi_data, package, version, is_url, all_urls, noprompt, m
 
     if not urls:
         # Try harder for a download location
-        if 'download_url' in data:
+        if data.get('download_url'):
             urls = [defaultdict(str, {'url': data['download_url']})]
             if not urls[0]['url']:
                 # The package doesn't have a url, or maybe it only has a wheel.


### PR DESCRIPTION
I am trying to build a package for tensorboardX on pypi, but it fails to skeletonize. I'm still working my way through the process, but the problem I get with the existing conda-build is that when I run `conda skeleton pypi tensorboardX` it fails with the following error:

```
Error: Could not build recipe for tensorboardX. Could not find any valid urls.
```

The issue is that for this package `download_url` is defined, but is the empty string:

```
(Pdb) p data['download_url']
''
```

With this change, the branch will skip to the case when `download_url` is not defined, and print a message like:

```
Error: No source urls found for tensorboardX
```

I think this error message is much more informative in this case.