### PR TITLE
try again to keep key order in squished variants

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -39,8 +39,14 @@ from conda_build.exceptions import DependencyNeedsBuildingError
 from conda_build.index import get_build_index
 # from conda_build.jinja_context import pin_subpackage_against_outputs
 
+
+def odict_representer(dumper, data):
+    return dumper.represent_dict(data.items())
+
+
 yaml.add_representer(set, yaml.representer.SafeRepresenter.represent_list)
 yaml.add_representer(tuple, yaml.representer.SafeRepresenter.represent_list)
+yaml.add_representer(OrderedDict, odict_representer)
 
 
 def bldpkg_path(m):

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -422,7 +422,7 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
     """
     if not list_of_dicts:
         return
-    squished = {}
+    squished = OrderedDict()
     all_zip_keys = set()
     groups = None
     zip_key_groups = (list_of_dicts[0]['zip_keys'] if 'zip_keys' in list_of_dicts[0] and
@@ -441,7 +441,7 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
             if k == 'zip_keys':
                 continue
             if hasattr(v, 'keys'):
-                existing_value = squished.get(k, {})
+                existing_value = squished.get(k, OrderedDict())
                 existing_value.update(v)
                 squished[k] = existing_value
             elif isinstance(v, list):


### PR DESCRIPTION
Supplement to #2830; key order was being lost when the dictionaries from many configs were being squished together.