### PR TITLE
utils: replace glob2 by glob for PY3

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -4,7 +4,6 @@ import base64
 from collections import defaultdict
 import contextlib
 import fnmatch
-from glob2 import glob
 import json
 from locale import getpreferredencoding
 import logging
@@ -13,7 +12,7 @@ import mmap
 import operator
 import os
 from os.path import (dirname, getmtime, getsize, isdir, join, isfile, abspath, islink,
-                     expanduser, expandvars)
+                     expanduser, expandvars, normcase)
 import re
 import stat
 import subprocess
@@ -42,12 +41,23 @@ from conda_build.conda_interface import rm_rf as _rm_rf # NOQA
 from conda_build.os_utils import external
 
 if PY3:
+    from glob import iglob
+
+    # stdlib glob is less feature-rich but considerably faster than glob2
+    def glob(pathname, recursive=True):
+        return list(map(normcase, iglob(pathname, recursive=recursive)))
+
     import urllib.parse as urlparse
     import urllib.request as urllib
     # NOQA because it is not used in this file.
     from contextlib import ExitStack  # NOQA
     PermissionError = PermissionError  # NOQA
 else:
+    from glob2 import glob as glob2_glob
+
+    def glob(pathname, recursive=True):
+        return glob2_glob(pathname, recursive=recursive)
+
     import urlparse
     import urllib
     # NOQA because it is not used in this file.


### PR DESCRIPTION
`glob2` is considerably slower than `glob` from the Python 3's standard library acc. to the measurements from gh-2936:
```
# conda-build 3.10.6
7.650 glob
3.055 parse_config_file
18.984 render

# conda-build 3.10.6 + monkeypatched glob
2.514 glob
3.124 parse_config_file
14.154 render
```
If I didn't miss anything else, the differences between `glob2.glob` and `glob.glob` are that `glob2.glob` offers more fine grained behavior via additional parameters, i.e., `with_matches, include_hidden, norm_paths, case_sensitive, sep`, uses `recursive=True` instead `False` on default and also calls `normcase` on each returned path.

BEWARE: I did not check whether `conda-build` uses any of the additional parameters of `glob2.glob` or if there are other possible differences/cornercases between the two implementations.

But since `glob.glob` (`glob.iglob`) from Python 3 also handles `**` patterns with `recursive=True`, using it could offer a considerable speedup.