### PR TITLE
For discussion only at present.

### DIFF
--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -983,6 +983,14 @@ def is_codefile(filename, skip_symlinks=True):
     return True
 
 
+def codefile_type(filename, skip_symlinks=True):
+    "Returns None, 'machofile' or 'elffile'"
+    klass = codefile_class(filename, skip_symlinks=skip_symlinks)
+    if not klass:
+        return None
+    return klass.__name__
+
+
 def _trim_sysroot(sysroot):
     while sysroot.endswith('/') or sysroot.endswith('\\'):
         sysroot = sysroot[:-1]

--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -1055,7 +1055,6 @@ def inspect_rpaths(filename, resolve_dirnames=True, use_os_varnames=True,
 def get_runpaths(filename, arch='native'):
     if not os.path.exists(filename):
         return []
-    sysroot = _trim_sysroot(sysroot)
     arch = _get_arch_if_native(arch)
     with open(filename, 'rb') as f:
         cf = codefile(f, arch, ['/lib', '/usr/lib'])

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -25,7 +25,7 @@ from conda_build.conda_interface import PY3
 from conda_build.conda_interface import TemporaryDirectory
 
 from conda_build import utils
-from conda_build.os_utils.pyldd import is_codefile, inspect_linkages
+from conda_build.os_utils.pyldd import is_codefile, inspect_linkages, get_runpaths
 from conda_build.inspect_pkg import which_package
 
 if sys.platform == 'darwin':

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -489,6 +489,11 @@ def check_overlinking(m, files):
         info_prelude = "   INFO ({},{})".format(pkg_name, f)
         msg_prelude = err_prelude if m.config.error_overlinking else warn_prelude
 
+        runpaths = get_runpaths(path)
+        if len(runpaths):
+            print_msg(errors, '{}: runpaths {} found in {}'.format(msg_prelude,
+                                                                   runpaths,
+                                                                   path))
         needed = inspect_linkages(path, resolve_filenames=True, recurse=False)
         for needed_dso in needed:
             if needed_dso.startswith(m.config.host_prefix):


### PR DESCRIPTION
Here I raise an error or warning if any DT_RUNPATH entries are found.

Some people (e.g. glibc developers) consider DT_RUNPATH the right thing to do. It is non-transitive and allows LD_LIBRARY_PATH to take precedence over it. It is enabled by passing --enable-new-dtags to ld, and by default when using gold where it can be disabled with --disable-new-dtags.

I believe the Anaconda Distribution never wants this however. We've wasted a lot of time tracking down non-bugs because someone has set LD_LIBRARY_PATH by mistake and I see no real use for it outside of a software developer testing their own fixes to a system library, personally.

I would welcome other people's opinions and some discussion here though: @msarahan, @nehaljwani, @jjhelmus, @kalefranz, @jakirkham, @mbargull, @ocefpaf, @isuruf.
