### PR TITLE
fix path globbing and filtering replacing prefix not at start of path

### DIFF
--- a/tests/test-recipes/metadata/nested_prefix/bld.bat
+++ b/tests/test-recipes/metadata/nested_prefix/bld.bat
@@ -1,0 +1,8 @@
+rem this tests an issue where the prefix folder structure was captured into
+rem packages, and the later occurrence was being replaced in conda-builds notion,
+rem but not on disk. It should have only been getting replaced for the first
+rem instance, to obtain a relative path.
+
+rem this test creates a file in such a path, and triggers the behavior
+mkdir %PREFIX%\include\%PREFIX%
+echo 'weeee' > %PREFIX%\include\%PREFIX%\test

--- a/tests/test-recipes/metadata/nested_prefix/build.sh
+++ b/tests/test-recipes/metadata/nested_prefix/build.sh
@@ -1,0 +1,8 @@
+# this tests an issue where the prefix folder structure was captured into
+# packages, and the later occurrence was being replaced in conda-builds notion,
+# but not on disk. It should have only been getting replaced for the first
+# instance, to obtain a relative path.
+
+# this test creates a file in such a path, and triggers the behavior
+mkdir -p $PREFIX/include/$PREFIX
+echo 'weeee' > $PREFIX/include/$PREFIX/test

--- a/tests/test-recipes/metadata/nested_prefix/meta.yaml
+++ b/tests/test-recipes/metadata/nested_prefix/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: test_nested_prefix_structure
+  version: 1.0


### PR DESCRIPTION
This was especially showing up as failures to copy files when those files lived in paths mimicking the  prefix, like $PREFIX/shared/gdb/$SHARED/something