### PR TITLE
set PYTHON and other language path vars based on presence in reqs

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -838,7 +838,7 @@ def bundle_conda(output, metadata, env, stats, **kw):
         output['script'] = script_fn
 
     if output.get('script'):
-        env = environ.get_dict(config=metadata.config, m=metadata)
+        env = environ.get_dict(m=metadata)
 
         interpreter = output.get('script_interpreter')
         if not interpreter:
@@ -1026,7 +1026,7 @@ def bundle_wheel(output, metadata, env, stats):
             _write_activation_text(dest_file, metadata)
 
         # run the appropriate script
-        env = environ.get_dict(config=metadata.config, m=metadata).copy()
+        env = environ.get_dict(m=metadata).copy()
         env['TOP_PKG_NAME'] = env['PKG_NAME']
         env['TOP_PKG_VERSION'] = env['PKG_VERSION']
         env['PKG_VERSION'] = metadata.version()
@@ -1174,7 +1174,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
     output_metas = []
 
     with utils.path_prepended(m.config.build_prefix):
-        env = environ.get_dict(config=m.config, m=m)
+        env = environ.get_dict(m=m)
     env["CONDA_BUILD_STATE"] = "BUILD"
     if env_path_backup_var_exists:
         env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
@@ -1378,7 +1378,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                 if isfile(build_file) or script:
 
                     with utils.path_prepended(m.config.build_prefix):
-                        env = environ.get_dict(config=m.config, m=m)
+                        env = environ.get_dict(m=m)
                     env["CONDA_BUILD_STATE"] = "BUILD"
 
                     work_file = join(m.config.work_dir, 'conda_build.sh')
@@ -1552,7 +1552,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                     # we must refresh the environment variables because our env for each package
                     #    can be different from the env for the top level build.
                     with utils.path_prepended(m.config.build_prefix):
-                        env = environ.get_dict(config=m.config, m=m)
+                        env = environ.get_dict(m=m)
                     built_package = bundlers[output_d.get('type', 'conda')](output_d, m, env, stats)
                     # warn about overlapping files.
                     if 'checksums' in output_d:
@@ -1877,8 +1877,7 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True):
 
     with utils.path_prepended(metadata.config.test_prefix):
         env = dict(os.environ.copy())
-        env.update(environ.get_dict(config=metadata.config, m=metadata,
-                                    prefix=config.test_prefix))
+        env.update(environ.get_dict(m=metadata, prefix=config.test_prefix))
         env["CONDA_BUILD_STATE"] = "TEST"
         if env_path_backup_var_exists:
             env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
@@ -1926,8 +1925,7 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True):
 
     with utils.path_prepended(metadata.config.test_prefix):
         env = dict(os.environ.copy())
-        env.update(environ.get_dict(config=metadata.config, m=metadata,
-                                    prefix=metadata.config.test_prefix))
+        env.update(environ.get_dict(m=metadata, prefix=metadata.config.test_prefix))
         env["CONDA_BUILD_STATE"] = "TEST"
         if env_path_backup_var_exists:
             env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -497,9 +497,9 @@ def context_processor(initial_metadata, recipe_dir, config, permit_undefined_jin
     initial_metadata: Augment the context with values from this MetaData object.
                       Used to bootstrap metadata contents via multiple parsing passes.
     """
-    ctx = get_environ(config=config, m=initial_metadata, for_env=False, skip_build_id=skip_build_id)
+    ctx = get_environ(m=initial_metadata, for_env=False, skip_build_id=skip_build_id)
     environ = dict(os.environ)
-    environ.update(get_environ(config=config, m=initial_metadata, skip_build_id=skip_build_id))
+    environ.update(get_environ(m=initial_metadata, skip_build_id=skip_build_id))
 
     ctx.update(
         load_setup_py_data=partial(load_setup_py_data, config=config, recipe_dir=recipe_dir,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -19,7 +19,7 @@ from .conda_interface import MatchSpec
 from .conda_interface import envs_dirs
 from .conda_interface import string_types
 
-from conda_build import exceptions, utils, variants
+from conda_build import exceptions, utils, variants, environ
 from conda_build.features import feature_list
 from conda_build.config import Config, get_or_merge_config
 from conda_build.utils import (ensure_list, find_recipe, expand_globs, get_installed_packages,
@@ -89,6 +89,7 @@ def ns_cfg(config):
     if not hasattr(py, 'split'):
         py = py[0]
     py = int("".join(py.split('.')[:2]))
+
     d.update(dict(py=py,
                     py3k=bool(30 <= py < 40),
                     py2k=bool(20 <= py < 30),
@@ -1421,6 +1422,7 @@ class MetaData(object):
         env = jinja2.Environment(loader=loader, undefined=undefined_type)
 
         env.globals.update(ns_cfg(self.config))
+        env.globals.update(environ.get_dict(m=self))
         env.globals.update({"CONDA_BUILD_STATE": "RENDER"})
         env.globals.update(context_processor(self, path, config=self.config,
                                              permit_undefined_jinja=permit_undefined_jinja,

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -888,7 +888,7 @@ def create_entry_point(path, module, func, config):
             os.remove(path)
         with open(path, 'w') as fo:
             if not config.noarch:
-                fo.write('#!%s\n' % config.build_python)
+                fo.write('#!%s\n' % config.host_python)
             fo.write(pyscript)
         os.chmod(path, 0o775)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -260,7 +260,7 @@ def _write_bat_activation_text(file_handle, m):
 def build(m, bld_bat, stats):
     with path_prepended(m.config.build_prefix):
         with path_prepended(m.config.host_prefix):
-            env = environ.get_dict(config=m.config, m=m)
+            env = environ.get_dict(m=m)
     env["CONDA_BUILD_STATE"] = "BUILD"
 
     # set variables like CONDA_PY in the test environment

--- a/tests/test-recipes/metadata/_setup_py_data_in_env/meta.yaml
+++ b/tests/test-recipes/metadata/_setup_py_data_in_env/meta.yaml
@@ -11,7 +11,7 @@ source:
   path: ../../test-package
 
 build:
-  script: python setup.py install --old-and-unmanageable
+  script: {{ PYTHON }} setup.py install --old-and-unmanageable
 
 requirements:
   build:

--- a/tests/test-recipes/split-packages/_entry_points/test-pkg1.py
+++ b/tests/test-recipes/split-packages/_entry_points/test-pkg1.py
@@ -4,4 +4,5 @@ import sys
 import pkg1
 pkg1.main()
 bindir = 'Scripts' if sys.platform == 'win32' else 'bin'
+print("attempting to call ", os.path.join(os.getenv('PREFIX'), bindir, 'pkg1'))
 subprocess.check_call([os.path.join(os.getenv('PREFIX'), bindir, 'pkg1')])

--- a/tests/test-recipes/split-packages/_entry_points/test-pkg2.py
+++ b/tests/test-recipes/split-packages/_entry_points/test-pkg2.py
@@ -4,4 +4,5 @@ import sys
 import pkg2
 pkg2.main()
 bindir = 'Scripts' if sys.platform == 'win32' else 'bin'
+print("attempting to call ", os.path.join(os.getenv('PREFIX'), bindir, 'pkg2'))
 subprocess.check_call([os.path.join(os.getenv('PREFIX'), bindir, 'pkg2')])


### PR DESCRIPTION
as opposed to the old way of seeing if the python executable was there.  This makes {{ PYTHON }} usable in rendering, where it was previously only available in the build scripts afterwards.

CC @tomashek