### PR TITLE
implement subspace selection

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -14,7 +14,7 @@ import time
 
 from .conda_interface import root_dir, root_writable
 from .conda_interface import binstar_upload
-from .variants import get_default_variants
+from .variants import get_default_variant
 from .conda_interface import cc_platform, cc_conda_build, subdir
 
 from .utils import get_build_folders, rm_rf, get_logger, get_conda_operation_locks
@@ -359,7 +359,7 @@ class Config(object):
 
     # TODO: This is probably broken on Windows, but no one has a lua package on windows to test.
     def _get_lua(self, prefix):
-        lua_ver = self.variant.get('lua', get_default_variants()[0]['lua'])
+        lua_ver = self.variant.get('lua', get_default_variant(self)['lua'])
         binary_name = "luajit" if (lua_ver and lua_ver[0] == "2") else "lua"
         if sys.platform == 'win32':
             res = join(prefix, 'Library', 'bin', '{}.exe'.format(binary_name))

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -27,7 +27,7 @@ from conda_build.features import feature_list
 from conda_build.index import get_build_index
 from conda_build.os_utils import external
 from conda_build.utils import ensure_list, prepend_bin_path
-from conda_build.variants import get_default_variants
+from conda_build.variants import get_default_variant
 
 
 # these are things that we provide env vars for more explicitly.  This list disables the
@@ -36,26 +36,26 @@ LANGUAGES = ('PERL', 'LUA', 'R', "NUMPY", 'PYTHON')
 
 
 def get_perl_ver(config):
-    return '.'.join(config.variant.get('perl', get_default_variants()[0]['perl']).split('.')[:2])
+    return '.'.join(config.variant.get('perl', get_default_variant(config)['perl']).split('.')[:2])
 
 
 def get_lua_ver(config):
-    return '.'.join(config.variant.get('lua', get_default_variants()[0]['lua']).split('.')[:2])
+    return '.'.join(config.variant.get('lua', get_default_variant(config)['lua']).split('.')[:2])
 
 
 def get_py_ver(config):
     return '.'.join(config.variant.get('python',
-                                       get_default_variants()[0]['python']).split('.')[:2])
+                                       get_default_variant(config)['python']).split('.')[:2])
 
 
 def get_r_ver(config):
     return '.'.join(config.variant.get('r_base',
-                                       get_default_variants()[0]['r_base']).split('.')[:3])
+                                       get_default_variant(config)['r_base']).split('.')[:3])
 
 
 def get_npy_ver(config):
     conda_npy = ''.join(str(config.variant.get('numpy') or
-                            get_default_variants()[0]['numpy']).split('.'))
+                            get_default_variant(config)['numpy']).split('.'))
     # Convert int -> string, e.g.
     #   17 -> '1.7'
     #   110 -> '1.10'
@@ -313,7 +313,7 @@ def python_vars(config, prefix):
             'PYTHON': config.python_bin(prefix),
         })
 
-    np_ver = config.variant.get('numpy', get_default_variants()[0]['numpy'])
+    np_ver = config.variant.get('numpy', get_default_variant(config)['numpy'])
     vars_['NPY_VER'] = '.'.join(np_ver.split('.')[:2])
     vars_['CONDA_NPY'] = ''.join(np_ver.split('.')[:2])
     return vars_

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -13,6 +13,7 @@ from .utils import (get_installed_packages, apply_pin_expressions, get_logger, H
                     string_types)
 from .render import get_env_dependencies
 from .utils import copy_into, check_call_env, rm_rf, ensure_valid_spec
+from .variants import DEFAULT_COMPILERS
 from . import _load_setup_py_data
 
 
