### PR TITLE
simplify hashing, fix pin_compatible within a single output

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -236,7 +236,8 @@ def pin_compatible(m, package_name, lower_bound=None, upper_bound=None, min_pin=
                     else:
                         compatibility = apply_pin_expressions(version, min_pin, max_pin)
 
-    if not compatibility and not permit_undefined_jinja and not bypass_env_check:
+    if (not compatibility and not permit_undefined_jinja and not bypass_env_check and
+            'pin_compatible' in m.extract_requirements_text()):
         raise RuntimeError("Could not get compatibility information for {} package.  "
                            "Is it one of your build dependencies?".format(package_name))
     return "  ".join((package_name, compatibility)) if compatibility is not None else package_name

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1317,3 +1317,11 @@ def match_peer_job(target_matchspec, other_m, this_m=None):
             if v in other_m_used_vars:
                 variant_matches &= this_m.config.variant[v] == other_m.config.variant[v]
     return matchspec_matches and variant_matches
+
+
+def expand_reqs(reqs_entry):
+    if not hasattr(reqs_entry, 'keys'):
+        original = ensure_list(reqs_entry)[:]
+        reqs_entry = {'host': original,
+                        'run': original}
+    return reqs_entry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,8 @@ def testing_metadata(request, testing_config):
     d['package']['version'] = '1.0'
     d['build']['number'] = '1'
     d['build']['entry_points'] = []
-    d['requirements']['build'] = ['python']
-    d['requirements']['run'] = ['python']
+    d['requirements']['build'] = []
+    d['requirements']['run'] = []
     d['test']['commands'] = ['echo "A-OK"', 'exit 0']
     d['about']['home'] = "sweet home"
     d['about']['license'] = "contract in blood"

--- a/tests/test-recipes/metadata/_legacy_noarch_python/run_test.py
+++ b/tests/test-recipes/metadata/_legacy_noarch_python/run_test.py
@@ -5,7 +5,7 @@ import subprocess
 import noarch_test_package
 
 pkgs_dir = os.path.abspath(os.path.join(os.environ["ROOT"], 'pkgs'))
-pkg_dir = glob(os.path.join(pkgs_dir, 'noarch_test_package-1.0-pyh*_0'))[0]
+pkg_dir = glob(os.path.join(pkgs_dir, 'noarch_test_package-1.0-py*_0'))[0]
 
 assert os.path.isdir(pkg_dir)
 

--- a/tests/test-recipes/metadata/_noarch_python_with_tests/run_test.py
+++ b/tests/test-recipes/metadata/_noarch_python_with_tests/run_test.py
@@ -5,7 +5,7 @@ import subprocess
 import noarch_python_test_package
 
 pkgs_dir = os.path.abspath(os.path.join(os.environ["ROOT"], 'pkgs'))
-pkg_dir = glob(os.path.join(pkgs_dir, 'noarch_python_test_package-1.0-pyh*_0'))[0]
+pkg_dir = glob(os.path.join(pkgs_dir, 'noarch_python_test_package-1.0-py_0'))[0]
 
 assert os.path.isdir(pkg_dir)
 

--- a/tests/test-recipes/metadata/_numpy_xx/run_test.bat
+++ b/tests/test-recipes/metadata/_numpy_xx/run_test.bat
@@ -1,5 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py..h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/_numpy_xx/run_test.sh
+++ b/tests/test-recipes/metadata/_numpy_xx/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain NumPy, but not the version
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py..h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py.._0"

--- a/tests/test-recipes/metadata/_numpy_xx_host/run_test.bat
+++ b/tests/test-recipes/metadata/_numpy_xx_host/run_test.bat
@@ -1,5 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py..h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/_numpy_xx_host/run_test.sh
+++ b/tests/test-recipes/metadata/_numpy_xx_host/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain NumPy, but not the version
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py..h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-np112py.._0"

--- a/tests/test-recipes/metadata/_python_xx/run_test.bat
+++ b/tests/test-recipes/metadata/_python_xx/run_test.bat
@@ -1,5 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-xx-1\.0-py34h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-xx-1\.0-py34_0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/_python_xx/run_test.sh
+++ b/tests/test-recipes/metadata/_python_xx/run_test.sh
@@ -1,2 +1,2 @@
 conda list -p $PREFIX --canonical
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-xx-1\.0-py34h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-xx-1\.0-py34_0"

--- a/tests/test-recipes/metadata/_test_early_abort/meta.yaml
+++ b/tests/test-recipes/metadata/_test_early_abort/meta.yaml
@@ -2,6 +2,10 @@ package:
   name: foobar
   version: 1.0
 
+requirements:
+  run:
+    - python
+
 test:
   commands:
     - python --version

--- a/tests/test-recipes/metadata/_test_failed_test_exits/meta.yaml
+++ b/tests/test-recipes/metadata/_test_failed_test_exits/meta.yaml
@@ -3,7 +3,5 @@ package:
     version: 1.0
 
 test:
-    requires:
-        - python
     commands:
-        - python -V
+        - exit 1

--- a/tests/test-recipes/metadata/_test_failed_test_exits/run_test.py
+++ b/tests/test-recipes/metadata/_test_failed_test_exits/run_test.py
@@ -1,1 +1,0 @@
-assert False

--- a/tests/test-recipes/metadata/ignore_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/ignore_prefix_files/run_test.py
@@ -2,7 +2,7 @@ from glob import glob
 import os
 
 pkgs = os.path.join(os.environ["ROOT"], "pkgs")
-pkg_dir = glob(os.path.join(pkgs, "conda-build-test-ignore-prefix-files-1.0-h*_0"))[0]
+pkg_dir = glob(os.path.join(pkgs, "conda-build-test-ignore-prefix-files-1.0-0"))[0]
 info_dir = os.path.join(pkg_dir, 'info')
 assert os.path.isdir(info_dir)
 assert not os.path.isfile(os.path.join(info_dir, "has_prefix"))

--- a/tests/test-recipes/metadata/ignore_some_prefix_files/run_test.py
+++ b/tests/test-recipes/metadata/ignore_some_prefix_files/run_test.py
@@ -2,7 +2,7 @@ from glob import glob
 import os
 
 pkgs = os.path.join(os.environ["ROOT"], "pkgs")
-pkg_dir = glob(os.path.join(pkgs, "conda-build-test-ignore-some-prefix-files-1.0-h*_0"))[0]
+pkg_dir = glob(os.path.join(pkgs, "conda-build-test-ignore-some-prefix-files-1.0-0"))[0]
 info_dir = os.path.join(pkg_dir, 'info')
 has_prefix_file = os.path.join(info_dir, "has_prefix")
 print(info_dir)

--- a/tests/test-recipes/metadata/numpy_build/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-1.0-h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-1.0-0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build/run_test.sh
@@ -1,1 +1,1 @@
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-1.0-h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-1.0-0"

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.bat
@@ -1,5 +1,5 @@
 @echo on
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-py..h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-build-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_build_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain NumPy, but not the version
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-py..h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-build-run-1\.0-py.._0"

--- a/tests/test-recipes/metadata/numpy_run/run_test.bat
+++ b/tests/test-recipes/metadata/numpy_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-run-1\.0-h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-numpy-run-1\.0-0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/numpy_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contian NumPy, but not the version
-conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-0"

--- a/tests/test-recipes/metadata/python_build/run_test.bat
+++ b/tests/test-recipes/metadata/python_build/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-build-1.0-h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-build-1.0-0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build/run_test.sh
+++ b/tests/test-recipes/metadata/python_build/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should not contain Python
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-1.0-h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-1.0-0"

--- a/tests/test-recipes/metadata/python_build_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_build_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-build-run-1\.0-py..h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_build_run/run_test.sh
+++ b/tests/test-recipes/metadata/python_build_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain Python
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-run-1\.0-py..h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-build-run-1\.0-py.._0"

--- a/tests/test-recipes/metadata/python_run/run_test.bat
+++ b/tests/test-recipes/metadata/python_run/run_test.bat
@@ -1,4 +1,4 @@
 conda list -p "%PREFIX%" --canonical
 if errorlevel 1 exit 1
-conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-run-1\.0-h......._0"
+conda list -p "%PREFIX%" --canonical | grep "conda-build-test-python-run-1\.0-0"
 if errorlevel 1 exit 1

--- a/tests/test-recipes/metadata/python_run/run_test.sh
+++ b/tests/test-recipes/metadata/python_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
 # Test the build string. Should contain Python
-conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-h......._0"
+conda list -p $PREFIX --canonical | grep "conda-build-test-python-run-1\.0-0"

--- a/tests/test-recipes/split-packages/_intradependencies_circular/meta.yaml
+++ b/tests/test-recipes/split-packages/_intradependencies_circular/meta.yaml
@@ -9,9 +9,16 @@ package:
 
 outputs:
   - name: a
-    run_exports:
-      - {{ pin_subpackage('b', exact=True) }}
+    build:
+      run_exports:
+        - {{ pin_subpackage('b', exact=True) }}
+    requirements:
+      build:
+        # compiler requirement is to force this package to have a hash
+        - {{ compiler('c') }}
   - name: b
     requirements:
       build:
         - {{ pin_subpackage('a', exact=True) }}
+        # compiler requirement is to force this package to have a hash
+        - {{ compiler('c') }}

--- a/tests/test-recipes/split-packages/_pin_compatible_in_output/meta.yaml
+++ b/tests/test-recipes/split-packages/_pin_compatible_in_output/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: test_pin_compatible_in_output
+  version: 1.0
+
+outputs:
+  - name: test1
+    requirements:
+      build:
+        - python
+        - numpy
+      run:
+        - python
+        - {{ pin_compatible('numpy') }}

--- a/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/meta.yaml
+++ b/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/meta.yaml
@@ -13,12 +13,12 @@ requirements:
 outputs:
   - name: my_script_subpackage
     requirements:
-      - python
-      - cython
+      run:
+        - zlib 1.2.11
   - name: my_script_subpackage_2
     requirements:
-      - python
-      - click
+      run:
+        - jpeg 9b
 
-# tests are in run_test.py, and they check that the packages above are both installed
-#    Note that run_test.py should only actually apply as tests for the implicit metapackage
+# tests are in run_test.sh/bat, and they check that the packages above are both installed
+#    Note that run_test.sh/bat should only actually apply as tests for the implicit metapackage

--- a/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/run_test.bat
+++ b/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/run_test.bat
@@ -1,0 +1,2 @@
+if not exist %PREFIX%\Library\bin\zlib.dll exit 1
+if not exist %PREFIX%\Library\bin\libjpeg.dll exit 1

--- a/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/run_test.py
+++ b/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/run_test.py
@@ -1,2 +1,0 @@
-import cython
-import click

--- a/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/run_test.sh
+++ b/tests/test-recipes/split-packages/compose_run_requirements_from_subpackages/run_test.sh
@@ -1,0 +1,9 @@
+set -ex
+
+if [ "$(uname)" == "Darwin" ]; then
+    test -e $PREFIX/lib/libz.dylib
+    test -e $PREFIX/lib/libjpeg.dylib
+else
+    test -e $PREFIX/lib/libz.so
+    test -e $PREFIX/lib/libjpeg.so
+fi

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -56,23 +56,17 @@ def test_get_output_file_path(testing_workdir, testing_metadata):
     build_path = api.get_output_file_paths(os.path.join(testing_workdir, 'recipe'),
                                           config=testing_metadata.config,
                                           no_download_source=True)[0]
-    _hash = testing_metadata.hash_dependencies()
-    python = ''.join(testing_metadata.config.variant['python'].split('.')[:2])
     assert build_path == os.path.join(testing_metadata.config.croot,
                                       testing_metadata.config.host_subdir,
-                                      "test_get_output_file_path-1.0-py{}{}_1.tar.bz2".format(
-                                          python, _hash))
+                                      "test_get_output_file_path-1.0-1.tar.bz2")
 
 
 def test_get_output_file_path_metadata_object(testing_metadata):
     testing_metadata.final = True
     build_path = api.get_output_file_paths(testing_metadata)[0]
