### PR TITLE
Check HTTP status code of pkg manifest before decoding it

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -215,7 +215,13 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
         else:
             sort_by_version = lambda l: sorted(l, key=parse_version)
 
-            pypi_data = requests.get(package_pypi_url).json()
+            pypi_resp = requests.get(package_pypi_url)
+
+            if pypi_resp.status_code != 200:
+                sys.exit("Request to fetch %s failed with status: %d"
+                        % (package_pypi_url, pypi_resp.status_code))
+
+            pypi_data = pypi_resp.json()
 
             versions = sort_by_version(pypi_data['releases'].keys())
 


### PR DESCRIPTION
If a package is not available on PyPI the skeleton command fails with
the traceback:
```
  File "/spare/scratch/1507796551/conda-build/conda_build/skeletons/pypi.py", line 220, in skeletonize
    pypi_data = pypi_data.json()
  File "/spare/scratch/1507796551/m3/lib/python3.6/site-packages/requests/models.py", line 850, in json
    return complexjson.loads(self.text, **kwargs)
  File "/spare/scratch/1507796551/m3/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/spare/scratch/1507796551/m3/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/spare/scratch/1507796551/m3/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
This patch adds a check for the HTTP status code before decoding the
response, which it expects to be in JSON format.