### PR TITLE
check skip status in more places, to avoid confusion

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -308,8 +308,8 @@ def pin_subpackage(metadata, subpackage_name, min_pin='x.x.x.x.x.x', max_pin='x'
         matching_package_keys = [k for k in keys if k[0] == subpackage_name]
         if len(matching_package_keys) == 1:
             key = matching_package_keys[0]
-            pin = pin_subpackage_against_outputs(key, metadata.other_outputs, min_pin, max_pin,
-                                                 exact, permit_undefined_jinja)
+        pin = pin_subpackage_against_outputs(key, metadata.other_outputs, min_pin, max_pin,
+                                             exact, permit_undefined_jinja)
     if not pin:
         pin = subpackage_name
     return pin

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,10 +146,7 @@ def test_build_output_build_path_multiple_recipes(testing_workdir, testing_metad
     main_build.execute(args)
 
     test_path = lambda pkg: os.path.join(sys.prefix, "conda-bld", testing_config.host_subdir, pkg)
-    test_paths = [test_path(
-        "test_build_output_build_path_multiple_recipes-1.0-1.tar.bz2"),
-        "Skipped: conda-build-skip from {} defines build/skip for this configuration ({{}}).".format(
-            os.path.abspath(skip_recipe))]
+    test_paths = [test_path("test_build_output_build_path_multiple_recipes-1.0-1.tar.bz2"), ]
 
     output, error = capfd.readouterr()
     # assert error == ""


### PR DESCRIPTION
@nehaljwani reported issues rendering a recipe for mxnet, which had a number of problems on windows:

- run_exports from other packages were not taking effect (opencv, mkl)
- exact subpackage pins weren't taking effect

With more aggressively skipping metadata and outputs, these confusions go away.