### PR TITLE
Force text interpretation of CRAN DESCRIPTION files

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -122,7 +122,7 @@ export DISABLE_AUTOBREW=1
 
 # R refuses to build packages that mark themselves as Priority: Recommended
 mv DESCRIPTION DESCRIPTION.old
-grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+grep -va '^Priority: ' DESCRIPTION.old > DESCRIPTION
 $R CMD INSTALL --build .
 
 # Add more build steps here, if they are necessary.


### PR DESCRIPTION
Fixes #2805. 

If there are special characters in the DESCRIPTION file, then `grep -v ...` has undesirable behavior when applied to it. This tells grep to assume the file is text.