### PR TITLE
set NPY_DISTUTILS_APPEND_FLAGS=1

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -322,6 +322,7 @@ def python_vars(metadata, prefix):
     np_ver = metadata.config.variant.get('numpy', get_default_variant(metadata.config)['numpy'])
     vars_['NPY_VER'] = '.'.join(np_ver.split('.')[:2])
     vars_['CONDA_NPY'] = ''.join(np_ver.split('.')[:2])
+    vars_['NPY_DISTUTILS_APPEND_FLAGS'] = '1'
     return vars_
 
 


### PR DESCRIPTION
numpy distutils would override LDFLAGS if it is set. conda-build and
anaconda compilers set LDFLAGS which means important flags like
-shared used when building a fortran extension is not there anymore
With new numpy versions, setting NPY_DISTUTILS_APPEND_FLAGS=1
appends LDFLAGS from the environment.

see https://github.com/numpy/numpy/pull/11525