### PR TITLE
include icon.png in filtered info directory files

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1022,6 +1022,7 @@ def filter_info_files(files_list, prefix):
                     'info[\\\\/]platform',
                     'info[\\\\/]no_link',
                     'info[\\\\/]link.json',
+                    'info[\\\\/]icon.png',
             ))
 
 


### PR DESCRIPTION
icon.png files can be included via the app section of a recipe.

closes #2544