### PR TITLE
Support custom language in compilers

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -329,10 +329,14 @@ def pin_subpackage(metadata, subpackage_name, min_pin='x.x.x.x.x.x', max_pin='x'
 
 
 def native_compiler(language, config):
-    try:
-        compiler = DEFAULT_COMPILERS[config.platform][language]
-    except KeyError:
-        compiler = DEFAULT_COMPILERS[config.platform.split('-')[0]][language]
+    compiler = "unknown_compiler"
+
+    for platform in [config.platform, config.platform.split('-')[0]]:
+        try:
+            compiler = DEFAULT_COMPILERS[platform][language]
+            break
+        except KeyError:
+            continue
     if hasattr(compiler, 'keys'):
         compiler = compiler.get(config.variant.get('python', 'nope'), 'vs2015')
     return compiler

--- a/tests/test-recipes/variants/28_custom_compiler/conda_build_config.yaml
+++ b/tests/test-recipes/variants/28_custom_compiler/conda_build_config.yaml
@@ -1,0 +1,6 @@
+go_compiler:
+  - go
+target_platform:
+  - linux-64
+  - osx-64
+  - win-64

--- a/tests/test-recipes/variants/28_custom_compiler/meta.yaml
+++ b/tests/test-recipes/variants/28_custom_compiler/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: custom
+  version: 1.0
+
+requirements:
+  build:
+    - {{ compiler('go') }}

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -406,3 +406,9 @@ def test_variant_as_dependency_name(testing_config):
     outputs = api.render(os.path.join(recipe_dir, '27_requirements_host'),
                                         config=testing_config)
     assert len(outputs) == 2
+
+
+def test_custom_compiler():
+    recipe = os.path.join(recipe_dir, '28_custom_compiler')
+    ms = api.render(recipe, permit_unsatisfiable_variants=True, finalize=False, bypass_env_check=True)
+    assert len(ms) == 3


### PR DESCRIPTION
As of 3.10.5 there is a bug where it is not possible to define
a custom compiler for a language different from the default ones.

This PR includes test case variants/28_custom_compiler to show
the error.