### PR TITLE
Recipe appending: avoid losing ordering of both original and appended commands.

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1401,7 +1401,7 @@ def merge_or_update_dict(base, new, path, merge, raise_on_clobber=False):
                 if base_value and base_value != value:
                     base_value.extend(value)
                 try:
-                    base[key] = list(set(base_value))
+                    base[key] = list(base_value)
                 except TypeError:
                     base[key] = base_value
             else:


### PR DESCRIPTION
This PR is to address #2821, for appending to recipes (https://conda.io/docs/user-guide/tasks/build-packages/variants.html#appending-to-recipes):

> Any contents in recipe_append.yaml will add to the contents of meta.yaml. List values will be extended [...]

However, I'm not really clear on the intent of the function I'm modifying here, so I could do with some guidance. For instance, although line 1401 doesn't affect me right now, I also don't see its purpose (I would expect just line 1402).
