### PR TITLE
Add --variant interface to the commandline

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -29,6 +29,14 @@ on_win = (sys.platform == 'win32')
 
 logging.basicConfig(level=logging.INFO)
 
+# see: https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
+class StoreDictKeyPair(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        my_dict = {}
+        for kv in values.split(","):
+            k, v = kv.split("=")
+            my_dict[k] = v
+        setattr(namespace, self.dest, my_dict)
 
 def parse_args(args):
     p = get_render_parser()
@@ -323,6 +331,10 @@ different sets of packages."""
                    help=('Extra dependencies to add to all environment creation steps.  This '
                          'is only enabled for testing with the -t or --test flag.  Change '
                          'meta.yaml or use templates otherwise.'), )
+
+    p.add_argument('--variant',
+                   action=StoreDictKeyPair,
+                   help='Variants to extend the build matrix', )
 
     add_parser_channels(p)
 


### PR DESCRIPTION
This PR tries to solve #3128, it adds the following commandline interface:

`conda-build recipe --variant target_platform=linux-aarch64,c_compiler_version=7.2.0`

This allows for easier build scripts, because otherwise we'd need to store this information in files and call conda-build with a path to these files...

The name `--variant` was chosen, because its already present in the `Config` class. To have minimal change, I chose to re-use it. Besides that, I would prefer `--variants` (plural) because it reflects better what it is. What do you think @msarahan ?

Only limitation is, that i can only hold values of 1 hierarchy level, but I think thats sufficient for now..