### PR TITLE
skeleton (pypi): Avoid checking for '~' in NoneType when spec parse f…

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -733,13 +733,13 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                 dep = dep.split('#')[0].strip()
                 if dep:  # ... and empty (or comment only) lines
                     spec = spec_from_line(dep)
+                    if spec is None:
+                        sys.exit("Error: Could not parse: %s" % dep)
                     if '~' in spec:
                         version = spec.split()[-1]
                         tilde_version = '~ {}' .format(version)
                         pin_compatible = convert_version(version)
                         spec = spec.replace(tilde_version, pin_compatible)
-                    if spec is None:
-                        sys.exit("Error: Could not parse: %s" % dep)
                     deps.append(spec)
 
         if 'setuptools' in deps:


### PR DESCRIPTION
…ails (see zope)

```
  File "/Users/rdonnelly/conda/conda-build/conda_build/skeletons/pypi.py", line 738, in get_package_metadata
    if '~' in spec:
TypeError: argument of type 'NoneType' is not iterable
```