### PR TITLE
[WIP] Speed up fixing linking phase for macos binary builds

### DIFF
--- a/conda_build/os_utils/macho.py
+++ b/conda_build/os_utils/macho.py
@@ -224,7 +224,7 @@ def delete_rpath(path, rpath, verbose=False):
         % p.returncode)
 
 
-def install_name_change(path, cb_func, verbose=False):
+def install_name_change(path, cb_func, dylibs, verbose=False):
     """Change dynamic shared library load name or id name of Mach-O Binary `path`.
 
     `cb_func` is called for each shared library load command. The dictionary of
@@ -234,7 +234,7 @@ def install_name_change(path, cb_func, verbose=False):
     When dealing with id load commands, `install_name_tool -id` is used.
     When dealing with dylib load commands `install_name_tool -change` is used.
     """
-    dylibs = otool(path)
+
     changes = []
     for index, dylib in enumerate(dylibs):
         new_name = cb_func(path, dylib)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -311,7 +311,6 @@ def osx_ch_link(path, link_dict, prefix, files):
 
     return ret
 
-
 def mk_relative_osx(path, prefix, files, build_prefix=None):
     '''
     if build_prefix is None, then this is a standard conda build. The path
@@ -327,9 +326,10 @@ def mk_relative_osx(path, prefix, files, build_prefix=None):
         prefix = build_prefix
 
     assert sys.platform == 'darwin' and is_obj(path)
-    s = macho.install_name_change(path, partial(osx_ch_link, prefix=prefix, files=files))
 
     names = macho.otool(path)
+    s = macho.install_name_change(path, partial(osx_ch_link, prefix=prefix, files=files), dylibs=names)
+
     if names:
         # Add an rpath to every executable to increase the chances of it
         # being found.
@@ -397,7 +397,6 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
 def assert_relative_osx(path, prefix):
     for name in macho.get_dylibs(path):
         assert not name.startswith(prefix), path
-
 
 def mk_relative(m, f, prefix, files):
     assert sys.platform != 'win32'

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -311,6 +311,7 @@ def osx_ch_link(path, link_dict, prefix, files):
 
     return ret
 
+
 def mk_relative_osx(path, prefix, files, build_prefix=None):
     '''
     if build_prefix is None, then this is a standard conda build. The path
@@ -328,7 +329,8 @@ def mk_relative_osx(path, prefix, files, build_prefix=None):
     assert sys.platform == 'darwin' and is_obj(path)
 
     names = macho.otool(path)
-    s = macho.install_name_change(path, partial(osx_ch_link, prefix=prefix, files=files), dylibs=names)
+    s = macho.install_name_change(path, partial(osx_ch_link, prefix=prefix, files=files),
+                                  dylibs=names)
 
     if names:
         # Add an rpath to every executable to increase the chances of it
@@ -397,6 +399,7 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
 def assert_relative_osx(path, prefix):
     for name in macho.get_dylibs(path):
         assert not name.startswith(prefix), path
+
 
 def mk_relative(m, f, prefix, files):
     assert sys.platform != 'win32'

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -22,6 +22,7 @@ from .conda_interface import walk_prefix
 from .conda_interface import md5_file
 from .conda_interface import PY3
 from .conda_interface import TemporaryDirectory
+from .conda_interface import memoized
 
 from conda_build import utils
 from conda_build.os_utils.pyldd import is_codefile
