### PR TITLE
fix handling of <= on upper bound constraints being forced to <

### DIFF
--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -900,8 +900,8 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     testing_metadata.meta['requirements']['build'] = ['test_has_run_exports']
     api.output_yaml(testing_metadata, 'meta.yaml')
     m = api.render(testing_workdir, config=testing_config)[0][0]
-    assert 'strong_pinned_package >=1.0,<1.1.0a0' in m.meta['requirements']['run']
-    assert 'weak_pinned_package >=1.0,<1.1.0a0' in m.meta['requirements']['run']
+    assert 'strong_pinned_package 1.0.*' in m.meta['requirements']['run']
+    assert 'weak_pinned_package 1.0.*' in m.meta['requirements']['run']
 
     #    2. host present.  Use run_exports from host, ignore 'weak' ones from build.  All are
     #           weak by default.
@@ -910,7 +910,7 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     testing_metadata.meta['requirements']['host'] = ['python']
     api.output_yaml(testing_metadata, 'host_present_weak/meta.yaml')
     m = api.render(os.path.join(testing_workdir, 'host_present_weak'), config=testing_config)[0][0]
-    assert 'weak_pinned_package >=2.0,<2.1.0a0' not in m.meta['requirements'].get('run', [])
+    assert 'weak_pinned_package 2.0.*' not in m.meta['requirements'].get('run', [])
 
     #    3. host present, and deps in build have "strong" run_exports section.  use host, add
     #           in "strong" from build.
@@ -920,11 +920,11 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     m = api.render(os.path.join(testing_workdir, 'host_present_strong'),
                    config=testing_config)[0][0]
     assert 'strong_pinned_package 1.0 0' in m.meta['requirements']['host']
-    assert 'strong_pinned_package >=1.0,<1.1.0a0' in m.meta['requirements']['run']
+    assert 'strong_pinned_package 1.0.*' in m.meta['requirements']['run']
     # weak one from test_has_run_exports should be excluded, since it is a build dep
-    assert 'weak_pinned_package >=1.0,<1.1.0a0' not in m.meta['requirements']['run']
+    assert 'weak_pinned_package 1.0.*' not in m.meta['requirements']['run']
     # weak one from test_has_run_exports_implicit_weak should be present, since it is a host dep
-    assert 'weak_pinned_package >=2.0,<2.1.0a0' in m.meta['requirements']['run']
+    assert 'weak_pinned_package 2.0.*' in m.meta['requirements']['run']
 
 
 def test_ignore_run_exports(testing_metadata, testing_config):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -39,4 +39,4 @@ def test_reduce_duplicate_specs(testing_metadata):
     assert 'stardot >=1.2,<1.3.0a0' in simplified_deps['build']
     # currently we lose the >= in the upper bound.  I don't think that's going to be a huge issue,
     #     but we'll see.  I don't really want to track the bound - just the bound type (upper/lower)
-    assert 'bounded >=1.5,<1.8' in simplified_deps['build']
+    assert 'bounded >=1.5,<=1.8' in simplified_deps['build']

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -16,27 +16,13 @@ def test_output_with_noarch_python_says_noarch(testing_metadata):
 
 
 def test_reduce_duplicate_specs(testing_metadata):
-    reqs = {'build': ['exact', 'exact 1.2.3 1', 'exact >1.0,<2',
-                      'bounded >=1.0,<2.0', 'bounded >=1.5', 'bounded <=1.8',
-                      'equals ==1.3', 'star  1.2*', 'star 1*', 'stardot 1.2.*', 'stardot 1.*'],
-            'host': ['exact', 'exact 1.2.3 1',
-                     'bounded >=1.0,<2.0', 'bounded >=1.5', 'bounded <=1.8',
-                     'equals >=1.3,<1.4.0a0', 'star >=1.2,<1.3.0a0', 'stardot >=1.2,<1.3.0a0'],
-            'run': ['exact', 'exact 1.2.3 1', 'bounded >=1.0,<2.0',
-                    'bounded >=1.5', 'bounded <=1.8',
-                    'equals >=1.3,<1.4.0a0', 'star >=1.2,<1.3.0a0', 'stardot >=1.2,<1.3.0a0'],
+    reqs = {'build': ['exact', 'exact 1.2.3 1', 'exact >1.0,<2'],
+            'host': ['exact', 'exact 1.2.3 1']
     }
     testing_metadata.meta['requirements'] = reqs
-    render._simplify_to_tightest_constraint(testing_metadata)
+    render._simplify_to_exact_constraints(testing_metadata)
     assert (testing_metadata.meta['requirements']['build'] ==
-            testing_metadata.meta['requirements']['host'] ==
-            testing_metadata.meta['requirements']['run'])
+            testing_metadata.meta['requirements']['host'])
     simplified_deps = testing_metadata.meta['requirements']
-    assert len(simplified_deps['build']) == 5
+    assert len(simplified_deps['build']) == 1
     assert 'exact 1.2.3 1' in simplified_deps['build']
-    # these get translated from the star syntax into bounded
-    assert 'star >=1.2,<1.3.0a0' in simplified_deps['build']
-    assert 'stardot >=1.2,<1.3.0a0' in simplified_deps['build']
-    # currently we lose the >= in the upper bound.  I don't think that's going to be a huge issue,
-    #     but we'll see.  I don't really want to track the bound - just the bound type (upper/lower)
-    assert 'bounded >=1.5,<=1.8' in simplified_deps['build']

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -74,7 +74,7 @@ def test_run_exports_in_subpackage(testing_metadata):
     p2 = testing_metadata.copy()
     p2.meta['requirements']['host'] = ['has_run_exports']
     p2_final = finalize_metadata(p2)
-    assert 'bzip2 >=1.0,<1.1.0a0' in p2_final.meta['requirements']['run']
+    assert 'bzip2 1.0.*' in p2_final.meta['requirements']['run']
 
 
 def test_subpackage_variant_override(testing_config):


### PR DESCRIPTION
Fixes issue raised by @tkelman in https://github.com/conda-forge/conda-build-feedstock/pull/41#issuecomment-384470429

wherein he had an upper bound with <=, and it just so happened that conda-forge's only available packages were exactly that upper bound.  The old behavior of ignoring the operator and always forcing < was broken.  This fixes it and does the comparison a little more straightforwardly.

fixes #2806 