### PR TITLE
source: allow to omit fn with multiple urls

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -42,7 +42,10 @@ def download_to_cache(cache_folder, recipe_path, source_dict):
     if not isdir(cache_folder):
         os.makedirs(cache_folder)
 
-    unhashed_fn = fn = source_dict['fn'] if 'fn' in source_dict else basename(source_dict['url'])
+    source_urls = source_dict['url']
+    if not isinstance(source_urls, list):
+        source_urls = [source_urls]
+    unhashed_fn = fn = source_dict['fn'] if 'fn' in source_dict else basename(source_urls[0])
     hash_added = False
     for hash_type in ('md5', 'sha1', 'sha256'):
         if hash_type in source_dict:
@@ -58,10 +61,8 @@ def download_to_cache(cache_folder, recipe_path, source_dict):
         print('Found source in cache: %s' % fn)
     else:
         print('Downloading source to cache: %s' % fn)
-        if not isinstance(source_dict['url'], list):
-            source_dict['url'] = [source_dict['url']]
 
-        for url in source_dict['url']:
+        for url in source_urls:
             if "://" not in url:
                 if url.startswith('~'):
                     url = expanduser(url)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -11,6 +11,15 @@ from conda_build.utils import reset_deduplicator
 from .utils import thisdir
 
 
+def test_alternative_url_no_fn(testing_metadata):
+    testing_metadata.meta['source'] = {'url': [
+        os.path.join(thisdir, 'archives', 'a.tar.bz2'),
+        os.path.join(thisdir, 'archives', 'a.tar.bz2'),
+    ]}
+    source.provide(testing_metadata)
+    assert os.path.exists(os.path.join(testing_metadata.config.work_dir, 'a'))
+
+
 def test_multiple_url_sources(testing_metadata):
 
     testing_metadata.meta['source'] = [


### PR DESCRIPTION
Generally, `source/url` is allowed to be a list of alternative/backup URLs. Though if `source/fn` is omitted, `download_to_cache` assumes `source/url` to be a single URL (running `basename(source_dict['url']`).
This PR fixes that false assumption and simply tries to infer the filename by calling `basename` for the first URL in that list.