### PR TITLE
ensure the file handle is closed upon out-of-scope

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -184,7 +184,8 @@ def load_file_regex(config, load_file, regex_pattern, from_recipe_dir=False,
             raise RuntimeError(message)
 
     if os.path.isfile(load_file):
-        match = re.search(regex_pattern, open(load_file, 'r').read())
+        with open(load_file, 'r') as lfile:
+            match = re.search(regex_pattern, lfile.read())
     else:
         if not permit_undefined_jinja:
             raise TypeError('{} is not a file that can be read'.format(load_file))


### PR DESCRIPTION
When using the load_file_regex() in a jinja template, we were receiving a resource warning:
```
/miniconda3/lib/python3.6/site-packages/conda_build/jinja_context.py:187: ResourceWarning: unclosed file <_io.TextIOWrapper name='/localdisk/ipp/linux/include/ippversion.h' mode='r' encoding='ISO-8859-1'>
  match = re.search(regex_pattern, open(load_file, 'r').read())
```
This patch makes sure the file is closed

fixes #2917 