### PR TITLE
don't loop in all zip_keys when collecting used vars

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1084,7 +1084,7 @@ class MetaData(object):
         # used variables - anything with a value in conda_build_config.yaml that applies to this
         #    recipe.  Includes compiler if compiler jinja2 function is used.
         """
-        dependencies = self.get_used_vars(add_zip_keys=False)
+        dependencies = self.get_used_vars()
 
         # filter out ignored versions
         build_string_excludes = ['python', 'r_base', 'perl', 'lua', 'numpy', 'target_platform']
@@ -1800,11 +1800,10 @@ class MetaData(object):
         return variants.get_vars(_variants, loop_only=True)
 
     def get_used_loop_vars(self, force_top_level=False):
-        return {var for var in self.get_used_vars(force_top_level=force_top_level,
-                                                  add_zip_keys=False)
+        return {var for var in self.get_used_vars(force_top_level=force_top_level)
                 if var in self.get_loop_vars()}
 
-    def get_used_vars(self, force_top_level=False, add_zip_keys=True):
+    def get_used_vars(self, force_top_level=False):
         global used_vars_cache
         if (self.name(), force_top_level, self.config.subdir) in used_vars_cache:
             used_vars = used_vars_cache[(self.name(), force_top_level, self.config.subdir)]
@@ -1824,18 +1823,7 @@ class MetaData(object):
                         self.get_variants_as_dict_of_lists()['target_platform'])):
                 used_vars.add('target_platform')
             used_vars_cache[(self.name(), force_top_level, self.config.subdir)] = used_vars
-
-        zip_reqs = set()
-        if add_zip_keys:
-            # each group looks like {key1#key2: [val1_1#val2_1, val1_2#val2_2]
-            for group in variants._get_zip_groups(self.config.variant):
-                # get the keys to each dict
-                for group_key in group:
-                    # break those keys into individual keys - these are the keys in the config
-                    individual_keys = set(group_key.split('#'))
-                    if any(k in used_vars for k in individual_keys):
-                        zip_reqs.update(individual_keys)
-        return used_vars | zip_reqs
+        return used_vars
 
     def _get_used_vars_meta_yaml(self, force_top_level=False):
         # recipe text is the best, because variables can be used anywhere in it.

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -593,18 +593,11 @@ def distribute_variants(metadata, variants, permit_unsatisfiable_variants=False,
         for env in ('build', 'host', 'run'):
             utils.insert_variant_versions(mv.meta.get('requirements', {}),
                                           mv.config.variant, env)
-
-        fm = mv.copy()
-        # HACK: trick conda-build into thinking this is final, and computing a hash based
-        #     on the current meta.yaml.  The accuracy doesn't matter, all that matters is
-        #     our ability to differentiate configurations
-        fm.final = True
-        rendered_metadata[(fm.dist(),
-                           fm.config.variant.get('target_platform', fm.config.subdir),
-                           tuple((var, fm.config.variant[var])
-                                 for var in fm.get_used_loop_vars()))] = \
+        rendered_metadata[(mv.dist(),
+                           mv.config.variant.get('target_platform', mv.config.subdir),
+                           tuple((var, mv.config.variant[var])
+                                 for var in mv.get_used_loop_vars()))] = \
                                     (mv, need_source_download, None)
-
     # list of tuples.
     # each tuple item is a tuple of 3 items:
     #    metadata, need_download, need_reparse_in_env

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -250,7 +250,7 @@ def test_get_used_loop_vars(testing_config):
     #   some_package is explicitly used as a jinja2 variable
     assert m.get_used_loop_vars() == {'python', 'some_package'}
     # these are all used vars - including those with only one value (and thus not loop vars)
-    assert m.get_used_vars() == {'python', 'some_package', 'zlib', 'zipped_var'}
+    assert m.get_used_vars() == {'python', 'some_package', 'zlib'}
 
 
 def test_reprovisioning_source(testing_config):


### PR DESCRIPTION
leave cleanup of zip_keys for others

The issue here was that for conda-smithy, we were ending up with too many configurations due to zipped keys that were ultimately unused.  We need to deduplicate those somehow, but having the zip_keys pulled in made that much harder.

https://github.com/conda-forge/conda-smithy/pull/625#issuecomment-353518158

This is a companion PR for https://github.com/conda-forge/conda-smithy/pull/625/commits/2cfd07288855dececaff67fd9148ccbfa8375444