### PR TITLE
Add a `recipe_url` to `about`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -446,7 +446,8 @@ FIELDS = {
     'app': {'entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'},
     'test': {'requires', 'commands', 'files', 'imports', 'source_files'},
-    'about': {'home', 'dev_url', 'doc_url', 'doc_source_url', 'license_url',  # these are URLs
+    'about': {'home', 'dev_url', 'doc_url', 'doc_source_url', # these are URLs
+              'license_url', 'recipe_url',  # these are more URLs
               'license', 'summary', 'description', 'license_family',  # text
               'license_file', 'readme',  # paths in source tree
               },


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/2462

If Anaconda supports this some day, it will make it easier for people to navigate from the package back to the recipe source. Seems pretty handy if one finds the package has an issue and would like to figure out why. Could also be helpful for someone that is curious.