### PR TITLE
Record build stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
         conda info;
     fi
   - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION
-  - conda install -q pyflakes conda-verify beautifulsoup4 chardet pycrypto glob2
+  - conda install -q pyflakes conda-verify beautifulsoup4 chardet pycrypto glob2 psutil
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - conda config --set always_yes yes
   - conda config --set auto_update_conda False
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      conda install -q futures;
+      conda install -q futures scandir;
     fi
   - conda update -q --all
   - if [ -n "$CONDA_VERSION" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,7 @@ install:
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
   - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil
+  - if "%PYTHON_VERSION%" == "2.7" conda install -q scandir
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo
+  - conda install -q pip pytest pytest-cov jinja2 patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy conda-verify beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil
   # this is to ensure dependencies
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,8 +33,10 @@ requirements:
     - jinja2
     - patchelf      # [linux]
     - pkginfo
+    - psutil
     - python
     - pyyaml
+    - scandir
     - six
     - glob2
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - psutil
     - python
     - pyyaml
-    - scandir
+    - scandir       # [py<34]
     - six
     - glob2
 

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -143,7 +143,8 @@ def check(recipe_path, no_download_source=False, config=None, variants=None, **k
 
 
 def build(recipe_paths_or_metadata, post=None, need_source_download=True,
-          build_only=False, notest=False, config=None, variants=None, **kwargs):
+          build_only=False, notest=False, config=None, variants=None, stats=None,
+          **kwargs):
     """Run the build step.
 
     If recipe paths are provided, renders recipe before building.
@@ -190,10 +191,11 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
     if not absolute_recipes:
         raise ValueError('No valid recipes found for input: {}'.format(recipe_paths_or_metadata))
     return build_tree(absolute_recipes, build_only=build_only, post=post, notest=notest,
-                      need_source_download=need_source_download, config=config, variants=variants)
+                      need_source_download=need_source_download, config=config, variants=variants,
+                      stats=stats)
 
 
-def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwargs):
+def test(recipedir_or_package_or_metadata, move_broken=True, config=None, stats=None, **kwargs):
     """Run tests on either packages (.tar.bz2 or extracted) or recipe folders
 
     For a recipe folder, it renders the recipe enough to know what package to download, and obtains
@@ -210,7 +212,8 @@ def test(recipedir_or_package_or_metadata, move_broken=True, config=None, **kwar
         #   doesn't already have one. What this means is that if we're
         #   running a test immediately after build, we use the one that the
         #   build already provided
-        test_result = test(recipedir_or_package_or_metadata, config=config, move_broken=move_broken)
+        test_result = test(recipedir_or_package_or_metadata, config=config, move_broken=move_broken,
+                           stats=stats)
     return test_result
 
 

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -160,6 +160,11 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
 
     config = get_or_merge_config(config, **kwargs)
 
+    # if people don't pass in an object to capture stats in, they won't get them returned.
+    #     We'll still track them, though.
+    if not stats:
+        stats = {}
+
     recipe_paths_or_metadata = _ensure_list(recipe_paths_or_metadata)
     for recipe in recipe_paths_or_metadata:
         if not any((hasattr(recipe, "config"), isinstance(recipe, string_types))):
@@ -190,9 +195,8 @@ def build(recipe_paths_or_metadata, post=None, need_source_download=True,
 
     if not absolute_recipes:
         raise ValueError('No valid recipes found for input: {}'.format(recipe_paths_or_metadata))
-    return build_tree(absolute_recipes, build_only=build_only, post=post, notest=notest,
-                      need_source_download=need_source_download, config=config, variants=variants,
-                      stats=stats)
+    return build_tree(absolute_recipes, config, stats, build_only=build_only, post=post,
+                      notest=notest, need_source_download=need_source_download, variants=variants)
 
 
 def test(recipedir_or_package_or_metadata, move_broken=True, config=None, stats=None, **kwargs):
@@ -206,6 +210,11 @@ def test(recipedir_or_package_or_metadata, move_broken=True, config=None, stats=
         config = recipedir_or_package_or_metadata.config
     else:
         config = get_or_merge_config(config, **kwargs)
+
+    # if people don't pass in an object to capture stats in, they won't get them returned.
+    #     We'll still track them, though.
+    if not stats:
+        stats = {}
 
     with config:
         # This will create a new local build folder if and only if config

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2094,10 +2094,10 @@ for Python 3.5 and needs to be rebuilt."""
         handle_pypi_upload(wheels, config=config)
 
     total_time = time.time() - initial_time
-    max_memory_used = max([step.get('rss') for step in stats.values()])
-    total_disk = sum([step.get('disk') for step in stats.values()])
-    total_cpu_sys = sum([step.get('cpu_sys') for step in stats.values()])
-    total_cpu_user = sum([step.get('cpu_user') for step in stats.values()])
+    max_memory_used = max([step.get('rss') for step in stats.values()] or 0)
+    total_disk = sum([step.get('disk') for step in stats.values()] or 0)
+    total_cpu_sys = sum([step.get('cpu_sys') for step in stats.values()] or 0)
+    total_cpu_user = sum([step.get('cpu_user') for step in stats.values()] or 0)
 
     print("#####################################################")
     print("Resource usage summary:")

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -18,6 +18,7 @@ import sys
 import tarfile
 import hashlib
 import logging
+import time
 
 # this is to compensate for a requests idna encoding error.  Conda is a better place to fix,
 #   eventually
@@ -74,6 +75,37 @@ if 'bsd' in sys.platform:
     shell_path = '/bin/sh'
 else:
     shell_path = '/bin/bash'
+
+
+def stats_key(metadata, desc):
+    # get the build string from whatever conda-build makes of the configuration
+    used_loop_vars = metadata.get_used_loop_vars()
+    build_vars = '-'.join([k + '_' + str(metadata.config.variant[k]) for k in used_loop_vars
+                          if k != 'target_platform'])
+    # kind of a special case.  Target platform determines a lot of output behavior, but may not be
+    #    explicitly listed in the recipe.
+    tp = metadata.config.variant.get('target_platform')
+    if tp and tp != metadata.config.subdir and 'target_platform' not in build_vars:
+        build_vars += '-target_' + tp
+    key = [metadata.name(), metadata.version()]
+    if build_vars:
+        key.append(build_vars)
+    key = "-".join(key)
+    key = desc + key
+    return key
+
+
+def seconds_to_text(secs):
+    m, s = divmod(int(secs), 60)
+    h, m = divmod(m, 60)
+    return "%d:%02d:%02d" % (h, m, s)
+
+
+def log_stats(stats_dict, descriptor):
+    print("\nResource usage statistics from {}:".format(descriptor))
+    print("   Memory: {}".format(utils.bytes2human(stats_dict['rss'])))
+    print("   Disk usage: {}".format(utils.bytes2human(stats_dict['disk'])))
+    print("   Time elapsed: {}\n".format(seconds_to_text(stats_dict['elapsed'])))
 
 
 def create_post_scripts(m):
@@ -730,7 +762,7 @@ can lead to packages that include their dependencies.""" % meta_files))
     return new_files
 
 
-def bundle_conda(output, metadata, env, **kw):
+def bundle_conda(output, metadata, env, stats, **kw):
     log = utils.get_logger(__name__)
     log.info('Packaging %s', metadata.dist())
 
@@ -784,8 +816,14 @@ def bundle_conda(output, metadata, env, **kw):
         utils.copy_into(os.path.join(recipe_dir, output['script']), dest_file)
         if activate_script:
             _write_activation_text(dest_file, metadata)
+
+        bundle_stats = {}
         utils.check_call_env(interpreter.split(' ') + [dest_file],
-                            cwd=metadata.config.work_dir, env=env_output)
+                             cwd=metadata.config.work_dir, env=env_output, stats=bundle_stats)
+        log_stats(bundle_stats, "bundling {}".format(metadata.name()))
+        if stats is not None:
+            stats[stats_key(metadata, 'bundle_{}'.format(metadata.name()))] = bundle_stats
+
     elif files:
         # Files is specified by the output
         # we exclude the list of files that we want to keep, so post-process picks them up as "new"
@@ -905,7 +943,7 @@ def bundle_conda(output, metadata, env, **kw):
     return final_output
 
 
-def bundle_wheel(output, metadata, env):
+def bundle_wheel(output, metadata, env, stats):
     with TemporaryDirectory() as tmpdir, utils.tmp_chdir(metadata.config.work_dir):
         utils.check_call_env(['pip', 'wheel', '--wheel-dir', tmpdir, '--no-deps', '.'], env=env)
         wheel_files = glob(os.path.join(tmpdir, "*.whl"))
@@ -1001,8 +1039,8 @@ def _write_activation_text(script_path, m):
         fh.write(data)
 
 
-def build(m, post=None, need_source_download=True, need_reparse_in_env=False, built_packages=None,
-          notest=False):
+def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=False,
+          built_packages=None, notest=False):
     '''
     Build the package with the specified metadata.
 
@@ -1244,9 +1282,14 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                     os.chmod(work_file, 0o766)
 
                     cmd = [shell_path] + (['-x'] if m.config.debug else []) + ['-e', work_file]
+
                     # this should raise if any problems occur while building
-                    utils.check_call_env(cmd, env=env, cwd=src_dir)
+                    build_stats = {}
+                    utils.check_call_env(cmd, env=env, cwd=src_dir, stats=build_stats)
                     utils.remove_pycache_from_scripts(m.config.host_prefix)
+                    log_stats(build_stats, "building {}".format(m.name()))
+                    if stats is not None:
+                        stats[stats_key(m, 'build')] = build_stats
 
     prefix_file_list = join(m.config.build_folder, 'prefix_files.txt')
     initial_files = set()
@@ -1379,7 +1422,7 @@ def build(m, post=None, need_source_download=True, need_reparse_in_env=False, bu
                     #    can be different from the env for the top level build.
                     with utils.path_prepended(m.config.build_prefix):
                         env = environ.get_dict(config=m.config, m=m)
-                    built_package = bundlers[output_d.get('type', 'conda')](output_d, m, env)
+                    built_package = bundlers[output_d.get('type', 'conda')](output_d, m, env, stats)
                     # warn about overlapping files.
                     if 'checksums' in output_d:
                         for file, csum in output_d['checksums'].items():
@@ -1590,7 +1633,7 @@ def construct_metadata_for_test(recipedir_or_package, config):
     return m, hash_input
 
 
-def test(recipedir_or_package_or_metadata, config, move_broken=True):
+def test(recipedir_or_package_or_metadata, config, stats, move_broken=True):
     '''
     Execute any test scripts for the given package.
 
