### PR TITLE
Make the --long-test-prefix switch configurable via .condarc

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -281,15 +281,17 @@ different sets of packages."""
         default=cc_conda_build.get('error_overlinking', 'false').lower() == 'true',
     )
     p.add_argument(
-        "--long-test-prefix", default=True, action="store_false",
+        "--long-test-prefix", action="store_true",
         help=("Use a long prefix for the test prefix, as well as the build prefix.  Affects only "
               "Linux and Mac.  Prefix length matches the --prefix-length flag.  This is on by "
-              "default in conda-build 3.0+")
+              "default in conda-build 3.0+"),
+        default=cc_conda_build.get('long_test_prefix', 'true').lower() == 'true',
     )
     p.add_argument(
         "--no-long-test-prefix", dest="long_test_prefix", action="store_false",
         help=("Do not use a long prefix for the test prefix, as well as the build prefix."
-              "  Affects only Linux and Mac.  Prefix length matches the --prefix-length flag.  ")
+              "  Affects only Linux and Mac.  Prefix length matches the --prefix-length flag.  "),
+        default=cc_conda_build.get('long_test_prefix', 'true').lower() == 'true',
     )
     p.add_argument(
         '--keep-going', '-k', action='store_true',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from conda_build.conda_interface import download, reset_context
 from conda_build.tarcheck import TarCheck
 
 from conda_build import api
+from conda_build.config import Config
 from conda_build.utils import (get_site_packages, on_win, get_build_folders, package_has_file,
                                check_call_env, tar_xf)
 from conda_build.conda_interface import TemporaryDirectory, conda_43
@@ -654,3 +655,18 @@ def test_test_extra_dep(testing_metadata):
         args = [output, '-t']
         # extra_deps will add it in
         main_build.execute(args)
+
+
+@pytest.mark.parametrize(
+    'additional_args, is_long_test_prefix',
+    [
+        ([], True),
+        (['--long-test-prefix'], True),
+        (['--no-long-test-prefix'], False)
+    ],
+)
+def test_long_test_prefix(additional_args, is_long_test_prefix):
+    args = ['non_existing_recipe'] + additional_args
+    parser, args = main_build.parse_args(args)
+    config = Config(**args.__dict__)
+    assert config.long_test_prefix is is_long_test_prefix


### PR DESCRIPTION
Forgot to add this to #3265, sorry.

The reason I'd like this to be configurable via `.condarc` is simply because I need the switch and would like to do everything via `.condarc`.

Also, I think the original action of `--long-test-prefix` was wrong and changed it to `store_true`. This might cause some headaches though for people who used the switch as a feature bug.