### PR TITLE
add optional argument for providing extra dep specs at test time

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1791,6 +1791,8 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True):
         # not sure how this shakes out
         specs += ['r-base']
 
+    specs.extend(utils.ensure_list(metadata.config.extra_deps))
+
     with utils.path_prepended(metadata.config.test_prefix):
         env = dict(os.environ.copy())
         env.update(environ.get_dict(config=metadata.config, m=metadata,

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -300,6 +300,11 @@ different sets of packages."""
     )
     p.add_argument('--stats-file', help=('File path to save build statistics to.  Stats are '
                                          'in JSON format'), )
+    p.add_argument('--extra-deps',
+                   nargs='+',
+                   help=('Extra dependencies to add to all environment creation steps.  This '
+                         'is only enabled for testing with the -t or --test flag.  Change '
+                         'meta.yaml or use templates otherwise.'), )
 
     add_parser_channels(p)
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -162,6 +162,9 @@ DEFAULTS = [Setting('activate', True),
 
             # path to output build statistics to
             Setting('stats_file', None),
+
+            # extra deps to add to test env creation
+            Setting('extra_deps', [])
             ]
 
 

--- a/tests/test_api_test.py
+++ b/tests/test_api_test.py
@@ -4,6 +4,8 @@ This module tests the test API.  These are high-level integration tests.
 
 import os
 
+import pytest
+
 from conda_build import api
 from .utils import metadata_dir
 
@@ -41,3 +43,15 @@ def test_package_with_jinja2_does_not_redownload_source(testing_workdir, testing
     provide = mocker.patch('conda_build.source.provide')
     api.test(outputs[0], config=metadata.config)
     assert not provide.called
+
+
+def test_api_extra_dep(testing_metadata):
+    testing_metadata.meta['test']['imports'] = ['click']
+    output = api.build(testing_metadata, notest=True, anaconda_upload=False)[0]
+
+    # extra_deps will add it in
+    api.test(output, config=testing_metadata.config, extra_deps=['click'])
+
+    # missing click dep will fail tests
+    with pytest.raises(SystemExit):
+        api.test(output, config=testing_metadata.config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -617,3 +617,20 @@ def test_render_with_python_arg_reduces_subspace(capfd):
     args = [recipe, '--python=3.6', '--output']
     with pytest.raises(ValueError):
         main_render.execute(args)
+
+
+def test_test_extra_dep(testing_metadata):
+    testing_metadata.meta['test']['imports'] = ['click']
+    api.output_yaml(testing_metadata, 'meta.yaml')
+    output = api.build(testing_metadata, notest=True, anaconda_upload=False)[0]
+
+    # tests version constraints.  CLI would quote this - "click <6.7"
+    args = [output, '-t', '--extra-deps', 'click <6.7']
+    # extra_deps will add it in
+    main_build.execute(args)
+
+    # missing click dep will fail tests
+    with pytest.raises(SystemExit):
+        args = [output, '-t']
+        # extra_deps will add it in
+        main_build.execute(args)


### PR DESCRIPTION
Numba team splits their builds between build and test.  With recent conda-build versions, we're no longer re-rendering the test-time recipe - it's baked in.  This is to support testing when the recipe isn't included.

So, to support Numba being able to dynamically specify dependencies at test time, this is a new feature that allows extra specs at the CLI.  This argument is only respected for testing, not for building or rendering.

CC @stuartarchibald