### PR TITLE
Bring back automake for CRAN on Unix

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1105,6 +1105,8 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                         indent=INDENT, sel=sel_src_and_win))
                     deps.append("{indent}{{{{posix}}}}autoconf        {sel}".format(
                         indent=INDENT, sel=sel_src))
+                    deps.append("{indent}{{{{posix}}}}automake        {sel}".format(
+                        indent=INDENT, sel=sel_src_not_win))
                     deps.append("{indent}{{{{posix}}}}automake-wrapper{sel}".format(
                         indent=INDENT, sel=sel_src_and_win))
                     deps.append("{indent}{{{{posix}}}}pkg-config".format(indent=INDENT))


### PR DESCRIPTION
Fixes what I broke in #3030:
```
requirements:
  build:
    - {{ compiler('c') }}        # [not win]
    - {{ compiler('fortran') }}  # [not win]
    - {{native}}toolchain        # [win]
    - {{posix}}filesystem        # [win]
    - {{posix}}sed               # [win]
    - {{posix}}grep              # [win]
    - {{posix}}autoconf
    - {{posix}}automake          # [not win]
    - {{posix}}automake-wrapper  # [win]
    - {{posix}}pkg-config
    - {{posix}}make
    - {{posix}}coreutils         # [win]
    - {{posix}}zip               # [win]
```