### PR TITLE
fix implict pinning in outputs; fix incorrect matching of subpkgs

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -875,8 +875,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
 
     # this should be a no-op if source is already here
-    if m.needs_source_for_render:
-        try_download(m, False)
+    try_download(m, no_download_source=False)
 
     if post in [False, None]:
         output_metas = expand_outputs([(m, need_source_download, need_reparse_in_env)])
@@ -927,7 +926,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         build_ms_deps = None
 
         for env in ('build', 'host'):
-            utils.insert_variant_versions(m, env)
+            utils.insert_variant_versions(m.meta.get('requirements', {}), m.config.variant, env)
 
         if (m.config.host_subdir != m.config.build_subdir and
                 m.config.host_subdir != "noarch"):
@@ -968,7 +967,8 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
 
         try:
             if not notest:
-                utils.insert_variant_versions(m, 'run')
+                utils.insert_variant_versions(m.meta.get('requirements', {}),
+                                              m.config.variant, 'run')
                 test_run_ms_deps = m.get_value('test/requires', []) + \
                                    m.get_value('requirements/run', [])
                 # make sure test deps are available before taking time to create build env

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -256,7 +256,7 @@ def check_circular_dependencies(render_order):
 
 def _variants_equal(metadata, output_metadata):
     match = True
-    for key, val in metadata.config.variant:
+    for key, val in metadata.config.variant.items():
         if key in output_metadata.config.variant and val != output_metadata.config.variant[key]:
             match = False
     return match
@@ -681,6 +681,14 @@ def get_updated_output_dict_from_reparsed_metadata(original_dict, new_outputs):
         assert len(output_ds) == 1
         output_d = output_ds[0]
     return output_d
+
+
+def _expand_reqs(reqs_entry):
+    if not hasattr(reqs_entry, 'keys'):
+        original = ensure_list(reqs_entry)[:]
+        reqs_entry = {'build': original,
+                        'run': original}
+    return reqs_entry
 
 
 class MetaData(object):
@@ -1616,22 +1624,14 @@ class MetaData(object):
             name = output.get('name', self.name()) + '_' + output['type']
             output_metadata.meta['package']['name'] = name
 
-        output_reqs = output.get('requirements', {})
-        if hasattr(output_reqs, 'keys'):
-            build_reqs = output_reqs.get('build', [])
-            host_reqs = output_reqs.get('host', [])
-            run_reqs = output_reqs.get('run', [])
-            constrain_reqs = output_reqs.get('run_constrained', [])
-            # pass through any other unrecognized req types
-            other_reqs = {k: v for k, v in output_reqs.items() if k not in
-                          ('build', 'host', 'run', 'run_constrained')}
-        else:
-            output_reqs = ensure_list(output_reqs)
-            build_reqs = output_reqs
-            host_reqs = []
-            run_reqs = output_reqs
-            constrain_reqs = []
-            other_reqs = {}
+        output_reqs = _expand_reqs(output.get('requirements', {}))
+        build_reqs = output_reqs.get('build', [])
+        host_reqs = output_reqs.get('host', [])
+        run_reqs = output_reqs.get('run', [])
+        constrain_reqs = output_reqs.get('run_constrained', [])
+        # pass through any other unrecognized req types
+        other_reqs = {k: v for k, v in output_reqs.items() if k not in
+                        ('build', 'host', 'run', 'run_constrained')}
 
         if 'name' in output:
             # since we are copying reqs from the top-level package, which
@@ -1717,7 +1717,8 @@ class MetaData(object):
                 try:
                     for out in outputs:
                         for env in ('build', 'host', 'run'):
