### PR TITLE
exclude zipped keys from used vars when computing hash

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1081,7 +1081,7 @@ class MetaData(object):
         # used variables - anything with a value in conda_build_config.yaml that applies to this
         #    recipe.  Includes compiler if compiler jinja2 function is used.
         """
-        dependencies = self.get_used_vars()
+        dependencies = self.get_used_vars(add_zip_keys=False)
 
         # filter out ignored versions
         build_string_excludes = ['python', 'r_base', 'perl', 'lua', 'numpy']

--- a/tests/test-recipes/split-packages/script_install_files/meta.yaml
+++ b/tests/test-recipes/split-packages/script_install_files/meta.yaml
@@ -20,5 +20,3 @@ outputs:
     test:
       script: test_subpackage1.py
       script_interpreter: python
-  # this is to make sure that wheel doesn't pick up a crazy file list
-  - type: wheel


### PR DESCRIPTION
too many things were getting hashed after zip_keys was considered in judging what variables are "used".  This fixes things back to the expected behavior: only direct dependencies affect the hash.