### PR TITLE
 fix duplicate env creation with no explicit outputs section

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -77,6 +77,7 @@ def get_output_file_paths(recipe_path_or_metadata, no_download_source=False, con
     """
     from conda_build.render import bldpkg_path
     from conda_build.conda_interface import string_types
+    from conda_build.utils import get_skip_message
     config = get_or_merge_config(config, **kwargs)
     if hasattr(recipe_path_or_metadata, '__iter__') and not isinstance(recipe_path_or_metadata,
                                                                        string_types):
@@ -99,8 +100,7 @@ def get_output_file_paths(recipe_path_or_metadata, no_download_source=False, con
     outs = []
     for (m, _, _) in metadata:
         if m.skip():
-            outs.append("Skipped: {} defines build/skip for this configuration."
-                        .format(m.path))
+            outs.append(get_skip_message(m))
         else:
             outs.append(bldpkg_path(m))
     return sorted(list(set(outs)))

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1181,9 +1181,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                     # for more than one output, we clear and rebuild the environment before each
                     #    package.  We also do this for single outputs that present their own
                     #    build reqs.
-                    output_reqs = output_d.get('requirements', {})
-                    if len(outputs) > 1 or output_reqs and (isinstance(output_reqs, list) or
-                                                            output_reqs.get('build', {})):
+                    if m.meta['extra'].get('parent_recipe'):
                         utils.rm_rf(m.config.host_prefix)
                         utils.rm_rf(m.config.build_prefix)
                         utils.rm_rf(m.config.test_prefix)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -860,7 +860,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         built_packages = {}
 
     if m.skip():
-        utils.print_skip_message(m)
+        print(utils.get_skip_message(m))
         return default_return
 
     log = utils.get_logger(__name__)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -703,9 +703,10 @@ def convert_path_for_cygwin_or_msys2(exe, path):
     return path
 
 
-def print_skip_message(metadata):
-    print("Skipped: {} defines build/skip for this "
-          "configuration.".format(metadata.path))
+def get_skip_message(metadata):
+    return ("Skipped: {} defines build/skip for this configuration ({}).".format(
+        metadata.path,
+        {k: metadata.config.variant[k] for k in metadata.get_used_loop_vars()}))
 
 
 @memoized

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,8 +149,8 @@ def test_build_output_build_path_multiple_recipes(testing_workdir, testing_metad
     test_paths = [test_path(
         "test_build_output_build_path_multiple_recipes-1.0-py{}{}{}_1.tar.bz2".format(
             sys.version_info.major, sys.version_info.minor, _hash)),
-        "Skipped: {} defines build/skip for this "
-        "configuration.".format(os.path.abspath(skip_recipe))]
+        "Skipped: {} defines build/skip for this configuration ({{}}).".format(
+            os.path.abspath(skip_recipe))]
 
     output, error = capfd.readouterr()
     # assert error == ""


### PR DESCRIPTION
also make skipped package output more informative (show used variables and their values)