### PR TITLE
split-packages: handle empty build section in output

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1858,6 +1858,8 @@ class MetaData(object):
             #    It clobbers everything else, aside from build number
             if 'build' in output:
                 build = output['build']
+                if build is None:
+                    build = {}
                 if 'number' not in build:
                     build['number'] = output.get('number', output_metadata.build_number())
             output_metadata.meta['build'] = build

--- a/tests/test-recipes/split-packages/_inherit_build_number/conda_build_config.yaml
+++ b/tests/test-recipes/split-packages/_inherit_build_number/conda_build_config.yaml
@@ -1,0 +1,3 @@
+maybe:
+  - True
+  - False

--- a/tests/test-recipes/split-packages/_inherit_build_number/meta.yaml
+++ b/tests/test-recipes/split-packages/_inherit_build_number/meta.yaml
@@ -14,3 +14,8 @@ outputs:
     build:
       missing_dso_whitelist:
         - '*'
+  - name: inherit_build_number_empty_build
+    build:
+  - name: inherit_build_number_empty_build_selector
+    build:
+      skip: True  # [maybe]


### PR DESCRIPTION
xref: https://github.com/conda-forge/cryptominisat-feedstock/pull/11#discussion_r221037068