### PR TITLE
bugfix: append activation to the wheel script

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1099,7 +1099,7 @@ def bundle_wheel(output, metadata, env, stats):
             f.write('\n')
             f.write('pip wheel --wheel-dir {} --no-deps .'.format(tmpdir))
             f.write('\n')
-        if metadata.activate_build_script:
+        if metadata.config.activate:
             _write_activation_text(dest_file, metadata)
 
         # run the appropriate script


### PR DESCRIPTION
Wheel creation as an output was not appending the environment activation to the wheel_output script. It looks like the metadata reference for the activation config was wrong. This PR fixed it for us internally. It now matches the reference in the bundle_conda method, line 867.