### PR TITLE
cache used variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,8 +62,7 @@ install:
       conda install -q flake8;
     else
       conda install -c c3i_test -q perl;
-      conda install -q pytest pip pytest-cov numpy mock;
-      $HOME/miniconda/bin/pip install pytest-xdist==1.16.0 pytest-catchlog pytest-mock;
+      conda install -q pytest pip pytest-cov pytest-forked pytest-xdist numpy mock pytest-mock;
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
     fi
   - pip install --no-deps .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,13 +43,11 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl
-  - conda install -q pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo pytest-forked
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - pip install --no-deps .
-  - pip install pytest-xdist==1.16.0 pytest-catchlog pytest-env pytest-mock filelock pkginfo
   - set PATH
   - conda build --version
   - call ci\appveyor\setup_x64.bat
@@ -75,10 +73,10 @@ test_script:
   - set PYTHON=
   - set LUA=
   - set R=
-  - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial" --durations=15
+  - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
   # remove all folders to avoid permission errors.  Leave root files (may have coverage info there)
   - for /d %%F in (c:\cbtmp\*) do rd /s /q "%%F"
-  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial" --durations=15
+  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial" --forked
 
 # For debugging, this is helpful - zip up the test environment and make it available for later download.
 #    However, it eats up a fair amount of time.  Better to disable until you need it.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo pytest-forked
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
@@ -76,7 +76,7 @@ test_script:
   - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
   # remove all folders to avoid permission errors.  Leave root files (may have coverage info there)
   - for /d %%F in (c:\cbtmp\*) do rd /s /q "%%F"
-  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial" --forked
+  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial"
 
 # For debugging, this is helpful - zip up the test environment and make it available for later download.
 #    However, it eats up a fair amount of time.  Better to disable until you need it.

--- a/ci/travis/run.sh
+++ b/ci/travis/run.sh
@@ -14,6 +14,5 @@ if [[ "$FLAKE8" == "true" ]]; then
     conda build conda.recipe --no-anaconda-upload
 else
     $HOME/miniconda/bin/py.test -v -n 0 --basetemp /tmp/cb --cov conda_build --cov-report xml -m "serial" tests
-    $HOME/miniconda/bin/py.test -v -n 2 --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --durations=15
-    # $HOME/miniconda/bin/py.test -v --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml tests --durations=15
+    $HOME/miniconda/bin/py.test -v -n 2 --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --forked
 fi

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1821,7 +1821,7 @@ class MetaData(object):
             # force target_platform to always be included, because it determines behavior
             if ('target_platform' in self.config.variant and
                     any(plat != self.config.subdir for plat in
-                        ensure_list(self.config.variant['target_platform']))):
+                        self.get_variants_as_dict_of_lists()['target_platform'])):
                 used_vars.add('target_platform')
             used_vars_cache[(self.name(), force_top_level, self.config.subdir)] = used_vars
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -509,9 +509,10 @@ def find_used_variables_in_text(variant, recipe_text):
     used_variables = set()
     for v in variant:
         variant_regex = r"(^.*\{\{\s*%s\s*(?:.*?)?\}\})" % v
+        selector_regex = r"\#?\s\[(?:.*[^_\w\d])?(%s)[^_\w\d]" % v
         conditional_regex = r"(.*\{%\s*(?:el)?if\s*" + v + r"\s*(?:.*?)?%\})"
         requirement_regex = r"(\-\s+%s(?:\s+|$))" % v.replace('_', '[-_]')
-        all_res = '|'.join((variant_regex, requirement_regex, conditional_regex))
+        all_res = '|'.join((variant_regex, requirement_regex, conditional_regex, selector_regex))
         compiler_match = re.match(r'(.*?)_compiler$', v)
         if compiler_match:
             compiler_regex = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ def testing_metadata(request, testing_config):
     d['about']['license'] = "contract in blood"
     d['about']['summary'] = "a test package"
     testing_config.variant = get_default_variant(testing_config)
+    testing_config.variants = [testing_config.variant]
     return MetaData.fromdict(d, config=testing_config)
 
 

--- a/tests/test-recipes/variants/25_target_platform_looping/conda_build_config.yaml
+++ b/tests/test-recipes/variants/25_target_platform_looping/conda_build_config.yaml
@@ -1,0 +1,3 @@
+target_platform:
+  - win-64
+  - win-32

--- a/tests/test-recipes/variants/25_target_platform_looping/meta.yaml
+++ b/tests/test-recipes/variants/25_target_platform_looping/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: test_platform_looping
+  version: 1

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -264,7 +264,7 @@ def test_checkout_tool_as_dependency(testing_workdir, testing_config, monkeypatc
 
 platforms = ["64" if sys.maxsize > 2**32 else "32"]
 if sys.platform == "win32":
-    platforms = set(["32", ] + platforms)
+    platforms = sorted(list(set(["32", ] + platforms)))
     compilers = ["2.7", "3.5"]
     msvc_vers = ['9.0', '14.0']
 else:

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -883,8 +883,9 @@ def test_append_python_app_osx(testing_config):
 
 @pytest.mark.serial
 def test_run_exports(testing_metadata, testing_config, testing_workdir):
-    api.build(os.path.join(metadata_dir, '_run_exports'), config=testing_config)
-    api.build(os.path.join(metadata_dir, '_run_exports_implicit_weak'), config=testing_config)
+    api.build(os.path.join(metadata_dir, '_run_exports'), config=testing_config, notest=True)
+    api.build(os.path.join(metadata_dir, '_run_exports_implicit_weak'), config=testing_config,
+              notest=True)
 
     # run_exports is tricky.  We mostly only ever want things in "host".  Here are the conditions:
 
@@ -919,9 +920,10 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
 
 @pytest.mark.serial
 def test_ignore_run_exports(testing_metadata, testing_config):
-    # need to clear conda's index, or else we somehow pick up the test_run_exports folder
-    #     above for our package here.
-    api.build(os.path.join(metadata_dir, '_run_exports'), config=testing_config)
+    # build the package with run exports for ensuring that we ignore it
+    api.build(os.path.join(metadata_dir, '_run_exports'), config=testing_config,
+              notest=True)
+    # customize our fixture metadata with our desired changes
     testing_metadata.meta['requirements']['host'] = ['test_has_run_exports']
     testing_metadata.meta['build']['ignore_run_exports'] = ['downstream_pinned_package']
     testing_metadata.config.index = None

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -330,3 +330,9 @@ def test_detect_variables_in_build_and_output_scripts(testing_config):
             assert 'BASH_VAR2' not in used_vars
             assert 'BAT_VAR' not in used_vars
             assert 'OUTPUT_VAR' in used_vars
+
+
+def test_target_platform_looping(testing_config):
+    outputs = api.get_output_file_paths(os.path.join(recipe_dir, '25_target_platform_looping'),
+                                   platform='win', arch='64')
+    assert len(outputs) == 2


### PR DESCRIPTION
3.1.4 was a dud release because it was much, much slower.  The test suite wasn't terribly affected because it is so simple.  Rendering the conda-build recipe to build the 3.1.4 release was painfully slow.

This was the main hotspot.