### PR TITLE
fix merge_build_host functionality.  Empty host section splits envs.

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -302,18 +302,8 @@ def pin_subpackage(metadata, subpackage_name, min_pin='x.x.x.x.x.x', max_pin='x'
     pinning on the runtime package that is also created by the compiler package recipe
     """
     pin = None
-    try:
-        metadata_name = metadata.name()
-    except SystemExit:
-        # in very early passes, we can't yet evaluate the name() attribute.
-        metadata_name = None
-    if metadata_name and subpackage_name == metadata_name:
-        if exact:
-            pin = ' '.join((metadata.name(), metadata.version(), metadata.build_id()))
-        else:
-            pin = ' '.join((subpackage_name,
-                            apply_pin_expressions(metadata.version(), min_pin, max_pin)))
-    elif not hasattr(metadata, 'other_outputs'):
+
+    if not hasattr(metadata, 'other_outputs'):
         if allow_no_other_outputs:
             pin = subpackage_name
         else:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1398,8 +1398,11 @@ def merge_or_update_dict(base, new, path, merge, raise_on_clobber=False):
             base[key] = base_value
         elif hasattr(value, '__iter__') and not isinstance(value, string_types):
             if merge:
-                if base_value and base_value != value:
-                    base_value.extend(value)
+                if base_value != value:
+                    try:
+                        base_value.extend(value)
+                    except TypeError:
+                        base_value = value
                 try:
                     base[key] = list(base_value)
                 except TypeError:
@@ -1604,5 +1607,9 @@ def match_peer_job(target_matchspec, other_m, this_m=None):
 def expand_reqs(reqs_entry):
     if not hasattr(reqs_entry, 'keys'):
         original = ensure_list(reqs_entry)[:]
-        reqs_entry = {'host': original, 'run': original} if original else {}
+        reqs_entry = {'host': ensure_list(original),
+                      'run': ensure_list(original)} if original else {}
+    else:
+        for sec in reqs_entry:
+            reqs_entry[sec] = ensure_list(reqs_entry[sec])
     return reqs_entry

--- a/tests/test-recipes/metadata/_empty_host_avoids_merge/meta.yaml
+++ b/tests/test-recipes/metadata/_empty_host_avoids_merge/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: pkg
+
+# build:
+#   merge_build_host: False
+
+requirements:
+  build:
+    - bzip2
+  host:

--- a/tests/test-recipes/metadata/_no_merge_build_host/meta.yaml
+++ b/tests/test-recipes/metadata/_no_merge_build_host/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pkg
+
+build:
+  merge_build_host: False
+
+requirements:
+  build:
+    - bzip2

--- a/tests/test-recipes/split-packages/noarch_subpackage/meta.yaml
+++ b/tests/test-recipes/split-packages/noarch_subpackage/meta.yaml
@@ -9,6 +9,6 @@ requirements:
 
 outputs:
   - name: pkg_subpackage
-    noarch: True
+    noarch: generic
   - name: pkg_subpackage_python_noarch
     noarch: python

--- a/tests/test-recipes/variants/numpy_used/meta.yaml
+++ b/tests/test-recipes/variants/numpy_used/meta.yaml
@@ -4,21 +4,8 @@ package:
   name: tifffile
   version: {{ version }}
 
-source:
-  git_url: https://github.com/blink1073/tifffile
-  git_tag: v{{ version }}
-
 build:
   number: 3
-  # conda 4.4+
-  skip: True  # [blas_impl != "mkl" and win]
-  requires_features:
-    blas: {{ blas_impl }}
-  # conda 4.3-
-  features:
-    - nomkl  # [x86 and blas_impl != "mkl"]
-
-  script: python setup.py install
 
 requirements:
   build:

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -587,7 +587,7 @@ def test_noarch(testing_workdir):
                 ('name', 'test'),
                 ('version', '0.0.0')])),
             ('build', OrderedDict([
-                 ('noarch', str(noarch))]))
+                 ('noarch', noarch)]))
             ])
         with open(filename, 'w') as outfile:
             outfile.write(yaml.dump(data, default_flow_style=False, width=999999999))
@@ -901,11 +901,13 @@ def test_run_exports(testing_metadata, testing_config, testing_workdir):
     # run_exports is tricky.  We mostly only ever want things in "host".  Here are the conditions:
 
     #    1. only build section present (legacy recipe).  Here, use run_exports from build.
+    #       note that because strong_run_exports creates a host section, the weak exports from build
+    #       will not apply.
     testing_metadata.meta['requirements']['build'] = ['test_has_run_exports']
     api.output_yaml(testing_metadata, 'meta.yaml')
     m = api.render(testing_workdir, config=testing_config)[0][0]
     assert 'strong_pinned_package 1.0.*' in m.meta['requirements']['run']
-    assert 'weak_pinned_package 1.0.*' in m.meta['requirements']['run']
+    assert 'weak_pinned_package 1.0.*' not in m.meta['requirements']['run']
 
     #    2. host present.  Use run_exports from host, ignore 'weak' ones from build.  All are
     #           weak by default.

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -205,3 +205,13 @@ def test_ignore_build_only_deps(testing_config):
     ms = api.render(os.path.join(thisdir, 'test-recipes', 'variants', 'python_in_build_only'),
                 bypass_env_check=True, finalize=False)
     assert len(ms) == 1
+
+
+def test_merge_build_host_build_key(testing_workdir, testing_metadata):
+    m = api.render(os.path.join(metadata_dir, '_no_merge_build_host'))[0][0]
+    assert not any('bzip2' in dep for dep in m.meta['requirements']['run'])
+
+
+def test_merge_build_host_empty_host_section(testing_config):
+    m = api.render(os.path.join(metadata_dir, '_empty_host_avoids_merge'))[0][0]
+    assert not any('bzip2' in dep for dep in m.meta['requirements']['run'])


### PR DESCRIPTION
fixes #2887 

Note that this changes some behavior with run_exports.  If a strong run_exports is present in the build section, any weak run_exports in the build section will not apply, because the strong run_export creates the host section with its injection of the strong run_exports.

This also switches from the yaml BaseLoader to the default.  This interprets booleans more directly.  I have attempted to keep the version number parsing as a string, but there may be some small issues that the test suite doesn't cover.