### PR TITLE
tell pip to not go find things on PyPI (turn off downloading), simila…

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1867,6 +1867,10 @@ def write_build_scripts(m, script, build_file):
     # set PIP_CACHE_DIR to a path in the work dir that does not exist.
     env['PIP_CACHE_DIR'] = m.config.pip_cache_dir
 
+    # tell pip to not get anything from PyPI, please.  We have everything we need
+    # locally, and if we don't, it's a problem.
+    env["PIP_NO_INDEX"] = True
+
     work_file = join(m.config.work_dir, 'conda_build.sh')
     env_file = join(m.config.work_dir, 'build_env_setup.sh')
     with open(env_file, 'w') as bf:

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -314,6 +314,10 @@ def build(m, bld_bat, stats, provision_only=False):
     # set PIP_CACHE_DIR to a path in the work dir that does not exist.
     env['PIP_CACHE_DIR'] = m.config.pip_cache_dir
 
+    # tell pip to not get anything from PyPI, please.  We have everything we need
+    # locally, and if we don't, it's a problem.
+    env["PIP_NO_INDEX"] = True
+
     # set variables like CONDA_PY in the test environment
     env.update(set_language_env_vars(m.config.variant))
 


### PR DESCRIPTION
…r to our setuptools monkeypatch

NOTE: right now, this is a bad idea, due to #3094.  Many packages erroneously think that a given thing is not installed.  This PR is a good idea in the long run, but we should probably wait to deploy it for a while, until the dust has settled from #3094 