### PR TITLE
fix test scripts from subpackage outputs not being detected

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -873,7 +873,7 @@ def bundle_conda(output, metadata, env, stats, **kw):
     # first filter is so that info_files does not pick up ignored files
     files = utils.filter_files(files, prefix=metadata.config.host_prefix)
     output['checksums'] = create_info_files(metadata, files, prefix=metadata.config.host_prefix)
-    for ext in ('.py', '.r', '.pl', '.lua', '.sh'):
+    for ext in ('.py', '.r', '.pl', '.lua', '.sh', '.bat'):
         test_dest_path = os.path.join(metadata.config.info_dir, 'test', 'run_test' + ext)
         script = output.get('test', {}).get('script')
         if script and script.endswith(ext):
@@ -1689,10 +1689,10 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True):
     if not in_pkg_cache:
         environ.clean_pkg_cache(metadata.dist(), metadata.config)
 
+    copy_test_source_files(metadata, metadata.config.test_dir)
     # this is also copying tests/source_files from work_dir to testing workdir
     _, pl_files, py_files, r_files, lua_files, shell_files = \
-        create_all_test_files(metadata)
-    copy_test_source_files(metadata, metadata.config.test_dir)
+        create_all_test_files(metadata, existing_test_dir=metadata.config.test_dir)
     if not any([py_files, shell_files, pl_files, lua_files, r_files]):
         print("Nothing to test for:", test_package_name)
         return True

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -226,13 +226,18 @@ def create_lua_files(m, test_dir=None):
     return tf if (tf_exists or imports) else False
 
 
-def create_all_test_files(m, test_dir=None):
+def create_all_test_files(m, test_dir=None, existing_test_dir=None):
     if not test_dir:
         test_dir = m.config.test_dir
     files = create_files(m, test_dir)
     pl_files = create_pl_files(m, test_dir)
-    py_files = create_py_files(m, test_dir)
-    r_files = create_r_files(m, test_dir)
-    lua_files = create_lua_files(m, test_dir)
-    shell_files = create_shell_files(m, test_dir)
+    py_files = create_py_files(m, test_dir) or (
+        existing_test_dir and os.path.isfile(os.path.join(existing_test_dir, 'run_test.py')))
+    r_files = create_r_files(m, test_dir) or (
+        existing_test_dir and os.path.isfile(os.path.join(existing_test_dir, 'run_test.r')))
+    lua_files = create_lua_files(m, test_dir) or (
+        existing_test_dir and os.path.isfile(os.path.join(existing_test_dir, 'run_test.lua')))
+    shell_files = create_shell_files(m, test_dir) or (
+        existing_test_dir and (os.path.isfile(os.path.join(existing_test_dir, 'run_test.sh')) or
+                               os.path.isfile(os.path.join(existing_test_dir, 'run_test.bat'))))
     return files, pl_files, py_files, r_files, lua_files, shell_files

--- a/tests/test-recipes/split-packages/_output_test_script/meta.yaml
+++ b/tests/test-recipes/split-packages/_output_test_script/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: test_output_test_script
+  version: 1.0
+
+outputs:
+  - name: output_2
+    test:
+      script: run_output_2_test.py

--- a/tests/test-recipes/split-packages/_output_test_script/run_output_2_test.py
+++ b/tests/test-recipes/split-packages/_output_test_script/run_output_2_test.py
@@ -1,0 +1,2 @@
+import sys
+sys.exit(1)

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -229,6 +229,12 @@ def test_per_output_tests(testing_config, capfd):
     assert out.count("top-level test") == count, out
 
 
+def test_per_output_tests_script(testing_config):
+    recipe_dir = os.path.join(subpackage_dir, '_output_test_script')
+    with pytest.raises(SystemExit):
+        api.build(recipe_dir, config=testing_config)
+
+
 def test_pin_compatible_in_outputs(testing_config):
     recipe_dir = os.path.join(subpackage_dir, '_pin_compatible_in_output')
     m = api.render(recipe_dir, config=testing_config)[0][0]


### PR DESCRIPTION
observed this with h2o, but it seems to have been a long-standing problem.  Outputs using

```
test:
  script: some_script.py
```

were not ending up picking up the test at all.  This adds a test of that test functionality.