### PR TITLE
enable py37 selector for meta.yaml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,10 +82,10 @@ test_script:
   - conda create -n blarg -yq --download-only python cmake
   # remove all folders to avoid permission errors.  Leave root files (may have coverage info there)
   - for /d %%F in (c:\cbtmp\*) do rd /s /q "%%F"
-  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial" --instafail
+  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial"
   # install conda-verify later, so we are ignoring checks in most tests
   - conda install -y conda-verify
-  - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial" --instafail
+  - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
 
 # For debugging, this is helpful - zip up the test environment and make it available for later download.
 #    However, it eats up a fair amount of time.  Better to disable until you need it.

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -101,7 +101,8 @@ def ns_cfg(config):
                     py33=bool(py == 33),
                     py34=bool(py == 34),
                     py35=bool(py == 35),
-                    py36=bool(py == 36),))
+                    py36=bool(py == 36),
+                    py37=bool(py == 37),))
 
     np = config.variant.get('numpy')
     if not np:

--- a/docs/source/define-metadata.rst
+++ b/docs/source/define-metadata.rst
@@ -1550,6 +1550,8 @@ variables are booleans.
      - True if the Python version is 3.5.
    * - py36
      - True if the Python version is 3.6.
+   * - py37
+     - True if the Python version is 3.7.
    * - np
      - The NumPy version as an integer such as ``111``. See the
        CONDA_NPY :ref:`environment variable <build-envs>`.


### PR DESCRIPTION
The intention of this PR is to use `py37` in `meta.yaml` for cases like:

```
skip: True  # [py37]
```

I just tried to do a quick grep of the codebase to see where the existing ones were defined, but may have missed something.