### PR TITLE
create channel-level channeldata.json

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -166,13 +166,10 @@ def _build_channeldata(dir_path, subdir_paths):
             for fn, record in index_data[subdir_path].items():
                 record.update(about_data.get(subdir_path, {}).get(fn, {}))
                 _source_section = recipe_data.get(subdir_path, {}).get(fn, {}).get('source', {})
+                if isinstance(_source_section, (list, tuple)):
+                    _source_section = _source_section[0]
                 for key in ('url', 'git_url', 'git_rev', 'git_tag'):
-                    try:
-                        value = _source_section.get(key)
-                    except AttributeError:
-                        print("WARNING: bad recipe detected for %s/%s" % (subdir_path, fn))
-                        # AttributeError: 'list' object has no attribute 'get'
-                        value = None
+                    value = _source_section.get(key)
                     if value:
                         record['source_%s' % key] = value
                 package_groups[record['name']].append(record)
@@ -203,7 +200,12 @@ def _build_channeldata(dir_path, subdir_paths):
             best_record = sorted(latest_version_records, key=lambda x: x['build_number'])[-1]
             # Only subdirs that contain the latest version number are included here.
             # Build numbers are ignored for reporting which subdirs contain the latest version of the package.
-            subdirs = sorted(set(rec['subdir'] for rec in latest_version_records))
+            try:
+                subdirs = sorted(set(rec['subdir'] for rec in latest_version_records))
+            except Exception as e:
+                import pdb; pdb.set_trace()
+                subdirs = []
+                assert 1
             package_data[name] = {k: v for k, v in best_record.items() if k in FIELDS}
             package_data[name]['subdirs'] = subdirs
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -309,9 +309,12 @@ def _read_index_tar(tar_path, lock, locking=True, timeout=90):
                 paths_json = {}
 
             try:
-                recipe_json = yaml.load(t.extractfile('info/recipe/meta.yaml').read().decode('utf-8'))
+                recipe_json = yaml.load(
+                    t.extractfile('info/recipe/meta.yaml').read().decode('utf-8')
+                )
             except Exception as e:
-                log.warn('Error extracting info/recipe/meta.yaml in %s: %r', tar_path, e, exc_info=True)
+                log.warn('Error extracting info/recipe/meta.yaml in %s: %r',
+                         tar_path, e, exc_info=True)
                 recipe_json = {}
 
             # If a conda package contains an icon, also extract and cache that in an .icon/
@@ -398,7 +401,9 @@ def _build_channeldata(dir_path, subdir_paths):
                 value = _source_section.get(key)
                 if value:
                     record['source_%s' % key] = value