@@ -1821,11 +1864,16 @@ def test(recipedir_or_package_or_metadata, config, move_broken=True):
     else:
         cmd = [shell_path] + (['-x'] if metadata.config.debug else []) + ['-e', test_script]
     try:
-        utils.check_call_env(cmd, env=env, cwd=metadata.config.test_dir)
+        test_stats = {}
+        utils.check_call_env(cmd, env=env, cwd=metadata.config.test_dir, stats=test_stats)
+        log_stats(test_stats, "testing {}".format(metadata.name()))
+        if stats is not None:
+            stats[stats_key(metadata, 'test_{}'.format(metadata.name()))] = test_stats
     except subprocess.CalledProcessError:
         tests_failed(metadata, move_broken=move_broken, broken_dir=metadata.config.broken_dir,
                         config=metadata.config)
         raise
+
     if config.need_cleanup and config.recipe_dir is not None:
         utils.rm_rf(config.recipe_dir)
     print("TEST END:", test_package_name)
@@ -1871,7 +1919,7 @@ Error:
 """ % (os.pathsep.join(external.dir_paths)))
 
 
-def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
+def build_tree(recipe_list, config, stats, build_only=False, post=False, notest=False,
                need_source_download=True, need_reparse_in_env=False, variants=None):
 
     to_build_recursive = []
@@ -1888,6 +1936,8 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
     extra_help = ""
     built_packages = OrderedDict()
     retried_recipes = []
+    initial_time = time.time()
+    stats_file = config.stats_file
 
     # this is primarily for exception handling.  It's OK that it gets clobbered by
     #     the loop below.
@@ -1954,7 +2004,7 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                 if metadata.name() not in metadata.config.build_folder:
                     metadata.config.compute_build_id(metadata.name(), reset=True)
 
-                packages_from_this = build(metadata,
+                packages_from_this = build(metadata, stats,
                                            post=post,
                                            need_source_download=need_source_download,
                                            need_reparse_in_env=need_reparse_in_env,
@@ -1965,7 +2015,7 @@ def build_tree(recipe_list, config, build_only=False, post=False, notest=False,
                     for pkg, dict_and_meta in packages_from_this.items():
                         if pkg.endswith('.tar.bz2'):
                             # we only know how to test conda packages
-                            test(pkg, config=metadata.config)
+                            test(pkg, config=metadata.config, stats=stats)
                         built_packages.update({pkg: dict_and_meta})
                 else:
                     built_packages.update(packages_from_this)
@@ -2039,6 +2089,23 @@ for Python 3.5 and needs to be rebuilt."""
         wheels = [f for f in built_packages if f.endswith('.whl')]
         handle_anaconda_upload(tarballs, config=config)
         handle_pypi_upload(wheels, config=config)
