### PR TITLE
fix outputs not loading hash info at test time correctly

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1452,6 +1452,9 @@ def _construct_metadata_for_test_from_package(package, config):
         else:
             config.filename_hashing = False
             hash_input = {}
+        # not actually used as a variant, since metadata will have been finalized.
+        #    This is still necessary for computing the hash correctly though
+        config.variant = hash_input
 
     log = utils.get_logger(__name__)
 
@@ -1569,7 +1572,6 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
 
     trace = '-x ' if metadata.config.debug else ''
 
-    metadata.append_metadata_sections(hash_input, merge=False)
     metadata.config.compute_build_id(metadata.name())
 
     # Must download *after* computing build id, or else computing build id will change

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -980,9 +980,9 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                         "are already built in {0}, skipping.".format(package_locations))
                 return default_return
             else:
-                package_locations = [bldpkg_path(om) for _, om in output_metas]
+                package_locations = [bldpkg_path(om) for _, om in output_metas if not om.skip()]
         else:
-            package_locations = [bldpkg_path(om) for _, om in output_metas]
+            package_locations = [bldpkg_path(om) for _, om in output_metas if not om.skip()]
 
         print("BUILD START:", [os.path.basename(pkg) for pkg in package_locations])
 
@@ -1243,6 +1243,9 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                                 os.path.join(prefix_files_backup, f),
                                 symlinks=True)
             for (output_d, m) in outputs:
+                if m.skip():
+                    print(utils.get_skip_message(m))
+                    continue
                 if (top_level_meta.name() == output_d.get('name') and not (output_d.get('files') or
                                                                            output_d.get('script'))):
                     output_d['files'] = (utils.prefix_files(prefix=m.config.host_prefix) -

--- a/tests/test-recipes/split-packages/split_packages_hash_resolution/conda_build_config.yaml
+++ b/tests/test-recipes/split-packages/split_packages_hash_resolution/conda_build_config.yaml
@@ -1,0 +1,3 @@
+blas_impl:
+  - mkl                        # [x86 or x86_64]
+  - openblas

--- a/tests/test-recipes/split-packages/split_packages_hash_resolution/meta.yaml
+++ b/tests/test-recipes/split-packages/split_packages_hash_resolution/meta.yaml
@@ -2,10 +2,12 @@ package:
   name: test
   version: 1.0.0
 
+build:
+
 outputs:
   - name: test-split1
     build:
-      skip: True  # [blas_impl == 'openblas' and win]
+      skip: True  # [blas_impl != 'mkl' and win]
       # conda > 4.4 might be able to use this
       requires_features:
         blas: {{ blas_impl }}

--- a/tests/test-recipes/split-packages/split_packages_hash_resolution/meta.yaml
+++ b/tests/test-recipes/split-packages/split_packages_hash_resolution/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: test
+  version: 1.0.0
+
+outputs:
+  - name: test-split1
+    build:
+      skip: True  # [blas_impl == 'openblas' and win]
+      # conda > 4.4 might be able to use this
+      requires_features:
+        blas: {{ blas_impl }}
+      # this is for conda 4.4 and below
+      features:
+        - nomkl    # [x86 and blas_impl != 'mkl']
+    requirements:
+      host:
+        - zlib
+      build:
+        - {{ compiler('c') }}
+        - make
+      run:
+        - nomkl    # [blas_impl != 'mkl']
+    test:
+      commands:
+        - echo hello


### PR DESCRIPTION
fixes #2606 

@nehaljwani note that I needed to add a runtime dep on nomkl for the nomkl-featured package.  Without that, you'll get unsatisfiable errors that are very confusing.  They'll tell you that the package you just built is not installable, but won't mention anything about the feature.