### PR TITLE
Use proper temp directory

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -9,6 +9,7 @@ import locale
 import re
 import os
 import stat
+import tempfile
 from subprocess import call, check_output
 import sys
 try:
@@ -506,10 +507,8 @@ def make_hardlink_copy(path, prefix):
     if not os.path.isabs(path) and not os.path.exists(path):
         path = os.path.normpath(os.path.join(prefix, path))
     nlinks = os.lstat(path).st_nlink
-    dest = 'tmpfile'
-    if os.path.isabs(path):
-        dest = os.path.join(os.getcwd(), dest)
     if nlinks > 1:
+        dest = tempfile.mkdtemp()
         # copy file to new name
         utils.copy_into(path, dest)
         # remove old file

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -9,7 +9,6 @@ import locale
 import re
 import os
 import stat
-import tempfile
 from subprocess import call, check_output
 import sys
 try:
@@ -22,6 +21,7 @@ from .conda_interface import lchmod
 from .conda_interface import walk_prefix
 from .conda_interface import md5_file
 from .conda_interface import PY3
+from .conda_interface import TemporaryDirectory
 
 from conda_build import utils
 from conda_build.os_utils.pyldd import is_codefile
@@ -504,18 +504,17 @@ def check_symlinks(files, prefix, croot):
 def make_hardlink_copy(path, prefix):
     """Hardlinks create invalid packages.  Copy files to break the link.
     Symlinks are OK, and unaffected here."""
-    if not os.path.isabs(path) and not os.path.exists(path):
+    if not os.path.isabs(path):
         path = os.path.normpath(os.path.join(prefix, path))
-    nlinks = os.lstat(path).st_nlink
-    if nlinks > 1:
-        dest = tempfile.mkdtemp()
-        # copy file to new name
-        utils.copy_into(path, dest)
-        # remove old file
-        utils.rm_rf(path)
-        # rename copy to original filename
-        utils.copy_into(dest, path)
-        utils.rm_rf(dest)
+    fn = os.path.basename(path)
+    if os.lstat(path).st_nlink > 1:
+        with TemporaryDirectory() as dest:
+            # copy file to new name
+            utils.copy_into(path, dest)
+            # remove old file
+            utils.rm_rf(path)
+            # rename copy to original filename
+            os.rename(os.path.join(dest, fn), path)
 
 
 def get_build_metadata(m):


### PR DESCRIPTION
Windows consoles by default generally start in C:\. It is common to not have write permission in the root C:\ without escalating privilege. It's better to use a proper temp directory, as the current approach fails in this case unless running as administrator, whereas with these changes it runs fine without running as administrator.