### PR TITLE
fix exact pinning in subpackages due to non-final output data

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -299,7 +299,7 @@ def pin_subpackage(metadata, subpackage_name, min_pin='x.x.x.x.x.x', max_pin='x'
         metadata_name = None
     if metadata_name and subpackage_name == metadata_name:
         if exact:
-            pin = ' '.join(metadata.dist().rsplit('-', 2))
+            pin = ' '.join((metadata.name(), metadata.version(), metadata.build_id()))
         else:
             pin = ' '.join((subpackage_name,
                             apply_pin_expressions(metadata.version(), min_pin, max_pin)))

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1052,13 +1052,17 @@ class MetaData(object):
         return build_int
 
     def get_depends_top_and_out(self, typ):
-        meta_requirements = ensure_list(self.get_value('requirements/' + typ, []))
+        meta_requirements = ensure_list(self.get_value('requirements/' + typ, []))[:]
+        req_names = set(req.split()[0] for req in meta_requirements)
+        extra_reqs = []
         if 'outputs' in self.meta:
             matching_output = [out for out in self.meta.get('outputs') if
                                out.get('name') == self.name()]
             if matching_output:
-                meta_requirements += utils.expand_reqs(
+                extra_reqs = utils.expand_reqs(
                     matching_output[0].get('requirements', [])).get(typ, [])
+                extra_reqs = [dep for dep in extra_reqs if dep.split()[0] not in req_names]
+        meta_requirements = list(set(meta_requirements) | set(extra_reqs))
         return meta_requirements
 
     def ms_depends(self, typ='run'):


### PR DESCRIPTION
Non-final output data was entering into lists of dependencies.  For exact subpackage pins, this led to solver conflicts.  This PR ignores the output metadata in favor of the original metadata obtained from the top-level, which is further along at this point.