### PR TITLE
Change default build timeout to 900

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -72,7 +72,7 @@ def _get_default_settings():
             Setting('verbose', True),
 
             Setting('debug', False),
-            Setting('timeout', 90),
+            Setting('timeout', 900),
             Setting('set_build_id', True),
             Setting('disable_pip', False),
             Setting('_output_folder', None),

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -706,7 +706,7 @@ last_index_ts = 0
 
 def get_install_actions(prefix, specs, env, retries=0, subdir=None,
                         verbose=True, debug=False, locking=True,
-                        bldpkgs_dirs=None, timeout=90, disable_pip=False,
+                        bldpkgs_dirs=None, timeout=900, disable_pip=False,
                         max_env_retry=3, output_folder=None, channel_urls=None):
     global cached_actions
     global last_index_ts

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -856,7 +856,7 @@ class ChannelIndex(object):
                 self.subdirs = subdirs = sorted(set(self._subdirs) | {'noarch'})
 
             # Step 1. Lock local channel.
-            with utils.try_acquire_locks([utils.get_lock(self.channel_root)], timeout=90):
+            with utils.try_acquire_locks([utils.get_lock(self.channel_root)], timeout=900):
                 # Step 2. Collect repodata from packages.
                 repodata_from_packages = {}
                 with tqdm(total=len(subdirs), disable=(verbose or not progress)) as t:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -129,7 +129,7 @@ def hoist_single_extracted_folder(nested_folder):
 
 
 def unpack(source_dict, src_dir, cache_folder, recipe_path, croot, verbose=False,
-           timeout=90, locking=True):
+           timeout=900, locking=True):
     ''' Uncompress a downloaded source. '''
     src_path, unhashed_fn = download_to_cache(cache_folder, recipe_path, source_dict)
 
@@ -405,7 +405,7 @@ def hg_source(source_dict, src_dir, hg_cache, verbose):
     return src_dir
 
 
-def svn_source(source_dict, src_dir, svn_cache, verbose=True, timeout=90, locking=True):
+def svn_source(source_dict, src_dir, svn_cache, verbose=True, timeout=900, locking=True):
     ''' Download a source from SVN repo. '''
     if verbose:
         stdout = None

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -444,7 +444,7 @@ def get_prefix_replacement_paths(src, dst):
     return os.path.join(*ssplit), os.path.join(*dsplit)
 
 
-def copy_into(src, dst, timeout=90, symlinks=False, lock=None, locking=True, clobber=False):
+def copy_into(src, dst, timeout=900, symlinks=False, lock=None, locking=True, clobber=False):
     """Copy all the files and directories in src to the directory dst"""
     log = get_logger(__name__)
     if symlinks and islink(src):
@@ -543,7 +543,7 @@ def copytree(src, dst, symlinks=False, ignore=None, dry_run=False):
     return dst_lst
 
 
-def merge_tree(src, dst, symlinks=False, timeout=90, lock=None, locking=True, clobber=False):
+def merge_tree(src, dst, symlinks=False, timeout=900, lock=None, locking=True, clobber=False):
     """
     Merge src into dst recursively by copying all files from src into dst.
     Return a list of all files copied.
@@ -581,7 +581,7 @@ _lock_folders = (os.path.join(root_dir, 'locks'),
                  os.path.expanduser(os.path.join('~', '.conda_build_locks')))
 
 
-def get_lock(folder, timeout=90):
+def get_lock(folder, timeout=900):
     fl = None
     try:
         location = os.path.abspath(os.path.normpath(folder))
@@ -613,7 +613,7 @@ def get_lock(folder, timeout=90):
     return fl
 
 
-def get_conda_operation_locks(locking=True, bldpkgs_dirs=None, timeout=90):
+def get_conda_operation_locks(locking=True, bldpkgs_dirs=None, timeout=900):
     locks = []
     bldpkgs_dirs = ensure_list(bldpkgs_dirs)
     # locks enabled by default
@@ -950,7 +950,7 @@ def get_skip_message(m):
 def package_has_file(package_path, file_path):
     try:
         locks = get_conda_operation_locks()
-        with try_acquire_locks(locks, timeout=90):
+        with try_acquire_locks(locks, timeout=900):
             with tarfile.open(package_path) as t:
                 try:
                     # internal paths are always forward slashed on all platforms


### PR DESCRIPTION
With a timeout of 90 seconds, we consistently get failures when performing multiple builds in parallel.

@msarahan I see that this setting is defined in config.py, but for the life of me I cannot figure out how to change this setting at runtime. There doesn't appear to be a corresponding condarc entry, nor a flag I can pass to conda build. Please let me know if I'm missing something. In the meantime, increasing the default timeout seems like a reasonable approach if this value cannot be easily changed at runtime.