### PR TITLE
[2.1.x test backport] change r skeleton from nmf to acs; nmf got removed

### DIFF
--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -9,7 +9,7 @@ from conda_build import api
 thisdir = os.path.dirname(os.path.realpath(__file__))
 
 repo_packages = [('', 'pypi', 'pip', "8.1.2"),
-                 ('r', 'cran', 'nmf', ""),
+                 ('r', 'cran', 'acs', ""),
                  ('r', 'cran', 'https://github.com/twitter/AnomalyDetection.git', ""),
                  ('perl', 'cpan', 'Moo', ""),
                  # ('lua', luarocks', 'LuaSocket'),


### PR DESCRIPTION
Do we need this for the `conda` tests? Ref: https://circleci.com/gh/conda/conda/6995