### PR TITLE
allow looping over compiler_version matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       conda install -q futures scandir;
     fi
-  - conda update -q --all
   - if [ "$CONDA_VERSION" = "4.3.x" ]; then
         rm -rf /opt/conda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda;
         rm -rf /opt/conda/lib/python$TRAVIS_PYTHON_VERSION/site-packages/conda*.egg-info;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
     else
         git clone -b $CONDA_VERSION --single-branch --depth 1000 https://github.com/conda/conda.git;
         pushd conda;
-        python -m conda init --dev;
+        /opt/conda/bin/python -m conda init --dev;
         hash -r;
         conda info;
         popd;

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -970,9 +970,9 @@ def package_has_file(package_path, file_path):
                     return False
                 except OSError as e:
                     raise RuntimeError("Could not extract %s (%s)" % (package_path, e))
-    except tarfile.ReadError:
-        raise RuntimeError("Could not extract metadata from %s. "
-                            "File probably corrupt." % package_path)
+    except (tarfile.ReadError, IOError, EOFError):
+        raise RuntimeError("Could not extract metadata from %s. File probably corrupt.  "
+                           "Please manually remove this file and try again." % package_path)
 
 
 def ensure_list(arg):

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -538,7 +538,7 @@ def find_used_variables_in_text(variant, recipe_text, selectors=False):
     recipe_lines = recipe_text.splitlines()
     for v in variant:
         all_res = []
-        compiler_match = re.match(r'(.*?)_compiler$', v)
+        compiler_match = re.match(r'(.*?)_compiler(_version)?$', v)
         if compiler_match and not selectors:
             compiler_lang = compiler_match.group(1)
             compiler_regex = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 180
 ignore = E122,E123,E126,E127,E128,E731,E722
 exclude = build,conda_build/_version.py,tests,conda.recipe,.git,versioneer.py,conda,relative,benchmarks,.asv,docs
 


### PR DESCRIPTION
This also has the important effect of capturing any ```*_compiler_version``` config stuff in the used variables, and thus in the hash.