### PR TITLE
don't filter out all files in info dir when checking tar

### DIFF
--- a/conda_build/tarcheck.py
+++ b/conda_build/tarcheck.py
@@ -4,7 +4,7 @@ import json
 from os.path import basename
 import tarfile
 
-from conda_build.utils import codec
+from conda_build.utils import codec, filter_info_files
 
 
 def dist_fn(fn):
@@ -37,10 +37,10 @@ class TarCheck(object):
         if len(lista) != len(seta):
             raise Exception('info/files: duplicates')
 
-        listb = [m.path for m in self.t.getmembers()
-                 if not (m.path.startswith('info/') or m.isdir())]
-        setb = set(listb)
-        if len(listb) != len(setb):
+        files_in_tar = [m.path for m in self.t.getmembers()]
+        files_in_tar = filter_info_files(files_in_tar, '')
+        setb = set(files_in_tar)
+        if len(files_in_tar) != len(setb):
             raise Exception('info_files: duplicate members')
 
         if seta == setb:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1002,6 +1002,29 @@ def filter_files(files_list, prefix, filter_patterns=('(.*[\\\\/])?\.git[\\\\/].
             os.path.islink(os.path.join(prefix, f))]
 
 
+def filter_info_files(files_list, prefix):
+    return filter_files(files_list, prefix, filter_patterns=(
+                    'info/index.json',
+                    'info/files',
+                    'info/paths.json',
+                    'info/about.json',
+                    'info/has_prefix',
+                    'info/hash_input_files',   # legacy, not used anymore
+                    'info/hash_input.json',
+                    'info/run_exports.yaml',
+                    'info/git',
+                    'info/recipe/.*',
+                    'info/recipe.tar',
+                    'info/test/.*',
+                    'info/LICENSE.txt',
+                    'info/requires',
+                    'info/meta',
+                    'info/platform',
+                    'info/no_link',
+                    'info/link.json',
+            ))
+
+
 def rm_rf(path, config=None):
     if on_win:
         # native windows delete is potentially much faster

--- a/tests/test-recipes/metadata/arbitrary_file_in_info_dir/meta.yaml
+++ b/tests/test-recipes/metadata/arbitrary_file_in_info_dir/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: test_arbitrary_file_in_info_dir
+  version: 1.0
+
+build:
+  script: mkdir -p $PREFIX/info && echo "test" > $PREFIX/info/testfile   # [unix]
+  script: mkdir %PREFIX%\info && echo "test" > $PREFIX/info/testfile   # [win]
+
+test:
+  commands:
+    - test -f $PREFIX/info/testfile  # [unix]
+    - if not exist %PREFIX%\info\testfile  exit 1  # [win]


### PR DESCRIPTION
fixes #2532 

It's less that the info dir was being clobbered, and more that the tarcheck code was written badly with the assumption that nothing else would ever put anything in the info dir.

This PR allows other stuff to be present in the info dir, and handles it properly.  Conflicts may still occur, but I think (hope?) they'll be very rare.