### PR TITLE
index.py: import PermissionError from utils

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -40,7 +40,7 @@ import libarchive
 from . import conda_interface, utils
 from .conda_interface import MatchSpec, VersionOrder, human_bytes
 from .conda_interface import CondaHTTPError, get_index, url_path
-from .utils import glob, get_logger, FileNotFoundError
+from .utils import glob, get_logger, FileNotFoundError, PermissionError
 
 try:
     from conda.base.constants import CONDA_TARBALL_EXTENSIONS


### PR DESCRIPTION
As this exception is not defined on python 2.7.

Fixes the following error when running `conda skeleton pypi`:

```
Traceback (most recent call last):
  File "/dls_sw/apps/python/anaconda/1.7.0/64/bin/conda-skeleton", line 11, in <module>
    sys.exit(main())
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/cli/main_skeleton.py", line 65, in main
    return execute(sys.argv[1:])
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/cli/main_skeleton.py", line 61, in execute
    version=args.version, config=config)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/api.py", line 282, in skeletonize
    recursive=recursive, config=config, **kwargs)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/skeletons/pypi.py", line 290, in skeletonize
    setup_options=setup_options)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/skeletons/pypi.py", line 698, in get_package_metadata
    config=config)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/skeletons/pypi.py", line 996, in get_pkginfo
    setup_options=setup_options)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/skeletons/pypi.py", line 1033, in run_setuppy
    subdir=config.host_subdir, clear_cache=False, config=config)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/environ.py", line 839, in create_env
    channel_urls=tuple(config.channel_urls))
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/environ.py", line 734, in get_install_actions
    locking=locking, timeout=timeout)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/index.py", line 210, in get_build_index
    update_index(output_folder, verbose=debug)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/index.py", line 272, in update_index
    hotfix_source_repo=hotfix_source_repo)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/index.py", line 880, in index
    self._write_repodata(subdir, patched_repodata[subdir])
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/index.py", line 1189, in _write_repodata
    _maybe_write(repodata_bz2_path, bz2_content, content_is_binary=True)
  File "/dls_sw/apps/python/anaconda/1.7.0/64/lib/python2.7/site-packages/conda_build/index.py", line 414, in _maybe_write
    except PermissionError:
NameError: global name 'PermissionError' is not defined

```