### PR TITLE
Fix fix_shebang

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -52,7 +52,8 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
 
     bytes_ = False
 
-    with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
+    os.chmod(path, 0o775)
+    with io.open(path, mode='r+', encoding=locale.getpreferredencoding()) as fi:
         try:
             data = fi.read(100)
             fi.seek(0)
@@ -98,7 +99,6 @@ def fix_shebang(f, prefix, build_python, osx_is_app=False):
             fo.write(new_data)
         except TypeError:
             fo.write(new_data.decode())
-    os.chmod(path, 0o775)
 
 
 def write_pth(egg_path, config):

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1452,8 +1452,8 @@ def mmap_mmap(fileno, length, tagname=None, flags=0, prot=mmap_PROT_READ | mmap_
     Hides the differences between mmap.mmap on Windows and Unix.
     Windows has `tagname`.
     Unix does not, but makes up for it with `flags` and `prot`.
-    On both, the defaule value for `access` is determined from how the file
-    was opened so must not be passed in at all to get this default behaviour
+    On both, the default value for `access` is determined from how the file
+    was opened so must not be passed in at all to get this default behaviour.
     '''
     if on_win:
         if access:

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -50,6 +50,16 @@ def test_postbuild_files_raise(testing_metadata, testing_workdir):
         assert f in str(exc)
 
 
+@pytest.mark.skipif(on_win, reason="fix_shebang is not executed on win32")
+def test_fix_shebang(testing_config):
+    fname = 'test1'
+    with open(fname, 'w') as f:
+        f.write("\n")
+    os.chmod(fname, 0o000)
+    post.fix_shebang(fname, '.', '/test/python')
+    assert os.stat(fname).st_mode == 33277  # file with permissions 0o775
+
+
 def test_postlink_script_in_output_explicit(testing_config):
     recipe = os.path.join(metadata_dir, '_post_link_in_output')
     pkg = api.build(recipe, config=testing_config, notest=True)[0]


### PR DESCRIPTION
Move the permission fix before opening the file. Fix #2824

Fix the following traceback ( from https://circleci.com/gh/bioconda/bioconda-recipes/24304 ), which affects macOS builds of some Bioconda Perl packages:

```
Traceback (most recent call last):
  File "/Users/distiller/project/miniconda/bin/conda-build", line 11, in <module>
    sys.exit(main())
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 424, in main
    execute(sys.argv[1:])
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 415, in execute
    verify=args.verify)
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/api.py", line 200, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/build.py", line 2206, in build_tree
    notest=notest,
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/build.py", line 1600, in build
    built_package = bundlers[output_d.get('type', 'conda')](output_d, m, env, stats)
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/build.py", line 945, in bundle_conda
    files = post_process_files(metadata, initial_files)
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/build.py", line 807, in post_process_files
    post_build(m, new_files, build_python=python)
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/post.py", line 646, in post_build
    osx_is_app=osx_is_app)
  File "/Users/distiller/project/miniconda/lib/python3.6/site-packages/conda_build/post.py", line 55, in fix_shebang
    with io.open(path, encoding=locale.getpreferredencoding(), mode='r+') as fi:
PermissionError: [Errno 13] Permission denied: '/Users/distiller/project/miniconda/conda-bld/perl-xml-entities_1535224805006/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/download-entities.pl'
```

Also add:
- a test that fails without the patch
- a small unrelated typo fix.