### PR TITLE
make always_include_files act on host_prefix, not build_prefix

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1281,7 +1281,7 @@ class MetaData(object):
         if on_win:
             files = [f.replace("/", "\\") for f in files]
 
-        return expand_globs(files, self.config.build_prefix)
+        return expand_globs(files, self.config.host_prefix)
 
     def binary_relocation(self):
         ret = self.get_value('build/binary_relocation', True)


### PR DESCRIPTION
host_prefix is where the target platform's libs should be, so having this act on build_prefix was actually broken.  It was OK for most builds because most builds are not cross.  This was broken on win-64 compiling for win-32.