### PR TITLE
Rendering speedups

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -537,12 +537,18 @@ def osx_vars(m, get_default):
     get_default('BUILD', OSX_ARCH + '-apple-darwin13.4.0')
 
 
+@memoized
+def _machine_and_architecture():
+    return platform.machine(), platform.architecture()
+
+
 def linux_vars(m, get_default):
     """This is setting variables on a dict that is part of the get_default function"""
-    build_arch = platform.machine()
+    platform_machine, platform_architecture = _machine_and_architecture()
+    build_arch = platform_machine
     # Python reports x86_64 when running a i686 Python binary on a 64-bit CPU
     # unless run through linux32. Issue a warning when we detect this.
-    if build_arch == 'x86_64' and platform.architecture()[0] == '32bit':
+    if build_arch == 'x86_64' and platform_architecture[0] == '32bit':
         print("Warning: You are running 32-bit Python on a 64-bit linux installation")
         print("         but have not launched it via linux32. Various qeuries *will*")
         print("         give unexpected results (uname -m, platform.machine() etc)")

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -536,7 +536,7 @@ def find_used_variables_in_text(variant, recipe_text):
     for v in variant:
         variant_regex = r"\{\s*(?:pin_[a-z]+\(\s*?['\"])?%s[^'\"]*?\}\}" % v
         selector_regex = r"^[^#\[]*?\#?\s\[[^\]]*?(?<![_\w\d])%s[=\s<>!\]]" % v
-        conditional_regex = r"[^\{]*?\{%\s*(?:el)?if\s*" + v + r"\s*(?:[^%]*?)?%\}"
+        conditional_regex = r"(?:^|[^\{])\{%\s*(?:el)?if\s*" + v + r"\s*(?:[^%]*?)?%\}"
         # plain req name, no version spec.  Look for end of line after name, or comment or selector
         requirement_regex = r"^\s+\-\s+%s(?:\s+[\[#]|$)" % v.replace('_', '[-_]')
         all_res = [variant_regex, selector_regex, conditional_regex, requirement_regex]
@@ -548,7 +548,7 @@ def find_used_variables_in_text(variant, recipe_text):
             all_res.append(compiler_regex)
         # consolidate all re's into one big one for speedup
         all_res = r"|".join(all_res)
-        if re.search(all_res, recipe_text, flags=re.MULTILINE | re.DOTALL):
+        if re.search(all_res, recipe_text):
             used_variables.add(v)
     return used_variables
 


### PR DESCRIPTION
The first commit makes `platform` module's calls cached. `platform.machine()` is not costly, but `platform.architecture()` causes a `subprocess.Popen` one the `file` executable at https://github.com/python/cpython/blob/v3.6.5/Lib/platform.py#L835. Esp. if processing recipes in  a batch, this has a noticeable performance impact. (Idk whether an alternative to caching might be to call `platform.architecture(executable=None)` to get the output from https://github.com/python/cpython/blob/v3.6.5/Lib/platform.py#L824-L837 -- I didn't look into this, just noticed the duplicate subprocess calls).

The second commit is the one with the most performance impact. The speedup heavily depends on the size of `meta.yaml` but on average I saw a ~7-fold time reduction on a preprocessing step, calling  `api.render(r, config=config, finalize=False, bypass_env_check=True)` (Bioconda recipes).
The reason for the slow performance is the use of `flags=re.MULTILINE | re.DOTALL` and the non-greedy regexp at the beginning of `conditional_regex`, i.e., `[^\{]*?`.
I can't say I completely grasped the intention of `[^\{]*?` and using the multiline mode. So I just assumed you want something like `(^|[^\{])`, i.e., "either the start of the line or not directly preceded by `{`". I am absolutely not sure about the original intention, though.
Is the multiline mode really necessary? It has a huge performance impact.