### PR TITLE
always split build and host prefixes

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -118,7 +118,8 @@ class CondaDistribution(Distribution):
 
 class bdist_conda(install):
     description = "create a conda package"
-    config = Config(build_id="bdist_conda" + "_" + str(int(time.time() * 1000)))
+    config = Config(build_id="bdist_conda" + "_" + str(int(time.time() * 1000)),
+                    build_is_host=True)
 
     def initialize_options(self):
         if not PY3:
@@ -173,7 +174,7 @@ class bdist_conda(install):
 
         # XXX: I'm not really sure if it is correct to combine requires
         # and install_requires
-        d['requirements']['run'] = d['requirements']['host'] = \
+        d['requirements']['run'] = d['requirements']['build'] = \
             [spec_from_line(i) for i in
                 (metadata.requires or []) +
                 (getattr(self.distribution, 'install_requires', []) or

--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -173,7 +173,7 @@ class bdist_conda(install):
 
         # XXX: I'm not really sure if it is correct to combine requires
         # and install_requires
-        d['requirements']['run'] = d['requirements']['build'] = \
+        d['requirements']['run'] = d['requirements']['host'] = \
             [spec_from_line(i) for i in
                 (metadata.requires or []) +
                 (getattr(self.distribution, 'install_requires', []) or

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -989,6 +989,8 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         utils.insert_variant_versions(m.meta.get('requirements', {}), m.config.variant, 'build')
         utils.insert_variant_versions(m.meta.get('requirements', {}), m.config.variant, 'host')
 
+        build_ms_deps = m.ms_depends('build')
+
         if m.is_cross:
             if VersionOrder(conda_version) < VersionOrder('4.3.2'):
                 raise RuntimeError("Non-native subdir support only in conda >= 4.3.2")
@@ -1009,9 +1011,6 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
             environ.create_env(m.config.host_prefix, host_actions, env='host', config=m.config,
                                subdir=m.config.host_subdir, is_cross=m.is_cross,
                                is_conda=m.name() == 'conda')
-            build_ms_deps = m.ms_depends('build')
-        else:
-            build_ms_deps = m.ms_depends('build')
         build_ms_deps = tuple(utils.ensure_valid_spec(spec) for spec in build_ms_deps)
         build_actions = environ.get_install_actions(m.config.build_prefix,
                                                     build_ms_deps, 'build',

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1055,10 +1055,9 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                 raise e
         if (not m.config.dirty or not os.path.isdir(m.config.build_prefix) or
                 not os.listdir(m.config.build_prefix)):
-            if build_actions:
-                environ.create_env(m.config.build_prefix, build_actions, env='build',
-                                   config=m.config, subdir=m.config.build_subdir,
-                                   is_cross=m.is_cross, is_conda=m.name() == 'conda')
+            environ.create_env(m.config.build_prefix, build_actions, env='build',
+                               config=m.config, subdir=m.config.build_subdir,
+                               is_cross=m.is_cross, is_conda=m.name() == 'conda')
 
         # this check happens for the sake of tests, but let's do it before the build so we don't
         #     make people wait longer only to see an error

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1055,9 +1055,10 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                 raise e
         if (not m.config.dirty or not os.path.isdir(m.config.build_prefix) or
                 not os.listdir(m.config.build_prefix)):
-            environ.create_env(m.config.build_prefix, build_actions, env='build', config=m.config,
-                               subdir=m.config.build_subdir, is_cross=m.is_cross,
-                               is_conda=m.name() == 'conda')
+            if build_actions:
+                environ.create_env(m.config.build_prefix, build_actions, env='build',
+                                   config=m.config, subdir=m.config.build_subdir,
+                                   is_cross=m.is_cross, is_conda=m.name() == 'conda')
 
         # this check happens for the sake of tests, but let's do it before the build so we don't
         #     make people wait longer only to see an error

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -989,8 +989,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
         utils.insert_variant_versions(m.meta.get('requirements', {}), m.config.variant, 'build')
         utils.insert_variant_versions(m.meta.get('requirements', {}), m.config.variant, 'host')
 
-        if (m.config.host_subdir != m.config.build_subdir and
-                m.config.host_subdir != "noarch"):
+        if m.is_cross:
             if VersionOrder(conda_version) < VersionOrder('4.3.2'):
                 raise RuntimeError("Non-native subdir support only in conda >= 4.3.2")
 
@@ -1012,8 +1011,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                is_conda=m.name() == 'conda')
             build_ms_deps = m.ms_depends('build')
         else:
-            # When not cross-compiling, the build deps are the aggregate of 'build' and 'host'.
-            build_ms_deps = m.ms_depends('build') + m.ms_depends('host')
+            build_ms_deps = m.ms_depends('build')
         build_ms_deps = tuple(utils.ensure_valid_spec(spec) for spec in build_ms_deps)
         build_actions = environ.get_install_actions(m.config.build_prefix,
                                                     build_ms_deps, 'build',

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -88,6 +88,9 @@ DEFAULTS = [Setting('activate', True),
             Setting('copy_test_source_files', True),
 
             Setting('index', None),
+            # support legacy recipes where only build is specified and expected to be the
+            #    folder that packaging is done on
+            Setting('build_is_host', False),
 
             # these are primarily for testing.  They override the native build platform/arch,
             #     which is useful in tests, but makes little sense on actual systems.
@@ -500,11 +503,10 @@ class Config(object):
         """The temporary folder where the build environment is created.  The build env contains
         libraries that may be linked, but only if the host env is not specified.  It is placed on
         PATH."""
-        if (self.host_subdir != self.build_subdir and self.host_subdir != 'noarch' and not
-                self.build_prefix_override):
-            prefix = join(self.build_folder, '_build_env')
-        else:
+        if self.build_is_host:
             prefix = self.host_prefix
+        else:
+            prefix = join(self.build_folder, '_build_env')
         return prefix
 
     @property

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -832,6 +832,13 @@ class MetaData(object):
             if self.config.bootstrap:
                 dependencies = _get_dependencies_from_environment(self.config.bootstrap)
                 self.append_metadata_sections(dependencies, merge=True)
+            if (not self.meta.get('requirements', {}).get('host', []) and not
+                    self.uses_new_style_compiler_activation):
+                self.config.build_is_host = True
+            if ('split_build_host' in self.meta.get('build', {}) and
+                    self.meta['build']['split_build_host']):
+                self.config.build_is_host = False
+
         except:
             raise
         finally:

--- a/tests/test-recipes/metadata/_set_env_var_activate_build/install-output.bat
+++ b/tests/test-recipes/metadata/_set_env_var_activate_build/install-output.bat
@@ -1,4 +1,4 @@
 echo VS90COMNTOOLS is "%VS90COMNTOOLS%" (should be some path to vs)
 if "%VS90COMNTOOLS%" == "" exit 1
 
-call "%PREFIX%\Scripts\activate.bat" "%PREFIX%"
+call "%PREFIX%\..\_build_env\Scripts\activate.bat"

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -1,14 +1,6 @@
 import os
-import platform
-import tempfile
 
-import pytest
-
-from conda_build import environ, api
-from conda_build.conda_interface import PaddingError, LinkError, CondaError, subdir, MatchSpec
-from conda_build.utils import on_win
-
-from .utils import metadata_dir
+from conda_build import environ
 
 
 def test_environment_creation_preserves_PATH(testing_workdir, testing_config):
@@ -16,46 +8,3 @@ def test_environment_creation_preserves_PATH(testing_workdir, testing_config):
     environ.create_env(testing_workdir, ['python'], env='host', config=testing_config,
                        subdir=testing_config.build_subdir)
     assert os.environ['PATH'] == ref_path
-
-
-@pytest.mark.serial
-@pytest.mark.skipif(on_win, reason=("Windows binary prefix replacement (for pip exes)"
-                                    " not length dependent"))
-def test_env_creation_with_short_prefix_does_not_deadlock(testing_workdir, caplog):
-    tempdir = '/tmp' if platform.system() == 'Darwin' else tempfile.gettempdir()
-    config = api.Config(croot=os.path.join(tempdir, 'cb'), anaconda_upload=False, verbose=True,
-                        set_build_id=False, _prefix_length=80)
-    recipe_path = os.path.join(metadata_dir, "has_prefix_files")
-    metadata = api.render(recipe_path, config=config)[0][0]
-    output = api.build(metadata)[0]
-    assert not api.inspect_prefix_length(output, 255)
-    config.prefix_length = 255
-    environ.create_env(config.build_prefix, specs_or_actions=["python", metadata.name()],
-                       env='build', config=config, subdir=subdir)
-    assert 'One or more of your package dependencies needs to be rebuilt' in caplog.text
-
-
-@pytest.mark.serial
-@pytest.mark.skipif(on_win, reason=("Windows binary prefix replacement (for pip exes)"
-                                    " not length dependent"))
-def test_env_creation_with_prefix_fallback_disabled(testing_config):
-    tempdir = '/tmp' if platform.system() == 'Darwin' else tempfile.gettempdir()
-    testing_config.croot = os.path.join(tempdir, 'cb')
-    testing_config.anaconda_upload = False
-    testing_config.anaconda_upload = False
-    testing_config.prefix_length_fallback = False
-    testing_config.prefix_length = 80
-
-    recipe_path = os.path.join(metadata_dir, "has_prefix_files")
-    metadata = api.render(recipe_path, config=testing_config)[0][0]
-    fn = api.get_output_file_paths(metadata)[0]
-    if os.path.isfile(fn):
-        os.remove(fn)
-
-    with pytest.raises((SystemExit, PaddingError, LinkError, CondaError)):
-        output = api.build(metadata)[0]
-        assert not api.inspect_prefix_length(output, 255)
-        testing_config.prefix_length = 255
-        environ.create_env(testing_config.build_prefix,
-                           specs_or_actions=["python", metadata.name()],
-                           env='build', config=testing_config, subdir=subdir)


### PR DESCRIPTION
Keeps build and host envs always separate.  Still merges them when only build section is present, unless {{ compiler() }} jinja2 is used in build.

fixes #1467