### PR TITLE
Exactly match package name in build_folder selection

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -380,7 +380,7 @@ class Config(object):
                                                      "to preserve croot during path joins")
             build_folders = sorted([os.path.basename(build_folder)
                             for build_folder in get_build_folders(self.croot)
-                            if os.path.basename(build_folder).startswith(package_name + "_")])
+                            if build_folder[:build_folder.rfind('_')] == package_name])
             if self.dirty and build_folders:
                 # Use the most recent build with matching recipe name
                 self._build_id = build_folders[-1]

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -378,8 +378,8 @@ class Config(object):
         if self.set_build_id and (not self._build_id or reset):
             assert not os.path.isabs(package_name), ("package name should not be a absolute path, "
                                                      "to preserve croot during path joins")
-            build_folders = sorted([os.path.basename(build_folder)
-                            for build_folder in get_build_folders(self.croot)
+            folder_basenames = [os.path.basename(fldr) for fldr in get_build_folders(self.croot)]
+            build_folders = sorted([build_folder for build_folder in folder_basenames
                             if build_folder[:build_folder.rfind('_')] == package_name])
             if self.dirty and build_folders:
                 # Use the most recent build with matching recipe name


### PR DESCRIPTION
* Corrects behavior in dirty environments where a package name already encountered in a build session may appear as a prefix or suffix, with our without '_' characters, of other package names.
* Meant to be the final incarnation of the previous fixes here #1931, #1953, which were both insufficiently general to cover all combinations of cases.