### PR TITLE
utils: apply abspath for consistency between glob and glob2

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -45,7 +45,7 @@ if PY3:
 
     # stdlib glob is less feature-rich but considerably faster than glob2
     def glob(pathname, recursive=True):
-        return list(map(normcase, iglob(pathname, recursive=recursive)))
+        return list(map(abspath, map(normcase, iglob(pathname, recursive=recursive))))
 
     import urllib.parse as urlparse
     import urllib.request as urllib
@@ -53,10 +53,10 @@ if PY3:
     from contextlib import ExitStack  # NOQA
     PermissionError = PermissionError  # NOQA
 else:
-    from glob2 import glob as glob2_glob
+    from glob2 import glob as glob2_iglob
 
     def glob(pathname, recursive=True):
-        return glob2_glob(pathname, recursive=recursive)
+        return list(map(abspath, glob2_iglob(pathname, recursive=recursive)))
 
     import urlparse
     import urllib

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import stat
 import subprocess
 import sys
@@ -195,17 +196,20 @@ def test_expand_globs(testing_workdir):
 
     # Test dirs
     exp = utils.expand_globs([os.path.join('sub1', 'ssub1')], testing_workdir)
-    assert sorted(exp) == sorted([os.path.sep.join(('sub1', 'ssub1', 'ghi')),
-                                  os.path.sep.join(('sub1', 'ssub1', 'abc'))])
+    assert sorted(exp) == sorted(map(os.path.abspath,
+                                     [os.path.sep.join(('sub1', 'ssub1', 'ghi')),
+                                      os.path.sep.join(('sub1', 'ssub1', 'abc'))]))
 
     # Test files
     exp = sorted(utils.expand_globs(['abc', files[2]], testing_workdir))
-    assert exp == sorted(['abc', os.path.sep.join(('sub1', 'def'))])
+    assert exp == sorted(map(os.path.abspath,
+                             ['abc', os.path.sep.join(('sub1', 'def'))]))
 
     # Test globs
     exp = sorted(utils.expand_globs(['a*', '*/*f', '**/*i'], testing_workdir))
-    assert exp == sorted(['abc', 'acb', os.path.sep.join(('sub1', 'def')),
-                          os.path.sep.join(('sub1', 'ssub1', 'ghi'))])
+    assert exp == sorted(map(os.path.abspath,
+                             ['abc', 'acb', os.path.sep.join(('sub1', 'def')),
+                              os.path.sep.join(('sub1', 'ssub1', 'ghi'))]))
 
 
 def test_filter_files():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,22 +194,24 @@ def test_expand_globs(testing_workdir):
         with open(f, 'w') as _f:
             _f.write('weee')
 
+    abspath_workdir = os.path.abspath(testing_workdir)
+
     # Test dirs
     exp = utils.expand_globs([os.path.join('sub1', 'ssub1')], testing_workdir)
-    assert sorted(exp) == sorted(map(os.path.abspath,
-                                     [os.path.sep.join(('sub1', 'ssub1', 'ghi')),
-                                      os.path.sep.join(('sub1', 'ssub1', 'abc'))]))
+    assert sorted(exp) == sorted(os.path.sep.join((abspath_workdir, p))
+                                 for p in [os.path.sep.join(('sub1', 'ssub1', 'ghi')),
+                                           os.path.sep.join(('sub1', 'ssub1', 'abc'))])
 
     # Test files
     exp = sorted(utils.expand_globs(['abc', files[2]], testing_workdir))
-    assert exp == sorted(map(os.path.abspath,
-                             ['abc', os.path.sep.join(('sub1', 'def'))]))
+    assert exp == sorted(os.path.sep.join((abspath_workdir, p))
+                         for p in ['abc', os.path.sep.join(('sub1', 'def'))])
 
     # Test globs
     exp = sorted(utils.expand_globs(['a*', '*/*f', '**/*i'], testing_workdir))
-    assert exp == sorted(map(os.path.abspath,
-                             ['abc', 'acb', os.path.sep.join(('sub1', 'def')),
-                              os.path.sep.join(('sub1', 'ssub1', 'ghi'))]))
+    assert exp == sorted(os.path.sep.join((abspath_workdir, p))
+                         for p in ['abc', 'acb', os.path.sep.join(('sub1', 'def')),
+                                   os.path.sep.join(('sub1', 'ssub1', 'ghi'))])
 
 
 def test_filter_files():


### PR DESCRIPTION
ref gh-2937

> So, it looks like we now get absolute paths from utils.expand_globs on Windows... Not sure if this causes any trouble, though.

> Yeah, that's an annoying inconsistency. I'll work on that. I don't know if it would cause trouble, but better to just make it consistent.

Not the nicest solution, but I'm just curious if the CI runs fine if we just `map(abspath, ...)` everything...