### PR TITLE
Backport "only set env vars in build scripts that actually have values"

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -213,7 +213,8 @@ def build(m, bld_bat, config):
             # more debuggable with echo on
             fo.write('@echo on\n')
             for key, value in env.items():
-                fo.write('set "{key}={value}"\n'.format(key=key, value=value))
+                if value:
+                    fo.write('set "{key}={value}"\n'.format(key=key, value=value))
             fo.write(msvc_env_cmd(bits=bits, config=config,
                                   override=m.get_value('build/msvc_compiler', None)))
             # Reset echo on, because MSVC scripts might have turned it off


### PR DESCRIPTION
Partial backport of PR ( https://github.com/conda/conda-build/pull/2259 ). Related to issue ( https://github.com/conda/conda-build/issues/2257 ).

Pulls this change from commit ( https://github.com/conda/conda-build/commit/4c2ecd375cc4cf76c561d9c82553ce9dffe46841 ) in `conda-build` 3.x and brings it back to `conda-build` 2.x. Only pulls back the Windows functionality change as there doesn't appear to be an equivalent change for UNIX.