### PR TITLE
Write all `about` metadata fields out

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -52,7 +52,7 @@ from conda_build.render import (output_yaml, bldpkg_path, render_recipe, reparse
                                 distribute_variants, expand_outputs, try_download,
                                 add_upstream_pins)
 import conda_build.os_utils.external as external
-from conda_build.metadata import MetaData
+from conda_build.metadata import FIELDS, MetaData
 from conda_build.post import (post_process, post_build,
                               fix_permissions, get_build_metadata)
 
@@ -390,8 +390,7 @@ def write_link_json(m):
 def write_about_json(m):
     with open(join(m.config.info_dir, 'about.json'), 'w') as fo:
         d = {}
-        for key in ('home', 'dev_url', 'doc_url', 'doc_source_url', 'license_url',
-                    'license', 'summary', 'description', 'license_family'):
+        for key in FIELDS["about"]:
             value = m.get_value('about/%s' % key)
             if value:
                 d[key] = value


### PR DESCRIPTION
Not sure if there is a reason to write only some of the `about` fields out and not others. If there is, I guess I'll soon find out. 😄 If there isn't, this should make things a little easier to manage and avoid missing a few things.