### PR TITLE
revert #2831, Add license file for R packages from CRAN

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -94,7 +94,6 @@ about:
   license: {license}
   {summary_comment}summary:{summary}
   license_family: {license_family}
-  {license_file}
 
 {extra_recipe_maintainers}
 
@@ -959,8 +958,6 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
         d['license'] = cran_package.get("License", "None")
         d['license_family'] = guess_license_family(d['license'], allowed_license_families)
 
-        d['license_file'] = get_license_file(d['license'])
-
         if 'License_is_FOSS' in cran_package:
             d['license'] += ' (FOSS)'
         if cran_package.get('License_restricts_use') == 'yes':
@@ -1255,57 +1252,3 @@ def up_to_date(cran_metadata, package):
         return False
 
     return True
-
-
-def get_license_file(license_text):
-    '''
-    Most R packages on CRAN do not include a license file. Instead, to avoid
-    duplication, R base ships with common software licenses:
-
-    complete: AGPL-3, Artistic-2.0, GPL-2, GPL-3, LGPL-2, LGPL-2.1, LGPL-3
-    template: BSD_2_clause BSD_3_clause, MIT
-
-    The complete licenses can be included in conda binaries by pointing to the
-    license file shipped with R base. The template files are more complicated
-    because they would need to be combined with the license information provided
-    by the package authors (e.g. copyright owners and date).
-
-    This function returns the path to the license file for the unambigious
-    cases. Any time an R pacage refers to one of the templates or a custom
-    license file (e.g. 'GPL-2 | file LICENSE'), an emptry string is returned.
-    '''
-
-    d_license = {'agpl3': ['AGPL-3', 'AGPL (>= 3)', 'AGPL',
-                           'GNU Affero General Public License'],
-                 'artistic2': ['Artistic-2.0', 'Artistic License 2.0'],
-                 'gpl2': ['GPL-2', 'GPL (>= 2)', 'GNU General Public License (>= 2)'],
-                 'gpl3': ['GPL-3', 'GPL (>= 3)', 'GNU General Public License (>= 3)',
-                          'GPL', 'GNU General Public License'],
-                 'lgpl2': ['LGPL-2', 'LGPL (>= 2)'],
-                 'lgpl21': ['LGPL-2.1', 'LGPL (>= 2.1)'],
-                 'lgpl3': ['LGPL-3', 'LGPL (>= 3)', 'LGPL',
-                           'GNU Lesser General Public License']}
-
-    license_file_template = '''\
-license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/{license}'  # [unix]
-  license_file: '{{ environ["PREFIX"] }}/R/share/licenses/{license}'  # [win]
-'''
-
-    if license_text in d_license['agpl3']:
-        license_file = license_file_template.format(license='AGPL-3')
-    elif license_text in d_license['artistic2']:
-        license_file = license_file_template.format(license='Artistic-2.0')
-    elif license_text in d_license['gpl2']:
-        license_file = license_file_template.format(license='GPL-2')
-    elif license_text in d_license['gpl3']:
-        license_file = license_file_template.format(license='GPL-3')
-    elif license_text in d_license['lgpl2']:
-        license_file = license_file_template.format(license='LGPL-2')
-    elif license_text in d_license['lgpl21']:
-        license_file = license_file_template.format(license='LGPL-2.1')
-    elif license_text in d_license['lgpl3']:
-        license_file = license_file_template.format(license='LGPL-3')
-    else:
-        license_file = ''
-
-    return license_file


### PR DESCRIPTION
Per @mingwandroid's advice, this stuff should not have been merged until https://github.com/conda-forge/r-base-feedstock/pull/43 is merged.  There is a difference in the filesystem paths on Windows after that PR, and conda-forge and defaults are out of sync.

@jdblischak please resubmit this PR after the r-base PR above gets merged.
