### PR TITLE
reverse build/host activation order, to give build exe's higher priority

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -986,18 +986,6 @@ def _write_sh_activation_text(file_handle, m):
     activate_path = ''.join((cygpath_prefix,
                             os.path.join(utils.root_script_dir, 'activate').replace('\\', '\\\\'),
                             cygpath_suffix))
-    build_prefix_path = ''.join((cygpath_prefix,
-                                m.config.build_prefix.replace('\\', '\\\\'),
-                                cygpath_suffix))
-
-    file_handle.write('source "{0}" "{1}"\n'.format(activate_path, build_prefix_path))
-
-    # conda 4.4 requires a conda-meta/history file for a valid conda prefix
-    history_file = join(m.config.build_prefix, 'conda-meta', 'history')
-    if not isfile(history_file):
-        if not isdir(dirname(history_file)):
-            os.makedirs(dirname(history_file))
-        open(history_file, 'a').close()
 
     if m.is_cross:
         # HACK: we need both build and host envs "active" - i.e. on PATH,
@@ -1019,12 +1007,26 @@ def _write_sh_activation_text(file_handle, m):
             if not isdir(dirname(history_file)):
                 os.makedirs(dirname(history_file))
             open(history_file, 'a').close()
-        file_handle.write('unset CONDA_PATH_BACKUP\n')
-        file_handle.write('export CONDA_MAX_SHLVL=2\n')
         host_prefix_path = ''.join((cygpath_prefix,
                                    m.config.host_prefix.replace('\\', '\\\\'),
                                    cygpath_suffix))
         file_handle.write('source "{0}" "{1}"\n' .format(activate_path, host_prefix_path))
+        file_handle.write('unset CONDA_PATH_BACKUP\n')
+        file_handle.write('export CONDA_MAX_SHLVL=2\n')
+
+    # Write build prefix activation AFTER host prefix, so that its executables come first
+    build_prefix_path = ''.join((cygpath_prefix,
+                                m.config.build_prefix.replace('\\', '\\\\'),
+                                cygpath_suffix))
+
+    file_handle.write('source "{0}" "{1}"\n'.format(activate_path, build_prefix_path))
+
+    # conda 4.4 requires a conda-meta/history file for a valid conda prefix
+    history_file = join(m.config.build_prefix, 'conda-meta', 'history')
+    if not isfile(history_file):
+        if not isdir(dirname(history_file)):
+            os.makedirs(dirname(history_file))
+        open(history_file, 'a').close()
 
 
 def _write_activation_text(script_path, m):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -202,9 +202,6 @@ def msvc_env_cmd(bits, config, override=None):
 
 
 def _write_bat_activation_text(file_handle, m):
-    file_handle.write('call "{conda_root}\\activate.bat" "{prefix}"\n'.format(
-        conda_root=root_script_dir,
-        prefix=m.config.build_prefix))
     if m.is_cross:
         # HACK: we need both build and host envs "active" - i.e. on PATH,
         #     and with their activate.d scripts sourced. Conda only
@@ -225,12 +222,16 @@ def _write_bat_activation_text(file_handle, m):
             if not isdir(dirname(history_file)):
                 os.makedirs(dirname(history_file))
             open(history_file, 'a').close()
-        # removing this placeholder should make conda double-activate with conda 4.3
-        file_handle.write('set "PATH=%PATH:CONDA_PATH_PLACEHOLDER;=%"\n')
-        file_handle.write('set CONDA_MAX_SHLVL=2\n')
         file_handle.write('call "{conda_root}\\activate.bat" "{prefix}"\n'.format(
             conda_root=root_script_dir,
             prefix=m.config.host_prefix))
+        # removing this placeholder should make conda double-activate with conda 4.3
+        file_handle.write('set "PATH=%PATH:CONDA_PATH_PLACEHOLDER;=%"\n')
+        file_handle.write('set CONDA_MAX_SHLVL=2\n')
+    # Write build prefix activation AFTER host prefix, so that its executables come first
+    file_handle.write('call "{conda_root}\\activate.bat" "{prefix}"\n'.format(
+        conda_root=root_script_dir,
+        prefix=m.config.build_prefix))
 
 
 def build(m, bld_bat):

--- a/tests/test-recipes/metadata/_compiler_python_build_section/meta.yaml
+++ b/tests/test-recipes/metadata/_compiler_python_build_section/meta.yaml
@@ -1,0 +1,13 @@
+# common point of confusion around the split between build and host
+
+package:
+  name: empty_pkg_with_python_build_host
+  version: 1.0
+
+build:
+  script: echo weeee
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - python

--- a/tests/test-recipes/metadata/_empty_pkg_with_python_build_host/meta.yaml
+++ b/tests/test-recipes/metadata/_empty_pkg_with_python_build_host/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: empty_pkg_with_python_build_host
+  version: 1.0
+
+build:
+  script: echo weeee
+
+requirements:
+  build:
+    - python
+  host:
+    - python

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -32,7 +32,7 @@ from conda_build.render import finalize_metadata
 from conda_build.utils import (copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2,
                                package_has_file, check_output_env, get_conda_operation_locks, rm_rf)
 from conda_build.os_utils.external import find_executable
-from conda_build.exceptions import DependencyNeedsBuildingError
+from conda_build.exceptions import DependencyNeedsBuildingError, CondaBuildException
 
 from .utils import is_valid_dir, metadata_dir, fail_dir, add_mangling, FileNotFoundError
 
@@ -1224,3 +1224,15 @@ def test_overlinking_detection(testing_config):
     with pytest.raises(SystemExit):
         api.build(recipe, config=testing_config)
     rm_rf(dest_file)
+
+
+def test_empty_package_with_python_in_build_and_host_barfs(testing_config):
+    recipe = os.path.join(metadata_dir, '_empty_pkg_with_python_build_host')
+    with pytest.raises(CondaBuildException):
+        api.build(recipe, config=testing_config)
+
+
+def test_empty_package_with_python_and_compiler_in_build_barfs(testing_config):
+    recipe = os.path.join(metadata_dir, '_compiler_python_build_section')
+    with pytest.raises(CondaBuildException):
+        api.build(recipe, config=testing_config)


### PR DESCRIPTION
@mingwandroid reported problems building R recipes where he needed the compilers to be in the host section for some reason.  This PR is a WIP as we explore this idea - it might break stuff pretty badly.