### PR TITLE
several speedups focused on rendering

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -47,7 +47,8 @@ def render(recipe_path, config=None, variants=None, permit_unsatisfiable_variant
         if not meta.skip() or not config.trim_skip:
             for od, om in meta.get_output_metadata_set(
                     permit_unsatisfiable_variants=permit_unsatisfiable_variants,
-                    permit_undefined_jinja=not finalize):
+                    permit_undefined_jinja=not finalize,
+                    bypass_env_check=bypass_env_check):
                 if not om.skip() or not config.trim_skip:
                     # only show conda packages right now
                     if 'type' not in od or od['type'] == 'conda':

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -637,10 +637,13 @@ def distribute_variants(metadata, variants, permit_unsatisfiable_variants=False,
     elif not PY3 and hasattr(recipe_text, 'encode'):
         recipe_text = recipe_text.encode()
 
-    for variant in variants:
+    metadata.config.variant = variants[0]
+    used_variables = metadata.get_used_loop_vars(force_global=False)
+    top_loop = metadata.get_reduced_variant_set(used_variables)
+
+    for variant in top_loop:
         mv = metadata.copy()
         mv.config.variant = variant
-        used_variables = mv.get_used_loop_vars()
         conform_dict = {}
         for key in used_variables:
             # We use this variant in the top-level recipe.
@@ -807,6 +810,9 @@ def _unicode_representer(dumper, uni):
 class _IndentDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(_IndentDumper, self).increase_indent(flow, False)
+
+    def ignore_aliases(self, data):
+        return True
 
 
 yaml.add_representer(_MetaYaml, _represent_omap)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -279,14 +279,13 @@ def _func_defaulting_env_to_os_environ(func, *popenargs, **kwargs):
         if proc.returncode != 0:
             raise subprocess.CalledProcessError(proc.returncode, _args)
 
-        if stats is not None:
-            stats.update({'elapsed': proc.elapsed,
-                        'disk': proc.disk,
-                        'processes': proc.processes,
-                        'cpu_user': proc.cpu_user,
-                        'cpu_sys': proc.cpu_sys,
-                        'rss': proc.rss,
-                        'vms': proc.vms})
+        stats.update({'elapsed': proc.elapsed,
+                    'disk': proc.disk,
+                    'processes': proc.processes,
+                    'cpu_user': proc.cpu_user,
+                    'cpu_sys': proc.cpu_sys,
+                    'rss': proc.rss,
+                    'vms': proc.vms})
     else:
         if func == 'call':
             subprocess.check_call(_args, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -301,13 +301,13 @@ def test_insert_variant_versions(testing_metadata):
     assert len(testing_metadata.meta['requirements']['build']) == 2
 
 
-def test_subprocess_stats_call():
+def test_subprocess_stats_call(testing_workdir):
     stats = {}
-    utils.check_call_env(['ls'], stats=stats)
+    utils.check_call_env(['hostname'], stats=stats, cwd=testing_workdir)
     assert stats
     stats = {}
-    out = utils.check_output_env(['ls'], stats=stats)
+    out = utils.check_output_env(['hostname'], stats=stats, cwd=testing_workdir)
     assert out
     assert stats
     with pytest.raises(subprocess.CalledProcessError):
-        utils.check_call_env(['bash', '-c', 'exit 1'])
+        utils.check_call_env(['bash', '-c', 'exit 1'], cwd=testing_workdir)


### PR DESCRIPTION
General points:

* Variant space is reduced based on knowledge of which variables are "used" in a recipe.  This dramatically cuts back the rendering time
* Regex improvements for finding out which variable is used.  Mostly this was replacing ``.*`` with more specific things, like ``[^\{]``.
* memoizing string splitting for repeat words (helps speed up splitting of zipped keys)