### PR TITLE
Specify 'jinja2' as an install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
                             'conda-skeleton = conda_build.cli.main_skeleton:main',
                             ]},
     install_requires=['conda', 'requests', 'filelock', 'pyyaml', 'conda-verify',
-                      'pkginfo', 'glob2', 'beautifulsoup4'],
+                      'jinja2', 'pkginfo', 'glob2', 'beautifulsoup4'],
     package_data={'conda_build': ['templates/*', 'cli-*.exe']},
     zip_safe=False,
 )


### PR DESCRIPTION
This is helpful for installing this package via setuptools. The conda
recipe already mentions 'jinja2' as a runtime dependency.

Fixes #2565 