-                            insert_variant_versions(out.get('requirements', {}), variant, env)
+                            insert_variant_versions(_expand_reqs(out.get('requirements', {})),
+                                                    variant, env)
                         out_metadata_map[HashableDict(out)] = om.get_output_metadata(out)
                 except SystemExit:
                     if not permit_undefined_jinja:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -528,7 +528,8 @@ def distribute_variants(metadata, variants, permit_unsatisfiable_variants=False,
         # if python is in the build specs, but doesn't have a specific associated
         #    version, make sure to add one to newly parsed 'requirements/build'.
         for env in ('build', 'host', 'run'):
-            utils.insert_variant_versions(mv, env)
+            utils.insert_variant_versions(mv.meta.get('requirements', {}),
+                                          mv.config.variant, env)
         fm = mv.copy()
         # HACK: trick conda-build into thinking this is final, and computing a hash based
         #     on the current meta.yaml.  The accuracy doesn't matter, all that matters is

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1269,9 +1269,9 @@ def ensure_valid_spec(spec, warn=False):
     return spec
 
 
-def insert_variant_versions(metadata, env):
-    reqs = metadata.get_value('requirements/' + env)
-    for key, val in metadata.config.variant.items():
+def insert_variant_versions(requirements_dict, variant, env):
+    reqs = requirements_dict.get(env, [])
+    for key, val in variant.items():
         regex = re.compile(r'^(%s)(?:\s*$)' % key.replace('_', '[-_]'))
         matches = [regex.match(pkg) for pkg in reqs]
         if any(matches):
@@ -1287,9 +1287,8 @@ def insert_variant_versions(metadata, env):
         for i, x in enumerate(matches):
             if x:
                 del reqs[i]
-                reqs.insert(i, ensure_valid_spec(' '.join((x.group(1),
-                                                metadata.config.variant.get(x.group(1))))))
-    metadata.meta['requirements'][env] = reqs
+                reqs.insert(i, ensure_valid_spec(' '.join((x.group(1), variant.get(x.group(1))))))
+    requirements_dict[env] = reqs
 
 
 def match_peer_job(target_matchspec, other_m, this_m=None):

--- a/tests/test-recipes/variants/20_reprovision_source/bld.bat
+++ b/tests/test-recipes/variants/20_reprovision_source/bld.bat
@@ -1,0 +1,2 @@
+if not exist setup.py exit 1
+echo "found setup.py in workdir (%CD%) OK"

--- a/tests/test-recipes/variants/20_reprovision_source/build.sh
+++ b/tests/test-recipes/variants/20_reprovision_source/build.sh
@@ -1,0 +1,5 @@
+if [ ! -f setup.py ]; then
+    exit 1
+else
+    echo "found setup.py in workdir ($(pwd)) OK"
+fi

--- a/tests/test-recipes/variants/20_reprovision_source/conda_build_config.yaml
+++ b/tests/test-recipes/variants/20_reprovision_source/conda_build_config.yaml
@@ -1,0 +1,16 @@
+shared_lib:
+  - top_a
+  - top_b
+output_loop_var:
+  - output_a
+  - output_b
+dep_tied_to_shared_lib:
+  - dep_a
+  - dep_b
+zlib:
+  - 1.2.8
+  - 1.2.11
+zip_keys:
+  -
+    - shared_lib
+    - dep_tied_to_shared_lib

--- a/tests/test-recipes/variants/20_reprovision_source/install-output.bat
+++ b/tests/test-recipes/variants/20_reprovision_source/install-output.bat
@@ -1,0 +1,8 @@
+cd %SRC_DIR%
+
+if not exist setup.py (
+    dir
+    exit 1
+    ) else (
+    echo "found setup.py in workdir (%CD%) OK"
+)

--- a/tests/test-recipes/variants/20_reprovision_source/install-output.sh
+++ b/tests/test-recipes/variants/20_reprovision_source/install-output.sh
@@ -1,0 +1,11 @@
+set -ex
+
+cd $SRC_DIR
+
+if [ ! -f setup.py ]; then
+    ls
+    echo $(pwd)
+    exit 1
+else
+    echo "found setup.py in workdir ($(pwd)) OK"
+fi

--- a/tests/test-recipes/variants/20_reprovision_source/meta.yaml
+++ b/tests/test-recipes/variants/20_reprovision_source/meta.yaml
@@ -1,0 +1,54 @@
+# this is testing a few behaviors:
+#  1. Looping over top-level variables (ensure that source is clean each runner)
+#  2. looping over output-only variables (ensure that source with any build intermediaries are still present)
+
+# Ideal flow is:
+
+# outer loop (iter 0):
+# build shared_lib-top_a
+# build output_with_zipped_loops-output_zip_a against shared_lib-top_a
+# build output_with_zipped_loops-output_zip_b against shared_lib-top_a
+# inner loop:
+# build output_with_independent_loops-output_a against shared_lib-top_a
+# build output_with_independent_loops-output_b against shared_lib-top_a
+# (work dir moved, source re-provisioned)
+# outer loop (iter 1):
+# build shared_lib-top_a
+# build output_with_zipped_loops-output_zip_a against shared_lib-top_b
+# build output_with_zipped_loops-output_zip_b against shared_lib-top_b
+# inner loop:
+# build output_with_independent_loops-output_a against shared_lib-top_b
+# build output_with_independent_loops-output_b against shared_lib-top_b
+
+package:
+  name: test_reprovision_source
+  # this version is set to one of the loop vars, so that it becomes a "top level" variable
+  version: {{ shared_lib }}
+
+source:
+  path: ../../test-package
+
+# build.sh / bld.bat are creating files that are specific to the value of shared_lib loop var
+
+test:
+  commands:
+    - echo "weee"
+
+outputs:
+  # the "top-level" output, here explicitly because of other output
+  - name: test_reprovision_source
+
+  # There are 4 variants here.  Inner loop builds 2 per outer loop (source cache NOT cleaned between inner loop iters)
+  #    When using api.render, there should be 2 MetaData objects for this output.
+  - name: output_with_independent_loops
+    version: {{ output_loop_var }}
+    script: install-output.sh   # [unix]
+    script: install-output.bat  # [win]
+    requirements:
+      build:
+        - test_reprovision_source
+      run:
+        - test_reprovision_source  {{ shared_lib }}
+    test:
+      commands:
+        - echo "weee"

--- a/tests/test-recipes/variants/20_reprovision_source/run_test.bat
+++ b/tests/test-recipes/variants/20_reprovision_source/run_test.bat
@@ -1,0 +1,1 @@
+echo "weee"

--- a/tests/test-recipes/variants/20_reprovision_source/run_test.sh
+++ b/tests/test-recipes/variants/20_reprovision_source/run_test.sh
@@ -1,0 +1,1 @@
+echo "weee"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -287,7 +287,8 @@ def test_ensure_valid_spec():
 def test_insert_variant_versions(testing_metadata):
     testing_metadata.meta['requirements']['build'] = ['python', 'numpy 1.13']
     testing_metadata.config.variant = {'python': '2.7', 'numpy': '1.11'}
-    utils.insert_variant_versions(testing_metadata, 'build')
+    utils.insert_variant_versions(testing_metadata.meta.get('requirements', {}),
+                                  testing_metadata.config.variant, 'build')
     # this one gets inserted
     assert 'python 2.7.*' in testing_metadata.meta['requirements']['build']
     # this one should not be altered

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -246,3 +246,7 @@ def test_get_used_loop_vars(testing_config):
     #   python and zlib are both implicitly used (depend on name matching), while
     #   some_package is explicitly used as a jinja2 variable
     assert ms[0][0].get_used_loop_vars() == {'python', 'some_package', 'zlib'}
+
+
+def test_reprovisioning_source(testing_config):
+    ms = api.render(os.path.join(recipe_dir, '20_reprovision_source'))


### PR DESCRIPTION
before this, error messages like:

```
conda_build.exceptions.RecipeError: Mismatching hashes in recipe. Exact pins in dependencies that contribute to the hash often cause this. Can you change one or more exact pins to version bound constraints?
Involved packages were:
Mismatching package: py-boost; consumer package: boost
```

showed up with non-top-level variants (such as a top-level shared lib with subpackages that consume it)

This PR also fixes some instances where the pins from the variant weren't being inserted early enough into outputs, which led to them not being differentiated well enough, which led to some of them (again, non-top-level ones) being ignored.

This PR needs tests before merging.