### PR TITLE
Issue2521 condarc env vars WIP

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -168,7 +168,9 @@ different sets of packages."""
     pypi_grp.add_argument(
         '--config-file',
         help="path to .pypirc file to use when uploading to pypi",
-        default=abspath(expanduser(expandvars(cc_conda_build.get('pypirc')))) if cc_conda_build.get('pypirc') else None,
+        default=(abspath(expanduser(expandvars(cc_conda_build.get('pypirc'))))
+                 if cc_conda_build.get('pypirc')
+                 else cc_conda_build.get('pypirc')),
     )
     pypi_grp.add_argument(
         '--repository', '-r', help="PyPI repository to upload to",

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -265,7 +265,9 @@ different sets of packages."""
     p.add_argument(
         '--cache-dir',
         help=('Path to store the source files (archives, git clones, etc.) during the build.'),
-        default=cc_conda_build.get('cache_dir'),
+        default=(abspath(expanduser(expandvars(cc_conda_build.get('cache_dir'))))
+                 if cc_conda_build.get('cache_dir')
+                 else cc_conda_build.get('cache_dir')),
     )
     p.add_argument(
         "--no-copy-test-source-files", dest="copy_test_source_files", action="store_false",

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -23,6 +23,7 @@ from conda_build.cli.main_render import get_render_parser
 import conda_build.source as source
 from conda_build.utils import LoggingContext
 from conda_build.config import Config
+from os.path import abspath, expanduser, expandvars
 
 on_win = (sys.platform == 'win32')
 
@@ -167,7 +168,7 @@ different sets of packages."""
     pypi_grp.add_argument(
         '--config-file',
         help="path to .pypirc file to use when uploading to pypi",
-        default=cc_conda_build.get('pypirc'),
+        default=abspath(expanduser(expandvars(cc_conda_build.get('pypirc')))) if cc_conda_build.get('pypirc') else None,
     )
     pypi_grp.add_argument(
         '--repository', '-r', help="PyPI repository to upload to",

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -7,7 +7,7 @@ import copy
 from collections import namedtuple
 import math
 import os
-from os.path import abspath, expanduser, join
+from os.path import abspath, expanduser, join, expandvars
 import shutil
 import sys
 import time
@@ -324,7 +324,7 @@ class Config(object):
             if _bld_root_env:
                 self._croot = abspath(expanduser(_bld_root_env))
             elif _bld_root_rc:
-                self._croot = abspath(expanduser(_bld_root_rc))
+                self._croot = abspath(expanduser(expandvars(_bld_root_rc)))
             elif root_writable:
                 self._croot = join(root_dir, 'conda-bld')
             else:

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -83,7 +83,8 @@ DEFAULTS = [Setting('activate', True),
             Setting('filename_hashing', cc_conda_build.get('filename_hashing',
                                                            'true').lower() == 'true'),
             Setting('keep_old_work', False),
-            Setting('_src_cache_root', cc_conda_build.get('cache_dir')),
+            Setting('_src_cache_root', abspath(expanduser(expandvars(
+                cc_conda_build.get('cache_dir')))) if cc_conda_build.get('cache_dir') else None),
             Setting('copy_test_source_files', True),
 
             Setting('index', None),

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -12,7 +12,8 @@ import logging.config
 import mmap
 import operator
 import os
-from os.path import dirname, getmtime, getsize, isdir, join, isfile, abspath, islink
+from os.path import (dirname, getmtime, getsize, isdir, join, isfile, abspath, islink,
+                     expanduser, expandvars)
 import re
 import stat
 import subprocess
@@ -1074,7 +1075,9 @@ def reset_deduplicator():
 
 
 def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers=True):
-    config_file = cc_conda_build.get('log_config_file')
+    config_file = None
+    if cc_conda_build.get('log_config_file'):
+        config_file = abspath(expanduser(expandvars(cc_conda_build.get('log_config_file'))))
     # by loading config file here, and then only adding handlers later, people
     # should be able to override conda-build's logger settings here.
     if config_file:

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from itertools import product
 import logging
 import os
+from os.path import abspath, expanduser, expandvars
 from pkg_resources import parse_version
 import sys
 
@@ -133,9 +134,9 @@ def find_config_files(metadata_or_path, additional_files=None, ignore_system_con
 
     if not ignore_system_config:
         if cc_conda_build.get('config_file'):
-            system_path = cc_conda_build['config_file']
+            system_path = abspath(expanduser(expandvars(cc_conda_build['config_file'])))
         else:
-            system_path = os.path.join(os.path.expanduser('~'), "conda_build_config.yaml")
+            system_path = os.path.join(expanduser('~'), "conda_build_config.yaml")
         if os.path.isfile(system_path):
             files.append(system_path)
 


### PR DESCRIPTION
This PR attempts to allow the conda-build section of the .condarc file to include environment variables in the two path entries; namely, `pypirc` and `root-dir`. The changes are straightforward, but I'm not sure how to test them.