@@ -235,16 +236,9 @@ def post_process(files, prefix, config, preserve_egg_dir=False, noarch=False, sk
     rm_py_along_so(prefix)
 
 
-files_cache = {}
-
-
+@memoized
 def find_lib(link, prefix, path=None):
-    global files_cache
-    if prefix in files_cache:
-        files = files_cache[prefix]
-    else:
-        files = utils.prefix_files(prefix)
-        files_cache[prefix] = files
+    files = utils.prefix_files(prefix)
 
     if link.startswith(prefix):
         link = os.path.normpath(link[len(prefix) + 1:])

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -235,8 +235,17 @@ def post_process(files, prefix, config, preserve_egg_dir=False, noarch=False, sk
     rm_py_along_so(prefix)
 
 
+files_cache = {}
+
+
 def find_lib(link, prefix, path=None):
-    files = utils.prefix_files(prefix)
+    global files_cache
+    if prefix in files_cache:
+        files = files_cache[prefix]
+    else:
+        files = utils.prefix_files(prefix)
+        files_cache[prefix] = files
+
     if link.startswith(prefix):
         link = os.path.normpath(link[len(prefix) + 1:])
         if link not in files:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -753,7 +753,9 @@ def expand_globs(path_list, root_dir):
     for path in path_list:
         if not os.path.isabs(path):
             path = os.path.join(root_dir, path)
-        if os.path.islink(path) or os.path.isfile(path):
+        if os.path.isfile(path):
+            files.append(path)
+        elif os.path.islink(path):
             files.append(path)
         elif os.path.isdir(path):
             files.extend(os.path.join(root, f) for root, _, fs in os.walk(path) for f in fs)


### PR DESCRIPTION
This PR is in relation to Issue https://github.com/conda/conda-build/issues/2291

On MacOS, when building relocatable binaries the the post build "fixing linking" stage can take hours to complete on a large library (VTK, QT). I've traced the main source of the issue to a single function that is repeatedly called for every shared library that is examined. 

 **I see a 21% reduction in the time spent on this last phase (on a common library I compile it went from from 628.304 sec before to 498.068 sec after) when building the ITK library**

The line profile output pasted below traces the major time suck from post build instantiation to the problem function. 

```
Total time: 606.69 s
File: /Users/rick/projects/conda-build/conda_build/post.py
Function: post_build at line 455

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   455                                           @do_profile(follow=[mk_relative])
   456                                           def post_build(m, files, prefix, build_python, croot):
   457         1           45     45.0      0.0      print('number of files:', len(files))
   458         1       335402 335402.0      0.1      fix_permissions(files, prefix)
   459                                           
   460      4607         3736      0.8      0.0      for f in files:
   461      4606       166853     36.2      0.0          make_hardlink_copy(f, prefix)
   462                                           
   463         1            1      1.0      0.0      if sys.platform == 'win32':
   464                                                   return
   465                                           
   466         1           31     31.0      0.0      binary_relocation = m.binary_relocation()
   467         1            0      0.0      0.0      if not binary_relocation:
   468                                                   print("Skipping binary relocation logic")
   469         1            7      7.0      0.0      osx_is_app = bool(m.get_value('build/osx_is_app', False)) and sys.platform == 'darwin'
   470                                           
   471         1       110099 110099.0      0.0      check_symlinks(files, prefix, croot)
   472                                           
   473      4607         6357      1.4      0.0      for f in files:
   474      4606         4815      1.0      0.0          if f.startswith('bin/'):
   475         1         1077   1077.0      0.0              fix_shebang(f, prefix=prefix, build_python=build_python, osx_is_app=osx_is_app)
   476      4606         2461      0.5      0.0          if binary_relocation is True or (isinstance(binary_relocation, list) and
   477                                                                                    f in binary_relocation):
   478      4606    606058739 131580.3     99.9              mk_relative(m, f, prefix)

Timer unit: 1e-06 s

Total time: 606.04 s
File: /Users/rick/projects/conda-build/conda_build/post.py
Function: mk_relative at line 403

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   403                                           def mk_relative(m, f, prefix):
   404      4606         4165      0.9      0.0      assert sys.platform != 'win32'
   405      4606        32170      7.0      0.0      path = os.path.join(prefix, f)
   406      4606       369296     80.2      0.1      if not is_obj(path):
   407      4520         3254      0.7      0.0          return
   408                                           
   409        86          140      1.6      0.0      if sys.platform.startswith('linux'):
   410                                                   mk_relative_linux(f, prefix=prefix, rpaths=m.get_value('build/rpaths', ['lib']))
   411        86           51      0.6      0.0      elif sys.platform == 'darwin':
   412        86    605630470 7042214.8     99.9          mk_relative_osx(path, prefix=prefix)


Total time: 1.90857 s
File: /Users/rick/projects/conda-build/conda_build/post.py
Function: mk_relative_osx at line 333

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   333                                           @do_profile(follow=[macho.install_name_change])
   334                                           def mk_relative_osx(path, prefix, build_prefix=None):
   335                                               '''
   336                                               if build_prefix is None, then this is a standard conda build. The path
   337                                               and all dependencies are in the build_prefix.
   338                                           
   339                                               if package is built in develop mode, build_prefix is specified. Object
   340                                               specified by 'path' needs to relink runtime dependences to libs found in
   341                                               build_prefix/lib/. Also, in develop mode, 'path' is not in 'build_prefix'
   342                                               '''
   343         1            6      6.0      0.0      if build_prefix is None:
   344         1            2      2.0      0.0          assert path.startswith(prefix + '/')
   345                                               else:
   346                                                   prefix = build_prefix
   347                                           
   348         1          125    125.0      0.0      assert sys.platform == 'darwin' and is_obj(path)
   349         1      1874056 1874056.0     98.2      s = macho.install_name_change(path, partial(osx_ch_link, prefix=prefix))
   350                                           
   351         1        12561  12561.0      0.7      names = macho.otool(path)
   352         1            2      2.0      0.0      if names:
   353                                                   # Add an rpath to every executable to increase the chances of it
   354                                                   # being found.
   355         1           28     28.0      0.0          rpath = os.path.join('@loader_path',
   356         1           30     30.0      0.0                       os.path.relpath(os.path.join(prefix, 'lib'),
   357         1          110    110.0      0.0                               os.path.dirname(path)), '').replace('/./', '/')
   358         1         7884   7884.0      0.4          macho.add_rpath(path, rpath, verbose=True)
   359                                           
   360                                                   # 10.7 install_name_tool -delete_rpath causes broken dylibs, I will revisit this ASAP.
   361                                                   # .. and remove config.build_prefix/lib which was added in-place of
   362                                                   # DYLD_FALLBACK_LIBRARY_PATH since El Capitan's SIP.
   363                                                   # macho.delete_rpath(path, config.build_prefix + '/lib', verbose = True)
   364                                           
   365         1            2      2.0      0.0      if s:
   366                                                   # Skip for stub files, which have to use binary_has_prefix_files to be
   367                                                   # made relocatable.
   368         1        13767  13767.0      0.7          assert_relative_osx(path, prefix)

Total time: 1.87402 s
File: /Users/rick/projects/conda-build/conda_build/os_utils/macho.py
Function: install_name_change at line 227

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   227                                           def install_name_change(path, cb_func, verbose=False):
   228                                               """Change dynamic shared library load name or id name of Mach-O Binary `path`.
   229                                           
   230                                               `cb_func` is called for each shared library load command. The dictionary of
   231                                               the load command is passed in and the callback returns the new name or None
   232                                               if the name should be unchanged.
   233                                           
   234                                               When dealing with id load commands, `install_name_tool -id` is used.
   235                                               When dealing with dylib load commands `install_name_tool -change` is used.
   236                                               """
   237         1        19405  19405.0      1.0      dylibs = otool(path)
   238         1            1      1.0      0.0      changes = []
   239         4            6      1.5      0.0      for index, dylib in enumerate(dylibs):
   240         3      1854599 618199.7     99.0          new_name = cb_func(path, dylib)
   241         3            7      2.3      0.0          if new_name:
   242                                                       changes.append((index, new_name))
   243                                           
   244         1            1      1.0      0.0      ret = True
   245         1            1      1.0      0.0      for index, new_name in changes:
   246                                                   args = ['install_name_tool']
   247                                                   if dylibs[index]['cmd'] == 'LC_ID_DYLIB':
   248                                                       args.extend(('-id', new_name, path))
   249                                                   else:
   250                                                       args.extend(('-change', dylibs[index]['name'], new_name, path))
   251                                                   if verbose:
   252                                                       print(' '.join(args))
   253                                                   p = Popen(args, stderr=PIPE)
   254                                                   _, stderr = p.communicate()
   255                                                   stderr = stderr.decode('utf-8')
   256                                                   if "Mach-O dynamic shared library stub file" in stderr:
   257                                                       print("Skipping Mach-O dynamic shared library stub file %s" % path)
   258                                                       ret = False
   259                                                       continue
   260                                                   else:
   261                                                       print(stderr, file=sys.stderr)
   262                                                   if p.returncode:
   263                                                       raise RuntimeError("install_name_tool failed with exit status %d"
   264                                                           % p.returncode)
   265         1            0      0.0      0.0      return ret

Total time: 0.64057 s
File: /Users/rick/projects/conda-build/conda_build/post.py
Function: osx_ch_link at line 294

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   294                                           @do_profile(follow=[find_lib])
   295                                           def osx_ch_link(path, link_dict, prefix):
   296         1            2      2.0      0.0      link = link_dict['name']
   297         1            9      9.0      0.0      print("Fixing linking of %s in %s" % (link, path))
   298         1       640557 640557.0    100.0      link_loc = find_lib(link, prefix, path)
   299         1            1      1.0      0.0      if not link_loc:
   300         1            1      1.0      0.0          return
   301                                           
   302                                               lib_to_link = os.path.relpath(os.path.dirname(link_loc), 'lib')
   303                                               # path_to_lib = utils.relative(path[len(prefix) + 1:])
   304                                           
   305                                               # e.g., if
   306                                               # path = '/build_prefix/lib/some/stuff/libstuff.dylib'
   307                                               # link_loc = 'lib/things/libthings.dylib'
   308                                           
   309                                               # then
   310                                           
   311                                               # lib_to_link = 'things'
   312                                               # path_to_lib = '../..'
   313                                           
   314                                               # @rpath always means 'lib', link will be at
   315                                               # @rpath/lib_to_link/basename(link), like @rpath/things/libthings.dylib.
   316                                           
   317                                               # For when we can't use @rpath, @loader_path means the path to the library
   318                                               # ('path'), so from path to link is
   319                                               # @loader_path/path_to_lib/lib_to_link/basename(link), like
   320                                               # @loader_path/../../things/libthings.dylib.
   321                                           
   322                                               ret = '@rpath/%s/%s' % (lib_to_link, os.path.basename(link))
   323                                           
   324                                               # XXX: IF the above fails for whatever reason, the below can be used
   325                                               # TODO: This might contain redundant ..'s if link and path are both in
   326                                               # some subdirectory of lib.
   327                                               # ret = '@loader_path/%s/%s/%s' % (path_to_lib, lib_to_link, basename(link))
   328                                           
   329                                               ret = ret.replace('/./', '/')
   330                                           
   331                                               return ret

Total time: 0.640287 s
File: /Users/rick/projects/conda-build/conda_build/post.py
Function: find_lib at line 256

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   256                                           def find_lib(link, prefix, path=None):
   257         1       640282 640282.0    100.0      files = utils.prefix_files(prefix)
   258         1            3      3.0      0.0      if link.startswith(prefix):
   259                                                   link = os.path.normpath(link[len(prefix) + 1:])
   260                                                   if link not in files:
   261                                                       sys.exit("Error: Could not find %s" % link)
   262                                                   return link
   263         1            1      1.0      0.0      if link.startswith('/'):  # but doesn't start with the build prefix
   264                                                   return
   265         1            1      1.0      0.0      if link.startswith('@rpath/'):
   266                                                   # Assume the rpath already points to lib, so there is no need to
   267                                                   # change it.
   268         1            0      0.0      0.0          return
   269                                               if '/' not in link or link.startswith('@executable_path/'):
   270                                                   link = os.path.basename(link)
   271                                                   file_names = defaultdict(list)
   272                                                   for f in files:
   273                                                       file_names[os.path.basename(f)].append(f)
   274                                                   if link not in file_names:
   275                                                       sys.exit("Error: Could not find %s" % link)
   276                                                   if len(file_names[link]) > 1:
   277                                                       if path and os.path.basename(path) == link:
   278                                                           # The link is for the file itself, just use it
   279                                                           return path
   280                                                       # Allow for the possibility of the same library appearing in
   281                                                       # multiple places.
   282                                                       md5s = set()
   283                                                       for f in file_names[link]:
   284                                                           md5s.add(md5_file(os.path.join(prefix, f)))
   285                                                       if len(md5s) > 1:
   286                                                           sys.exit("Error: Found multiple instances of %s: %s" % (link, file_names[link]))
   287                                                       else:
   288                                                           file_names[link].sort()
   289                                                           print("Found multiple instances of %s (%s).  "
   290                                                               "Choosing the first one." % (link, file_names[link]))
   291                                                   return file_names[link][0]
   292                                               print("Don't know how to find %s, skipping" % link)

Total time: 0.778892 s
File: /Users/rick/projects/conda-build/conda_build/utils.py
Function: prefix_files at line 1191

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
  1191                                           @do_profile(follow=[expand_globs])
  1192                                           def prefix_files(prefix):
  1193                                               '''
  1194                                               Returns a set of all files in prefix.
  1195                                               '''
  1196         1            1      1.0      0.0      res = set()
  1197       661       115461    174.7     14.8      for root, dirs, files in os.walk(prefix):
  1198     15613         5958      0.4      0.8          for fn in files:
  1199     14953        59731      4.0      7.7              res.add(join(root, fn)[len(prefix) + 1:])
  1200      1320          644      0.5      0.1          for dn in dirs:
  1201       660         2639      4.0      0.3              path = join(root, dn)
  1202       660         5526      8.4      0.7              if islink(path):
  1203         1            2      2.0      0.0                  res.add(path[len(prefix) + 1:])
  1204         1       588928 588928.0     75.6      res = set(expand_globs(res, prefix))
  1205         1            2      2.0      0.0      return res

Total time: 0.530403 s
File: /Users/rick/projects/conda-build/conda_build/utils.py
Function: expand_globs at line 767

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   767                                           def expand_globs(path_list, root_dir):
   768         1            1      1.0      0.0      files = []
   769     14955        12271      0.8      2.3      for path in path_list:
   770     14954        39512      2.6      7.4          if not os.path.isabs(path):
   771     14954        67470      4.5     12.7              path = os.path.join(root_dir, path)
```
```python
   772     14954       378640     25.3     71.4          if os.path.islink(path) or os.path.isfile(path):
```
```
   773     14954        14897      1.0      2.8              files.append(path)
   774                                                   elif os.path.isdir(path):
   775                                                       files.extend(os.path.join(root, f) for root, _, fs in os.walk(path) for f in fs)
   776                                                   else:
   777                                                       # File compared to the globs use / as separator indenpendently of the os
   778                                                       glob_files = glob(path)
   779                                                       if not glob_files:
   780                                                           log = get_logger(__name__)
   781                                                           log.error('invalid recipe path: {}'.format(path))
   782                                                       files.extend(glob_files)
   783         1          150    150.0      0.0      prefix_path_re = re.compile('^' + re.escape('%s%s' % (root_dir, os.path.sep)))
   784         1        17461  17461.0      3.3      files = [prefix_path_re.sub('', f, 1) for f in files]
   785         1            1      1.0      0.0      return files
```

Since this is a function that is called by a wide variety of other functions, the most general way to speed this up that I could think of was to split the path operation into an separate elif statements so we don't check the os.path.islink(path) if we don't need to. (os.path.isfile(path)) had ~80% hit rate in my very preliminary tests. 

There are a whole lot more optimizations to make here (I have a hunch that this is calculating the same thing over and over again, since the prefix that we are walking over shouldn't change often - if at all??). Looking forward to hearing your feedback. 