### PR TITLE
ensure that merge_build_host is updated correctly before build and be…

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1249,6 +1249,8 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
         host_ms_deps = m.ms_depends('host')
         host_ms_deps = [utils.ensure_valid_spec(spec) for spec in host_ms_deps]
 
+        m.config._merge_build_host = m.build_is_host
+
         if m.is_cross and not m.build_is_host:
             if VersionOrder(conda_version) < VersionOrder('4.3.2'):
                 raise RuntimeError("Non-native subdir support only in conda >= 4.3.2")
@@ -1474,6 +1476,8 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                         utils.rm_rf(m.config.host_prefix)
                         utils.rm_rf(m.config.build_prefix)
                         utils.rm_rf(m.config.test_prefix)
+
+                        m.config._merge_build_host = m.build_is_host
 
                         host_ms_deps = m.ms_depends('host')
                         sub_build_ms_deps = m.ms_depends('build')

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -72,13 +72,12 @@ def create_shell_files(m, test_dir=None):
                 f.write(cmd)
                 f.write('\n')
                 if on_win:
-                    f.write("IF %ERRORLEVEL% NEQ 0 exit \b 1\n")
+                    f.write("IF %ERRORLEVEL% NEQ 0 exit /B 1\n")
                 has_tests = True
             if on_win:
-                f.write('exit \b 0\n')
+                f.write('exit /B 0\n')
             else:
                 f.write('exit 0\n')
-
     return has_tests or os.path.isfile(os.path.join(m.config.test_dir, name))
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -816,7 +816,6 @@ class MetaData(object):
         self.parse_again(permit_undefined_jinja=True, allow_no_other_outputs=True)
         self.config.disable_pip = self.disable_pip
         # establish whether this recipe should squish build and host together
-        self.config._merge_build_host = self.build_is_host
 
     @property
     def is_cross(self):


### PR DESCRIPTION
…fore each output

The state for merging was being considered incorrectly especially with outputs.  It was behaving properly for the top-level, but not being recomputed for each output.