### PR TITLE
Sync default cran mran setting

### DIFF
--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -57,7 +57,6 @@ def execute(args):
         parser.print_help()
         sys.exit()
 
-    # for package in args.packages:
     api.skeletonize(args.packages, args.repo, output_dir=args.output_dir, recursive=args.recursive,
                     version=args.version, config=config)
 

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from conda_build import source, metadata
 from conda_build.config import get_or_merge_config
-from conda_build.conda_interface import text_type, iteritems, TemporaryDirectory
+from conda_build.conda_interface import text_type, iteritems, TemporaryDirectory, cc_conda_build
 from conda_build.license_family import allowed_license_families, guess_license_family
 from conda_build.utils import rm_rf, ensure_list
 from conda_build.variants import get_package_variants
@@ -370,9 +370,9 @@ def add_parser(repos):
     )
     cran.add_argument(
         '-m', '--variant-config-files',
-        action="append",
-        help="""Additional variant config files to add.  These yaml files can contain
-        keys such as `cran_mirror`"""
+        default=cc_conda_build.get('skeleton_config_yaml', None),
+        help="""Variant config file to add.  These yaml files can contain
+        keys such as `cran_mirror`.  Only one can be provided here."""
     )
 
 
@@ -669,12 +669,11 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                 variant_config_files=None):
 
     output_dir = realpath(output_dir)
-
     config = get_or_merge_config(config, variant_config_files=variant_config_files)
-    with TemporaryDirectory() as t:
-        _variant = get_package_variants(t, config)[0]
 
     if not cran_url:
+        with TemporaryDirectory() as t:
+            _variant = get_package_variants(t, config)[0]
         cran_url = ensure_list(_variant.get('cran_mirror', "https://cran.r-project.org"))[0]
 
     if len(in_packages) > 1 and version_compare:

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -303,7 +303,7 @@ def add_parser(repos):
     )
     cran.add_argument(
         "--cran-url",
-        default='https://cran.r-project.org/',
+        default='https://mran.microsoft.com/snapshot/2018-01-01/',
         help="URL to use for as source package repository",
     )
     cran.add_argument(

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -333,8 +333,8 @@ def _get_zip_dict_of_lists(combined_variant, list_of_strings):
         length = len(ensure_list(combined_variant[used_keys[0]]))
         for key in used_keys:
             if not len(ensure_list(combined_variant[key])) == length:
-                raise ValueError("zip field {} ({}) length does not match zip field {} ({}) length.  All zip "
-                                 "fields within a group must be the same length."
+                raise ValueError("zip field {} ({}) length does not match zip field {} ({}) "
+                                 "length.  All zip fields within a group must be the same length."
                                  .format(used_keys[0], combined_variant[used_keys[0]],
                                          key, combined_variant[key]))
         values = list(zip(*[ensure_list(combined_variant[key]) for key in used_keys]))

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -32,8 +32,6 @@ DEFAULT_VARIANTS = {
     'ignore_version': [],
     'ignore_build_only_deps': ['python'],
     'extend_keys': ['pin_run_as_build', 'ignore_version', 'ignore_build_only_deps'],
-    # We use MRAN here because they take snapshots which improves reproducibility.
-    'cran_mirror': 'https://mran.microsoft.com/snapshot/2018-01-01',
 }
 
 # map python version to default compiler on windows, to match upstream python


### PR DESCRIPTION
Supersedes #2833 

For Anaconda, we'll need to use -m and specify our config file.  I can also put in a condarc setting to help us avoid forgetting to pass that.

CC @mingwandroid 