### PR TITLE
Allow local channel to have the appropriate priority in test environments

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1729,14 +1729,6 @@ def _construct_metadata_for_test_from_package(package, config):
             log.info("Updating index at %s to make package installable with dependencies" % folder)
             update_index(folder)
 
-    # make an url out of the channel and add to channel list
-    local_channel_url = url_path(local_channel)
-
-    # channel_urls is an iterable, but we don't know if it's a tuple or list.  Don't know
-    #    how to add elements.
-    config.channel_urls = list(config.channel_urls)
-    config.channel_urls.append(local_channel_url)
-
     try:
         metadata = render_recipe(os.path.join(info_dir, 'recipe'), config=config,
                                         reset_build_id=False)[0][0]

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1735,7 +1735,7 @@ def _construct_metadata_for_test_from_package(package, config):
     # channel_urls is an iterable, but we don't know if it's a tuple or list.  Don't know
     #    how to add elements.
     config.channel_urls = list(config.channel_urls)
-    config.channel_urls.insert(0, local_channel_url)
+    config.channel_urls.append(local_channel_url)
 
     try:
         metadata = render_recipe(os.path.join(info_dir, 'recipe'), config=config,


### PR DESCRIPTION
@msarahan https://github.com/conda/conda-build/pull/3038 does *not* resolve https://github.com/conda/conda-build/issues/3036.  I've tested this change and it has the desired behavior:

```
If a user specifies "conda build -c mychannel -c local":
    conda will prioritize packages in mychannel over packages in the local conda-bld folder for the test environment
If a user specifies "conda build -c mychannel":
    conda will prioritize packages in the local conda-bld folder over packages in mychannel for the test environment
If a user specifies "conda build -c local -c mychannel":
    conda will prioritize packages in the local conda-bld folder over packages in mychannel for the test environment
```

Without this change, in all 3 cases conda will prioritize packages in the local conda-bld folder over packages in mychannel for the test environment

This change works because if 'local' is present (like in the first example), it stays in the order that it already is in the list, and if 'local' is not present (like in the second example) it gets add with top priority - as implemented by https://github.com/conda/conda-build/pull/3038/files. This is just the missing piece to have the expected behavior in the test phase in addition to the the build phase.