### PR TITLE
allow whitelisting runpath entries

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -481,6 +481,7 @@ def check_overlinking(m, files):
                      '/System/Library/Frameworks/SystemConfiguration.framework/*',
                      '/System/Library/Frameworks/WebKit.framework/*']
     whitelist += m.meta.get('build', {}).get('missing_dso_whitelist') or []
+    runpath_whitelist = m.meta.get('build', {}).get('runpath_whitelist') or []
     for f in files:
         path = os.path.join(m.config.host_prefix, f)
         if not codefile_type(path):
@@ -495,7 +496,8 @@ def check_overlinking(m, files):
         except:
             print_msg(errors, '{}: pyldd.py failed to process'.format(warn_prelude))
             continue
-        if len(runpaths):
+        if runpaths and not (runpath_whitelist or
+                             any(fnmatch.fnmatch(f, w) for w in runpath_whitelist)):
             print_msg(errors, '{}: runpaths {} found in {}'.format(msg_prelude,
                                                                    runpaths,
                                                                    path))


### PR DESCRIPTION
GCC is currently failing to build because of

```
ERROR (gcc_impl_linux-64,x86_64-conda_cos6-linux-gnu/sysroot/lib/librt-2.12.2.so): runpaths ['$ORIGIN/../../../lib/'] found in /opt/conda/conda-bld/compilers_linux-64_1533843820745/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/x86_64-conda_cos6-linux-gnu/sysroot/lib/librt-2.12.2.so
```

@mingwandroid is very hesitant to monkey with any of this stuff, as GCC handles it own relocatability stuff.  This PR allows us to whitelist runpath stuff and avoid this error.