### PR TITLE
Test noarch Python with Python version constrained

### DIFF
--- a/tests/test-recipes/metadata/_noarch_python2/meta.yaml
+++ b/tests/test-recipes/metadata/_noarch_python2/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: noarch_python2_only_test_package
+  version: "1.0"
+
+source:
+  path: ./noarch_python_test_package
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+  entry_points:
+    - noarch_python_test_package_script = noarch_python_test_package:main
+
+requirements:
+  build:
+    - python >=2,<3
+    - setuptools
+  run:
+    - python >=2,<3
+  preferred_env: _env_
+  preferred_env_executable_paths:
+    - test/path
+    - test/path2

--- a/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/MANIFEST.in
+++ b/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/MANIFEST.in
@@ -1,0 +1,2 @@
+include setup.py
+recursive-exclude shell *

--- a/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/noarch_python_test_package.py
+++ b/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/noarch_python_test_package.py
@@ -1,0 +1,11 @@
+""" This functions as a module but also as entry point.
+"""
+
+answer = 142
+
+
+def main():
+    print(answer + 100)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/setup.py
+++ b/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup
+
+name = 'noarch_python_test_package'
+
+setup(
+    name=name,
+    version='1.0',
+    author='Almar',
+    author_email='almar@notmyemail.com',
+    url='http://continuum.io',
+    license='(new) BSD',
+    description='testing noarch python package building',
+    platforms='any',
+    provides=[name],
+    py_modules=[name],
+    entry_points={'console_scripts': ['%s_script = %s:main' % (name, name)], },
+    scripts=[
+        'shell/test-executable',
+        'shell/test-executable.bat',
+    ],
+)

--- a/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/shell/test-executable
+++ b/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/shell/test-executable
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "hello world"

--- a/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/shell/test-executable.bat
+++ b/tests/test-recipes/metadata/_noarch_python2/noarch_python_test_package/shell/test-executable.bat
@@ -1,0 +1,1 @@
+ECHO "hello world"

--- a/tests/test-recipes/metadata/_noarch_python3/meta.yaml
+++ b/tests/test-recipes/metadata/_noarch_python3/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: noarch_python3_only_test_package
+  version: "1.0"
+
+source:
+  path: ./noarch_python_test_package
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+  entry_points:
+    - noarch_python_test_package_script = noarch_python_test_package:main
+
+requirements:
+  build:
+    - python >=3,<4
+    - setuptools
+  run:
+    - python >=3,<4
+  preferred_env: _env_
+  preferred_env_executable_paths:
+    - test/path
+    - test/path2

--- a/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/MANIFEST.in
+++ b/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/MANIFEST.in
@@ -1,0 +1,2 @@
+include setup.py
+recursive-exclude shell *

--- a/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/noarch_python_test_package.py
+++ b/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/noarch_python_test_package.py
@@ -1,0 +1,11 @@
+""" This functions as a module but also as entry point.
+"""
+
+answer = 142
+
+
+def main():
+    print(answer + 100)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/setup.py
+++ b/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup
+
+name = 'noarch_python_test_package'
+
+setup(
+    name=name,
+    version='1.0',
+    author='Almar',
+    author_email='almar@notmyemail.com',
+    url='http://continuum.io',
+    license='(new) BSD',
+    description='testing noarch python package building',
+    platforms='any',
+    provides=[name],
+    py_modules=[name],
+    entry_points={'console_scripts': ['%s_script = %s:main' % (name, name)], },
+    scripts=[
+        'shell/test-executable',
+        'shell/test-executable.bat',
+    ],
+)

--- a/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/shell/test-executable
+++ b/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/shell/test-executable
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "hello world"

--- a/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/shell/test-executable.bat
+++ b/tests/test-recipes/metadata/_noarch_python3/noarch_python_test_package/shell/test-executable.bat
@@ -1,0 +1,1 @@
+ECHO "hello world"

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -661,6 +661,16 @@ def test_noarch_python2_only(testing_config):
     assert 'package_metadata_version' in extra
 
 
+def test_noarch_python3_only(testing_config):
+    output = api.build(os.path.join(metadata_dir, "_noarch_python3"), config=testing_config)[0]
+    assert package_has_file(output, 'info/files') is not ''
+    extra = json.loads(package_has_file(output, 'info/link.json').decode())
+    assert 'noarch' in extra
+    assert 'entry_points' in extra['noarch']
+    assert 'type' in extra['noarch']
+    assert 'package_metadata_version' in extra
+
+
 def test_legacy_noarch_python(testing_config):
     output = api.build(os.path.join(metadata_dir, "_legacy_noarch_python"),
                        config=testing_config)[0]

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -651,6 +651,16 @@ def test_noarch_python_1(testing_config):
     assert 'package_metadata_version' in extra
 
 
+def test_noarch_python2_only(testing_config):
+    output = api.build(os.path.join(metadata_dir, "_noarch_python2"), config=testing_config)[0]
+    assert package_has_file(output, 'info/files') is not ''
+    extra = json.loads(package_has_file(output, 'info/link.json').decode())
+    assert 'noarch' in extra
+    assert 'entry_points' in extra['noarch']
+    assert 'type' in extra['noarch']
+    assert 'package_metadata_version' in extra
+
+
 def test_legacy_noarch_python(testing_config):
     output = api.build(os.path.join(metadata_dir, "_legacy_noarch_python"),
                        config=testing_config)[0]


### PR DESCRIPTION
Adds some tests to make sure that noarch Python works when the Python version is constrained to Python 2 only or Python 3 only.