### PR TITLE
Add license file for R packages from CRAN

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -94,6 +94,7 @@ about:
   license: {license}
   {summary_comment}summary:{summary}
   license_family: {license_family}
+  {license_file}
 
 {extra_recipe_maintainers}
 
@@ -957,6 +958,18 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
         # XXX: We should maybe normalize these
         d['license'] = cran_package.get("License", "None")
         d['license_family'] = guess_license_family(d['license'], allowed_license_families)
+
+        # Add license file
+        d['license_file'] = ''
+
+        license_file_template = 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/{}\''
+        if d['license'] == 'GPL-2':
+            d['license_file'] = license_file_template.format('GPL-2')
+
+        if d['license'] == 'GPL-3':
+            d['license_file'] = license_file_template.format('GPL-3')
+
+        #import ipdb; ipdb.set_trace()
 
         if 'License_is_FOSS' in cran_package:
             d['license'] += ' (FOSS)'

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -959,17 +959,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
         d['license'] = cran_package.get("License", "None")
         d['license_family'] = guess_license_family(d['license'], allowed_license_families)
 
-        # Add license file
-        d['license_file'] = ''
-
-        license_file_template = 'license_file: \'{{ environ["PREFIX"] }}/lib/R/share/licenses/{}\''
-        if d['license'] == 'GPL-2':
-            d['license_file'] = license_file_template.format('GPL-2')
-
-        if d['license'] == 'GPL-3':
-            d['license_file'] = license_file_template.format('GPL-3')
-
-        #import ipdb; ipdb.set_trace()
+        d['license_file'] = get_license_file(d['license'])
 
         if 'License_is_FOSS' in cran_package:
             d['license'] += ' (FOSS)'
@@ -1265,3 +1255,56 @@ def up_to_date(cran_metadata, package):
         return False
 
     return True
+
+def get_license_file(license_text):
+    '''
+    Most R packages on CRAN do not include a license file. Instead, to avoid
+    duplication, R base ships with common software licenses:
+
+    complete: AGPL-3, Artistic-2.0, GPL-2, GPL-3, LGPL-2, LGPL-2.1, LGPL-3
+    template: BSD_2_clause BSD_3_clause, MIT
+
+    The complete licenses can be included in conda binaries by pointing to the
+    license file shipped with R base. The template files are more complicated
+    because they would need to be combined with the license information provided
+    by the package authors (e.g. copyright owners and date).
+
+    This function returns the path to the license file for the unambigious
+    cases. Any time an R pacage refers to one of the templates or a custom
+    license file (e.g. 'GPL-2 | file LICENSE'), an emptry string is returned.
+    '''
+
+    d_license = {'agpl3': ['AGPL-3', 'AGPL (>= 3)', 'AGPL',
+                           'GNU Affero General Public License'],
+                 'artistic2': ['Artistic-2.0', 'Artistic License 2.0'],
+                 'gpl2': ['GPL-2', 'GPL (>= 2)', 'GNU General Public License (>= 2)'],
+                 'gpl3': ['GPL-3', 'GPL (>= 3)', 'GNU General Public License (>= 3)',
+                          'GPL', 'GNU General Public License'],
+                 'lgpl2': ['LGPL-2', 'LGPL (>= 2)'],
+                 'lgpl21': ['LGPL-2.1', 'LGPL (>= 2.1)'],
+                 'lgpl3': ['LGPL-3', 'LGPL (>= 3)', 'LGPL',
+                           'GNU Lesser General Public License']}
+
+    license_file_template = '''\
+license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/{license}'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}/R/share/licenses/{license}'  # [win]
+'''
+
+    if license_text in d_license['agpl3']:
+        license_file = license_file_template.format(license = 'AGPL-3')
+    elif license_text in d_license['artistic2']:
+        license_file = license_file_template.format(license = 'Artistic-2.0')
+    elif license_text in d_license['gpl2']:
+        license_file = license_file_template.format(license = 'GPL-2')
+    elif license_text in d_license['gpl3']:
+        license_file = license_file_template.format(license = 'GPL-3')
+    elif license_text in d_license['lgpl2']:
+        license_file = license_file_template.format(license = 'LGPL-2')
+    elif license_text in d_license['lgpl21']:
+        license_file = license_file_template.format(license = 'LGPL-2.1')
+    elif license_text in d_license['lgpl3']:
+        license_file = license_file_template.format(license = 'LGPL-3')
+    else:
+        license_file = ''
+
+    return license_file


### PR DESCRIPTION
This PR adds the field `license_file` for CRAN R packages that use one of the complete licenses shipped with R.

xref: https://github.com/conda-forge/staged-recipes/issues/3234

To demonstrate the new behavior:

```
$ cd conda-build
$ export PYTHONPATH=.
$ python bin/conda-skeleton cran r-abf2 r-ada r-adapr r-arc r-bigml r-far r-grnn  r-gsa r-udunits2 r-usethis
$ grep license[:_] r-*/meta.yaml
r-abf2/meta.yaml:  license: Artistic-2.0
r-abf2/meta.yaml:  license_family: OTHER
r-abf2/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/Artistic-2.0'  # [unix]
r-abf2/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/Artistic-2.0'  # [win]
r-ada/meta.yaml:  license: GPL
r-ada/meta.yaml:  license_family: GPL
r-ada/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/GPL-3'  # [unix]
r-ada/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/GPL-3'  # [win]
r-adapr/meta.yaml:  license: LGPL-2
r-adapr/meta.yaml:  license_family: LGPL
r-adapr/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/LGPL-2'  # [unix]
r-adapr/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/LGPL-2'  # [win]
r-arc/meta.yaml:  license: AGPL-3
r-arc/meta.yaml:  license_family: AGPL
r-arc/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/AGPL-3'  # [unix]
r-arc/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/AGPL-3'  # [win]
r-bigml/meta.yaml:  license: LGPL-3
r-bigml/meta.yaml:  license_family: LGPL
r-bigml/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/LGPL-3'  # [unix]
r-bigml/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/LGPL-3'  # [win]
r-far/meta.yaml:  license: LGPL-2.1
r-far/meta.yaml:  license_family: LGPL
r-far/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/LGPL-2.1'  # [unix]
r-far/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/LGPL-2.1'  # [win]
r-grnn/meta.yaml:  license: AGPL
r-grnn/meta.yaml:  license_family: AGPL
r-grnn/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/AGPL-3'  # [unix]
r-grnn/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/AGPL-3'  # [win]
r-gsa/meta.yaml:  license: LGPL
r-gsa/meta.yaml:  license_family: LGPL
r-gsa/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/LGPL-3'  # [unix]
r-gsa/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/LGPL-3'  # [win]
r-udunits2/meta.yaml:  license: GPL-2
r-udunits2/meta.yaml:  license_family: GPL2
r-udunits2/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/GPL-2'  # [unix]
r-udunits2/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/GPL-2'  # [win]
r-usethis/meta.yaml:  license: GPL-3
r-usethis/meta.yaml:  license_family: GPL3
r-usethis/meta.yaml:  license_file: '{ environ["PREFIX"] }/lib/R/share/licenses/GPL-3'  # [unix]
r-usethis/meta.yaml:  license_file: '{ environ["PREFIX"] }/R/share/licenses/GPL-3'  # [win]
```