### PR TITLE
Check architecture in index.json for platforms other than Linux, macOS, and Windows

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -56,7 +56,13 @@ def retrieve_package_platform(file_path):
         index = json.loads(tar.extractfile('info/index.json').read().decode('utf-8'))
 
     platform = index['platform']
-    architecture = '64' if index['arch'] == 'x86_64' else '32'
+
+    if index.get('arch') == 'x86_64':
+        architecture = '64'
+    elif index.get('arch') == 'x86':
+        architecture = '32'
+    else:
+        architecture = index.get('arch')
 
     if platform.startswith('linux') or platform.startswith('osx'):
         return ('unix', platform, architecture)


### PR DESCRIPTION
I realized the last PR added the ability to convert from architectures like arm to linux, but not the other way around. This PR adds that capability.