@@ -280,43 +281,11 @@ def pin_subpackage(metadata, subpackage_name, min_pin='x.x.x.x.x.x', max_pin='x'
     return pin
 
 
-# map python version to default compiler on windows, to match upstream python
-#    This mapping only sets the "native" compiler, and can be overridden by specifying a compiler
-#    in the conda-build variant configuration
-compilers = {
-    'win': {
-        'c': {
-            '2.7': 'vs2008',
-            '3.3': 'vs2010',
-            '3.4': 'vs2010',
-            '3.5': 'vs2015',
-        },
-        'cxx': {
-            '2.7': 'vs2008',
-            '3.3': 'vs2010',
-            '3.4': 'vs2010',
-            '3.5': 'vs2015',
-        },
-        'fortran': 'gfortran',
-    },
-    'linux': {
-        'c': 'gcc',
-        'cxx': 'gxx',
-        'fortran': 'gfortran',
-    },
-    'osx': {
-        'c': 'clang',
-        'cxx': 'clangxx',
-        'fortran': 'gfortran',
-    },
-}
-
-
 def native_compiler(language, config):
     try:
-        compiler = compilers[config.platform][language]
+        compiler = DEFAULT_COMPILERS[config.platform][language]
     except KeyError:
-        compiler = compilers[config.platform.split('-')[0]][language]
+        compiler = DEFAULT_COMPILERS[config.platform.split('-')[0]][language]
     if hasattr(compiler, 'keys'):
         compiler = compiler.get(config.variant.get('python', 'nope'), 'vs2015')
     return compiler

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -66,7 +66,7 @@ def ns_cfg(config):
         nomkl=bool(int(os.environ.get('FEATURE_NOMKL', False)))
     )
 
