### PR TITLE
make outputs inherit build number if not provided otherwise

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1758,9 +1758,11 @@ class MetaData(object):
                 build['features'] = output['features']
 
             # 3.0.26+ - just pass through the whole build section from the output.
-            #    It clobbers everything else.
+            #    It clobbers everything else, aside from build number
             if 'build' in output:
                 build = output['build']
+                if 'number' not in build:
+                    build['number'] = output.get('number', output_metadata.build_number())
             output_metadata.meta['build'] = build
             if 'test' in output:
                 output_metadata.meta['test'] = output['test']

--- a/tests/test-recipes/split-packages/_inherit_build_number/meta.yaml
+++ b/tests/test-recipes/split-packages/_inherit_build_number/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: inherit_build_number
+  version: 1.0
+
+build:
+  number: 1
+
+outputs:
+  - name: test_inherit_build_number
+    build:
+      missing_dso_whitelist:
+        - '*'
+  - name: inherit_build_number
+    build:
+      missing_dso_whitelist:
+        - '*'

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -327,4 +327,4 @@ def test_inherit_build_number(testing_config):
     ms = api.render(recipe, config=testing_config)
     for m, _, _ in ms:
         assert 'number' in m.meta['build'], "build number was not inherited at all"
-        assert m.meta['build']['number'] == 1, "build number should have been inherited as '1'"
+        assert int(m.meta['build']['number']) == 1, "build number should have been inherited as '1'"

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -320,3 +320,11 @@ def test_activation_in_output_scripts(testing_config):
     recipe = os.path.join(subpackage_dir, '_output_activation')
     testing_config.activate = True
     api.build(recipe, config=testing_config)
+
+
+def test_inherit_build_number(testing_config):
+    recipe = os.path.join(subpackage_dir, '_inherit_build_number')
+    ms = api.render(recipe, config=testing_config)
+    for m, _, _ in ms:
+        assert 'number' in m.meta['build'], "build number was not inherited at all"
+        assert m.meta['build']['number'] == 1, "build number should have been inherited as '1'"


### PR DESCRIPTION
This had been default behavior but had regressed.