### PR TITLE
avoid discarding build string during pin_run_as_build and ensure_valid_spec

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -428,7 +428,12 @@ def _simplify_to_exact_constraints(metadata):
 
         deps_list = []
         for name, values in deps_dict.items():
-            exact_pins = [dep for dep in values if len(dep) > 1]
+            exact_pins = []
+            for dep in values:
+                if len(dep) > 1:
+                    version, build = dep[:2]
+                    if not (any(c in version for c in ('>', '<', '*')) or '*' in build):
+                        exact_pins.append(dep)
             if len(values) == 1 and not any(values):
                 deps_list.append(name)
             elif exact_pins:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -160,7 +160,11 @@ def strip_channel(spec_str):
 
 
 def get_pin_from_build(m, dep, build_dep_versions):
-    dep_name = dep.split()[0]
+    dep_split = dep.split()
+    dep_name = dep_split[0]
+    build = ''
+    if len(dep_split) >= 3:
+        build = dep_split[2]
     pin = None
     version = build_dep_versions.get(dep_name) or m.config.variant.get(dep_name)
     if (version and dep_name in m.config.variant.get('pin_run_as_build', {}) and
@@ -176,7 +180,7 @@ def get_pin_from_build(m, dep, build_dep_versions):
             raise ValueError("numpy x.x specified, but numpy not in build requirements.")
         pin = utils.apply_pin_expressions(version.split()[0], min_pin='x.x', max_pin='x.x')
     if pin:
-        dep = " ".join((dep_name, pin))
+        dep = " ".join((dep_name, pin, build)).strip()
     return dep
 
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1578,7 +1578,7 @@ spec_ver_needing_star_re = re.compile("^([0-9a-zA-Z\.]+)$")
 
 def ensure_valid_spec(spec, warn=False):
     if isinstance(spec, MatchSpec):
-        if (hasattr(spec, 'version') and spec.version and (not hasattr(spec, 'build') or spec.build) and
+        if (hasattr(spec, 'version') and spec.version and (not spec.get('build', '')) and
                 spec_ver_needing_star_re.match(str(spec.version))):
             if str(spec.name) not in ('python', 'numpy') or str(spec.version) != 'x.x':
                 spec = MatchSpec("{} {}".format(str(spec.name), str(spec.version) + '.*'))

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -26,3 +26,16 @@ def test_reduce_duplicate_specs(testing_metadata):
     simplified_deps = testing_metadata.meta['requirements']
     assert len(simplified_deps['build']) == 1
     assert 'exact 1.2.3 1' in simplified_deps['build']
+
+
+def test_pin_run_as_build_preserve_string(testing_metadata):
+    m = testing_metadata
+    m.config.variant['pin_run_as_build']['pkg'] = {
+        'max_pin': 'x.x'
+    }
+    dep = render.get_pin_from_build(
+        m,
+        'pkg * somestring*',
+        {'pkg': '1.2.3 somestring_h1234'}
+    )
+    assert dep == 'pkg >=1.2.3,<1.3.0a0 somestring*'


### PR DESCRIPTION
get_pin_from_build was discarding build string information when a given dep is in pin_run_as_build

This is coming up in attempts to ensure that packages built with a particular variant of a dependency have a runtime dependency on the same variant. It generally works, but when the dependency is in `pin_run_as_build`, the build string in requirements.run is discarded when the pinning is applied.

For example:

```yaml
# conda_build_config
pin_run_as_build:
  mpi:
    max_pin: x.x

# meta
requirements:
  host:
    - mpi * mpich
  run:
    - mpi * mpich
```

The result is runtime dependency on `mpi >=1.0,<2.0` without any mention of the `mpich` build string.