### PR TITLE
Use my latest version of check_overlinking

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -97,7 +97,7 @@ DEFAULTS = [Setting('activate', True),
             #    (GNU ld: -as-needed, Apple ld64: -dead_strip_dylibs -no_implicit_dylibs)
             # 2. A missing package in reqs/run (maybe that package is missing run_exports?)
             # 3. A missing (or broken) CDT package in reqs/build or (on systems without CDTs)
-            # 4. .. a missing value in the (to be implemented) system library whitelist
+            # 4. .. a missing value in the hard-coded but metadata-augmentable library whitelist
             # It is important that packages do not suffer from 2 because uninstalling that missing
             # package leads to an inability to run this package.
             #


### PR DESCRIPTION
It diverged a lot from the upstream one, and the split between in_prefix and in_system is less clear-cut
now that whitelists are supported.

Should whitelists be in conda_build_config.yaml and not hardcoded at all? I am leaning that way personally.