### PR TITLE
Proposed fix for #2798 

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -635,8 +635,8 @@ unxz is required to unarchive .xz source files.
         sys.exit("""\
 tarball contains unsafe path: 
 """ + member.name)
-      members[i]=member 
- 
+      members[i]=member
+
     if not PY3:
         t.extractall(path=dir_path.encode(codec))
     else:


### PR DESCRIPTION
This PR is aimed at preventing files from tarballs with absolute or parent-traversing paths from being extracted outside the intended directory.

The approach is 
  iterate through each tar member
  if it's path is absolute, replace with a path relative to '/' 
  if the 'realpath' doesn't start from cwd then strip any occurrences of '../' from the path
  if the 'realpath' still doesn't start from cwd due to some circumstance I haven't thought of, then die 
Once all paths have been checked, the normal 'extractall' method can be called on the tarfile object.

This could result in the relative locations between different components of the extracted tarball differing to that which was intended, but I think is far safer than allowing things to be written outside the intended destination. 

The test suite runs as well as it did before I changed anything (17 failures on my machine...) so I don't think I've broken anything...