### PR TITLE
use recipe_log.json instead of .txt; plumb info from commits there in…

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -369,7 +369,8 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
-                 subdir=None, threads=None, patch_generator=None, verbose=False, progress=False, **kwargs):
+                 subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
+                 hotfix_source_repo=None, **kwargs):
     from locale import getpreferredencoding
     import os
     from .conda_interface import PY3
@@ -385,4 +386,5 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
                                 threads=threads, verbose=verbose, progress=progress)
         else:
             update_index(path, check_md5=check_md5, channel_name=channel_name,
-                         patch_generator=patch_generator, threads=threads, verbose=verbose, progress=progress)
+                         patch_generator=patch_generator, threads=threads, verbose=verbose, progress=progress,
+                         hotfix_source_repo=hotfix_source_repo)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -361,14 +361,14 @@ def copy_license(m):
 def copy_recipe_log(m):
     # the purpose of this file is to capture some change history metadata that may tell people
     #    why a given build was changed the way that it was
-    log_file = m.get_value('about/recipe_log_file') or "recipe_log.txt"
+    log_file = m.get_value('about/recipe_log_file') or "recipe_log.json"
     # look in recipe folder first
     src_file = os.path.join(m.path, log_file)
     if not os.path.isfile(src_file):
         src_file = join(m.config.work_dir, log_file)
     if os.path.isfile(src_file):
         utils.copy_into(src_file,
-                        join(m.config.info_dir, 'recipe_log.txt'), m.config.timeout,
+                        join(m.config.info_dir, 'recipe_log.json'), m.config.timeout,
                         locking=m.config.locking)
 
 

--- a/conda_build/cli/main_index.py
+++ b/conda_build/cli/main_index.py
@@ -50,6 +50,10 @@ def parse_args(args):
         help="Path to Python file that outputs metadata patch instructions"
     )
     p.add_argument(
+        "--hotfix-source-repo",
+        help="URL of git repo that hosts your metadata patch instructions"
+    )
+    p.add_argument(
         "--verbose", help="show extra debugging info", action="store_true"
     )
     p.add_argument(
@@ -64,7 +68,7 @@ def execute(args):
     _, args = parse_args(args)
     api.update_index(args.dir, check_md5=args.check_md5, channel_name=args.channel_name,
                      threads=args.threads, subdir=args.subdir, patch_generator=args.patch_generator,
-                     verbose=args.verbose, progress=args.progress)
+                     verbose=args.verbose, progress=args.progress, hotfix_source_repo=args.hotfix_source_repo)
 
 
 def main():

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -226,7 +226,7 @@ def _read_specs_from_package(pkg_loc, pkg_dist):
         specs_json = utils.package_has_file(pkg_loc, 'info/run_exports.json')
         if hasattr(specs_json, "decode"):
             specs_json = specs_json.decode("utf-8")
-        
+
         if specs_json:
             specs = json.loads(specs_json)
         elif specs_yaml:

--- a/conda_build/templates/rss.xml.j2
+++ b/conda_build/templates/rss.xml.j2
@@ -8,11 +8,19 @@
     <language>en</language>
     <copyright>Copyright {{ current_time | strftime("%Y") }}, Anaconda, Inc.</copyright>
     <pubDate>{{ current_time | strftime("%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
-{% for name in package_order %}
+{% for name, commits_dict in commit_info.items() %}
     <item>
-      <title>{{ name }} {{ channeldata_packages[name].version }}</title>
-      <pubDate>{{ package_mtimes[name] | strftime("%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+      <title>{{ name }}</title>
+      <pubDate>{{ commits_dict['commits'][0]['timestamp'] | strftime("%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+      {% if "recipe_origin" in commits_dict and commits_dict['recipe_origin'] %}
+      <link>{{ commits_dict['recipe_origin'] }}</link>
+      <description>
+      {% for commit in commits_dict['commits'] %}
+        - {{ commit['hash'] }} ({{ commit['timestamp'] | strftime("%a, %d %b %Y %H:%M:%S %z") }}): {{ commit['description'] }}
+      {% endfor %}
+      </description>
+      {% endif %}
     </item>
-{%- endfor %}
+{% endfor %}
   </channel>
 </rss>

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1260,7 +1260,7 @@ def filter_info_files(files_list, prefix):
                     'info[\\\\/]run_exports.json',   # current
                     'info[\\\\/]git',
                     'info[\\\\/]recipe[\\\\/].*',
-                    'info[\\\\/]recipe_log.txt',
+                    'info[\\\\/]recipe_log.json',
                     'info[\\\\/]recipe.tar',
                     'info[\\\\/]test[\\\\/].*',
                     'info[\\\\/]LICENSE.txt',

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -118,5 +118,6 @@ def test_api_create_metapackage():
 
 def test_api_update_index():
     argspec = getargspec(api.update_index)
-    assert argspec.args == ['dir_paths', 'config', 'force', 'check_md5', 'remove', 'channel_name', 'subdir', 'threads', 'patch_generator', "verbose", "progress"]
-    assert argspec.defaults == (None, False, False, False, None, None, None, None, False, False)
+    assert argspec.args == ['dir_paths', 'config', 'force', 'check_md5', 'remove', 'channel_name', 'subdir',
+                            'threads', 'patch_generator', "verbose", "progress", "hotfix_source_repo"]
+    assert argspec.defaults == (None, False, False, False, None, None, None, None, False, False, None)


### PR DESCRIPTION
…to rss

This produces RSS feeds derived from user-set recipe info.  These recipe_log.json files are expected to contain:

```
{
  "recipe_origin": "your_git_url",
  "commits": [
     {"hash": _hash, "timestamp": _time,
      "author": _author, "description": _desc},
  ]
```

For Anaconda, we get this info from our build system at the time that a recipe is submitted:  https://github.com/conda/conda-concourse-ci/pull/102/files#diff-37ad8af277b4d4d1ca1c8474e11ad811R367

The automated index process produces RSS feeds like:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE rss PUBLIC "-//Netscape Communications//DTD RSS 0.91//EN" "http://www.rssboard.org/rss-0.91.dtd">
<rss version="0.91">
  <channel>
    <title>conda-bld updates</title>
    <link>https://anaconda.org</link>
    <description>Updates in the last two weeks</description>
    <language>en</language>
    <copyright>Copyright 2018, Anaconda, Inc.</copyright>
    <pubDate>Wed, 12 Sep 2018 19:23:37 +0000</pubDate>
    <item>
      <title>conda-build (3.14.4)</title>
      <pubDate>Wed, 12 Sep 2018 19:02:47 +0000</pubDate>
      <link>git@github.com:AnacondaRecipes/conda-build-feedstock.git</link>
      <description>
        - '6c7ccc5 (Wed, 12 Sep 2018 19:02:47 +0000): blah'
        - '2604285 (Tue, 11 Sep 2018 17:44:35 +0000): 3.14.4'
        - '7852b80 (Tue, 11 Sep 2018 17:02:01 +0000): 3.14.3; add tqdm dep'
        - '1db403a (Fri, 07 Sep 2018 22:09:46 +0000): 3.14.2'
        - '0669763 (Thu, 06 Sep 2018 18:07:31 +0000): 3.14.1'
        - '96bf75f (Wed, 05 Sep 2018 00:09:59 +0000): 3.14.0'
      </description>
    </item>
  </channel>
</rss>
```