### PR TITLE
WIP: Specify branch when cloning

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -217,6 +217,8 @@ def git_mirror_checkout_recursive(git, mirror_dir, checkout_dir, git_url, git_ca
                        cwd=mirror_dir, stdout=stdout, stderr=stderr)
     else:
         args = [git, 'clone', '--mirror']
+        if git_ref != 'HEAD':
+            args += ['--branch', git_ref]
         if git_depth > 0:
             args += ['--depth', str(git_depth)]
         try:


### PR DESCRIPTION
This is needed to make sure shallow clones on tags reference the number of commits relative to the tag location instead of the branch location. Currently this is still WIP and needs tests.

Note: Already know this doesn't work for `sha1`s, but need a mechanism to check that. Not sure if `conda-build` has one.

Note 2: Some versions of git suffer from a bug where combining this with mirror doesn't behave well. ( https://public-inbox.org/git/20180122110357.683b21a7@novascotia/t/ )

cc @jlstevens

xref: https://github.com/conda-forge/holoviews-feedstock/pull/28