### PR TITLE
create_test: Use exit \b N instead of exit N

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -72,9 +72,12 @@ def create_shell_files(m, test_dir=None):
                 f.write(cmd)
                 f.write('\n')
                 if on_win:
-                    f.write("IF %ERRORLEVEL% NEQ 0 exit 1\n")
+                    f.write("IF %ERRORLEVEL% NEQ 0 exit \b 1\n")
                 has_tests = True
-            f.write('exit 0\n')
+            if on_win:
+                f.write('exit \b 0\n')
+            else:
+                f.write('exit 0\n')
 
     return has_tests or os.path.isfile(os.path.join(m.config.test_dir, name))
 


### PR DESCRIPTION
.. this is so that you can 'call run_test.bat' without having it close your cmd.exe prompt
when you are trying to investigate why tests failed.