### PR TITLE
Make sure dst is recipe_dir/x and not just x

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -220,7 +220,7 @@ def copy_recipe(m):
                 file_paths = []
 
         for f in file_paths:
-            utils.copy_into(os.path.join(src_dir, f), recipe_dir,
+            utils.copy_into(join(src_dir, f), join(recipe_dir, f),
                             timeout=output_metadata.config.timeout,
                             locking=output_metadata.config.locking, clobber=True)
 


### PR DESCRIPTION
If the `test/files` section in `meta.yaml` has path to a file inside a
directory, example: `tests/hello.c`, `copy_recipe()` was copying the file
`hello.c` to `info/hello.c` instead of `info/tests/hello.c`

Fixes #2555 