### PR TITLE
allow detection of used variables in shell scripts, not just meta.yaml

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -49,7 +49,6 @@ def render(recipe_path, config=None, variants=None, permit_unsatisfiable_variant
                 permit_undefined_jinja=not finalize):
             # only show conda packages right now
             if 'type' not in od or od['type'] == 'conda':
-                assert hasattr(om.config, 'variants')
                 if finalize and not om.final:
                     try:
                         om = finalize_metadata(om,

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1802,13 +1802,16 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                 recipe_parent_dir = os.path.dirname(metadata.path)
                 to_build_recursive.append(metadata.name())
 
-                variants_ = (dict_of_lists_to_list_of_dicts(variants) if variants else
-                            get_package_variants(metadata))
+                if not metadata.final:
+                    variants_ = (dict_of_lists_to_list_of_dicts(variants) if variants else
+                                get_package_variants(metadata))
 
-                # This is where reparsing happens - we need to re-evaluate the meta.yaml for any
-                #    jinja2 templating
-                metadata_tuples = distribute_variants(metadata, variants_,
-                                                      permit_unsatisfiable_variants=False)
+                    # This is where reparsing happens - we need to re-evaluate the meta.yaml for any
+                    #    jinja2 templating
+                    metadata_tuples = distribute_variants(metadata, variants_,
+                                                        permit_unsatisfiable_variants=False)
+                else:
+                    metadata_tuples = ((metadata, False, False), )
             else:
                 recipe_parent_dir = os.path.dirname(recipe)
                 recipe = recipe.rstrip("/").rstrip("\\")

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -239,7 +239,7 @@ def get_hg_build_info(repo):
     return d
 
 
-def get_dict(config, m=None, prefix=None, for_env=True):
+def get_dict(config, m=None, prefix=None, for_env=True, skip_build_id=False):
     if not prefix:
         prefix = config.host_prefix
 
@@ -253,7 +253,7 @@ def get_dict(config, m=None, prefix=None, for_env=True):
     d.update(r_vars(config, prefix))
 
     if m:
-        d.update(meta_vars(m, config))
+        d.update(meta_vars(m, config, skip_build_id=skip_build_id))
 
     # system
     d.update(system_vars(d, prefix, config))
@@ -358,7 +358,7 @@ def r_vars(config, prefix):
     return vars_
 
 
-def meta_vars(meta, config):
+def meta_vars(meta, config, skip_build_id=False):
     d = {}
     for var_name in ensure_list(meta.get_value('build/script_env', [])):
         value = os.getenv(var_name)
@@ -416,7 +416,7 @@ def meta_vars(meta, config):
     d['PKG_NAME'] = meta.get_value('package/name')
     d['PKG_VERSION'] = meta.version()
     d['PKG_BUILDNUM'] = str(meta.build_number() or 0)
-    if meta.final:
+    if meta.final and not skip_build_id:
         d['PKG_BUILD_STRING'] = str(meta.build_id())
         d['PKG_HASH'] = meta.hash_dependencies()
     else:

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -405,16 +405,16 @@ def cdt(package_name, config, permit_undefined_jinja=False):
 
 
 def context_processor(initial_metadata, recipe_dir, config, permit_undefined_jinja,
-                      allow_no_other_outputs=False, bypass_env_check=False):
+                      allow_no_other_outputs=False, bypass_env_check=False, skip_build_id=False):
     """
     Return a dictionary to use as context for jinja templates.
 
     initial_metadata: Augment the context with values from this MetaData object.
                       Used to bootstrap metadata contents via multiple parsing passes.
     """
-    ctx = get_environ(config=config, m=initial_metadata, for_env=False)
+    ctx = get_environ(config=config, m=initial_metadata, for_env=False, skip_build_id=skip_build_id)
     environ = dict(os.environ)
