### PR TITLE
Support GIT_* vars even when a source folder was specified

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -370,8 +370,10 @@ def meta_vars(meta, config):
         else:
             d[var_name] = value
 
-    git_dir = join(config.work_dir, '.git')
-    hg_dir = join(config.work_dir, '.hg')
+    folder = meta.get_value('source/0/folder', '')
+    repo_dir = join(config.work_dir, folder)
+    git_dir = join(repo_dir, '.git')
+    hg_dir = join(repo_dir, '.hg')
 
     if not isinstance(git_dir, str):
         # On Windows, subprocess env can't handle unicode.


### PR DESCRIPTION
**tl;dr**: This little PR fixes `GIT_DESCRIBE_TAG`, etc. in the case when `meta.yaml` specifies a custom `source: folder:`.

**Details:**

As described in the [docs](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#destination-path), the `source` section can optionally specify a nested `folder` within the `work` directory for the source to be cloned into.  For example:

```yaml
source:
  git_url: http://github.com/foo/bar
  folder: foo-sources/bar
```

...but the code that sets jinja variables such as `GIT_DESCRIBE_TAG` had assumed that the recipe did not specify a custom `folder`.  This PR fixes that.

PS -- I didn't augment the test suite, partly because this is a tiny change and partly because a number of tests were already failing in my machine.  (I think there may be something wrong with my setup.)