### PR TITLE
Fix `noarch: python` with "python-scripts" for 2.1.x

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -374,12 +374,17 @@ def build_string_from_metadata(metadata):
     if metadata.meta.get('build', {}).get('string'):
         return metadata.get_value('build/string')
     res = []
+    metadata_noarch = str(metadata.get_value('build/noarch'))
+    metadata_noarch_python = metadata.get_value('build/noarch_python')
     version_pat = re.compile(r'(?:==)?(\d+)\.(\d+)')
     for name, s in (('numpy', 'np'), ('python', 'py'),
                     ('perl', 'pl'), ('lua', 'lua'),
                     ('r', 'r'), ('r-base', 'r')):
         for ms in metadata.ms_depends():
             if ms.name.split(' ')[0] == name:
+                if metadata_noarch == name or (metadata_noarch_python and name == 'python'):
+                    res.append(s)
+                    break
                 try:
                     v = ms.spec.split()[1]
                 except IndexError:

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -21,7 +21,8 @@ def _error_exit(exit_message):
 
 def rewrite_script(fn, prefix):
     """Take a file from the bin directory and rewrite it into the python-scripts
-    directory after it passes some sanity checks for noarch pacakges"""
+    directory with the same permissions after it passes some sanity checks for
+    noarch pacakges"""
 
     # Load and check the source file for not being a binary
     src = join(prefix, 'Scripts' if ISWIN else 'bin', fn)
@@ -30,6 +31,7 @@ def rewrite_script(fn, prefix):
             data = fi.read()
         except UnicodeDecodeError:  # file is binary
             _error_exit("Noarch package contains binary script: %s" % fn)
+    src_mode = os.stat(src).st_mode
     os.unlink(src)
 
     # Get rid of '-script.py' suffix on Windows
@@ -39,8 +41,10 @@ def rewrite_script(fn, prefix):
     # Rewrite the file to the python-scripts directory
     dst_dir = join(prefix, 'python-scripts')
     _force_dir(dst_dir)
-    with open(join(dst_dir, fn), 'w') as fo:
+    dst = join(dst_dir, fn)
+    with open(dst, 'w') as fo:
         fo.write(data)
+    os.chmod(dst, src_mode)
     return fn
 
 


### PR DESCRIPTION
This includes https://github.com/conda/conda-build/pull/2653 and also backports a change from
https://github.com/conda/conda-build/commit/4021815d8f618c859393b8d350ef64f79ce75891#diff-c86934c27c2f25579540ddb447fa45bdR361.
The latter allows `py_` to be added to the build string. This in turn fixes builds of `noarch: python` that include scripts in `bin` (`Scripts`) since the `2.1.x` code base explicitly tests for `py_` while handling those files (https://github.com/conda/conda-build/blob/2.1.18/conda_build/noarch_python.py#L115, https://github.com/conda/conda-build/blob/2.1.18/conda_build/tarcheck.py#L34).
This does not fix https://github.com/conda/conda-build/issues/1962 for non-`noarch` packages as the fix is only applied for `noarch: python` (and the old `noarch_python`).
(cc @jakirkham, @jjhelmus, @CJ-Wright)