### PR TITLE
fix hash handling of numpy pinning

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -561,7 +561,7 @@ def apply_patch(src_dir, path, config, git=None):
             or conda, m2-patch (Windows),
         """ % (os.pathsep.join(external.dir_paths)))
         patch_strip_level = _guess_patch_strip_level(files, src_dir)
-        patch_args = ['-p%d' % patch_strip_level, '-i', path]
+        patch_args = ['-p%d' % patch_strip_level, '--ignore-whitespace', '-i', path]
 
         # line endings are a pain.
         # https://unix.stackexchange.com/a/243748/34459

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -515,7 +515,7 @@ def get_vars(variants, loop_only=False):
 def find_used_variables_in_text(variant, recipe_text):
     used_variables = set()
     for v in variant:
-        variant_regex = r"(^.*\{\{\s*%s\s*(?:.*?)?\}\})" % v
+        variant_regex = r"(^.*\{\{\s*(?:pin_.*?)?%s[\'\"\s,]*(?:.*?)?\}\})" % v
         selector_regex = r"\#?\s\[(?:.*[^_\w\d])?(%s)[^_\w\d]" % v
         conditional_regex = r"(.*\{%\s*(?:el)?if\s*" + v + r"\s*(?:.*?)?%\})"
         requirement_regex = r"(\-\s+%s(?:\s+[\[#]|$))" % v.replace('_', '[-_]')

--- a/tests/test-recipes/variants/numpy_used/conda_build_config.yaml
+++ b/tests/test-recipes/variants/numpy_used/conda_build_config.yaml
@@ -1,0 +1,8 @@
+python:
+    - 3.5
+    - 3.6
+numpy:
+    - 1.11
+    - 1.13
+blas_impl:
+    - mkl

--- a/tests/test-recipes/variants/numpy_used/meta.yaml
+++ b/tests/test-recipes/variants/numpy_used/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.13.5" %}
+
+package:
+  name: tifffile
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/blink1073/tifffile
+  git_tag: v{{ version }}
+
+build:
+  number: 3
+  # conda 4.4+
+  skip: True  # [blas_impl != "mkl" and win]
+  requires_features:
+    blas: {{ blas_impl }}
+  # conda 4.3-
+  features:
+    - nomkl  # [x86 and blas_impl != "mkl"]
+
+  script: python setup.py install
+
+requirements:
+  build:
+    - nomkl  # [blas_impl != "mkl"]
+    - python {{ python }}
+    - numpy {{ numpy }}
+    - setuptools
+
+  run:
+    - nomkl  # [blas_impl != "mkl"]
+    - python {{ python }}
+    - {{ pin_compatible("numpy", min_pin="x.x", max_pin="x.x") }}
+
+test:
+  imports:
+    - tifffile
+
+about:
+  home: https://github.com/blink1073/tifffile
+  license:  BSD License
+  summary: 'Read and write image data from and to TIFF files.'

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -339,3 +339,9 @@ def test_target_platform_looping(testing_config):
     outputs = api.get_output_file_paths(os.path.join(recipe_dir, '25_target_platform_looping'),
                                    platform='win', arch='64')
     assert len(outputs) == 2
+
+
+def test_numpy_used_variable_looping(testing_config):
+    outputs = api.get_output_file_paths(os.path.join(recipe_dir, 'numpy_used'),
+                                   platform='win', arch='64')
+    assert len(outputs) == 4


### PR DESCRIPTION
fixes #2658 

The problem here was an unhappy medium between ``numpy x.x`` and having numpy unpinned.  ``numpy x.x`` worked ok, but the equivalent pin_compatible expression wasn't being treated correctly.

There are 3 outcomes with numpy:

1. ``numpy x.x`` or ``{{ pin_compatible('numpy', max_pin='x.x') }}`` - this is what gets you the npXYY in the build string.  You can have min_pin set to anything you want.  The key is having max_pin with **two** x's.
2. usage of ``{{ pin_compatible('numpy') }}`` either without max_pin arguments at all, or with arguments other than ``'x.x'`` - this makes numpy contribute to the hash
3. No usage of pin_compatible - this makes numpy not contribute to the hash