### PR TITLE
speed up ?

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -179,12 +179,12 @@ def find_pkg_dir_or_file_in_pkgs_dirs(pkg_dist, m):
     for pkgs_dir in _pkgs_dirs:
         pkg_dir = os.path.join(pkgs_dir, pkg_dist)
         pkg_file = os.path.join(pkgs_dir, pkg_dist + '.tar.bz2')
-
-        if os.path.isfile(pkg_file):
-            pkg_loc = pkg_file
-            break
-        elif os.path.isdir(pkg_dir):
+        
+        if os.path.isdir(pkg_dir):
             pkg_loc = pkg_dir
+            break
+        elif os.path.isfile(pkg_file):
+            pkg_loc = pkg_file
             break
     return pkg_loc
 


### PR DESCRIPTION
Hi,

I've had massive slowdown recently, which boils down to rendering the recipe.

Refering to https://github.com/conda/conda-build/commit/44f1fe995630e36ff4a420657e1b7156caf862ae, is there any reason to prefer using the archive file (which implies deflating the .tar.bz2 and is costly) over an existing cached directory ?