### PR TITLE
add conda 4.6 compat with activate --stack flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv
 junit.xml
 .cache
 .DS_Store
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
       conda install -q futures scandir;
     fi
   - conda update -q --all
-  - if [ -n "$CONDA_VERSION" ]; then
+  - if [ "$CONDA_VERSION" = "4.3.x" ]; then
         rm -rf /opt/conda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda;
         rm -rf /opt/conda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda*.egg-info;
         git clone -b $CONDA_VERSION --single-branch --depth 1000 https://github.com/conda/conda.git;
@@ -57,6 +57,13 @@ install:
         popd;
         hash -r;
         conda info;
+    else
+        git clone -b $CONDA_VERSION --single-branch --depth 1000 https://github.com/conda/conda.git;
+        pushd conda;
+        python -m conda init --dev;
+        hash -r;
+        conda info;
+        popd;
     fi
   - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION
   - conda install -q pyflakes conda-verify beautifulsoup4 chardet pycrypto glob2 psutil

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1099,8 +1099,8 @@ def _write_sh_activation_text(file_handle, m):
                                    m.config.host_prefix.replace('\\', '\\\\'),
                                    cygpath_suffix))
         if conda_46:
-            file_handle.write("eval \"$('{sys_prefix}' -m conda shell.bash hook)\"\n".format(
-                sys_prefix=sys.prefix,
+            file_handle.write("eval \"$('{sys_python}' -m conda shell.bash hook)\"\n".format(
+                sys_python=sys.executable,
             ))
             file_handle.write("conda activate \"{0}\"\n".format(host_prefix_path))
         else:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -32,7 +32,7 @@ from bs4 import UnicodeDammit
 import yaml
 
 # used to get version
-from .conda_interface import env_path_backup_var_exists
+from .conda_interface import env_path_backup_var_exists, conda_46
 from .conda_interface import PY3
 from .conda_interface import prefix_placeholder
 from .conda_interface import TemporaryDirectory
@@ -1088,6 +1088,8 @@ def _write_sh_activation_text(file_handle, m):
         #   levels deep.
         # conda 4.4 does require that a conda-meta/history file
         #   exists to identify a valid conda environment
+        # conda 4.6 changes this one final time, by adding a '--stack' flag to the 'activate'
+        #   command, and 'activate' does not stack environments by default without that flag
         history_file = join(m.config.host_prefix, 'conda-meta', 'history')
         if not isfile(history_file):
             if not isdir(dirname(history_file)):
@@ -1096,16 +1098,25 @@ def _write_sh_activation_text(file_handle, m):
         host_prefix_path = ''.join((cygpath_prefix,
                                    m.config.host_prefix.replace('\\', '\\\\'),
                                    cygpath_suffix))
-        file_handle.write('source "{0}" "{1}"\n' .format(activate_path, host_prefix_path))
-        file_handle.write('unset CONDA_PATH_BACKUP\n')
-        file_handle.write('export CONDA_MAX_SHLVL=2\n')
+        if conda_46:
+            file_handle.write("eval \"$('{sys_prefix}' -m conda shell.bash hook)\"\n".format(
+                sys_prefix=sys.prefix,
+            ))
+            file_handle.write("conda activate \"{0}\"\n".format(host_prefix_path))
+        else:
+            file_handle.write('source "{0}" "{1}"\n' .format(activate_path, host_prefix_path))
+            file_handle.write('unset CONDA_PATH_BACKUP\n')
+            file_handle.write('export CONDA_MAX_SHLVL=2\n')
 
     # Write build prefix activation AFTER host prefix, so that its executables come first
     build_prefix_path = ''.join((cygpath_prefix,
                                 m.config.build_prefix.replace('\\', '\\\\'),
                                 cygpath_suffix))
 
-    file_handle.write('source "{0}" "{1}"\n'.format(activate_path, build_prefix_path))
+    if conda_46:
+        file_handle.write("conda activate --stack \"{0}\"\n".format(build_prefix_path))
+    else:
+        file_handle.write('source "{0}" "{1}"\n'.format(activate_path, build_prefix_path))
 
     # conda 4.4 requires a conda-meta/history file for a valid conda prefix
     history_file = join(m.config.build_prefix, 'conda-meta', 'history')

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1073,6 +1073,11 @@ def _write_sh_activation_text(file_handle, m):
                             os.path.join(utils.root_script_dir, 'activate').replace('\\', '\\\\'),
                             cygpath_suffix))
 
+    if conda_46:
+        file_handle.write("eval \"$('{sys_python}' -m conda shell.bash hook)\"\n".format(
+            sys_python=sys.executable,
+        ))
+
     if m.is_cross:
         # HACK: we need both build and host envs "active" - i.e. on PATH,
         #     and with their activate.d scripts sourced. Conda only
@@ -1099,9 +1104,6 @@ def _write_sh_activation_text(file_handle, m):
                                    m.config.host_prefix.replace('\\', '\\\\'),
                                    cygpath_suffix))
         if conda_46:
