### PR TITLE
lgtm.com config

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,12 @@
+queries:
+  - exclude: py/redundant-assignment
+
+extraction:
+  python:
+    python_setup:
+      version: 3
+    index:
+      exclude:
+        - .git
+        - conda/_vendor
+        - tests

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,5 +8,4 @@ extraction:
     index:
       exclude:
         - .git
-        - conda/_vendor
         - tests


### PR DESCRIPTION
The product team has been known to use lgtm.com.  Conda and conda-build both get (well, fixed in conda now) bad scores primarily because of this one 'redundant-assignment' error.  Our use is perfectly legitimate though.  This is the config pretty much just copied over from conda (https://github.com/conda/conda/blob/master/.lgtm.yml) that wipes that one out for us.

To clarify, the redundant assignment error happens with we do

```python
from conda.exports import foo
foo = foo
```

but, because their inspection rule set is still probably young

```python
from conda.exports import foo, bar
foo, bar = foo, bar
```

doesn't trigger the error indicator.

Regardless, given how flake8 and pycharm interact, our use of the assignment here is the best technical solution.