### PR TITLE
conda-index: don't assume presence of key: 'depends'

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -277,7 +277,7 @@ def _determine_namespace(info):
         namespace = info['namespace']
     else:
         depends_names = set()
-        for spec in info['depends']:
+        for spec in info.get('depends', []):
             try:
                 depends_names.add(MatchSpec(spec).name)
             except CondaError:


### PR DESCRIPTION
Packages built with very old versions of conda-build might not have the
'depends' keyword with an empty list for packages with no dependencies
in the index.json inside the tarball.