### PR TITLE
skip elf section not in process memory image

### DIFF
--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -897,6 +897,10 @@ class elffile(UnixExecutable):
         'Can be called immediately after the elfsections have been constructed'
         for es in self.elfsections:
             if addr >= es.sh_addr and addr < es.sh_addr + es.sh_size:
+                # sections which do not appear in the memory image of the
+                # process should be skipped
+                if es.sh_addr == 0:
+                    continue
                 return es, addr - es.sh_addr
         return None, None
 


### PR DESCRIPTION
Do not return elf sections which are not included in the memory image of the
process. These include string tables which are only needed for debugging.

closes #3126