-    environ.update(get_environ(config=config, m=initial_metadata))
+    environ.update(get_environ(config=config, m=initial_metadata, skip_build_id=skip_build_id))
 
     ctx.update(
         load_setup_py_data=partial(load_setup_py_data, config=config, recipe_dir=recipe_dir,

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -508,8 +508,8 @@ def get_vars(variants, loop_only=False):
 def find_used_variables_in_text(variant, recipe_text):
     used_variables = set()
     for v in variant:
-        variant_regex = r"(\s*\{\{\s*%s\s*(?:.*?)?\}\})" % v
-        conditional_regex = r"(\s*\{%\s*(?:el)?if\s*" + v + r"\s*(?:.*?)?%\})"
+        variant_regex = r"(^.*\{\{\s*%s\s*(?:.*?)?\}\})" % v
+        conditional_regex = r"(.*\{%\s*(?:el)?if\s*" + v + r"\s*(?:.*?)?%\})"
         requirement_regex = r"(\-\s+%s(?:\s+|$))" % v.replace('_', '[-_]')
         all_res = '|'.join((variant_regex, requirement_regex, conditional_regex))
         compiler_match = re.match(r'(.*?)_compiler$', v)
@@ -518,5 +518,27 @@ def find_used_variables_in_text(variant, recipe_text):
                 r"(\s*\{\{\s*compiler\([\'\"]%s[\"\'].*\)\s*\}\})" % compiler_match.group(1))
             all_res = '|'.join((all_res, compiler_regex))
         if re.search(all_res, recipe_text, flags=re.MULTILINE | re.DOTALL):
+            used_variables.add(v)
+    return used_variables
+
+
+def find_used_variables_in_shell_script(variant, file_path):
+    with open(file_path) as f:
+        text = f.read()
+    used_variables = set()
+    for v in variant:
+        variant_regex = r"(^.*\$\{?\s*%s\s*[\s|\}])" % v
+        if re.search(variant_regex, text, flags=re.MULTILINE | re.DOTALL):
+            used_variables.add(v)
+    return used_variables
+
+
+def find_used_variables_in_batch_script(variant, file_path):
+    with open(file_path) as f:
+        text = f.read()
+    used_variables = set()
+    for v in variant:
+        variant_regex = r"\%" + v + r"\%"
+        if re.search(variant_regex, text, flags=re.MULTILINE | re.DOTALL):
             used_variables.add(v)
     return used_variables

--- a/tests/test-recipes/variants/24_test_used_vars_in_scripts/bld.bat
+++ b/tests/test-recipes/variants/24_test_used_vars_in_scripts/bld.bat
@@ -1,0 +1,1 @@
+echo %BAT_VAR%

--- a/tests/test-recipes/variants/24_test_used_vars_in_scripts/build.sh
+++ b/tests/test-recipes/variants/24_test_used_vars_in_scripts/build.sh
@@ -1,0 +1,2 @@
+echo ${BASH_VAR1}
+echo $BASH_VAR2

--- a/tests/test-recipes/variants/24_test_used_vars_in_scripts/conda_build_config.yaml
+++ b/tests/test-recipes/variants/24_test_used_vars_in_scripts/conda_build_config.yaml
@@ -1,0 +1,12 @@
+BASH_VAR1:
+  - abc
+  - 123
+BASH_VAR2:
+  - abc
+  - 123
+BAT_VAR:
+  - abc
+  - 123
+OUTPUT_VAR:
+  - abc123
+  - 123

--- a/tests/test-recipes/variants/24_test_used_vars_in_scripts/meta.yaml
+++ b/tests/test-recipes/variants/24_test_used_vars_in_scripts/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: test_find_used_variables_in_scripts
+  version: 1.0
+
+outputs:
+  - name: test_find_used_variables_in_scripts
+  - name: test_output_1
+    script: output_script.sh

--- a/tests/test-recipes/variants/24_test_used_vars_in_scripts/output_script.sh
+++ b/tests/test-recipes/variants/24_test_used_vars_in_scripts/output_script.sh
@@ -1,0 +1,1 @@
+echo ${OUTPUT_VAR}

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -291,3 +291,42 @@ def test_build_run_exports_act_on_host(testing_config, caplog):
     api.render(os.path.join(recipe_dir, '22_run_exports_rerendered_for_other_variants'),
                     platform='win', arch='64')
     assert "failed to get install actions, retrying" not in caplog.text
+
+
+def test_detect_variables_in_build_and_output_scripts(testing_config):
+    ms = api.render(os.path.join(recipe_dir, '24_test_used_vars_in_scripts'),
+                    platform='linux', arch='64')
+    for m, _, _ in ms:
+        if m.name() == 'test_find_used_variables_in_scripts':
+            used_vars = m.get_used_vars()
+            assert used_vars
+            assert 'BASH_VAR1' in used_vars
+            assert 'BASH_VAR2' in used_vars
+            assert 'BAT_VAR' not in used_vars
+            assert 'OUTPUT_VAR' not in used_vars
+        else:
+            used_vars = m.get_used_vars()
+            assert used_vars
+            assert 'BASH_VAR1' not in used_vars
+            assert 'BASH_VAR2' not in used_vars
+            assert 'BAT_VAR' not in used_vars
+            assert 'OUTPUT_VAR' in used_vars
+    # on windows, we find variables in bat scripts as well as shell scripts
+    ms = api.render(os.path.join(recipe_dir, '24_test_used_vars_in_scripts'),
+                    platform='win', arch='64')
+    for m, _, _ in ms:
+        if m.name() == 'test_find_used_variables_in_scripts':
+            used_vars = m.get_used_vars()
+            assert used_vars
+            assert 'BASH_VAR1' in used_vars
+            assert 'BASH_VAR2' in used_vars
+            # bat is in addition to bash, not instead of
+            assert 'BAT_VAR' in used_vars
+            assert 'OUTPUT_VAR' not in used_vars
+        else:
+            used_vars = m.get_used_vars()
+            assert used_vars
+            assert 'BASH_VAR1' not in used_vars
+            assert 'BASH_VAR2' not in used_vars
+            assert 'BAT_VAR' not in used_vars
+            assert 'OUTPUT_VAR' in used_vars


### PR DESCRIPTION
The purpose here is that with conda-build 3.1, we make up the hash from what variables (and values) are "used" in a recipe.  "Used" means the value was filled into a jinja2 template, or was applied to pin something in meta.yaml.  This PR expands that "used" definition to also include variables that are used as environment variables in build scripts or in output install scripts.

CC @mingwandroid @nehaljwani 