### PR TITLE
fix interpretation of zip_keys when testing pkgs

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -195,13 +195,14 @@ def _combine_spec_dictionaries(specs, extend_keys=None, filter_keys=None, zip_ke
                             # uniquify
                             values[k] = list(set(values[k]))
                     elif k == 'zip_keys':
-                        # should always be a list of lists, but users may specify as just a list
+                        v = [subval for subval in v if subval]
                         if not isinstance(v[0], list) and not isinstance(v[0], tuple):
                             v = [v]
+                        # should always be a list of lists, but users may specify as just a list
                         values[k] = values.get(k, [])
                         values[k].extend(v)
                         values[k] = list(list(set_group) for set_group in set(tuple(group)
-                                                                            for group in values[k]))
+                                                                        for group in values[k]))
                     else:
                         if hasattr(v, 'keys'):
                             values[k] = v.copy()
@@ -310,7 +311,7 @@ def _get_zip_key_set(combined_variant):
             # make sure that each key only occurs in one set
             _all_unique = all_unique(zip_keys)
             if _all_unique is not True:
-                raise ValueError("All package in zip keys must belong to only one group.  "
+                raise ValueError("All packages in zip keys must belong to only one group.  "
                                 "'{}' is in more than one group.".format(_all_unique))
             for ks in zip_keys:
                 # sets with only a single member aren't actually zipped.  Ignore them.


### PR DESCRIPTION
Fixes problems like:

```
Traceback (most recent call last):
  File "C:\MC2\Scripts\conda-build-script.py", line 11, in <module>
    load_entry_point('conda-build', 'console_scripts', 'conda-build')()
  File "z:\msarahan\code\conda-build\conda_build\cli\main_build.py", line 413, in main
    execute(sys.argv[1:])
  File "z:\msarahan\code\conda-build\conda_build\cli\main_build.py", line 383, in execute
    action(recipe, config)
  File "z:\msarahan\code\conda-build\conda_build\cli\main_build.py", line 323, in test_action
    return api.test(recipe, move_broken=False, config=config)
  File "z:\msarahan\code\conda-build\conda_build\api.py", line 213, in test
    test_result = test(recipedir_or_package_or_metadata, config=config, move_broken=move_broken)
  File "z:\msarahan\code\conda-build\conda_build\build.py", line 1609, in test
    config)
  File "z:\msarahan\code\conda-build\conda_build\build.py", line 1581, in construct_metadata_for_test
    m, hash_input = _construct_metadata_for_test_from_package(recipedir_or_package, config)
  File "z:\msarahan\code\conda-build\conda_build\build.py", line 1530, in _construct_metadata_for_test_from_package
    reset_build_id=False)[0][0]
  File "z:\msarahan\code\conda-build\conda_build\render.py", line 645, in render_recipe
    m.config.variants = get_package_variants(m, variants=variants)
  File "z:\msarahan\code\conda-build\conda_build\variants.py", line 488, in get_package_variants
    combined_spec, extend_keys = combine_specs(specs, log_output=config.verbose)
  File "z:\msarahan\code\conda-build\conda_build\variants.py", line 257, in combine_specs
    log_output=log_output).get('zip_keys', [])
  File "z:\msarahan\code\conda-build\conda_build\variants.py", line 204, in _combine_spec_dictionaries
    for group in values[k]))
TypeError: unhashable type: 'list'
```

These resulted from empty values incorporated during loading of data, such as:

```
ipdb> values
{u'zip_keys': [[u'', [u'vc', u'c_compiler', u'cxx_compiler', u'fortran_compiler_version', u'python', u'ipython']]]}
```
