### PR TITLE
Add a test case for #2912

### DIFF
--- a/tests/test-recipes/variants/27_requirements_host/conda_build_config.yaml
+++ b/tests/test-recipes/variants/27_requirements_host/conda_build_config.yaml
@@ -1,0 +1,2 @@
+mpi:
+  - openmpi

--- a/tests/test-recipes/variants/27_requirements_host/conda_build_config.yaml
+++ b/tests/test-recipes/variants/27_requirements_host/conda_build_config.yaml
@@ -1,2 +1,3 @@
 mpi:
   - openmpi
+  - mpich

--- a/tests/test-recipes/variants/27_requirements_host/meta.yaml
+++ b/tests/test-recipes/variants/27_requirements_host/meta.yaml
@@ -1,0 +1,7 @@
+package:
+    name: cfastpm
+
+requirements:
+    host:
+        - {{ mpi }}
+

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -400,3 +400,9 @@ def test_inner_python_loop_with_output(testing_config):
     assert len([out for out in outputs if out.startswith('tbb-2018')]) == 1
     assert len([out for out in outputs if out.startswith('tbb-devel-2018')]) == 1
     assert len([out for out in outputs if out.startswith('tbb4py-2018')]) == 3
+
+
+def test_variant_as_dependency_name(testing_config):
+    outputs = api.render(os.path.join(recipe_dir, '27_requirements_host'),
+                                        config=testing_config)
+    assert len(outputs) == 2


### PR DESCRIPTION
This is intended to be a test case for the fix in #2912.

I followed the conventions in the test-recipes directory, but I am not sure how to trigger these tests.

When triggered manually with conda-build 3.10.3's conda-render, no errors are raised.
When triggered manually with 3.10.4, the error as described in #2900 is reproduced.
