### PR TITLE
conda.recipe: replace 'which' with 'type -P'

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -47,30 +47,30 @@ test:
     # - pytest-xdist
     - mock
   commands:
-    - which conda-build  # [unix]
+    - type -P conda-build  # [unix]
     - where conda-build  # [win]
     - conda build -h
-    - which conda-convert  # [unix]
+    - type -P conda-convert  # [unix]
     - where conda-convert  # [win]
     - conda convert -h
-    - which conda-develop  # [unix]
+    - type -P conda-develop  # [unix]
     - where conda-develop  # [win]
     - conda develop -h
-    - which conda-index  # [unix]
+    - type -P conda-index  # [unix]
     - where conda-index  # [win]
     - conda index -h
-    - which conda-inspect  # [unix]
+    - type -P conda-inspect  # [unix]
     - where conda-inspect  # [win]
     - conda inspect -h
     - conda inspect linkages -h \| grep "--name ENVIRONMENT"  # [unix]
     - conda inspect objects -h \| grep "--name ENVIRONMENT"   # [osx]
-    - which conda-metapackage  # [unix]
+    - type -P conda-metapackage  # [unix]
     - where conda-metapackage  # [win]
     - conda metapackage -h
-    - which conda-render  # [unix]
+    - type -P conda-render  # [unix]
     - where conda-render  # [win]
     - conda render -h
-    - which conda-skeleton  # [unix]
+    - type -P conda-skeleton  # [unix]
     - where conda-skeleton  # [win]
     - conda skeleton -h
     # test that conda sees entry points appropriately in help


### PR DESCRIPTION
The 'which' command behaves differently on different systems and one can't rely
on a useful exit code. Till 2.21 it had problems with paths >256 bytes in length.

http://lists.gnu.org/archive/html/which-bugs/2015-06/threads.html