### PR TITLE
Always set filename, dirname for a machofile

### DIFF
--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -447,7 +447,10 @@ def _get_resolved_relocated_location(codefile, so, src_exedir, src_selfdir,
 
 class machofile(UnixExecutable):
     def __init__(self, file, arch, initial_rpaths_transitive=[]):
+        self.filename = file.name
         self.shared_libraries = []
+        # Not actually used ..
+        self.selfdir = os.path.dirname(file.name)
         results = mach_o_find_dylibs(file, arch)
         if not results:
             return
@@ -462,9 +465,6 @@ class machofile(UnixExecutable):
         self.shared_libraries.extend(
             [(so, self.from_os_varnames(so)) for so in sos[0] if so])
         file.seek(0)
-        # Not actually used ..
-        self.selfdir = os.path.dirname(file.name)
-        self.filename = file.name
 
     def to_os_varnames(self, input_):
         """Don't make these functions - they are methods to match the API for elffiles."""


### PR DESCRIPTION
This is required so that `cf.uniqueness_key()` doesn't error out with `AttributeError`:
```
patchelf: --print-rpath failed for
/opt/conda/conda-bld/cmake-binary_yyy/xxx/cmake-bin/share/cmake-3.9/Modules/CPack.OSXScriptLauncher.in
...
  File "/home/nwani/conda-build/conda_build/os_utils/pyldd.py", line 986, in _inspect_linkages_this
    return cf.uniqueness_key(), [], []
  File "/home/nwani/conda-build/conda_build/os_utils/pyldd.py", line 504, in uniqueness_key
    return self.filename
AttributeError: 'machofile' object has no attribute 'filename'
```