### PR TITLE
Fix directory_size on german windows by ignoring case

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -125,7 +125,8 @@ def directory_size(path):
             except UnicodeDecodeError:
                 pass
         if on_win:
-            out = re.search("([\d,]+)\sbytes", out).group(1).replace(',', '')
+            out = re.search("([\d,]+)\sbytes", out,
+                            flags=re.IGNORECASE).group(1).replace(',', '')
         else:
             out = out.split()[0]
     except subprocess.CalledProcessError:


### PR DESCRIPTION
I tried to build a package with the most recent version of conda today on my Windows machine and it failed in `conda_build.utils.directory_size`: https://github.com/conda/conda-build/blob/6b8f4b57f559b18d0b671257f7d58b571f90b45e/conda_build/utils.py#L128
It turns out the output of `dir /s` is different accross the different languages of Windows. In the german version the first letter of bytes is uppercase. I modified the regular expression to ignore the case.