### PR TITLE
add log messages when adding variant configs

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -24,9 +24,9 @@ import yaml
 from . import conda_interface, utils
 from .conda_interface import (CondaHTTPError, VersionOrder, get_index, human_bytes, md5_file,
                               url_path)
-from .utils import file_info, get_lock, rm_rf, try_acquire_locks
+from .utils import file_info, get_lock, rm_rf, try_acquire_locks, get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 local_index_timestamp = 0
 cached_index = None


### PR DESCRIPTION
This is helpful when trying to figure out why on earth you're seeing some strange values - it at least gives you a list of places to look.

Output looks like:

```
CONDA_SUBDIR=linux-64 conda render ctng-dbg-compilers-activation-feedstock -m ctng-dbg-compilers-activation-feedstock/recipe/conda_build_config.cos6.x86_64.yaml
Adding in variants from internal_defaults
Adding in variants from /Users/msarahan/code/aggregate/conda_build_config.yaml
Adding in variants from ctng-dbg-compilers-activation-feedstock/recipe/conda_build_config.cos6.x86_64.yaml
```