+
+    total_time = time.time() - initial_time
+    max_memory_used = max([step.get('rss') for step in stats.values()])
+    total_disk = sum([step.get('disk') for step in stats.values()])
+
+    print("#####################################################")
+    print("Resource usage summary:")
+    print("\nTotal time: {}".format(seconds_to_text(total_time)))
+    print("Maximum memory usage observed: {}".format(utils.bytes2human(max_memory_used)))
+    print("Total disk usage observed (not including envs): {}".format(
+        utils.bytes2human(total_disk)))
+    stats['total'] = {'time': total_time,
+                      'memory': max_memory_used,
+                      'disk': total_disk}
+    if stats_file:
+        with open(stats_file, 'w') as f:
+            json.dump(stats, f)
 
     return list(built_packages.keys())
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2094,10 +2094,10 @@ for Python 3.5 and needs to be rebuilt."""
         handle_pypi_upload(wheels, config=config)
 
     total_time = time.time() - initial_time
-    max_memory_used = max([step.get('rss') for step in stats.values()] or 0)
-    total_disk = sum([step.get('disk') for step in stats.values()] or 0)
-    total_cpu_sys = sum([step.get('cpu_sys') for step in stats.values()] or 0)
-    total_cpu_user = sum([step.get('cpu_user') for step in stats.values()] or 0)
+    max_memory_used = max([step.get('rss') for step in stats.values()] or [0])
+    total_disk = sum([step.get('disk') for step in stats.values()] or [0])
+    total_cpu_sys = sum([step.get('cpu_sys') for step in stats.values()] or [0])
+    total_cpu_user = sum([step.get('cpu_user') for step in stats.values()] or [0])
 
     print("#####################################################")
     print("Resource usage summary:")

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -96,13 +96,16 @@ def stats_key(metadata, desc):
 
 
 def seconds_to_text(secs):
-    m, s = divmod(int(secs), 60)
-    h, m = divmod(m, 60)
-    return "%d:%02d:%02d" % (h, m, s)
+    m, s = divmod(secs, 60)
+    h, m = divmod(int(m), 60)
+    return "{:d}:{:02d}:{:04.1f}".format(h, m, s)
 
 
 def log_stats(stats_dict, descriptor):
     print("\nResource usage statistics from {}:".format(descriptor))
+    print("   Process count: {}".format(stats_dict['processes']))
+    print("   CPU time: Sys={}, User={}".format(seconds_to_text(stats_dict['cpu_sys']),
+                                                seconds_to_text(stats_dict['cpu_user'])))
     print("   Memory: {}".format(utils.bytes2human(stats_dict['rss'])))
     print("   Disk usage: {}".format(utils.bytes2human(stats_dict['disk'])))
     print("   Time elapsed: {}\n".format(seconds_to_text(stats_dict['elapsed'])))
@@ -2093,10 +2096,14 @@ for Python 3.5 and needs to be rebuilt."""
     total_time = time.time() - initial_time
     max_memory_used = max([step.get('rss') for step in stats.values()])
     total_disk = sum([step.get('disk') for step in stats.values()])
