### PR TITLE
Improvements to CRAN skeletons

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1101,8 +1101,9 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                 if need_make:
                     deps.append("{indent}{{{{posix}}}}make            {sel}".format(
                         indent=INDENT, sel=sel_src))
-                    deps.append("{indent}{{{{posix}}}}sed             {sel}".format(
-                        indent=INDENT, sel=sel_src_and_win))
+                    if not need_autotools:
+                        deps.append("{indent}{{{{posix}}}}sed             {sel}".format(
+                            indent=INDENT, sel=sel_src_and_win))
                     deps.append("{indent}{{{{posix}}}}coreutils       {sel}".format(
                         indent=INDENT, sel=sel_src_and_win))
                 deps.append("{indent}{{{{posix}}}}zip             {sel}".format(

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1097,12 +1097,16 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                         indent=INDENT, sel=sel_src))
                     deps.append("{indent}{{{{posix}}}}automake-wrapper{sel}".format(
                         indent=INDENT, sel=sel_src_and_win))
-                    deps.append("{indent}{{{{posix}}}}automake        {sel}".format(
-                        indent=INDENT, sel=sel_src_and_win))
                     deps.append("{indent}{{{{posix}}}}pkg-config".format(indent=INDENT))
                 if need_make:
                     deps.append("{indent}{{{{posix}}}}make            {sel}".format(
                         indent=INDENT, sel=sel_src))
+                    deps.append("{indent}{{{{posix}}}}sed             {sel}".format(
+                        indent=INDENT, sel=sel_src_and_win))
+                    deps.append("{indent}{{{{posix}}}}coreutils       {sel}".format(
+                        indent=INDENT, sel=sel_src_and_win))
+                deps.append("{indent}{{{{posix}}}}zip             {sel}".format(
+                    indent=INDENT, sel=sel_src_and_win))
             elif dep_type == 'run':
                 if need_c or need_cxx or need_f:
                     deps.append("{indent}{{{{native}}}}gcc-libs       {sel}".format(


### PR DESCRIPTION
Three changes:

- Add Windows-specific `sed` and `coreutils` build dependencies whenever `make` is added, because the Makefiles seem to require these. Otherwise I would get errors that `sed` and `basename` were missing.
- Remove the `automake` build dependency. We don't actually _have_ an automake package; instead, we have `automake-wrapper` (which is already included), and this in turn pulls in all the versions of `automake` that we have. I don't know why it's structured this way, but it is!
- Add `zip` as a build dependency on Windows. I've noted that the Windows build step requires `zip`. I think it's used just to build the binary package, which if I understand correctly we don't need. But seeing the error when it fails to run `zip` makes me uneasy. I'd rather either patch the Makefile or just let it succeed.

As an example, here are the build dependencies for `fgarch` after this is applied:
```
# Suggests: RUnit, tcltk
requirements:
  build:
    - {{ compiler('c') }}        # [not win]
    - {{ compiler('fortran') }}  # [not win]
    - {{native}}toolchain        # [win]
    - {{posix}}filesystem        # [win]
    - {{posix}}make
    - {{posix}}sed               # [win]
    - {{posix}}coreutils         # [win]
    - {{posix}}zip               # [win]
```