### PR TITLE
cache used vars based also on recipe path, to avoid over-caching

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1453,18 +1453,17 @@ def _construct_metadata_for_test_from_package(package, config):
 
     if package_data['subdir'] != 'noarch':
         config.host_subdir = package_data['subdir']
-    if config.filename_hashing:
-        # We may be testing an (old) package built without filename hashing.
-        hash_input = os.path.join(info_dir, 'hash_input.json')
-        if os.path.isfile(hash_input):
-            with open(os.path.join(info_dir, 'hash_input.json')) as f:
-                hash_input = json.load(f)
-        else:
-            config.filename_hashing = False
-            hash_input = {}
-        # not actually used as a variant, since metadata will have been finalized.
-        #    This is still necessary for computing the hash correctly though
-        config.variant = hash_input
+    # We may be testing an (old) package built without filename hashing.
+    hash_input = os.path.join(info_dir, 'hash_input.json')
+    if os.path.isfile(hash_input):
+        with open(os.path.join(info_dir, 'hash_input.json')) as f:
+            hash_input = json.load(f)
+    else:
+        config.filename_hashing = False
+        hash_input = {}
+    # not actually used as a variant, since metadata will have been finalized.
+    #    This is still necessary for computing the hash correctly though
+    config.variant = hash_input
 
     log = utils.get_logger(__name__)
 
@@ -1514,6 +1513,9 @@ def _construct_metadata_for_test_from_package(package, config):
                                                 'string': package_data['build']},
                                       'requirements': {'run': package_data['depends']}
                                       }, config=config)
+    # HACK: because the recipe is fully baked, detecting "used" variables no longer works.  The set
+    #     of variables in the hash_input suffices, though.
+    metadata.config.used_vars = list(hash_input.keys())
     return metadata, hash_input
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1858,8 +1858,10 @@ class MetaData(object):
 
     def get_used_vars(self, force_top_level=False):
         global used_vars_cache
-        if (self.name(), force_top_level, self.config.subdir) in used_vars_cache:
-            used_vars = used_vars_cache[(self.name(), force_top_level, self.config.subdir)]
+        recipe_dir = self.path or self.meta.get('extra', {}).get('parent_recipe', {}).get('path')
+        if (self.name(), recipe_dir, force_top_level, self.config.subdir) in used_vars_cache:
+            used_vars = used_vars_cache[(self.name(), recipe_dir,
+                                         force_top_level, self.config.subdir)]
         else:
             meta_yaml_reqs = self._get_used_vars_meta_yaml(force_top_level=force_top_level)
             is_output = 'package:' not in self.get_recipe_text()
@@ -1875,7 +1877,8 @@ class MetaData(object):
                     any(plat != self.config.subdir for plat in
                         self.get_variants_as_dict_of_lists()['target_platform'])):
                 used_vars.add('target_platform')
-            used_vars_cache[(self.name(), force_top_level, self.config.subdir)] = used_vars
+            used_vars_cache[(self.name(), recipe_dir,
+                             force_top_level, self.config.subdir)] = used_vars
         return used_vars
 
     def _get_used_vars_meta_yaml(self, force_top_level=False):

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -179,7 +179,6 @@ def find_pkg_dir_or_file_in_pkgs_dirs(pkg_dist, m):
     for pkgs_dir in _pkgs_dirs:
         pkg_dir = os.path.join(pkgs_dir, pkg_dist)
         pkg_file = os.path.join(pkgs_dir, pkg_dist + '.tar.bz2')
-        
         if os.path.isdir(pkg_dir):
             pkg_loc = pkg_dir
             break


### PR DESCRIPTION
This was breaking the example from our blog post on conda-build 3, because many of the recipe package/names were identical.