### PR TITLE
implement exclusive config file

### DIFF
--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -96,10 +96,18 @@ source to try fill in related template variables.",
     )
     p.add_argument(
         '-m', '--variant-config-files',
-        dest='variant_config_files',
         action="append",
         help="""Additional variant config files to add.  These yaml files can contain
         keys such as `c_compiler` and `target_platform` to form a build matrix."""
+    )
+    p.add_argument(
+        '-e', '--exclusive-config-file',
+        help="""Exclusive variant config file to add.  Compared with --variant-config-files,
+        you're allowed only one file here.  Providing a file here disables searching in your
+        home directory and in cwd.  The file specified here comes at the start of the order,
+        as opposed to the end with --variant-config-files.  Any config files in recipes and
+        any config files specified with --variant-config-files will override values from
+        this file."""
     )
     p.add_argument(
         "--old-build-string", dest="filename_hashing", action="store_false",

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -116,6 +116,9 @@ DEFAULTS = [Setting('activate', True),
 
             # variants
             Setting('variant_config_files', []),
+            # this file precludes usage of any system-wide or cwd config files.  Config files in
+            #    recipes are still respected, and they override this file.
+            Setting('exclusive_config_file', None),
             Setting('ignore_system_variants', False),
             Setting('hash_length', 7),
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -134,13 +134,15 @@ def validate_spec(spec):
         raise ValueError("Variant configuration errors: \n{}".format(errors))
 
 
-def find_config_files(metadata_or_path, additional_files=None, ignore_system_config=False):
+def find_config_files(metadata_or_path, additional_files=None, ignore_system_config=False,
+                      exclusive_config_file=None):
     """Find files to load variables from.  Note that order here determines clobbering.
 
     Later files clobber earlier ones.  order is user-wide < cwd < recipe dir < additional files"""
-    files = []
+    files = ([os.path.abspath(os.path.expanduser(exclusive_config_file))]
+             if exclusive_config_file else [])
 
-    if not ignore_system_config:
+    if not ignore_system_config and not exclusive_config_file:
         if cc_conda_build.get('config_file'):
             system_path = abspath(expanduser(expandvars(cc_conda_build['config_file'])))
         else:
@@ -461,7 +463,8 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
         from conda_build.config import Config
         config = Config()
     files = find_config_files(recipedir_or_metadata, ensure_list(config.variant_config_files),
-                              ignore_system_config=config.ignore_system_variants)
+                              ignore_system_config=config.ignore_system_variants,
+                              exclusive_config_file=config.exclusive_config_file)
 
     specs = OrderedDict(internal_defaults=get_default_variant(config))
 

--- a/tests/test-recipes/variants/exclusive_config_file/conda_build_config.yaml
+++ b/tests/test-recipes/variants/exclusive_config_file/conda_build_config.yaml
@@ -1,0 +1,4 @@
+abc:
+  - 123
+unique_to_recipe:
+  - abc

--- a/tests/test-recipes/variants/exclusive_config_file/meta.yaml
+++ b/tests/test-recipes/variants/exclusive_config_file/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: test_exclusive_config_file
+  version: 1.0

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -345,3 +345,21 @@ def test_numpy_used_variable_looping(testing_config):
     outputs = api.get_output_file_paths(os.path.join(recipe_dir, 'numpy_used'),
                                    platform='win', arch='64')
     assert len(outputs) == 4
+
+
+def test_exclusive_config_file(testing_workdir):
+    with open('conda_build_config.yaml', 'w') as f:
+        yaml.dump({'abc': ['someval'], 'cwd': ['someval']}, f, default_flow_style=False)
+    os.makedirs('config_dir')
+    with open(os.path.join('config_dir', 'config.yaml'), 'w') as f:
+        yaml.dump({'abc': ['super'], 'exclusive': ['someval']}, f, default_flow_style=False)
+    output = api.render(os.path.join(recipe_dir, 'exclusive_config_file'),
+                        exclusive_config_file=os.path.join('config_dir', 'config.yaml'))[0][0]
+    variant = output.config.variant
+    # is cwd ignored?
+    assert 'cwd' not in variant
+    # did we load the exclusive config
+    assert 'exclusive' in variant
+    # does recipe config override exclusive?
+    assert 'unique_to_recipe' in variant
+    assert variant['abc'] == '123'


### PR DESCRIPTION
This is intended to address @jakirkham comments from https://github.com/conda-forge/conda-smithy/pull/625

This provides a slightly different CLI option and API argument to specify a config file that overrides the usual search in HOME and cwd.  The thought here was to help people avoid "oops" situations where they meant to use some specific config file, but their system-wide defaults crept in.

With an exclusive config file, the hierarchy is:

1. exclusive config file
2. config file in the recipe (alongside meta.yaml)
3. any additional files specified on the CLI with --variant-config-files/-m