### PR TITLE
fix handling of too many x.x.x.x in max_pin field for pin_* jinja2

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -963,6 +963,8 @@ def apply_pin_expressions(version, min_pin='x.x.x.x.x.x.x', max_pin='x'):
             flat_list.extend(item)
         else:
             flat_list.append(item)
+    if max_pin and len(max_pin.split('.')) > len(flat_list):
+        pins[1] = len(flat_list)
     versions = ['', '']
     # first idx is lower bound pin; second is upper bound pin.
     #    pin value is number of places to pin.

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -48,6 +48,13 @@ def test_pin_major_minor(testing_metadata, mocker):
     assert pin == 'test  >=1.2.3,<1.3.0a0'
 
 
+def test_pin_excessive_max_pin(testing_metadata, mocker):
+    get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
+    get_env_dependencies.return_value = ['test 1.2.3'], [], None
+    pin = jinja_context.pin_compatible(testing_metadata, 'test', max_pin='x.x.x.x.x.x')
+    assert pin == 'test  >=1.2.3,<1.2.4.0a0'
+
+
 def test_pin_upper_bound(testing_metadata, mocker):
     get_env_dependencies = mocker.patch.object(jinja_context, 'get_env_dependencies')
     get_env_dependencies.return_value = ['test 1.2.3'], [], None


### PR DESCRIPTION
As reported by @jjhelmus, max_pin values with more x's than the actual version ended up not correctly incrementing the upper bound:

  - test  >=1.2.3,<1.2.3