-            record['_has_icon'] = bool(recipe_data.get(subdir_path, {}).get(fn, {}).get('app', {}).get('icon'))
+            record['_has_icon'] = bool(
+                recipe_data.get(subdir_path, {}).get(fn, {}).get('app', {}).get('icon')
+            )
             package_groups[record['name']].append(record)
 
     FIELDS = (
@@ -421,14 +426,19 @@ def _build_channeldata(dir_path, subdir_paths):
 
     package_data = {}
     for name, package_group in package_groups.items():
-        latest_version = sorted(package_group, key=lambda x: VersionOrder(x['version']))[-1]['version']
-        latest_version_records = tuple(rec for rec in package_group if rec['version'] == latest_version)
+        latest_version = sorted(
+            package_group, key=lambda x: VersionOrder(x['version'])
+        )[-1]['version']
+        latest_version_records = tuple(rec for rec in package_group
+                                       if rec['version'] == latest_version)
         best_record = sorted(latest_version_records, key=lambda x: x['build_number'])[-1]
         # Only subdirs that contain the latest version number are included here.
-        # Build numbers are ignored for reporting which subdirs contain the latest version of the package.
+        # Build numbers are ignored for reporting which subdirs contain the latest version
+        # of the package.
         subdirs = sorted(filter(None, set(rec.get('subdir') for rec in latest_version_records)))
         package_data[name] = {k: v for k, v in best_record.items() if k in FIELDS}
-        package_data[name]["reference_package"] = "%s/%s" % (best_record['subdir'], best_record['fn'])
+        package_data[name]["reference_package"] = "%s/%s" % (best_record['subdir'],
+                                                             best_record['fn'])
 
         # recipe_data[best_record['subdir']][best_record['fn']]
 
@@ -437,9 +447,11 @@ def _build_channeldata(dir_path, subdir_paths):
         package_data[name]['subdirs'] = subdirs
 
         if best_record['_has_icon']:
-            icon_files = glob(join(dir_path, best_record['subdir'], '.icons', best_record['fn'] + '.*'))
+            icon_files = glob(join(dir_path, best_record['subdir'], '.icons',
+                                   best_record['fn'] + '.*'))
             if icon_files:
-                extracted_icon_path = join(dir_path, best_record['subdir'], '.icons', icon_files[0])
+                extracted_icon_path = join(dir_path, best_record['subdir'], '.icons',
+                                           icon_files[0])
                 icon_ext = extracted_icon_path.rsplit('.', 1)[-1]
 
                 icon_md5 = md5_file(extracted_icon_path)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -200,12 +200,7 @@ def _build_channeldata(dir_path, subdir_paths):
             best_record = sorted(latest_version_records, key=lambda x: x['build_number'])[-1]
             # Only subdirs that contain the latest version number are included here.
             # Build numbers are ignored for reporting which subdirs contain the latest version of the package.
-            try:
-                subdirs = sorted(set(rec['subdir'] for rec in latest_version_records))
-            except Exception as e:
-                import pdb; pdb.set_trace()
-                subdirs = []
-                assert 1
+            subdirs = sorted(filter(None, set(rec.get('subdir') for rec in latest_version_records)))
             package_data[name] = {k: v for k, v in best_record.items() if k in FIELDS}
             package_data[name]['subdirs'] = subdirs
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -351,7 +351,13 @@ def update_subdir_index(dir_path, force=False, check_md5=False, remove=True, loc
             if 'requires' in info and 'depends' not in info:
                 info['depends'] = info['requires']
 
-        repodata = {'packages': index, 'info': {}}
+        subdir = basename(dir_path)
+        repodata = {
+            'packages': index,
+            'info': {
+                'subdir': subdir,
+            },
+        }
         write_repodata(repodata, dir_path, lock=lock, locking=locking, timeout=timeout)
 
         if channel_name:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -14,7 +14,7 @@ import json
 import logging
 from numbers import Number
 import os
-from os.path import basename, dirname, getmtime, getsize, isdir, isfile, join, splitext
+from os.path import basename, dirname, getmtime, getsize, isdir, isfile, join
 from shutil import copy2
 import tarfile
 
@@ -140,6 +140,8 @@ def update_index(dir_path, force=False, check_md5=False, remove=True, lock=None,
         subdir_paths = (dir_path,)
 
     for subdir_path in subdir_paths:
+        if len(subdir_paths) > 1:
+            print('==> indexing: %s <==' % dir_path)
         update_subdir_index(subdir_path, force, check_md5, remove, lock,
                             could_be_mirror, verbose, locking, timeout,
                             channel_name)
@@ -171,8 +173,6 @@ def update_subdir_index(dir_path, force=False, check_md5=False, remove=True, loc
     log = utils.get_logger(__name__)
 
     log.debug("updating index in: %s", dir_path)
-
-    print('==> indexing: %s <==' % dir_path)
 
     if not os.path.isdir(dir_path):
         os.makedirs(dir_path)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -80,8 +80,9 @@ def _read_index_tar(tar_path, lock, locking=True, timeout=90):
                     if not isdir(icon_dir):
                         os.makedirs(icon_dir)
                     icon_filename = '.'.join((basename(tar_path), app_icon.rsplit('.')[-1]))
+                    icondata = t.extractfile(app_icon).read()
+                    assert len(icondata)
                     with open(join(icon_dir, icon_filename), 'wb') as fh:
-                        icondata = t.extractfile(app_icon).read()
                         fh.write(icondata)
             except Exception as e:
                 log.debug('%r', e, exc_info=True)
@@ -182,8 +183,11 @@ def _build_channeldata(dir_path, subdir_paths):
 
     package_groups = defaultdict(list)
     for subdir_path in index_data:
+        subdir = basename(subdir_path)
         for fn, record in index_data[subdir_path].items():
             record['fn'] = fn
+            if 'subdir' not in record:
+                record['subdir'] = subdir
             record.update(about_data.get(subdir_path, {}).get(fn, {}))
             _source_section = recipe_data.get(subdir_path, {}).get(fn, {}).get('source', {})
             if isinstance(_source_section, (list, tuple)):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -141,7 +141,7 @@ def update_index(dir_path, force=False, check_md5=False, remove=True, lock=None,
 
     for subdir_path in subdir_paths:
         if len(subdir_paths) > 1:
-            print('==> indexing: %s <==' % dir_path)
+            print('==> indexing: %s <==' % join(dir_path, subdir_path))
         update_subdir_index(subdir_path, force, check_md5, remove, lock,
                             could_be_mirror, verbose, locking, timeout,
                             channel_name)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -291,20 +291,23 @@ def _read_index_tar(tar_path, lock, locking=True, timeout=90):
             except tarfile.ReadError:
                 raise RuntimeError("Could not extract metadata from %s. "
                                 "File probably corrupt." % tar_path)
+            try:
+                about_json = json.loads(t.extractfile('info/about.json').read().decode('utf-8'))
+            except Exception as e:
+                log.warn('Error extracting info/about.json in %s: %r', tar_path, e, exc_info=True)
+                about_json = {}
 
-            def extract_single(path):
-                try:
-                    loader = {
-                        '.json': json.loads,
-                        '.yaml': yaml.load,
-                    }
-                    return loader[splitext(path)[-1]](t.extractfile(path).read().decode('utf-8'))
-                except Exception as e:
-                    log.warn('Error extracting %s in %s: %r', path, tar_path, e, exc_info=True)
-                    return {}
-            about_json = extract_single('info/about.json')
-            paths_json = extract_single('info/paths.json')
-            recipe_json = extract_single('info/recipe/meta.yaml')
+            try:
+                paths_json = json.loads(t.extractfile('info/paths.json').read().decode('utf-8'))
+            except Exception as e:
+                log.warn('Error extracting info/paths.json in %s: %r', tar_path, e, exc_info=True)
+                paths_json = {}
+
+            try:
+                recipe_json = yaml.load(t.extractfile('info/recipe/meta.yaml').read().decode('utf-8'))
+            except Exception as e:
+                log.warn('Error extracting info/recipe/meta.yaml in %s: %r', tar_path, e, exc_info=True)
+                recipe_json = {}
 
             # If a conda package contains an icon, also extract and cache that in an .icon/
             # directory.  The icon file name is the name of the package, plus the extension

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -376,7 +376,7 @@ def _build_channeldata(dir_path, subdir_paths):
         with open(join(subdir_path, '.recipe.json')) as fh:
             recipe_data[basename(subdir_path)] = json.loads(fh.read())
 
-    subdir_names = tuple(index_data)
+    subdir_names = tuple(sorted(index_data))
 
     package_groups = defaultdict(list)
     for subdir_path in index_data:
@@ -441,7 +441,6 @@ def _build_channeldata(dir_path, subdir_paths):
                 icon_size = getsize(extracted_icon_path)
 
                 artifact_icon_path = 'icons/%s.%s' % (best_record['name'], icon_ext)
-                print(">> artifact_icon_path: %s" % artifact_icon_path)
                 if not isdir(dirname(artifact_icon_path)):
                     os.makedirs(dirname(artifact_icon_path))
                 if isfile(artifact_icon_path):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -165,14 +165,14 @@ def _build_channeldata(dir_path, subdir_paths):
         for subdir_path in index_data:
             for fn, record in index_data[subdir_path].items():
                 record.update(about_data.get(subdir_path, {}).get(fn, {}))
-                try:
-                    _source_section = recipe_data.get(subdir_path, {}).get(fn, {}).get('source', {})
-                except Exception as e:
-                    import pdb; pdb.set_trace()
-                    _source_section = {}
-                    assert True
+                _source_section = recipe_data.get(subdir_path, {}).get(fn, {}).get('source', {})
                 for key in ('url', 'git_url', 'git_rev', 'git_tag'):
-                    value = _source_section.get(key)
+                    try:
+                        value = _source_section.get(key)
+                    except AttributeError:
+                        print("WARNING: bad recipe detected for %s/%s" % (subdir_path, fn))
+                        # AttributeError: 'list' object has no attribute 'get'
+                        value = None
                     if value:
                         record['source_%s' % key] = value
                 package_groups[record['name']].append(record)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -457,8 +457,8 @@ def _build_channeldata(dir_path, subdir_paths):
                 else:
                     copy2(extracted_icon_path, artifact_icon_path)
 
-                package_data['icon_url'] = artifact_icon_path
-                package_data['icon_hash'] = "md5:%s:%s" % (icon_md5, icon_size)
+                package_data[name]['icon_url'] = artifact_icon_path
+                package_data[name]['icon_hash'] = "md5:%s:%s" % (icon_md5, icon_size)
 
     channeldata = {
         'channeldata_version': 1,

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -165,7 +165,12 @@ def _build_channeldata(dir_path, subdir_paths):
         for subdir_path in index_data:
             for fn, record in index_data[subdir_path].items():
                 record.update(about_data.get(subdir_path, {}).get(fn, {}))
-                _source_section = recipe_data.get(subdir_path, {}).get(fn, {}).get('source', {})
+                try:
+                    _source_section = recipe_data.get(subdir_path, {}).get(fn, {}).get('source', {})
+                except Exception as e:
+                    import pdb; pdb.set_trace()
+                    _source_section = {}
+                    assert True
                 for key in ('url', 'git_url', 'git_rev', 'git_tag'):
                     value = _source_section.get(key)
                     if value:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -145,8 +145,10 @@ def update_index(dir_path, force=False, check_md5=False, remove=True, lock=None,
                             channel_name)
 
     if is_channel:
+        channeldata_path = join(dir_path, 'channeldata.json')
+        print('==> building: %s <==' % channeldata_path)
         channeldata = _build_channeldata(dir_path, subdir_paths)
-        with open(join(dir_path, 'channeldata.json'), 'w') as fh:
+        with open(channeldata_path, 'w') as fh:
             fh.write(json.dumps(channeldata, indent=2, sort_keys=True, separators=(',', ': ')))
 
 
@@ -169,6 +171,9 @@ def update_subdir_index(dir_path, force=False, check_md5=False, remove=True, loc
     log = utils.get_logger(__name__)
 
     log.debug("updating index in: %s", dir_path)
+
+    print('==> indexing: %s <==' % dir_path)
+
     if not os.path.isdir(dir_path):
         os.makedirs(dir_path)
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -145,7 +145,8 @@ def update_index(dir_path, force=False, check_md5=False, remove=True, lock=None,
 
 
 def _clear_newline_chars(record, field_name):
-    record[field_name] = record[field_name].strip().replace('\n', ' ')
+    if field_name in record:
+        record[field_name] = record[field_name].strip().replace('\n', ' ')
 
 
 def _build_channeldata(dir_path, subdir_paths):
@@ -281,6 +282,20 @@ def update_subdir_index(dir_path, force=False, check_md5=False, remove=True, loc
                     about = json.load(fi)
             except (IOError, ValueError):
                 about = {}
+
+            try:
+                mode_dict = {'mode': 'r', 'encoding': 'utf-8'} if PY3 else {'mode': 'rb'}
+                with open(paths_path, **mode_dict) as fi:
+                    paths = json.load(fi)
+            except (IOError, ValueError):
+                paths = {}
+
+            try:
+                mode_dict = {'mode': 'r', 'encoding': 'utf-8'} if PY3 else {'mode': 'rb'}
+                with open(recipe_path, **mode_dict) as fi:
+                    recipe = json.load(fi)
+            except (IOError, ValueError):
+                recipe = {}
 
         files = set(fn for fn in os.listdir(dir_path) if fn.endswith('.tar.bz2'))
         for fn in files:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -65,7 +65,9 @@ def test_index_on_single_subdir_1():
         with open(join(base_location, 'osx-64', 'repodata.json')) as fh:
             actual_repodata_json = json.loads(fh.read())
         expected_repodata_json = {
-            "info": {},
+            "info": {
+                'subdir': 'osx-64',
+            },
             "packages": {
                 "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2": {
                     "build": "py27h5e241af_0",
@@ -96,18 +98,19 @@ def test_index_on_single_subdir_1():
             "channeldata_version": 1,
             "packages": {
                 "conda-index-pkg-a": {
-                    "description": "Description field for conda-index-pkg-a. Actually, this is just the python description.\n"
-                                   "Python is a widely used high-level, general-purpose, interpreted, dynamic\n"
-                                   "programming language. Its design philosophy emphasizes code\n"
-                                   "readability, and its syntax allows programmers to express concepts in\n"
-                                   "fewer lines of code than would be possible in languages such as C++ or\n"
-                                   "Java. The language provides constructs intended to enable clear programs\n"
-                                   "on both a small and large scale.\n",
+                    "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
+                                   "Python is a widely used high-level, general-purpose, interpreted, dynamic "
+                                   "programming language. Its design philosophy emphasizes code "
+                                   "readability, and its syntax allows programmers to express concepts in "
+                                   "fewer lines of code than would be possible in languages such as C++ or "
+                                   "Java. The language provides constructs intended to enable clear programs "
+                                   "on both a small and large scale.",
                     "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
                     "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
                     "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
                     "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
                     "license": "BSD",
+                    "reference_package": "osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2",
                     "source_git_rev": "master",
                     "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
                     "subdirs": [
@@ -152,7 +155,9 @@ def test_index_noarch_osx64_1():
         with open(join(base_location, 'noarch', 'repodata.json')) as fh:
             actual_repodata_json = json.loads(fh.read())
         expected_repodata_json = {
-            "info": {},
+            "info": {
+                'subdir': 'noarch',
+            },
             "packages": {
                 "conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2": {
                     "build": "pyhed9eced_1",
@@ -184,18 +189,19 @@ def test_index_noarch_osx64_1():
             "channeldata_version": 1,
             "packages": {
                 "conda-index-pkg-a": {
-                    "description": "Description field for conda-index-pkg-a. Actually, this is just the python description.\n"
-                                   "Python is a widely used high-level, general-purpose, interpreted, dynamic\n"
-                                   "programming language. Its design philosophy emphasizes code\n"
-                                   "readability, and its syntax allows programmers to express concepts in\n"
-                                   "fewer lines of code than would be possible in languages such as C++ or\n"
-                                   "Java. The language provides constructs intended to enable clear programs\n"
-                                   "on both a small and large scale.\n",
+                    "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
+                                   "Python is a widely used high-level, general-purpose, interpreted, dynamic "
+                                   "programming language. Its design philosophy emphasizes code "
+                                   "readability, and its syntax allows programmers to express concepts in "
+                                   "fewer lines of code than would be possible in languages such as C++ or "
+                                   "Java. The language provides constructs intended to enable clear programs "
+                                   "on both a small and large scale.",
                     "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
                     "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
                     "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
                     "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
                     "license": "BSD",
+                    "reference_package": "noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2",
                     "source_git_rev": "master",
                     "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
                     "subdirs": [

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from contextlib import contextmanager
+import json
+from logging import getLogger
+import os
+from os.path import dirname, isdir, join, lexists, isfile
+import requests
+import shutil
+from tempfile import gettempdir
+from uuid import uuid4
+
+from conda_build.conda_interface import rm_rf
+from conda_build.index import update_index
+
+log = getLogger(__name__)
+
+# NOTE: The recipes for test packages used in this module are at https://github.com/kalefranz/conda-test-packages
+
+
+def create_temp_location():
+    tempdirdir = gettempdir()
+    dirname = str(uuid4())[:8]
+    return join(tempdirdir, dirname)
+
+
+@contextmanager
+def tempdir():
+    prefix = create_temp_location()
+    try:
+        os.makedirs(prefix)
+        yield prefix
+    finally:
+        if lexists(prefix):
+            rm_rf(prefix)
+
+
+def download(url, local_path):
+    # NOTE: The tests in this module download packages from the conda-test channel.
+    #       These packages are small, and could easily be included in the conda-build git
+    #       repository once their use stabilizes.
+    if not isdir(dirname(local_path)):
+        os.makedirs(dirname(local_path))
+    r = requests.get(url, stream=True)
+    with open(local_path, 'wb') as f:
+        shutil.copyfileobj(r.raw, f)
+    return local_path
+
+
+def test_index_on_single_subdir_1():
+    with tempdir() as base_location:
+        test_package_path = join(base_location, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
+        test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
+        download(test_package_url, test_package_path)
+
+        update_index(base_location, channel_name='test-channel')
+
+        # #######################################
+        # tests for osx-64 subdir
+        # #######################################
+        assert isfile(join(base_location, 'osx-64', 'index.html'))
+        assert isfile(join(base_location, 'osx-64', 'repodata.json.bz2'))
+
+        with open(join(base_location, 'osx-64', 'repodata.json')) as fh:
+            actual_repodata_json = json.loads(fh.read())
+        expected_repodata_json = {
+            "info": {},
+            "packages": {
+                "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2": {
+                    "build": "py27h5e241af_0",
+                    "build_number": 0,
+                    "depends": [
+                        "python >=2.7,<2.8.0a0"
+                    ],
+                    "license": "BSD",
+                    "md5": "37861df8111170f5eed4bff27868df59",
+                    "name": "conda-index-pkg-a",
+                    "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                    "size": 8733,
+                    "subdir": "osx-64",
+                    "timestamp": 1508520039632,
+                    "version": "1.0",
+                },
+            },
+        }
+        assert actual_repodata_json == expected_repodata_json
+
+        # #######################################
+        # tests for full channel
+        # #######################################
+
+        with open(join(base_location, 'channeldata.json')) as fh:
+            actual_channeldata_json = json.loads(fh.read())
+        expected_channeldata_json = {
+            "channeldata_version": 1,
+            "packages": {
+                "conda-index-pkg-a": {
+                    "description": "Description field for conda-index-pkg-a. Actually, this is just the python description.\n"
+                                   "Python is a widely used high-level, general-purpose, interpreted, dynamic\n"
+                                   "programming language. Its design philosophy emphasizes code\n"
+                                   "readability, and its syntax allows programmers to express concepts in\n"
+                                   "fewer lines of code than would be possible in languages such as C++ or\n"
+                                   "Java. The language provides constructs intended to enable clear programs\n"
+                                   "on both a small and large scale.\n",
+                    "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
+                    "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
+                    "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
+                    "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
+                    "license": "BSD",
+                    "source_git_rev": "master",
+                    "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
+                    "subdirs": [
+                        "osx-64",
+                    ],
+                    "summary": "Summary field for conda-index-pkg-a",
+                    "version": "1.0"
+                }
+            },
+            "subdirs": [
+                "osx-64"
+            ]
+        }
+        assert actual_channeldata_json == expected_channeldata_json
+
+
+def test_index_noarch_osx64_1():
+    with tempdir() as base_location:
+        test_package_path = join(base_location, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
+        test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
+        download(test_package_url, test_package_path)
+
+        test_package_path = join(base_location, 'noarch', 'conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2')
+        test_package_url = 'https://conda.anaconda.org/conda-test/noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2'
+        download(test_package_url, test_package_path)
+
+        update_index(base_location, channel_name='test-channel')
+
+        # #######################################
+        # tests for osx-64 subdir
+        # #######################################
+        assert isfile(join(base_location, 'osx-64', 'index.html'))
+        assert isfile(join(base_location, 'osx-64', 'repodata.json'))  # repodata is tested in test_index_on_single_subdir_1
+        assert isfile(join(base_location, 'osx-64', 'repodata.json.bz2'))
+
+        # #######################################
+        # tests for noarch subdir
+        # #######################################
+        assert isfile(join(base_location, 'osx-64', 'index.html'))
+        assert isfile(join(base_location, 'osx-64', 'repodata.json.bz2'))
+
+        with open(join(base_location, 'noarch', 'repodata.json')) as fh:
+            actual_repodata_json = json.loads(fh.read())
+        expected_repodata_json = {
+            "info": {},
+            "packages": {
+                "conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2": {
+                    "build": "pyhed9eced_1",
+                    "build_number": 1,
+                    "depends": [
+                        "python"
+                    ],
+                    "license": "BSD",
+                    "md5": "56b5f6b7fb5583bccfc4489e7c657484",
+                    "name": "conda-index-pkg-a",
+                    "noarch": "python",
+                    "sha256": "7430743bffd4ac63aa063ae8518e668eac269c783374b589d8078bee5ed4cbc6",
+                    "size": 7882,
+                    "subdir": "noarch",
+                    "timestamp": 1508520204768,
+                    "version": "1.0",
+                },
+            },
+        }
+        assert actual_repodata_json == expected_repodata_json
+
+        # #######################################
+        # tests for full channel
+        # #######################################
+
+        with open(join(base_location, 'channeldata.json')) as fh:
+            actual_channeldata_json = json.loads(fh.read())
+        expected_channeldata_json = {
+            "channeldata_version": 1,
+            "packages": {
+                "conda-index-pkg-a": {
+                    "description": "Description field for conda-index-pkg-a. Actually, this is just the python description.\n"
+                                   "Python is a widely used high-level, general-purpose, interpreted, dynamic\n"
+                                   "programming language. Its design philosophy emphasizes code\n"
+                                   "readability, and its syntax allows programmers to express concepts in\n"
+                                   "fewer lines of code than would be possible in languages such as C++ or\n"
+                                   "Java. The language provides constructs intended to enable clear programs\n"
+                                   "on both a small and large scale.\n",
+                    "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
+                    "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
+                    "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
+                    "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
+                    "license": "BSD",
+                    "source_git_rev": "master",
+                    "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
+                    "subdirs": [
+                        "noarch",
+                        "osx-64",
+                    ],
+                    "summary": "Summary field for conda-index-pkg-a. This is the python noarch version.",  # <- tests that the higher noarch build number is the data collected
+                    "version": "1.0"
+                }
+            },
+            "subdirs": [
+                "noarch",
+                "osx-64",
+            ]
+        }
+        assert actual_channeldata_json == expected_channeldata_json
+


### PR DESCRIPTION
This PR creates the equivalent of the current channel-level metadata.json.  The format is new, agreed to after discussion in https://github.com/conda/conda/issues/5340, and hence the new name.  In this case, there is a `channeldata_version` key, which we'll use if/when we need to change format in the future.

This PR also contains the foundation of a test framework for `conda index`.

The `conda index` command has used a caching strategy of keeping an `.index.json` file, so that rebuilding repodata is quicker on an incremental basis.  This PR adds *four* other caching files, that are in line with the typical conda package structure.  Those files are `.about.json`, `.paths.json`, and `.recipe.json`.  Actually, that's three.  The fourth is a directory `.icons/`, which holds extracted icon files for packages that contain them, as identified in the `app` key of a recipe.

All but the `.paths.json` file are necessary and used to implement the `channeldata.json` file.  It's my intention to use `.paths.json` in a near-future PR.  One purpose will be to add the ability to warn when paths overlap across package names.

I don't believe the addition of these four extra caching files will add significant run time to the `conda index` command.  That's because we have to decompress the entire .tar.bz2 file to extract a single element from it, and so we might as well archive all the components we need in one go.