### PR TITLE
provide CONDA_* config attributes that c-b-a expects

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -136,6 +136,16 @@ DEFAULTS = [Setting('activate', True),
             ]
 
 
+def print_function_deprecation_warning(func):
+    def func_wrapper(*args, **kw):
+        log = get_logger(__name__)
+        log.warn("WARNING: attribute {} is deprecated and will be removed in conda-build 4.0.  "
+                "Please update your code - file issues on the conda-build issue tracker "
+                 "if you need help.".format(func.__name__))
+        return func(*args, **kw)
+    return func_wrapper
+
+
 class Config(object):
     __file__ = __path__ = __file__
     __package__ = __package__
@@ -339,6 +349,62 @@ class Config(object):
         """This is the core folder for a given build.
         It has the environments and work directories."""
         return os.path.join(self.croot, self.build_id)
+
+    # back compat for conda-build-all - expects CONDA_* vars to be attributes of the config object
+    @property
+    @print_function_deprecation_warning
+    def CONDA_LUA(self):
+        return self.variant.get('lua', get_default_variant(self)['lua'])
+
+    @CONDA_LUA.setter
+    @print_function_deprecation_warning
+    def CONDA_LUA(self, value):
+        self.variant['lua'] = value
+
+    @property
+    @print_function_deprecation_warning
+    def CONDA_PY(self):
+        value = self.variant.get('python', get_default_variant(self)['python'])
+        return int(''.join(value.split('.')))
+
+    @CONDA_PY.setter
+    @print_function_deprecation_warning
+    def CONDA_PY(self, value):
+        value = str(value)
+        self.variant['python'] = '.'.join((value[0], value[1:]))
+
+    @property
+    @print_function_deprecation_warning
+    def CONDA_NPY(self):
+        value = self.variant.get('numpy', get_default_variant(self)['numpy'])
+        return int(''.join(value.split('.')))
+
+    @CONDA_NPY.setter
+    @print_function_deprecation_warning
+    def CONDA_NPY(self, value):
+        value = str(value)
+        self.variant['numpy'] = '.'.join((value[0], value[1:]))
+
+    @property
+    @print_function_deprecation_warning
+    def CONDA_PERL(self):
+        return self.variant.get('perl', get_default_variant(self)['perl'])
+
+    @CONDA_PERL.setter
+    @print_function_deprecation_warning
+    def CONDA_PERL(self, value):
+        self.variant['perl'] = value
+
+    @property
+    @print_function_deprecation_warning
+    def CONDA_R(self):
+
+        return self.variant.get('r_base', get_default_variant(self)['r_base'])
+
+    @CONDA_R.setter
+    @print_function_deprecation_warning
+    def CONDA_R(self, value):
+        self.variant['r_base'] = value
 
     def _get_python(self, prefix):
         if sys.platform == 'win32':

--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -82,7 +82,8 @@ class DependencyNeedsBuildingError(CondaBuildException):
 
     @property
     def message(self):
-        return "Unsatisfiable dependencies for platform {}: {}".format(self.subdir, self.matchspecs)
+        return "Unsatisfiable dependencies for platform {}: {}".format(self.subdir,
+                                                                       set(self.matchspecs))
 
 
 class RecipeError(CondaBuildException):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -337,6 +337,13 @@ def _read_index_tar(tar_path, lock, locking=True, timeout=90):
             return index_json, about_json, paths_json, recipe_json
 
 
+def write_repodata(repodata, dir_path, lock, locking=90, timeout=90, **kw):
+    """compatibility shim for conda-build-all"""
+    log.warn("Using unsupported internal conda-build api (write_repodata).  Please update your "
+             "code to use conda_build.api.update_index instead.")
+    return _write_repodata(repodata, dir_path, lock, locking, timeout)
+
+
 def _write_repodata(repodata, dir_path, lock, locking=90, timeout=90):
     """ Write updated repodata.json and repodata.json.bz2 """
     locks = []

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -744,7 +744,7 @@ class MetaData(object):
                                    raise_on_clobber=raise_on_clobber)
 
     def parse_again(self, permit_undefined_jinja=False, allow_no_other_outputs=False,
-                    bypass_env_check=False):
+                    bypass_env_check=False, **kw):
         """Redo parsing for key-value pairs that are not initialized in the
         first pass.
 
@@ -757,6 +757,9 @@ class MetaData(object):
         assert not self.final, "modifying metadata after finalization"
 
         log = utils.get_logger(__name__)
+        if kw:
+            log.warn("using unsupported internal conda-build function `parse_again`.  Please use "
+                     "conda_build.api.render instead.")
 
         if isfile(self.requirements_path) and not self.get_value('requirements/run'):
             self.meta.setdefault('requirements', {})

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import os
 import json
 
@@ -13,18 +14,19 @@ recipe_dir = os.path.join(thisdir, 'test-recipes', 'variants')
 
 def test_later_spec_priority(single_version, no_numpy_version):
     # override a single key
-    combined_spec, extend_keys = variants.combine_specs({
-        'no_numpy': no_numpy_version,
-        'single_ver': single_version})
+    specs = OrderedDict()
+    specs['no_numpy'] = no_numpy_version
+    specs['single_ver'] = single_version
+    combined_spec, extend_keys = variants.combine_specs(specs)
     assert len(combined_spec) == 2
     assert combined_spec["python"] == ["2.7.*"]
     assert extend_keys == {'ignore_version', 'pin_run_as_build'}
 
     # keep keys that are not overwritten
-    combined_spec, extend_keys = variants.combine_specs({
-        'single_ver': single_version,
-        'no_numpy': no_numpy_version,
-        })
+    specs = OrderedDict()
+    specs['single_ver'] = single_version
+    specs['no_numpy'] = no_numpy_version
+    combined_spec, extend_keys = variants.combine_specs(specs)
     assert len(combined_spec) == 2
     assert len(combined_spec["python"]) == 2
 


### PR DESCRIPTION
also adds **kw to a couple of functions that I'd consider private, but c-b-a uses.  That's OK.  We ignore c-b-a's arguments to kw.