+    total_cpu_sys = sum([step.get('cpu_sys') for step in stats.values()])
+    total_cpu_user = sum([step.get('cpu_user') for step in stats.values()])
 
     print("#####################################################")
     print("Resource usage summary:")
     print("\nTotal time: {}".format(seconds_to_text(total_time)))
+    print("CPU usage: sys={}, user={}".format(seconds_to_text(total_cpu_sys),
+                                              seconds_to_text(total_cpu_user)))
     print("Maximum memory usage observed: {}".format(utils.bytes2human(max_memory_used)))
     print("Total disk usage observed (not including envs): {}".format(
         utils.bytes2human(total_disk)))

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -298,6 +298,7 @@ different sets of packages."""
               'jinja2 is present'),
         default=cc_conda_build.get('merge_build_host', 'false').lower() == 'true',
     )
+    p.add_argument('--stats-file', help=('File path to save build statistics to'), )
 
     add_parser_channels(p)
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -159,6 +159,9 @@ DEFAULTS = [Setting('activate', True),
             # involving compilers (not just python) will still require recipe modification to have
             # distinct host and build sections, but simple python stuff should work without.
             Setting('merge_build_host', False),
+
+            # path to output build statistics to
+            Setting('stats_file', None),
             ]
 
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -160,13 +160,14 @@ def remove_easy_install_pth(files, prefix, config, preserve_egg_dir=False):
 
 def rm_py_along_so(prefix):
     """remove .py (.pyc) files alongside .so or .pyd files"""
-    for root, _, files in os.walk(prefix):
-        for fn in files:
-            if fn.endswith(('.so', '.pyd')):
-                name, _ = os.path.splitext(fn)
-                for ext in '.py', '.pyc', '.pyo':
-                    if name + ext in files:
-                        os.unlink(os.path.join(root, name + ext))
+
+    files = list(os.scandir(prefix))
+    for fn in files:
+        if fn.is_file() and fn.name.endswith(('.so', '.pyd')):
+            name, _ = os.path.splitext(fn.path)
+            for ext in '.py', '.pyc', '.pyo':
+                if name + ext in files:
+                    os.unlink(name + ext)
 
 
 def rm_pyo(files, prefix):
@@ -543,9 +544,9 @@ def post_process_shared_lib(m, f, files):
 
 def fix_permissions(files, prefix):
     print("Fixing permissions")
-    for root, dirs, _ in os.walk(prefix):
-        for dn in dirs:
-            lchmod(os.path.join(root, dn), 0o775)
+    for path in os.scandir(prefix):
+        if path.is_dir():
+            lchmod(path.path, 0o775)
 
     for f in files:
         path = os.path.join(prefix, f)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -30,6 +30,11 @@ from conda_build.inspect_pkg import which_package
 if sys.platform == 'darwin':
     from conda_build.os_utils import macho
 
+if PY3:
+    scandir = os.scandir
+else:
+    from scandir import scandir
+
 
 def is_obj(path):
     return is_codefile(path)
@@ -161,7 +166,7 @@ def remove_easy_install_pth(files, prefix, config, preserve_egg_dir=False):
 def rm_py_along_so(prefix):
     """remove .py (.pyc) files alongside .so or .pyd files"""
 
-    files = list(os.scandir(prefix))
+    files = list(scandir(prefix))
     for fn in files:
         if fn.is_file() and fn.name.endswith(('.so', '.pyd')):
             name, _ = os.path.splitext(fn.path)
@@ -544,7 +549,7 @@ def post_process_shared_lib(m, f, files):
 
 def fix_permissions(files, prefix):
     print("Fixing permissions")
-    for path in os.scandir(prefix):
+    for path in scandir(prefix):
         if path.is_dir():
             lchmod(path.path, 0o775)
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -48,12 +48,14 @@ if PY3:
     # NOQA because it is not used in this file.
     from contextlib import ExitStack  # NOQA
     PermissionError = PermissionError  # NOQA
+    scandir = os.scandir
 else:
     import urlparse
     import urllib
     # NOQA because it is not used in this file.
     from contextlib2 import ExitStack  # NOQA
     PermissionError = OSError
+    from scandir import scandir
 
 
 on_win = (sys.platform == 'win32')
@@ -90,7 +92,7 @@ def directory_size(path):
     total_size = 0
     seen = set()
 
-    for path in os.scandir(path):
+    for path in scandir(path):
         if path.is_file():
             try:
                 stat = stat_file(path.path)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -162,7 +162,7 @@ class PopenWrapper(object):
                         child_cpu_usage['sys'] = cpu_stats.system
                         child_cpu_usage['user'] = cpu_stats.user
                         cpu_usage[child.pid] = child_cpu_usage
-                    except (psutil.ZombieProcess, psutil.AccessDenied):
+                    except (psutil.ZombieProcess, psutil.AccessDenied, psutil.NoSuchProcess):
                         # process already died.  Just ignore it.
                         continue
                     processes += 1
@@ -185,7 +185,7 @@ class PopenWrapper(object):
                     # builds hang
                     try:
                         _popen.kill()
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.NoSuchProcess):
                         pass
                     break
         except KeyboardInterrupt:

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -787,7 +787,10 @@ def test_build_expands_wildcards(mocker, testing_workdir):
             fh.write('\n')
     api.build(["a*"], config=config)
     output = [os.path.join(os.getcwd(), path, 'meta.yaml') for path in files]
-    build_tree.assert_called_once_with(output, build_only=False, config=mocker.ANY,
+    build_tree.assert_called_once_with(output,
+                                       mocker.ANY,  # config
+                                       mocker.ANY,  # stats
+                                       build_only=False,
                                        need_source_download=True, notest=False,
                                        post=None, variants=None)
 

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -47,14 +47,14 @@ def test_api_check():
 def test_api_build():
     argspec = getargspec(api.build)
     assert argspec.args == ['recipe_paths_or_metadata', 'post', 'need_source_download',
-                            'build_only', 'notest', 'config', 'variants']
-    assert argspec.defaults == (None, True, False, False, None, None)
+                            'build_only', 'notest', 'config', 'variants', 'stats']
+    assert argspec.defaults == (None, True, False, False, None, None, None)
 
 
 def test_api_test():
     argspec = getargspec(api.test)
-    assert argspec.args == ['recipedir_or_package_or_metadata', 'move_broken', 'config']
-    assert argspec.defaults == (True, None)
+    assert argspec.args == ['recipedir_or_package_or_metadata', 'move_broken', 'config', 'stats']
+    assert argspec.defaults == (True, None, None)
 
 
 def test_api_list_skeletons():

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -45,7 +45,7 @@ def test_find_prefix_files(testing_workdir):
 def test_build_preserves_PATH(testing_workdir, testing_config):
     m = api.render(os.path.join(metadata_dir, 'source_git'), config=testing_config)[0][0]
     ref_path = os.environ['PATH']
-    build.build(m)
+    build.build(m, stats=None)
     assert os.environ['PATH'] == ref_path
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import stat
+import subprocess
 import sys
 import unittest
 import zipfile
@@ -297,3 +298,15 @@ def test_insert_variant_versions(testing_metadata):
     assert 'numpy 1.13' in testing_metadata.meta['requirements']['build']
     # the overall length does not change
     assert len(testing_metadata.meta['requirements']['build']) == 2
+
+
+def test_subprocess_stats_call():
+    stats = {}
+    utils.check_call_env(['ls'], stats=stats)
+    assert stats
+    stats = {}
+    out = utils.check_output_env(['ls'], stats=stats)
+    assert out
+    assert stats
+    with pytest.raises(subprocess.CalledProcessError):
+        utils.check_call_env(['bash', '-c', 'exit 1'])


### PR DESCRIPTION
The primary purpose of the build stats here is to feed into CI systems that have different classes of workers.  We'll be aggregating the needs of given package builds, and then we'll use that information to dispatch jobs to the smallest worker that is capable (and available).