### PR TITLE
Convert empty git refs to 'HEAD' (Fixes #2992)

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -195,6 +195,9 @@ def git_mirror_checkout_recursive(git, mirror_dir, checkout_dir, git_url, git_ca
     git_mirror_dir = convert_path_for_cygwin_or_msys2(git, mirror_dir).rstrip('/')
     git_checkout_dir = convert_path_for_cygwin_or_msys2(git, checkout_dir).rstrip('/')
 
+    # Set default here to catch empty dicts
+    git_ref = git_ref or 'HEAD'
+
     mirror_dir = mirror_dir.rstrip('/')
     if not isdir(os.path.dirname(mirror_dir)):
         os.makedirs(os.path.dirname(mirror_dir))
@@ -291,7 +294,7 @@ def git_source(source_dict, git_cache, src_dir, recipe_path=None, verbose=True):
 
     git_url = source_dict['git_url']
     git_depth = int(source_dict.get('git_depth', -1))
-    git_ref = source_dict.get('git_rev', 'HEAD')
+    git_ref = source_dict.get('git_rev') or 'HEAD'
 
     if git_url.startswith('.'):
         # It's a relative path from the conda recipe


### PR DESCRIPTION
As discussed at #2992, if an empty `git_rev` line is included in a meta.yaml file, then conda-build may build from a stale git commit in the cache (rather than the cache being updated to the current HEAD).

This is because an empty line results in the Source_dict.git_rev key containing an empty dict, which does not get replaced with the default value ('HEAD') when returned with dict.get. Then that empty dict value causes `get_mirror_checkout_recursive` to skip the logic it has to update the local cache's HEAD (since it assumes any value other than 'HEAD' is a specific commit).

The two fixes here are currently redundant (either one would prevent the bug seen in #2992), but they both seem reasonable to me.

Thanks to @stuarteberg for suggestions.