### PR TITLE
Fix --check for optionally iterable fields

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,9 @@
+import os
+
+from conda_build import api
+from .utils import metadata_dir
+
+
+def test_check_multiple_sources():
+    recipe = os.path.join(metadata_dir, 'multiple_sources')
+    assert api.check(recipe)


### PR DESCRIPTION
`source` and `outputs` can contain a list of dictionaries, in which case checking would fail.

I couldn't exactly figure out where to put the regression test, so I created a new file for it.

Closes #3096.