### PR TITLE
decode to str before passing to json

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -663,6 +663,8 @@ def _cache_about_json(tf, tar_path, about_cache_path):
 def _cache_run_exports(tf, tar_path, run_exports_cache_path):
     try:
         binary_run_exports = tf.extractfile('info/run_exports.json')
+        if hasattr(binary_run_exports, "decode"):
+            binary_run_exports = binary_run_exports.decode("utf-8")
         run_exports = json.load(binary_run_exports)
     except KeyError:
         try:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -224,6 +224,9 @@ def _read_specs_from_package(pkg_loc, pkg_dist):
         # switching to json for consistency in conda-build 4
         specs_yaml = utils.package_has_file(pkg_loc, 'info/run_exports.yaml')
         specs_json = utils.package_has_file(pkg_loc, 'info/run_exports.json')
+        if hasattr(specs_json, "decode"):
+            specs_json = specs_json.decode("utf-8")
+        
         if specs_json:
             specs = json.loads(specs_json)
         elif specs_yaml:


### PR DESCRIPTION
This tries to fix #3119

I noticed that once json.load - and the other time json.loads is called.. I thought the first is to be called with a file descriptor? .. if so, why do we get the "need str not byte" error?