### PR TITLE
Make the --output-folder switch configurable via .condarc

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -225,7 +225,8 @@ different sets of packages."""
     p.add_argument(
         "--output-folder",
         help=("folder to dump output package to.  Package are moved here if build or test succeeds."
-              "  Destination folder must exist prior to using this.")
+              "  Destination folder must exist prior to using this."),
+        default=cc_conda_build.get('output_folder')
     )
     p.add_argument(
         "--no-prefix-length-fallback", dest='prefix_length_fallback',


### PR DESCRIPTION
This is convenient for e.g. passing build artifacts around during
CI. The root-dir option was already configurable via .condarc, but
since the root build dir also contains caches and non-purged builds,
it's cleaner to use to output-folder.

In a similar vain as #2074.