### PR TITLE
put local channel behind user-specified channels, for remote priority

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -71,14 +71,18 @@ def get_build_index(subdir, bldpkgs_dir, output_folder=None, clear_cache=False,
             log_context = partial(utils.LoggingContext, logging.CRITICAL + 1)
             capture = utils.capture
 
-        # priority: channels passed as args, local (can vary with either croot or output_folder),
+        # priority: (local as either croot or output_folder IF NOT EXPLICITLY IN CHANNEL ARGS),
+        #     then channels passed as args (if local in this, it remains in same order),
         #     then channels from condarc.
         urls = list(channel_urls)
 
         # this is where we add the "local" channel.  It's a little smarter than conda, because
         #     conda does not know about our output_folder when it is not the default setting.
         if os.path.isdir(output_folder):
-            urls.append(url_path(output_folder))
+            if 'local' not in urls:
+                urls.insert(0, url_path(output_folder))
+            # replace local with the appropriate real channel.  Order is maintained.
+            urls = [url if url != "local" else url_path(output_folder) for url in urls]
         _ensure_valid_channel(output_folder, subdir, verbose=verbose, locking=locking,
                               timeout=timeout)
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -62,8 +62,6 @@ def get_build_index(subdir, bldpkgs_dir, output_folder=None, clear_cache=False,
 
         log.debug("Building new index for subdir '{}' with channels {}, condarc channels "
                   "= {}".format(subdir, channel_urls, not omit_defaults))
-        # priority: local by croot (can vary), then channels passed as args,
-        #     then channels from config.
         capture = contextlib.contextmanager(lambda: (yield))
         if debug:
             log_context = partial(utils.LoggingContext, logging.DEBUG)
@@ -73,9 +71,14 @@ def get_build_index(subdir, bldpkgs_dir, output_folder=None, clear_cache=False,
             log_context = partial(utils.LoggingContext, logging.CRITICAL + 1)
             capture = utils.capture
 
+        # priority: channels passed as args, local (can vary with either croot or output_folder),
+        #     then channels from condarc.
         urls = list(channel_urls)
+
+        # this is where we add the "local" channel.  It's a little smarter than conda, because
+        #     conda does not know about our output_folder when it is not the default setting.
         if os.path.isdir(output_folder):
-            urls.insert(0, url_path(output_folder))
+            urls.append(url_path(output_folder))
         _ensure_valid_channel(output_folder, subdir, verbose=verbose, locking=locking,
                               timeout=timeout)
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -29,7 +29,7 @@ import filelock
 from .conda_interface import hashsum_file, md5_file, unix_path_to_win, win_path_to_unix
 from .conda_interface import PY3, iteritems
 from .conda_interface import root_dir, pkgs_dirs
-from .conda_interface import string_types, url_path, get_rc_urls
+from .conda_interface import string_types
 from .conda_interface import memoized
 from .conda_interface import StringIO
 from .conda_interface import VersionOrder, MatchSpec
@@ -1161,18 +1161,6 @@ def env_var(name, value, callback=None):
             del os.environ[name]
         if callback:
             callback()
-
-
-def collect_channels(config, is_host=False):
-    urls = [url_path(config.croot)] + get_rc_urls() + ['local', ]
-    if config.channel_urls:
-        urls.extend(config.channel_urls)
-    # defaults has a very limited set of repo urls.  Omit it from the URL list so
-    #     that it doesn't fail.
-    if config.is_cross and is_host:
-        urls.remove('defaults')
-        urls.remove('local')
-    return urls
 
 
 def trim_empty_keys(dict_):


### PR DESCRIPTION
fixes #3036 

Channels specified via --channel, -c on the CLI, or channel_urls (in the API) will take priority over locally built packages.  Locally built packages still take priority over anything configured in condarc.