### PR TITLE
Add test to show that pin_subpackage does not build in correct order

### DIFF
--- a/tests/test-recipes/split-packages/_order/meta.yaml
+++ b/tests/test-recipes/split-packages/_order/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: toplevel-ab
+outputs:
+  - name: a
+    version: 1
+  - name: b
+    version: 1
+    requirements:
+      host:
+        - {{ pin_subpackage('a',  min_pin='x.x.x.x.x.x.x.x', max_pin='x.x.x.x.x.x.x.x') }}

--- a/tests/test-recipes/split-packages/_order_bad/meta.yaml
+++ b/tests/test-recipes/split-packages/_order_bad/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: toplevel-dc
+  version: 1
+outputs:
+  - name: d
+    version: 1
+  - name: c
+    version: 1
+    requirements:
+      host:
+        - {{ pin_subpackage('d',  min_pin='x.x.x.x.x.x.x.x', max_pin='x.x.x.x.x.x.x.x') }}

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -273,7 +273,6 @@ def test_subpackage_order_natural(testing_config):
     assert len(outputs) == 2
 
 
-@pytest.mark.xfail
 def test_subpackage_order_bad(testing_config):
     recipe = os.path.join(subpackage_dir, '_order_bad')
     outputs = api.build(recipe, config=testing_config)

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -265,3 +265,16 @@ def test_output_same_name_as_top_level_does_correct_output_regex(testing_config)
         if m.name() == 'ipp':
             for env in ('build', 'host', 'run'):
                 assert not m.meta.get('requirements', {}).get(env)
+
+
+def test_subpackage_order_natural(testing_config):
+    recipe = os.path.join(subpackage_dir, '_order')
+    outputs = api.build(recipe, config=testing_config)
+    assert len(outputs) == 2
+
+
+@pytest.mark.xfail
+def test_subpackage_order_bad(testing_config):
+    recipe = os.path.join(subpackage_dir, '_order_bad')
+    outputs = api.build(recipe, config=testing_config)
+    assert len(outputs) == 2


### PR DESCRIPTION
test_subpackage_order_bad() is marked as xfail for now, but we need
to remove this marking when this is fixed.