### PR TITLE
work on test time with conda 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,14 +46,7 @@ install:
   - conda config --set auto_update_conda False
   - conda update -q --all
   - if [ -n "$CONDA_VERSION" ]; then
-        rm -rf $HOME/miniconda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda;
-        rm -rf $HOME/miniconda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda*.egg-info;
-        git clone -b $CONDA_VERSION --single-branch --depth 1000 https://github.com/conda/conda.git;
-        pushd conda;
-        $HOME/miniconda/bin/python utils/setup-testing.py install;
-        popd;
-        hash -r;
-        conda info;
+        . ci/travis/install-conda.sh;
     fi
   - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION
   - conda install -q pyflakes conda-verify beautifulsoup4 chardet pycrypto glob2

--- a/ci/travis/install-conda.sh
+++ b/ci/travis/install-conda.sh
@@ -1,0 +1,42 @@
+install_conda_43() {
+    rm -rf $HOME/miniconda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda;
+    rm -rf $HOME/miniconda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda*.egg-info;
+    git clone -b $CONDA_VERSION --single-branch --depth 1000 https://github.com/conda/conda.git;
+    pushd conda;
+    $HOME/miniconda/bin/python utils/setup-testing.py install;
+    popd;
+    hash -r;
+    conda info;
+}
+
+
+install_conda_44() {
+    rm -rf $HOME/miniconda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda
+    rm -rf $HOME/miniconda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda*.egg-info
+    rm -rf $HOME/miniconda/bin/activate
+    rm -rf $HOME/miniconda/bin/conda
+    rm -rf $HOME/miniconda/bin/conda-env
+    rm -rf $HOME/miniconda/bin/deactivate
+
+    git clone -b $CONDA_VERSION --single-branch --depth 1000 https://github.com/conda/conda.git $HOME/conda
+
+    pushd $HOME/conda
+    $HOME/miniconda/bin/python conda.recipe/setup.py install
+    popd
+
+    . $HOME/conda/utils/functions.sh
+    install_conda_shell_scripts $HOME/miniconda "$HOME/conda"
+    make_conda_entrypoint $HOME/miniconda/bin/conda $HOME/miniconda/bin/python "$HOME/conda" 'from conda.cli import main'
+    make_conda_entrypoint $HOME/miniconda/bin/conda-env $HOME/miniconda/bin/python "$HOME/conda" 'from conda_env.cli.main import main'
+
+    . "$HOME/miniconda/etc/profile.d/conda.sh"
+
+    conda info
+
+}
+
+
+case "$CONDA_VERSION" in
+  4.3*) install_conda_43;;
+  *) install_conda_44;;
+esac

--- a/ci/travis/install-conda.sh
+++ b/ci/travis/install-conda.sh
@@ -33,6 +33,8 @@ install_conda_44() {
 
     conda info
 
+    echo "safety_checks: disabled" >> "$HOME/.condarc"
+
 }
 
 

--- a/ci/travis/run.sh
+++ b/ci/travis/run.sh
@@ -13,7 +13,7 @@ if [[ "$FLAKE8" == "true" ]]; then
     source activate _cbtest
     conda build conda.recipe --no-anaconda-upload
 else
-    $HOME/miniconda/bin/py.test -v -n 0 --basetemp /tmp/cb --cov conda_build --cov-report xml -m "serial" tests
+    $HOME/miniconda/bin/py.test -v -n 0 --basetemp /tmp/cb --cov conda_build --cov-report xml -m "serial" tests --durations=15
     $HOME/miniconda/bin/py.test -v -n 2 --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --durations=15
     # $HOME/miniconda/bin/py.test -v --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml tests --durations=15
 fi


### PR DESCRIPTION
This PR takes the edge off, by disabling those safety checks.  I don't think it's a full or "real" solution yet.  It *does* install conda 4.4 correctly.  I recommend merging it.

I also think this shows that the safety checks we're disabling aren't the root cause of what's going on.  If that were the case, the test run time would be closer in line to the 4.3.x runs.

For now though, it at least takes off enough time that we should usually stay under the Travis CI cut-off limit.