-    _hash = testing_metadata.hash_dependencies()
-    python = ''.join(testing_metadata.config.variant['python'].split('.')[:2])
     assert build_path == os.path.join(testing_metadata.config.croot,
                                       testing_metadata.config.host_subdir,
-                "test_get_output_file_path_metadata_object-1.0-py{}{}_1.tar.bz2".format(
-                    python, _hash))
+                "test_get_output_file_path_metadata_object-1.0-1.tar.bz2")
 
 
 def test_get_output_file_path_jinja2(testing_workdir, testing_config):
@@ -116,8 +110,8 @@ def test_host_entries_finalized(testing_config):
     metadata = api.render(recipe, config=testing_config)
     assert len(metadata) == 2
     outputs = api.get_output_file_paths(recipe, config=testing_config)
-    assert any('py27h' in out for out in outputs)
-    assert any('py36h' in out for out in outputs)
+    assert any('py27' in out for out in outputs)
+    assert any('py36' in out for out in outputs)
 
 
 def test_hash_no_apply_to_custom_build_string(testing_metadata, testing_workdir):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -88,7 +88,7 @@ def test_disallow_dash_in_features(testing_metadata):
 def test_append_section_data(testing_metadata):
     testing_metadata.final = False
     testing_metadata.parse_again()
-    requirements_len = len(testing_metadata.meta['requirements']['build'])
+    requirements_len = len(testing_metadata.meta['requirements'].get('build', []))
     testing_metadata.config.append_sections_file = os.path.join(thisdir, 'test-append.yaml')
     testing_metadata.final = False
     testing_metadata.parse_again()
