### PR TITLE
Another attempt to add license file to CRAN recipes.

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1438,11 +1438,11 @@ def get_license_file(license_text):
                  'lgpl3': ['LGPL-3', 'LGPL (>= 3)', 'LGPL',
                            'GNU Lesser General Public License']}
 
-    license_file_template = 'license_file: \'{{{{ environ["PREFIX"] }}}}/lib/R/share/licenses/{license}\''
+    license_file_template = 'license_file: \'{{{{ environ["PREFIX"] }}}}/lib/R/share/licenses/{license_id}\''
 
-    for license in d_license.keys():
-        if license_text in d_license[license]:
-            license_file = license_file_template.format(license=d_license[license][0])
+    for license_id in d_license.keys():
+        if license_text in d_license[license_id]:
+            license_file = license_file_template.format(license_id=d_license[license_id][0])
             break
     else:
         license_file = ''

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -180,3 +180,25 @@ def test_pypi_section_order_preserved(testing_workdir):
     assert list(recipe['requirements']) == REQUIREMENTS_ORDER
     for k, v in PYPI_META_STATIC.items():
         assert list(v.keys()) == list(recipe[k])
+
+
+# CRAN packages to test license_file entry.
+# (package, license_id, license_family, license_file)
+cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),
+                 ('r-abf2', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),
+                 ('r-cortools', 'Artistic License 2.0', 'OTHER', 'Artistic-2.0'),
+                 ('r-ruchardet', 'MPL', 'OTHER', ''),
+                 ]
+
+
+@pytest.mark.parametrize("package, license_id, license_family, license_file", cran_packages)
+def test_cran_license(package, license_id, license_family, license_file, testing_workdir, testing_config):
+    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
+                    config=testing_config)
+    m = api.render(os.path.join(package, 'meta.yaml'))[0][0]
+    m_license_id = m.get_value('about/license')
+    assert m_license_id == license_id
+    m_license_family = m.get_value('about/license_family')
+    assert m_license_family == license_family
+    m_license_file = m.get_value('about/license_file', '')
+    assert os.path.basename(m_license_file) == license_file


### PR DESCRIPTION
Now that the installation path for R is the same across all operating systems (https://github.com/conda-forge/r-base-feedstock/pull/61), I am resubmitting an updated version of my previous PR (#2831) to add the license file to recipes of R packages that use the standard licenses shipped with R base.

Here are some examples:

* [usethis](https://cran.r-project.org/web/packages/usethis/DESCRIPTION) - GPL-3 (specifically `License: GPL-3`)
     * `license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'`
* [abf2](https://cran.r-project.org/web/packages/abf2/DESCRIPTION) - Artistic-2.0 (specifically `License: Artistic-2.0`)
    * `license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/Artistic-2.0'`
* [corTools](https://cran.r-project.org/web/packages/corTools/DESCRIPTION) - Artistic-2.0 (specifically `License: Artistic License 2.0`)
    * `license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/Artistic-2.0'` 
* [Ruchardet](https://cran.r-project.org/web/packages/Ruchardet/DESCRIPTION): Mozilla Public License (specifically `License: MPL`)
    * r-base does not ship the MPL license, so there is no `license_file` line added

I'd like to convert these examples into unit tests. I'm guessing that the appropriate location to add them is in https://github.com/conda/conda-build/blob/master/tests/test_api_skeleton.py, but I'd appreciate some guidance on how best to proceed with structuring the tests before I attempt this.

cc: @msarahan @mingwandroid @isuruf @bgruening 
xref: #2831, #2835, https://github.com/conda-forge/staged-recipes/issues/3234, https://github.com/conda-forge/r-base-feedstock/pull/61
