### PR TITLE
Format json files to include newlines and indentation

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -259,7 +259,7 @@ def copy_test_source_files(m):
 def write_hash_input(m):
     recipe_input, file_paths = m.get_hash_contents()
     with open(os.path.join(m.config.info_dir, 'hash_input.json'), 'w') as f:
-        json.dump(recipe_input, f)
+        json.dump(recipe_input, f, indent=2)
 
     if m.config.include_recipe and m.include_recipe():
         with codecs.open(os.path.join(m.config.info_dir, 'hash_input_files'), 'w', 'utf-8') as f:

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -197,7 +197,7 @@ def update_index_file(temp_dir, target_platform, dependencies, verbose):
         index['depends'] = update_dependencies(dependencies, index['depends'])
 
     with open(index_file, 'w') as file:
-        json.dump(index, file)
+        json.dump(index, file, indent=2)
 
     return index_file
 


### PR DESCRIPTION
When dumping to a json file if the dump contains only a dictionary or nested dictionary, the dictionary is written to the output file on a single line. This causes readability issues when the dictionary is long.

By adding the indent keyword to json.dump(), newlines are added after each key and the keys are spaced at the given indent level. I chose to indent 2 spaces as that is how ``conda`` indents its dumps.

Here is the relevant excerpt from the json module's documentation:
```
If indent is a non-negative integer or string, then JSON array elements and
object members will be pretty-printed with that indent level. An indent level of
0, negative, or "" will only insert newlines. None (the default) selects the most
compact representation. Using a positive integer indent indents that many 
spaces per level. If indent is a string (such as "\t"), that string is used to indent
each level.
```

