### PR TITLE
handle empty packages in check for duplicated files

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1565,7 +1565,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                         for file, csum in output_d['checksums'].items():
                             for _, prev_om in new_pkgs.items():
                                 prev_output_d, _ = prev_om
-                                if file in prev_output_d['checksums']:
+                                if file in prev_output_d.get('checksums', {}):
                                     prev_csum = prev_output_d['checksums'][file]
                                     nature = 'Exact' if csum == prev_csum else 'Inexact'
                                     log.warn("{} overlap between {} in packages {} and {}"

--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -26,6 +26,7 @@ NONE
 gpl2_regex = re.compile('GPL[^3]*2')  # match GPL2
 gpl3_regex = re.compile('GPL[^2]*3')  # match GPL3
 gpl23_regex = re.compile('GPL[^2]*>= *2')  # match GPL >= 2
+cc_regex = re.compile('CC\w+')  # match CC
 punk_regex = re.compile('[%s]' % re.escape(string.punctuation))  # removes punks
 
 
@@ -85,6 +86,8 @@ def guess_license_family(license_name=None,
         return 'GPL3'
     elif gpl2_regex.search(sans_lgpl):
         return 'GPL2'
+    elif cc_regex.search(license_name):
+        return 'CC'
 
     license_name = remove_special_characters(license_name)
     for family in recognized:

--- a/tests/test_license_family.py
+++ b/tests/test_license_family.py
@@ -122,8 +122,13 @@ def test_unlimited():
     assert guess_license_family(cens) == 'MIT'
 
 
+def test_cc():
+    fam = guess_license_family(u'CC0')
+    assert fam == u'CC'
+
+
 def test_other():
-    licenses = {u'file LICENSE (FOSS)', u'CC0',
+    licenses = {u'file LICENSE (FOSS)',
                 u'Open Source (http://www.libpng.org/pub/png/src/libpng-LICENSE.txt)',
                 u'zlib (http://zlib.net/zlib_license.html)',
                 u'Free software (X11 License)', u'Custom free software license'}


### PR DESCRIPTION
With split packages, you are warned when duplicate files are present across packages.  This check did not account for packages that have no files, and thus no checksums.