### PR TITLE
support multiple exclusive_config_files

### DIFF
--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -102,13 +102,13 @@ source to try fill in related template variables.",
         keys such as `c_compiler` and `target_platform` to form a build matrix."""
     )
     p.add_argument(
-        '-e', '--exclusive-config-file',
-        help="""Exclusive variant config file to add.  Compared with --variant-config-files,
-        you're allowed only one file here.  Providing a file here disables searching in your
-        home directory and in cwd.  The file specified here comes at the start of the order,
-        as opposed to the end with --variant-config-files.  Any config files in recipes and
-        any config files specified with --variant-config-files will override values from
-        this file."""
+        '-e', '--exclusive-config-files', '--exclusive-config-file',
+        action="append",
+        help="""Exclusive variant config files to add. Providing files here disables
+        searching in your home directory and in cwd.  The files specified here come at the
+        start of the order, as opposed to the end with --variant-config-files.  Any config
+        files in recipes and any config files specified with --variant-config-files will
+        override values from these files."""
     )
     p.add_argument(
         "--old-build-string", dest="filename_hashing", action="store_false",

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -119,9 +119,9 @@ DEFAULTS = [Setting('activate', True),
 
             # variants
             Setting('variant_config_files', []),
-            # this file precludes usage of any system-wide or cwd config files.  Config files in
-            #    recipes are still respected, and they override this file.
-            Setting('exclusive_config_file', None),
+            # these files preclude usage of any system-wide or cwd config files.
+            #    Config files in recipes are still respected, and they override this file.
+            Setting('exclusive_config_files', []),
             Setting('ignore_system_variants', False),
             Setting('hash_length', 7),
 
@@ -341,6 +341,23 @@ class Config(object):
     @target_subdir.setter
     def target_subdir(self, value):
         self._target_subdir = value
+
+    @property
+    def exclusive_config_file(self):
+        if self.exclusive_config_files:
+            return self.exclusive_config_files[0]
+        return None
+
+    @exclusive_config_file.setter
+    def exclusive_config_file(self, value):
+        if len(self.exclusive_config_files) > 1:
+            raise ValueError(
+                'Cannot set singular exclusive_config_file '
+                'if multiple exclusive_config_files are present.')
+        if value is None:
+            self.exclusive_config_files = []
+        else:
+            self.exclusive_config_files = [value]
 
     @property
     def src_cache_root(self):

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -54,7 +54,10 @@ SUBDIR_ALIASES = {
 
 
 Setting = namedtuple("ConfigSetting", "name, default")
-DEFAULTS = [Setting('activate', True),
+
+
+def _get_default_settings():
+    return [Setting('activate', True),
             Setting('anaconda_upload', binstar_upload),
             Setting('force_upload', True),
             Setting('channel_urls', []),
@@ -243,7 +246,7 @@ class Config(object):
             self._croot = getattr(self, '_croot', None)
 
         # handle known values better than unknown (allow defaults)
-        for value in DEFAULTS:
+        for value in _get_default_settings():
             self._set_attribute_from_kwargs(kwargs, value.name, value.default)
 
         # dangle remaining keyword arguments as attributes on this class

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -138,14 +138,16 @@ def validate_spec(spec):
 
 
 def find_config_files(metadata_or_path, additional_files=None, ignore_system_config=False,
-                      exclusive_config_file=None):
+                      exclusive_config_files=[]):
     """Find files to load variables from.  Note that order here determines clobbering.
 
     Later files clobber earlier ones.  order is user-wide < cwd < recipe dir < additional files"""
-    files = ([os.path.abspath(os.path.expanduser(exclusive_config_file))]
-             if exclusive_config_file else [])
+    files = [
+        os.path.abspath(os.path.expanduser(config_file))
+        for config_file in exclusive_config_files
+    ]
 
-    if not ignore_system_config and not exclusive_config_file:
+    if not ignore_system_config and not exclusive_config_files:
         if cc_conda_build.get('config_file'):
             system_path = abspath(expanduser(expandvars(cc_conda_build['config_file'])))
         else:
@@ -479,7 +481,7 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
         config = Config()
     files = find_config_files(recipedir_or_metadata, ensure_list(config.variant_config_files),
                               ignore_system_config=config.ignore_system_variants,
-                              exclusive_config_file=config.exclusive_config_file)
+                              exclusive_config_files=config.exclusive_config_files)
 
     specs = OrderedDict(internal_defaults=get_default_variant(config))
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -138,13 +138,13 @@ def validate_spec(spec):
 
 
 def find_config_files(metadata_or_path, additional_files=None, ignore_system_config=False,
-                      exclusive_config_files=[]):
+                      exclusive_config_files=None):
     """Find files to load variables from.  Note that order here determines clobbering.
 
     Later files clobber earlier ones.  order is user-wide < cwd < recipe dir < additional files"""
     files = [
         os.path.abspath(os.path.expanduser(config_file))
-        for config_file in exclusive_config_files
+        for config_file in (exclusive_config_files or [])
     ]
 
     if not ignore_system_config and not exclusive_config_files:

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -361,10 +361,10 @@ def test_exclusive_config_files(testing_workdir):
         yaml.dump({'abc': ['someval'], 'cwd': ['someval']}, f, default_flow_style=False)
     os.makedirs('config_dir')
     with open(os.path.join('config_dir', 'config-0.yaml'), 'w') as f:
-        yaml.dump({'abc': ['super-0'], 'exclusive-0': ['0'], 'exclusive-both': ['0']},
+        yaml.dump({'abc': ['super_0'], 'exclusive_0': ['0'], 'exclusive_both': ['0']},
                   f, default_flow_style=False)
     with open(os.path.join('config_dir', 'config-1.yaml'), 'w') as f:
-        yaml.dump({'abc': ['super-1'], 'exclusive-1': ['1'], 'exclusive-both': ['1']},
+        yaml.dump({'abc': ['super_1'], 'exclusive_1': ['1'], 'exclusive_both': ['1']},
                   f, default_flow_style=False)
     exclusive_config_files = (
         os.path.join('config_dir', 'config-0.yaml'),
@@ -376,10 +376,10 @@ def test_exclusive_config_files(testing_workdir):
     # is cwd ignored?
     assert 'cwd' not in variant
     # did we load the exclusive configs?
-    assert variant['exclusive-0'] == '0'
-    assert variant['exclusive-1'] == '1'
+    assert variant['exclusive_0'] == '0'
+    assert variant['exclusive_1'] == '1'
     # does later exclusive config override initial one?
-    assert variant['exclusive-both'] == '1'
+    assert variant['exclusive_both'] == '1'
     # does recipe config override exclusive?
     assert 'unique_to_recipe' in variant
     assert variant['abc'] == '123'

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -356,6 +356,35 @@ def test_numpy_used_variable_looping(testing_config):
     assert len(outputs) == 4
 
 
+def test_exclusive_config_files(testing_workdir):
+    with open('conda_build_config.yaml', 'w') as f:
+        yaml.dump({'abc': ['someval'], 'cwd': ['someval']}, f, default_flow_style=False)
+    os.makedirs('config_dir')
+    with open(os.path.join('config_dir', 'config-0.yaml'), 'w') as f:
+        yaml.dump({'abc': ['super-0'], 'exclusive-0': ['0'], 'exclusive-both': ['0']},
+                  f, default_flow_style=False)
+    with open(os.path.join('config_dir', 'config-1.yaml'), 'w') as f:
+        yaml.dump({'abc': ['super-1'], 'exclusive-1': ['1'], 'exclusive-both': ['1']},
+                  f, default_flow_style=False)
+    exclusive_config_files = (
+        os.path.join('config_dir', 'config-0.yaml'),
+        os.path.join('config_dir', 'config-1.yaml'),
+    )
+    output = api.render(os.path.join(recipe_dir, 'exclusive_config_file'),
+                        exclusive_config_files=exclusive_config_files)[0][0]
+    variant = output.config.variant
+    # is cwd ignored?
+    assert 'cwd' not in variant
+    # did we load the exclusive configs?
+    assert variant['exclusive-0'] == '0'
+    assert variant['exclusive-1'] == '1'
+    # does later exclusive config override initial one?
+    assert variant['exclusive-both'] == '1'
+    # does recipe config override exclusive?
+    assert 'unique_to_recipe' in variant
+    assert variant['abc'] == '123'
+
+
 def test_exclusive_config_file(testing_workdir):
     with open('conda_build_config.yaml', 'w') as f:
         yaml.dump({'abc': ['someval'], 'cwd': ['someval']}, f, default_flow_style=False)


### PR DESCRIPTION
@msarahan in https://gitter.im/conda/conda-build?at=5b0dc3d299fa7f4c062c0217:
>> Would you accept a PR to extend either the --exclusive-config-file CLI parameter or the conda_build: config_file .condarc parameter to accept multiple paths?
    The use case is Bioconda which is essentially a conda-forge downstream repository now. As such we want to use conda-forge-pinning's conda_build_config.yaml but also add our own on top of that. Using --variant-files won't work, due to the config file processing order, as soon as we would start to add per-recipe configuration files.
>
> Sure, I think that's fine. Just be really clear what the priority is. I think it would be most consistent to have later files have higher priority (this is backwards compared to channels in conda, but more consistent with the CLI behavior, and I hope consistent with the variant config files entry in condarc).

@mbargull in https://gitter.im/conda/conda-build?at=5b0dc77799fa7f4c062c1006:
>> I think it would be most consistent to have later files have higher priority
>
> Indeed, it would be `conda-build -e lower-prio-config.yaml -e higher-prio-config.yaml`


**EDIT: NB: not tested yet....**