### PR TITLE
Clean up the license field for pypi skeleton

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -832,7 +832,9 @@ def get_package_metadata(package, d, data, output_dir, python_version, all_extra
                                 package)
     else:
         license_name = ' or '.join(licenses)
-    d['license'] = license_name
+    # remove the word license from the license
+    clean_license_name = re.subn('(.*)\s+license', r'\1', license_name, flags=re.IGNORECASE)[0]
+    d['license'] = clean_license_name
     d['license_family'] = guess_license_family(license_name, allowed_license_families)
     if 'new_hash_value' in pkginfo:
         d['digest'] = pkginfo['new_hash_value']


### PR DESCRIPTION
Rationale for this: the conda forge linter moans when encountering things
like `BSD License`

We can attempt to make the output of conda skeleton pypi play a bit nicer
with conda-forge's linter by cleaning this up.