### PR TITLE
improve error message when modules are needed to render recipe

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1801,7 +1801,10 @@ class MetaData(object):
                     utils.rm_rf(om.config.work_dir)
                     provide(om)
                     om.parse_again()
-                om.parse_until_resolved(allow_no_other_outputs=True, bypass_env_check=True)
+                try:
+                    om.parse_until_resolved(allow_no_other_outputs=True, bypass_env_check=True)
+                except SystemExit:
+                    pass
                 outputs = get_output_dicts_from_metadata(om)
 
                 try:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -561,13 +561,16 @@ def distribute_variants(metadata, variants, permit_unsatisfiable_variants=False,
             source.provide(mv)
             mv.parse_again()
 
-        mv.parse_until_resolved(allow_no_other_outputs=allow_no_other_outputs,
-                                bypass_env_check=bypass_env_check)
+        try:
+            mv.parse_until_resolved(allow_no_other_outputs=allow_no_other_outputs,
+                                    bypass_env_check=bypass_env_check)
+        except SystemExit:
+            pass
         need_source_download = (not mv.needs_source_for_render or not mv.source_provided)
 
         rendered_metadata[(mv.dist(),
                            mv.config.variant.get('target_platform', mv.config.subdir),
-                           tuple((var, mv.config.variant[var])
+                           tuple((var, mv.config.variant.get(var))
                                  for var in mv.get_used_vars()))] = \
                                     (mv, need_source_download, None)
     # list of tuples.

--- a/tests/test-recipes/metadata/_numpy_setup_py_data/meta.yaml
+++ b/tests/test-recipes/metadata/_numpy_setup_py_data/meta.yaml
@@ -3,16 +3,14 @@ package:
   version: {{ load_setup_py_data().version }}
 
 source:
-  git_url: https://github.com/NCAR/load_setup_py_test
-
-build:
-  number: 1
-  detect_binary_files_with_prefix: true
+  path: .
 
 requirements:
   build:
-    - numpy x.x
+    - cython
+    - numpy
     - python
+    - setuptools
   run:
     - numpy x.x
     - python

--- a/tests/test-recipes/metadata/_numpy_setup_py_data/setup.py
+++ b/tests/test-recipes/metadata/_numpy_setup_py_data/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+import numpy.distutils.core
+from Cython.Build import cythonize
+
+requirements = [
+    "numpy>=1.9.0",
+    ]
+
+numpy.distutils.core.setup(
+    author = "Bill Ladwig",
+    author_email = "ladwig@ucar.edu",
+    description = "Test case for conda-build crash",
+    url = "https://github.com/NCAR/load_setup_py_test",
+    install_requires = requirements,
+    name = "fortest",
+    version =  "0.1.0",
+    package_dir = {"" : "src"},
+    scripts=[]
+)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -422,13 +422,17 @@ def test_build_metadata_object(testing_metadata):
     api.build(testing_metadata)
 
 
-@pytest.mark.skipif(on_win, reason="fortran compilers on win are hard.")
 def test_numpy_setup_py_data(testing_config):
     recipe_path = os.path.join(metadata_dir, '_numpy_setup_py_data')
+    subprocess.call('conda remove -y cython'.split())
+    with pytest.raises(CondaBuildException) as exc:
+        m = api.render(recipe_path, config=testing_config, numpy="1.11")[0][0]
+        assert "Cython" in str(exc)
+    subprocess.check_call('conda install -y cython'.split())
     m = api.render(recipe_path, config=testing_config, numpy="1.11")[0][0]
     _hash = m.hash_dependencies()
     assert os.path.basename(api.get_output_file_path(m)[0]) == \
-                            "load_setup_py_test-1.0a1-np111py{0}{1}{2}_1.tar.bz2".format(
+                            "load_setup_py_test-0.1.0-np111py{0}{1}{2}_0.tar.bz2".format(
                                 sys.version_info.major, sys.version_info.minor, _hash)
 
 


### PR DESCRIPTION
 for load_setup_py_data.  Because rendering is done before any environments are created, we can't fix this in conda-build.  We can't require that envs be created in order to render recipes.

fixes https://github.com/conda/conda-build/issues/2765

New error output looks like

```
conda_build.exceptions.CondaBuildException: Could not render recipe - need modules installed in root env.  Import error was "No module named 'Cython'"
```

so at least it should be less confusing.