### PR TITLE
about.json additions to support new channeldata.json index

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -577,6 +577,9 @@ def write_about_json(m):
         d['root_pkgs'] = env.package_specs()
         # Include the extra section of the metadata in the about.json
         d['extra'] = m.get_section('extra')
+        d['tags'] = m.get_section('tags')
+        d['keywords'] = m.get_section('keywords')
+        d['identifiers'] = m.get_section('identifiers')
         json.dump(d, fo, indent=2, sort_keys=True)
 
 

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -577,9 +577,9 @@ def write_about_json(m):
         d['root_pkgs'] = env.package_specs()
         # Include the extra section of the metadata in the about.json
         d['extra'] = m.get_section('extra')
-        d['tags'] = m.get_section('tags')
-        d['keywords'] = m.get_section('keywords')
-        d['identifiers'] = m.get_section('identifiers')
+        d['tags'] = list(m.get_section('tags'))
+        d['keywords'] = list(m.get_section('keywords'))
+        d['identifiers'] = list(m.get_section('identifiers'))
         json.dump(d, fo, indent=2, sort_keys=True)
 
 


### PR DESCRIPTION
Add "tags", "identifiers", and "keywords" to about.json to support the new index for channeldata.json(https://github.com/conda/conda-build/pull/3091) 

@msarahan, this is to support the https://github.com/conda/conda/issues/7583 issue, and the recent index rewrite https://github.com/conda/conda-build/pull/309. 