### PR TITLE
Configure `pip` to disable pulling in dependencies

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1399,6 +1399,10 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                     # hard-code this because we never want pip's build isolation
                     #    https://github.com/conda/conda-build/pull/2972#discussion_r198290241
                     env["PIP_NO_BUILD_ISOLATION"] = False
+                    # some other env vars to have pip ignore dependencies.
+                    # we supply them ourselves instead.
+                    env["PIP_NO_DEPENDENCIES"] = False
+                    env["PIP_IGNORE_INSTALLED"] = True
 
                     work_file = join(m.config.work_dir, 'conda_build.sh')
                     with open(work_file, 'w') as bf:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1403,6 +1403,8 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                     # we supply them ourselves instead.
                     env["PIP_NO_DEPENDENCIES"] = False
                     env["PIP_IGNORE_INSTALLED"] = True
+                    # disable use of pip's cache directory.
+                    env["PIP_NO_CACHE_DIR"] = False
 
                     work_file = join(m.config.work_dir, 'conda_build.sh')
                     with open(work_file, 'w') as bf:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1398,12 +1398,18 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
 
                     # hard-code this because we never want pip's build isolation
                     #    https://github.com/conda/conda-build/pull/2972#discussion_r198290241
+                    #
+                    # Note that pip env "NO" variables are inverted logic.
+                    #      PIP_NO_BUILD_ISOLATION=False means don't use build isolation.
+                    #
                     env["PIP_NO_BUILD_ISOLATION"] = False
                     # some other env vars to have pip ignore dependencies.
                     # we supply them ourselves instead.
+                    #    See note above about inverted logic on "NO" variables
                     env["PIP_NO_DEPENDENCIES"] = False
                     env["PIP_IGNORE_INSTALLED"] = True
                     # disable use of pip's cache directory.
+                    #    See note above about inverted logic on "NO" variables
                     env["PIP_NO_CACHE_DIR"] = False
 
                     work_file = join(m.config.work_dir, 'conda_build.sh')

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -265,12 +265,18 @@ def build(m, bld_bat, stats):
 
     # hard-code this because we never want pip's build isolation
     #    https://github.com/conda/conda-build/pull/2972#discussion_r198290241
+    #
+    # Note that pip env "NO" variables are inverted logic.
+    #      PIP_NO_BUILD_ISOLATION=False means don't use build isolation.
+    #
     env["PIP_NO_BUILD_ISOLATION"] = False
     # some other env vars to have pip ignore dependencies.
     # we supply them ourselves instead.
+    #    See note above about inverted logic on "NO" variables
     env["PIP_NO_DEPENDENCIES"] = False
     env["PIP_IGNORE_INSTALLED"] = True
     # disable use of pip's cache directory.
+    #    See note above about inverted logic on "NO" variables
     env["PIP_NO_CACHE_DIR"] = False
 
     # set variables like CONDA_PY in the test environment

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -270,6 +270,8 @@ def build(m, bld_bat, stats):
     # we supply them ourselves instead.
     env["PIP_NO_DEPENDENCIES"] = False
     env["PIP_IGNORE_INSTALLED"] = True
+    # disable use of pip's cache directory.
+    env["PIP_NO_CACHE_DIR"] = False
 
     # set variables like CONDA_PY in the test environment
     env.update(set_language_env_vars(m.config.variant))

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -266,6 +266,10 @@ def build(m, bld_bat, stats):
     # hard-code this because we never want pip's build isolation
     #    https://github.com/conda/conda-build/pull/2972#discussion_r198290241
     env["PIP_NO_BUILD_ISOLATION"] = False
+    # some other env vars to have pip ignore dependencies.
+    # we supply them ourselves instead.
+    env["PIP_NO_DEPENDENCIES"] = False
+    env["PIP_IGNORE_INSTALLED"] = True
 
     # set variables like CONDA_PY in the test environment
     env.update(set_language_env_vars(m.config.variant))


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/2748

We never want `pip` to install dependencies in the build as we will supply them ourselves.