### PR TITLE
[discuss] add option --debug_build

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1081,6 +1081,9 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
     if env_path_backup_var_exists:
         env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
 
+    if config.debug_build:
+        env["DEBUG_BUILD"] = "True"
+
     # this should be a no-op if source is already here
     if m.needs_source_for_render:
         try_download(m, no_download_source=False)

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -301,6 +301,9 @@ different sets of packages."""
     p.add_argument('--stats-file', help=('File path to save build statistics to.  Stats are '
                                          'in JSON format'), )
 
+    p.add_argument('--debug-build', help=('Sets a environment-variable DEBUG_BUILD, which can be unresolved ',
+                                          'in the meta_yaml and build files.'), )
+
     add_parser_channels(p)
 
     args = p.parse_args(args)


### PR DESCRIPTION
as we need a way to create debug builds, it would be nice to set this with an option. I guess this is not the right way to do it, but maybe we can start a discussion on how to implement something which adds the ability to build recipes in debug-mode.