### PR TITLE
don't show .* being added warning for vc dep automatically added by c…

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1256,7 +1256,7 @@ def ensure_valid_spec(spec, warn=False):
                 spec = spec_needing_star_re.sub(r"\1 \2", spec)
             else:
                 if "*" not in spec:
-                    if match.group(1) != 'python' and warn:
+                    if match.group(1) not in ('python', 'vc') and warn:
                         log = get_logger(__name__)
                         log.warn("Adding .* to spec '{}' to ensure satisfiability.  Please "
                                  "consider putting {{{{ var_name }}}}.* or some relational "


### PR DESCRIPTION
…ompiler

This is cosmetic.  It's so that people don't get worried about messages like

```
Adding .* to spec 'vc 9' to ensure satisfiability.  Please consider putting {{ var_name }}.* or some relational operator (>/</>=/<=) on this spec in meta.yaml, or if req is also a build req, using {{ pin_compatible() }} jinja2 function instead.  See https://conda.io/docs/user-guide/tasks/build-packages/variants.html#pinning-at-the-variant-level
```

when the ``vc 9`` spec is being added by the compiler activation package.