### PR TITLE
Update build.py to fix rewriting problem when running in WSL

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -142,9 +142,10 @@ def have_prefix_files(files, prefix):
                 # Use the placeholder for maximal backwards compatibility, and
                 # to minimize the occurrences of usernames appearing in built
                 # packages.
-                rewrite_file_with_new_prefix(path, mm[:], prefix_bytes, prefix_placeholder_bytes)
+                data = mm[:]
                 mm.close()
                 fi.close()
+                rewrite_file_with_new_prefix(path, data, prefix_bytes, prefix_placeholder_bytes)
                 fi = open(path, 'rb+')
                 mm = utils.mmap_mmap(fi.fileno(), 0, tagname=None, flags=utils.mmap_MAP_PRIVATE)
         if mm.find(prefix_bytes) != -1:


### PR DESCRIPTION
This change closes the memory map before rewriting it. This prevents problems when running on WSL and does not seem to cause problems in Windows or Linux. This is a fix for issue #2598 