-            file_handle.write("eval \"$('{sys_python}' -m conda shell.bash hook)\"\n".format(
-                sys_python=sys.executable,
-            ))
             file_handle.write("conda activate \"{0}\"\n".format(host_prefix_path))
         else:
             file_handle.write('source "{0}" "{1}"\n' .format(activate_path, host_prefix_path))

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -30,6 +30,7 @@ except ImportError:
 
 conda_43 = parse_version(CONDA_VERSION) >= parse_version("4.3")
 conda_44 = parse_version(CONDA_VERSION) >= parse_version("4.4")
+conda_46 = parse_version(CONDA_VERSION) >= parse_version("4.6")
 
 if conda_44:
     from conda.exports import display_actions, execute_actions, execute_plan, install_actions

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -28,9 +28,9 @@ except ImportError:
     # no need to patch if it doesn't exist
     pass
 
-conda_43 = parse_version(CONDA_VERSION) >= parse_version("4.3")
-conda_44 = parse_version(CONDA_VERSION) >= parse_version("4.4")
-conda_46 = parse_version(CONDA_VERSION) >= parse_version("4.6")
+conda_43 = parse_version(CONDA_VERSION) >= parse_version("4.3.0a0")
+conda_44 = parse_version(CONDA_VERSION) >= parse_version("4.4.0a0")
+conda_46 = parse_version(CONDA_VERSION) >= parse_version("4.6.0a0")
 
 if conda_44:
     from conda.exports import display_actions, execute_actions, execute_plan, install_actions

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -203,6 +203,10 @@ def msvc_env_cmd(bits, config, override=None):
 
 
 def _write_bat_activation_text(file_handle, m):
+    if conda_46:
+        file_handle.write('call "{conda_root}\\condacmd\\conda_hook.bat"\n'.format(
+            conda_root=root_script_dir,
+        ))
     if m.is_cross:
         # HACK: we need both build and host envs "active" - i.e. on PATH,
         #     and with their activate.d scripts sourced. Conda only
@@ -227,9 +231,6 @@ def _write_bat_activation_text(file_handle, m):
             open(history_file, 'a').close()
 
         if conda_46:
-            file_handle.write('call "{conda_root}\\condacmd\\conda_hook.bat"\n'.format(
-                conda_root=root_script_dir,
-            ))
             file_handle.write('conda activate "{prefix}"\n'.format(
                 prefix=m.config.host_prefix,
             ))

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -12,6 +12,7 @@ from distutils.msvc9compiler import find_vcvarsall as distutils_find_vcvarsall
 from distutils.msvc9compiler import Reg, WINSDK_BASE
 
 from conda_build import environ
+from conda_build.conda_interface import conda_46
 from conda_build.utils import check_call_env, root_script_dir, path_prepended, copy_into, get_logger
 from conda_build.variants import set_language_env_vars, get_default_variant
 
@@ -217,21 +218,38 @@ def _write_bat_activation_text(file_handle, m):
         #   levels deep.
         # conda 4.4 does require that a conda-meta/history file
         #   exists to identify a valid conda environment
+        # conda 4.6 changes this one final time, by adding a '--stack' flag to the 'activate'
+        #   command, and 'activate' does not stack environments by default without that flag
         history_file = join(m.config.host_prefix, 'conda-meta', 'history')
         if not isfile(history_file):
             if not isdir(dirname(history_file)):
                 os.makedirs(dirname(history_file))
             open(history_file, 'a').close()
+
+        if conda_46:
+            file_handle.write('call "{conda_root}\\condacmd\\conda_hook.bat"\n'.format(
+                conda_root=root_script_dir,
+            ))
+            file_handle.write('conda activate "{prefix}"\n'.format(
+                prefix=m.config.host_prefix,
+            ))
+        else:
+            file_handle.write('call "{conda_root}\\activate.bat" "{prefix}"\n'.format(
+                conda_root=root_script_dir,
+                prefix=m.config.host_prefix))
+            # removing this placeholder should make conda double-activate with conda 4.3
+            file_handle.write('set "PATH=%PATH:CONDA_PATH_PLACEHOLDER;=%"\n')
+            file_handle.write('set CONDA_MAX_SHLVL=2\n')
+
+    # Write build prefix activation AFTER host prefix, so that its executables come first
+    if conda_46:
+        file_handle.write('conda activate --stack "{prefix}"\n'.format(
+            prefix=m.config.build_prefix,
+        ))
+    else:
         file_handle.write('call "{conda_root}\\activate.bat" "{prefix}"\n'.format(
             conda_root=root_script_dir,
-            prefix=m.config.host_prefix))
-        # removing this placeholder should make conda double-activate with conda 4.3
-        file_handle.write('set "PATH=%PATH:CONDA_PATH_PLACEHOLDER;=%"\n')
-        file_handle.write('set CONDA_MAX_SHLVL=2\n')
-    # Write build prefix activation AFTER host prefix, so that its executables come first
-    file_handle.write('call "{conda_root}\\activate.bat" "{prefix}"\n'.format(
-        conda_root=root_script_dir,
-        prefix=m.config.build_prefix))
+            prefix=m.config.build_prefix))
 
 
 def build(m, bld_bat, stats):


### PR DESCRIPTION
Per fairly extensive discussion with @mingwandroid, we took out the default environment stacking from conda 4.4.  In conda 4.6, to get environment stacking, you now need to add a `--stack` flag to activate (from https://github.com/conda/conda/pull/7195).  This PR should maintain compatibility here.