-    defaults = variants.get_default_variants()[0]
+    defaults = variants.get_default_variant(config)
     py = config.variant.get('python', defaults['python'])
     py = int("".join(py.split('.')[:2]))
     d.update(dict(py=py,

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -24,7 +24,7 @@ from conda_build.conda_interface import CondaHTTPError, CondaError
 
 from conda_build.config import get_or_merge_config
 from conda_build.utils import on_win, check_call_env
-from conda_build.variants import get_default_variants
+from conda_build.variants import get_default_variant
 
 import requests
 
@@ -226,7 +226,7 @@ def skeletonize(packages, output_dir=".", version=None,
     config = get_or_merge_config(config)
     # TODO: load/use variants?
 
-    perl_version = config.variant.get('perl', get_default_variants()[0]['perl'])
+    perl_version = config.variant.get('perl', get_default_variant(config)['perl'])
     # wildcards are not valid for perl
     perl_version = perl_version.replace(".*", "")
     package_dicts = {}

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -1,31 +1,71 @@
 """This file handles the parsing of feature specifications from files,
 ending up with a configuration matrix"""
 
+from collections import OrderedDict
 from itertools import product
+import logging
 import os
+from pkg_resources import parse_version
 import sys
 
 import six
 import yaml
 
-from conda_build.utils import ensure_list, HashableDict, trim_empty_keys
+from conda_build.utils import ensure_list, trim_empty_keys
 from conda_build.conda_interface import string_types
-from conda_build.conda_interface import subdir, memoized
+from conda_build.conda_interface import subdir
 from conda_build.conda_interface import cc_conda_build
-from conda_build.conda_interface import cc_platform
+from conda_build.conda_interface import memoized
 
-DEFAULT_EXTEND_KEYS = ['pin_run_as_build', 'ignore_version']
 DEFAULT_VARIANTS = {
-    'python': ['{0}.{1}'.format(sys.version_info.major, sys.version_info.minor)],
-    'numpy': ['1.11'],
+    'python': '{0}.{1}'.format(sys.version_info.major, sys.version_info.minor),
+    'numpy': '1.11',
     # this one actually needs to be pretty specific.  The reason is that cpan skeleton uses the
     #    version to say what's in their standard library.
-    'perl': ['5.26.0'],
-    'lua': ['5'],
-    'r_base': ['3.4'],
-    'cpu_optimization_target': ['nocona'],
+    'perl': '5.26.0',
+    'lua': '5',
+    'r_base': '3.4',
+    'cpu_optimization_target': 'nocona',
     'pin_run_as_build': {'python': {'min_pin': 'x.x', 'max_pin': 'x.x'}},
     'ignore_version': [],
+    'extend_keys': ['pin_run_as_build', 'ignore_version'],
+}
+
+# map python version to default compiler on windows, to match upstream python
+#    This mapping only sets the "native" compiler, and can be overridden by specifying a compiler
+#    in the conda-build variant configuration
+DEFAULT_COMPILERS = {
+    'win': {
+        'c': {
+            '2.7': 'vs2008',
+            '3.3': 'vs2010',
+            '3.4': 'vs2010',
+            '3.5': 'vs2015',
+        },
+        'cxx': {
+            '2.7': 'vs2008',
+            '3.3': 'vs2010',
+            '3.4': 'vs2010',
+            '3.5': 'vs2015',
+        },
+        'vc': {
+            '2.7': '9',
+            '3.3': '10',
+            '3.4': '10',
+            '3.5': '14',
+        },
+        'fortran': 'gfortran',
+    },
+    'linux': {
+        'c': 'gcc',
+        'cxx': 'gxx',
+        'fortran': 'gfortran',
+    },
+    'osx': {
+        'c': 'clang',
+        'cxx': 'clangxx',
+        'fortran': 'gfortran',
+    },
 }
 
 arch_name = subdir.rsplit('-', 1)[-1]
@@ -35,6 +75,33 @@ SUFFIX_MAP = {'PY': 'python',
               'LUA': 'lua',
               'PERL': 'perl',
               'R': 'r_base'}
+
+
+@memoized
+def _get_default_compilers(platform, py_ver):
+    compilers = DEFAULT_COMPILERS[platform].copy()
+    if platform == 'win':
+        if parse_version(py_ver) >= parse_version('3.5'):
+            py_ver = '3.5'
+        elif parse_version(py_ver) <= parse_version('3.2'):
+            py_ver = '2.7'
+        compilers['c'] = compilers['c'][py_ver]
+        compilers['cxx'] = compilers['cxx'][py_ver]
+    compilers = {lang + '_compiler': pkg_name
+                 for lang, pkg_name in compilers.items() if lang != 'vc'}
+    # this one comes after, because it's not a _compiler key
+    if platform == 'win':
+        compilers['vc'] = DEFAULT_COMPILERS[platform]['vc'][py_ver]
+    return compilers
+
+
+def get_default_variant(config):
+    base = DEFAULT_VARIANTS.copy()
+    base['target_platform'] = config.subdir
+    python = base['python'] if (not hasattr(config, 'variant') or
+                                not config.variant.get('python')) else config.variant['python']
+    base.update(_get_default_compilers(config.platform, python))
+    return base
 
 
 def parse_config_file(path, config):
@@ -87,6 +154,62 @@ def find_config_files(metadata_or_path, additional_files=None, ignore_system_con
     return files
 
 
+def _combine_spec_dictionaries(specs, extend_keys=None, filter_keys=None, zip_keys=None):
+    # each spec is a dictionary.  Each subsequent spec replaces the previous one.
+    #     Only the last one with the key stays.
+    values = {}
+    keys = ensure_list(filter_keys)
+    extend_keys = ensure_list(extend_keys)
+
+    for spec_source, spec in specs.items():
+        if spec:
+            for k, v in spec.items():
+                if not keys or k in keys:
+                    if k in extend_keys:
+                        # update dictionaries, extend lists
+                        if hasattr(v, 'keys'):
+                            if k in values and hasattr(values[k], 'keys'):
+                                values[k].update(v)
+                            else:
+                                values[k] = v.copy()
+                        else:
+                            values[k] = ensure_list(values.get(k, []))
+                            values[k].extend(ensure_list(v))
+                            # uniquify
+                            values[k] = list(set(values[k]))
+                    elif k == 'zip_keys':
+                        # should always be a list of lists, but users may specify as just a list
+                        if not isinstance(v[0], list) and not isinstance(v[0], tuple):
+                            v = [v]
+                        values[k] = values.get(k, [])
+                        values[k].extend(v)
+                        values[k] = list(list(set_group) for set_group in set(tuple(group)
+                                                                            for group in values[k]))
+                    else:
+                        if hasattr(v, 'keys'):
+                            values[k] = v.copy()
+                        else:
+                            keys_in_group = [k]
+                            if zip_keys:
+                                for group in zip_keys:
+                                    if k in group:
+                                        keys_in_group = group
+                                        break
+                            # in order to clobber, one must replace ALL of the zipped keys.
+                            #    Otherwise, we filter later.
+                            if all(group_item in spec for group_item in keys_in_group):
+                                for group_item in keys_in_group:
+                                    values[group_item] = ensure_list(spec[group_item])
+                            else:
+                                if k in values and any(subvalue not in values[k]
+                                                    for subvalue in ensure_list(v)):
+                                    raise ValueError("variant config in {} is ambiguous because it "
+                                        "does not fully implement all zipped keys, or specifies "
+                                        "a subspace that is not fully implemented.".format(
+                                            spec_source))
+    return values
+
+
 def combine_specs(specs):
     """With arbitrary sets of sources, combine into a single aggregate spec.
 
@@ -96,55 +219,19 @@ def combine_specs(specs):
            names used in Jinja2 templated recipes.  Values can be either single
            values (strings or integers), or collections (lists, tuples, sets).
     """
-    extend_keys = DEFAULT_EXTEND_KEYS
-    extend_keys.extend([key for spec in specs if spec
+    extend_keys = DEFAULT_VARIANTS['extend_keys'][:]
+    extend_keys.extend([key for spec in specs.values() if spec
                         for key in ensure_list(spec.get('extend_keys'))])
 
-    values = {}
-    # each spec is a dictionary.  Each subsequent spec replaces the previous one.
-    #     Only the last one with the key stays.
-    for spec in specs:
-        if spec:
-            for k, v in spec.items():
-                if k in extend_keys:
-                    # update dictionaries, extend lists
-                    if hasattr(v, 'keys'):
-                        if k in values and hasattr(values[k], 'keys'):
-                            values[k].update(v)
-                        else:
-                            values[k] = v.copy()
-                    else:
-                        values[k] = ensure_list(values.get(k, []))
-                        values[k].extend(ensure_list(v))
-                        # uniquify
-                        values[k] = list(set(values[k]))
-                elif k == 'zip_keys':
-                    # should always be a list of lists, but users may specify as just a list
-                    if not isinstance(v[0], list) and not isinstance(v[0], tuple):
-                        v = [v]
-                    values[k] = values.get(k, [])
-                    values[k].extend(v)
-                    values[k] = list(list(set_group) for set_group in set(tuple(group)
-                                                                          for group in values[k]))
-                else:
-                    if hasattr(v, 'keys'):
-                        values[k] = v.copy()
-                    else:
-                        values[k] = ensure_list(v)
+    # first pass gets zip_keys entries from each and merges them.  We treat these specially
+    #   below, keeping the size of related fields identical, or else the zipping makes no sense
+
+    zip_keys = _combine_spec_dictionaries(specs, extend_keys=extend_keys,
+                                          filter_keys=['zip_keys']).get('zip_keys', [])
+    values = _combine_spec_dictionaries(specs, extend_keys=extend_keys, zip_keys=zip_keys)
+    if 'extend_keys' in values:
+        del values['extend_keys']
     return values, set(extend_keys)
-
-
-def combine_variants(*variants):
-    """Difference between this and combine_specs is that specs have lists of versions, whereas a
-    single variant has only one version per key.
-
-    The purpose of this function is to clobber earlier variant values with later ones, while merging
-    any values from 'extended' columns.
-
-    Many variants can be passed in, but only one unified variant is returned
-    """
-    combined_specs, extend_keys = combine_specs(variants)
-    return dict_of_lists_to_list_of_dicts(combined_specs)[0]
 
 
 def set_language_env_vars(variant):
@@ -225,7 +312,7 @@ def _get_zip_dict_of_lists(combined_variant, list_of_strings):
 
 
 def _get_zip_groups(combined_variant):
-    """returns a dictionary of dictionaries - each one is """
+    """returns a list of dictionaries - each one is a concatenated collection of """
     zip_keys = combined_variant.get('zip_keys')
     groups = []
     if zip_keys:
@@ -238,31 +325,37 @@ def _get_zip_groups(combined_variant):
     return groups
 
 
-def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts, platform=cc_platform):
+def filter_by_key_value(variants, key, values, source_name):
+    """variants is the exploded out list of dicts, with one value per key in each dict.
+    key and values come from subsequent variants before they are exploded out."""
+    reduced_variants = []
+    if hasattr(values, 'keys'):
+        reduced_variants = variants
+    else:
+        # break this out into a full loop so that we can show filtering output
+        for variant in variants:
+            if variant.get(key) and variant.get(key) in values:
+                reduced_variants.append(variant)
+            else:
+                log = logging.getLogger(__name__)
+                log.debug('Filtering variant with key {key} not matching target value(s) '
+                          '({tgt_vals}) from {source_name}, actual {actual_val}'.format(
+                              key=key, tgt_vals=values, source_name=source_name,
+                              actual_val=variant.get(key)))
+    return reduced_variants
+
+
+def dict_of_lists_to_list_of_dicts(dict_of_lists, extend_keys=None):
     # http://stackoverflow.com/a/5228294/1170370
     # end result is a collection of dicts, like [{'python': 2.7, 'numpy': 1.11},
     #                                            {'python': 3.5, 'numpy': 1.11}]
-    if hasattr(dict_or_list_of_dicts, 'keys'):
-        specs = [DEFAULT_VARIANTS, dict_or_list_of_dicts]
-    else:
-        specs = [DEFAULT_VARIANTS] + list(dict_or_list_of_dicts or [])
-
-    combined, extend_keys = combine_specs(specs)
-
-    # default target platform is native subdir
-    # if 'target_platform' not in combined:
-    #     from conda_build.config import Config
-    #     combined['target_platform'] = [Config().subdir]
-
-    if 'extend_keys' in combined:
-        del combined['extend_keys']
-
     dicts = []
-    pass_through_keys = (['extend_keys', 'zip_keys'] + list(extend_keys) +
-                         list(_get_zip_key_set(combined)))
-    dimensions = {k: v for k, v in combined.items() if k not in pass_through_keys}
-    # here's where we add in the zipped dimensions
-    for group in _get_zip_groups(combined):
+    pass_through_keys = (['extend_keys', 'zip_keys'] + list(ensure_list(extend_keys)) +
+                         list(_get_zip_key_set(dict_of_lists)))
+    dimensions = {k: v for k, v in dict_of_lists.items() if k not in pass_through_keys}
+    # here's where we add in the zipped dimensions.  Zipped stuff is concatenated strings, to avoid
+    #      being distributed in the product.
+    for group in _get_zip_groups(dict_of_lists):
         dimensions.update(group)
 
     # in case selectors nullify any groups - or else zip reduces whole set to nil
@@ -271,7 +364,7 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts, platform=cc_platform):
     for x in product(*dimensions.values()):
         remapped = dict(six.moves.zip(dimensions, x))
         for col in pass_through_keys:
-            v = combined.get(col)
+            v = dict_of_lists.get(col)
             if v:
                 remapped[col] = v
         # split out zipped keys
@@ -288,7 +381,7 @@ def dict_of_lists_to_list_of_dicts(dict_or_list_of_dicts, platform=cc_platform):
 
 
 def list_of_dicts_to_dict_of_lists(list_of_dicts):
-    """Opposite of above function.
+    """Opposite of dict_of_lists_to_list_of_dicts function.
 
     Take broken out collection of variants, and squish it into a dict, where each value is a list.
     Only squishes string/int values; does "update" for dict keys
@@ -333,17 +426,7 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
     return squished
 
 
-def conform_variants_to_value(list_of_dicts, dict_of_values):
-    """We want to remove some variability sometimes.  For example, when Python is used by the
-    top-level recipe, we do not want a further matrix for the outputs.  This function reduces
-    the variability of the variant set."""
-    for d in list_of_dicts:
-        for k, v in dict_of_values.items():
-            d[k] = v
-    return list(set([HashableDict(d) for d in list_of_dicts]))
-
-
-def get_package_variants(recipedir_or_metadata, config=None):
+def get_package_variants(recipedir_or_metadata, config=None, variants=None):
     if hasattr(recipedir_or_metadata, 'config'):
         config = recipedir_or_metadata.config
     if not config:
@@ -352,38 +435,39 @@ def get_package_variants(recipedir_or_metadata, config=None):
     files = find_config_files(recipedir_or_metadata, ensure_list(config.variant_config_files),
                               ignore_system_config=config.ignore_system_variants)
 
-    specs = get_default_variants(config.platform) + [parse_config_file(f, config) for f in files]
+    specs = OrderedDict(default=get_default_variant(config))
 
-    target_platform_default = [{'target_platform': config.subdir}]
+    for f in files:
+        specs[f] = parse_config_file(f, config)
+
     # this is the override of the variants from files and args with values from CLI or env vars
-    if config.variant:
-        combined_spec, extend_keys = combine_specs(target_platform_default + specs +
-                                                   [config.variant])
-    else:
-        # this tweaks behavior from clobbering to appending/extending
-        combined_spec, extend_keys = combine_specs(target_platform_default + specs)
+    if hasattr(config, 'variant') and config.variant:
+        specs['config.variant'] = config.variant
+    if variants:
+        specs['argument_variants'] = variants
 
-    # clobber the variant with anything in the config (stuff set via CLI flags or env vars)
-    for k, v in config.variant.items():
-        if k in extend_keys:
-            if hasattr(combined_spec[k], 'keys'):
-                combined_spec[k].update(v)
-            else:
-                combined_spec[k].extend(v)
-        elif k == 'zip_keys':
-            combined_spec[k].extend(v)
-            combined_spec[k] = list(list(set_group) for set_group in set(tuple(group)
-                                                            for group in combined_spec[k]))
-        else:
-            combined_spec[k] = [v]
+    # this merges each of the specs, providing a debug message when a given setting is overridden
+    #      by a later spec
+    combined_spec, extend_keys = combine_specs(specs)
 
     validate_variant(combined_spec)
-    return dict_of_lists_to_list_of_dicts(combined_spec, config.platform)
 
+    extend_keys.update({'zip_keys', 'extend_keys'})
 
-@memoized
-def get_default_variants(platform=cc_platform):
-    return dict_of_lists_to_list_of_dicts(DEFAULT_VARIANTS, platform)
+    # delete the default specs, so that they don't unnecessarily limit the matrix
+    specs = specs.copy()
+    del specs['default']
+
+    combined_spec = dict_of_lists_to_list_of_dicts(combined_spec, extend_keys=extend_keys)
+    for source, source_specs in reversed(specs.items()):
+        for k, vs in source_specs.items():
+            if k not in extend_keys:
+                # when filtering ends up killing off all variants, we just ignore that.  Generally,
+                #    this arises when a later variant config overrides, rather than selects a
+                #    subspace of earlier configs
+                combined_spec = (filter_by_key_value(combined_spec, k, vs, source_name=source) or
+                                 combined_spec)
+    return combined_spec
 
 
 def get_loop_vars(variants):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -13,7 +13,7 @@ from distutils.msvc9compiler import Reg, WINSDK_BASE
 
 from conda_build import environ
 from conda_build.utils import check_call_env, root_script_dir, path_prepended, copy_into, get_logger
-from conda_build.variants import set_language_env_vars, get_default_variants
+from conda_build.variants import set_language_env_vars, get_default_variant
 
 
 assert sys.platform == 'win32'
@@ -110,7 +110,7 @@ def msvc_env_cmd(bits, config, override=None):
     msvc_env_lines.append('set MSSdk=1')
 
     if not version:
-        py_ver = config.variant.get('python', get_default_variants()[0]['python'])
+        py_ver = config.variant.get('python', get_default_variant(config)['python'])
         if int(py_ver[0]) >= 3:
             if int(py_ver.split('.')[1]) < 5:
                 version = '10.0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from conda_build.config import Config
-from conda_build.variants import get_default_variants
+from conda_build.variants import get_default_variant
 from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, prepend_bin_path, copy_into
 
@@ -57,7 +57,7 @@ def testing_metadata(request, testing_config):
     d['about']['home'] = "sweet home"
     d['about']['license'] = "contract in blood"
     d['about']['summary'] = "a test package"
-    testing_config.variant = get_default_variants()[0]
+    testing_config.variant = get_default_variant(testing_config)
     return MetaData.fromdict(d, config=testing_config)
 
 

--- a/tests/test-recipes/variants/18_subspace_selection/conda_build_config.yaml
+++ b/tests/test-recipes/variants/18_subspace_selection/conda_build_config.yaml
@@ -1,0 +1,27 @@
+# this test ensures that we can merge and clobber fields that are part of zip_keys, and it will reduce
+#    any other associated zip keys
+
+# There's two ways this will work:
+#   1. people specify one key, say a, but not b.  The value of that key must already exist in a.  We select
+#      the matching set.  Here, if we select a: coffe, the set we get is [{a: coffee, b: 123}, {a: coffee, b: abc}]
+#   2. people specify more than one key:
+#       - select dimensions when keys match
+#       - if any key does not match, assert that all dimensions in zip_keys are specified, and rather than selecting
+#         subspace, clobber the other existing space
+
+a:
+  - coffee
+  - coffee
+  - llama
+b:
+  - 123
+  - abc
+  - concrete
+c:
+  - mooo
+  - baaa
+  - woof
+zip_keys:
+  - a
+  - b
+  - c

--- a/tests/test-recipes/variants/18_subspace_selection/meta.yaml
+++ b/tests/test-recipes/variants/18_subspace_selection/meta.yaml
@@ -1,0 +1,11 @@
+# this test ensures that we can merge and clobber fields that are part of zip_keys, and it will reduce
+#    any other associated zip keys
+
+package:
+  name: test_subspace_selection
+  version: 1.0
+
+requirements:
+  build:
+    - a
+    - b

--- a/tests/test-recipes/variants/20_subspace_selection_cli/conda_build_config.yaml
+++ b/tests/test-recipes/variants/20_subspace_selection_cli/conda_build_config.yaml
@@ -1,0 +1,11 @@
+python:
+  - 2.7
+  - 2.7
+  - 3.5
+vc:
+  - 9
+  - 14
+  - 14
+zip_keys:
+  - python
+  - vc

--- a/tests/test-recipes/variants/20_subspace_selection_cli/meta.yaml
+++ b/tests/test-recipes/variants/20_subspace_selection_cli/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: test_subspace_selection_cli
+  version: 1.0
+
+requirements:
+  build:
+    - python
+    - vc
+  run:
+    - python

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -145,9 +145,10 @@ def test_build_bootstrap_env_by_path(testing_metadata):
 def test_native_compiler_metadata_win(testing_config, py_ver, mocker):
     testing_config.platform = 'win'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'), config=testing_config,
-                          variants={'python': py_ver[0], 'target_platform': 'win-x86_64'},
-                          permit_unsatisfiable_variants=True,
-                          finalize=False)[0][0]
+                          variants={'target_platform': 'win-x86_64'},
+                          permit_unsatisfiable_variants=True, finalize=False,
+                          bypass_env_check=True, python=py_ver[0])[0][0]
+    # see parameterization - py_ver[1] is the compiler package name
     assert any(dep.startswith(py_ver[1]) for dep in metadata.meta['requirements']['build'])
 
 
@@ -155,7 +156,7 @@ def test_native_compiler_metadata_linux(testing_config, mocker):
     testing_config.platform = 'linux'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config, permit_unsatisfiable_variants=True,
-                          finalize=False)[0][0]
+                          finalize=False, bypass_env_check=True)[0][0]
     _64 = '64' if conda_interface.bits == 64 else '32'
     assert any(dep.startswith('gcc_linux-' + _64) for dep in metadata.meta['requirements']['build'])
     assert any(dep.startswith('gxx_linux-' + _64) for dep in metadata.meta['requirements']['build'])
@@ -166,7 +167,7 @@ def test_native_compiler_metadata_osx(testing_config, mocker):
     testing_config.platform = 'osx'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config, permit_unsatisfiable_variants=True,
-                          finalize=False)[0][0]
+                          finalize=False, bypass_env_check=True)[0][0]
     _64 = '64' if conda_interface.bits == 64 else '32'
     assert any(dep.startswith('clang_osx-' + _64) for dep in metadata.meta['requirements']['build'])
     assert any(dep.startswith('clangxx_osx-' + _64) for dep in metadata.meta['requirements']['build'])


### PR DESCRIPTION
With zip_keys, it was very frustrating to have a central config file that
specified several zip_keys (python, vc, c_compiler, etc.), but to not allow
easy reduction of that build matrix by other config files.  One variable would
get trimmed to the shorter set of values, but then conda-build would fail with
errors about mismatching zip_keys dimensions.

This commit filters out mismatching entries, but does so in a way that allows
the dimensionality of the composite configuration to be maintained.  This also
allows things like

``conda build somerecipe --python=2.7`` to work when larger python build
matrices are defined in conda_build_config.yaml