### PR TITLE
save parent recipe in subfolder of outputs for info/recipe

### DIFF
--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -199,10 +199,16 @@ def test_subpackage_hash_inputs(testing_config):
     for out in outputs:
         if os.path.basename(out).startswith('test_subpackage'):
             assert utils.package_has_file(out, 'info/recipe/install-script.sh')
-            assert utils.package_has_file(out, 'info/recipe/build.sh')
+            # will have full parent recipe in nested folder
+            assert utils.package_has_file(out, 'info/recipe/parent/build.sh')
+            assert not utils.package_has_file(out, 'info/recipe/meta.yaml.template')
+            assert utils.package_has_file(out, 'info/recipe/meta.yaml')
         else:
             assert utils.package_has_file(out, 'info/recipe/install-script.sh')
             assert utils.package_has_file(out, 'info/recipe/build.sh')
+            # will have full parent recipe in base recipe folder (this is an output for the top level)
+            assert utils.package_has_file(out, 'info/recipe/meta.yaml.template')
+            assert utils.package_has_file(out, 'info/recipe/meta.yaml')
 
 
 def test_overlapping_files(testing_config, caplog):


### PR DESCRIPTION
@mingwandroid commented that he had a hard time finding a recipe for curl, which is a split package where neither output matches the top-level name.  We were not copying the original top-level recipe into packages - only the rendered metadata.

This PR puts the top-level recipe into all output packages, in the "parent" subfolder, and maintains the previous behavior otherwise.