### PR TITLE
add method for getting all used vars, not just loop vars

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1815,9 +1815,12 @@ class MetaData(object):
     def get_loop_vars(self):
         _variants = (self.config.input_variants if hasattr(self.config, 'input_variants') else
                     self.config.variants)
-        return variants.get_loop_vars(_variants)
+        return variants.get_vars(_variants, loop_only=True)
 
     def get_used_loop_vars(self):
+        return {var for var in self.get_used_vars() if var in self.get_loop_vars()}
+
+    def get_used_vars(self):
         used_variables = set()
         # recipe text is the best, because variables can be used anywhere in it.
         #   we promise to detect anything in meta.yaml, but not elsewhere.
@@ -1828,7 +1831,7 @@ class MetaData(object):
                     self.get_value('requirements/run') +
                     self.get_value('requirements/host'))
             recipe_text = '- ' + "\n- ".join(requirements)
-        for v in self.get_loop_vars():
+        for v in self.config.variant:
             variant_regex = r"(\s*\{\{\s*%s\s*(?:.*?)?\}\})" % v
             requirement_regex = r"(\-\s+%s(?:\s+|$))" % v
             all_res = '|'.join((variant_regex, requirement_regex))

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -472,10 +472,11 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
     return combined_spec
 
 
-def get_loop_vars(variants):
+def get_vars(variants, loop_only=False):
     """For purposes of naming/identifying, provide a way of identifying which variables contribute
     to the matrix dimensionality"""
     special_keys = ('pin_run_as_build', 'zip_keys', 'ignore_version')
     loop_vars = [k for k in variants[0] if k not in special_keys and
-            any(variant[k] != variants[0][k] for variant in variants[1:])]
+                 (not loop_only or
+                  any(variant[k] != variants[0][k] for variant in variants[1:]))]
     return loop_vars

--- a/tests/test-recipes/variants/19_used_variables/conda_build_config.yaml
+++ b/tests/test-recipes/variants/19_used_variables/conda_build_config.yaml
@@ -5,7 +5,6 @@ unused_var:
   - abc
   - 123
 zlib:
-  - 1.2.8
   - 1.2.11
 some_package:
   - mooo

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -245,7 +245,9 @@ def test_get_used_loop_vars(testing_config):
     # conda_build_config.yaml has 4 loop variables defined, but only 3 are used.
     #   python and zlib are both implicitly used (depend on name matching), while
     #   some_package is explicitly used as a jinja2 variable
-    assert ms[0][0].get_used_loop_vars() == {'python', 'some_package', 'zlib'}
+    assert ms[0][0].get_used_loop_vars() == {'python', 'some_package'}
+    # these are all used vars - including those with only one value (and thus not loop vars)
+    assert ms[0][0].get_used_vars() == {'python', 'some_package', 'zlib'}
 
 
 def test_reprovisioning_source(testing_config):


### PR DESCRIPTION
This helps limit "used" variables to those that are used, even if they're just a single value.  Previously, it was only possible to obtain a list of "used" variables that had multiple values.

Prereq for https://github.com/conda-forge/conda-smithy/pull/618