### PR TITLE
Fix #3292

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -238,12 +238,10 @@ def get_uniqueness_key(file):
          and  # noqa
          (binary.type == lief.ELF.ELF_CLASS.CLASS32 or binary.type == lief.ELF.ELF_CLASS.CLASS64)):
         dynamic_entries = binary.dynamic_entries
-        for e in dynamic_entries:
-            result = [e.name for e in dynamic_entries if e.tag == lief.ELF.DYNAMIC_TAGS.SONAME]
-            if result:
-                return result[0]
-            return binary.name
-        return binary.soname
+        result = [e.name for e in dynamic_entries if e.tag == lief.ELF.DYNAMIC_TAGS.SONAME]
+        if result:
+            return result[0]
+        return binary.name
     return binary.name
 
 

--- a/tests/test-recipes/go-package/hello.go
+++ b/tests/test-recipes/go-package/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Printf("Hello, World!\n")
+}

--- a/tests/test-recipes/go-package/meta.yaml
+++ b/tests/test-recipes/go-package/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: go-hello
+  version: 1.0.0
+
+build:
+  number: 0
+  script:
+    - pushd ${RECIPE_DIR}  # [not win]
+    - mkdir $PREFIX/bin    # [not win]
+    - pushd %RECIPE_DIR%          # [win]
+    - mkdir %LIBRARY_PREFIX%/bin  # [win]
+
+    - go build hello.go
+
+    - mv hello ${PREFIX}/bin/go-hello  # [not win]
+    - mv hello.exe %LIBRARY_PREFIX%/bin/go-hello.exe  # [win]
+
+requirements:
+  build:
+    - {{ compiler('go') }}
+
+test:
+  commands:
+    - go-hello
+
+about:
+  summary: Tests that go-packages still compile correctly

--- a/tests/test_api_build_go_package.py
+++ b/tests/test_api_build_go_package.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+
+from conda_build import api
+
+from .utils import thisdir
+
+@pytest.fixture()
+def recipe():
+    return os.path.join(thisdir, 'test-recipes', 'go-package')
+
+def test_recipe_build(recipe, testing_config, testing_workdir, monkeypatch):
+    # These variables are defined solely for testing purposes,
+    # so they can be checked within build scripts
+    testing_config.activate = True
+    monkeypatch.setenv("CONDA_TEST_VAR", "conda_test")
+    monkeypatch.setenv("CONDA_TEST_VAR_2", "conda_test_2")
+    api.build(recipe, config=testing_config)
+
+


### PR DESCRIPTION
There was a typo when getting the binary unique name when using py-lief which was triggered while building go-packages because those ELF executables do not have `dynamic_entries`. 

The code section that needs to be fixed is here https://github.com/conda/conda-build/blob/b845f7598fda4c754fa8773bddf70ca42cc11a72/conda_build/os_utils/liefldd.py#L237-L246

The typo is on line 246, since there is no `soname` attribute in an ELF binary according to [lief's  documentation](https://lief.quarkslab.com/doc/stable/api/python/elf.html#lief.ELF.Binary.section_from_offset).

The proposed fix is to remove lines 241 and 246. Once you inspect the body of the `241-for-loop`,  you see that the outside iteration variable `e` is never used. 

Finally, I added a simple `go-package` recipe as part of the tests so we can capture go-related errors earlier in the process.
 
cc: @msarahan, @mingwandroid