@@ -107,8 +107,8 @@ def test_clobber_section_data(testing_metadata):
 
 
 def test_build_bootstrap_env_by_name(testing_metadata):
-    assert not any("git" in pkg for pkg in testing_metadata.meta["requirements"]["build"]), \
-        testing_metadata.meta["requirements"]["build"]
+    assert not any("git" in pkg for pkg in testing_metadata.meta["requirements"].get("build", [])), \
+        testing_metadata.meta["requirements"].get("build", [])
     try:
         cmd = "conda create -y -n conda_build_bootstrap_test git"
         subprocess.check_call(cmd.split())
@@ -123,8 +123,8 @@ def test_build_bootstrap_env_by_name(testing_metadata):
 
 
 def test_build_bootstrap_env_by_path(testing_metadata):
-    assert not any("git" in pkg for pkg in testing_metadata.meta["requirements"]["build"]), \
-        testing_metadata.meta["requirements"]["build"]
+    assert not any("git" in pkg for pkg in testing_metadata.meta["requirements"].get("build", [])), \
+        testing_metadata.meta["requirements"].get("build", [])
     path = os.path.join(thisdir, "conda_build_bootstrap_test")
     try:
         cmd = "conda create -y -p {} git".format(path)
@@ -186,14 +186,16 @@ def test_compiler_metadata_cross_compiler():
 
 
 def test_hash_build_id(testing_metadata):
-    testing_metadata.meta['requirements']['build'] = ['zlib 1.2.8']
+    testing_metadata.config.variant['zlib'] = '1.2'
+    testing_metadata.meta['requirements']['host'] = ['zlib']
     testing_metadata.final = True
-    assert testing_metadata.hash_dependencies() == 'h90ec539'
-    assert testing_metadata.build_id() == 'h90ec539_1'
+    assert testing_metadata.get_hash_contents() == {'zlib': '1.2'}
+    assert testing_metadata.hash_dependencies() == 'h1341992'
+    assert testing_metadata.build_id() == 'h1341992_1'
 
 
 def test_hash_build_id_key_order(testing_metadata):
-    deps = testing_metadata.meta['requirements']['build'][:]
+    deps = testing_metadata.meta['requirements'].get('build', [])[:]
 
     # first, prepend
     newdeps = deps[:]


### PR DESCRIPTION
fixes #2405 

Fixes an issue reported on the conda mailing list where within a given output, pin_compatible didn't respect build deps from that output, but instead was looking to the top-level requirements.