### PR TITLE
Replace JSONDecodeError with Py version agnostic solution

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -169,7 +169,7 @@ def _download_channeldata(channel_url):
         try:
             with open(tf) as f:
                 data = json.load(f)
-        except json.decoder.JSONDecodeError:
+        except JSONDecodeError:
             data = {}
     return data
 
@@ -270,7 +270,7 @@ def get_build_index(subdir, bldpkgs_dir, output_folder=None, clear_cache=False,
                             with open(channeldata_file, "r+") as f:
                                 channel_data[channel.name] = json.load(f)
                             break
-                        except (IOError, json.decoder.JSONDecodeError):
+                        except (IOError, JSONDecodeError):
                             time.sleep(0.2)
                             retry += 1
                 else:


### PR DESCRIPTION
#3303 introduced except clauses looking for `json.decoder.JSONDecodeError` objects instead of relying on the Python 2/3 agnostic solution from the header of the index.py file.

This PR corrects those 2 lines to prevent crashing on Python 2.7 builds which have gone live with conda-build 3.17.3

I don't have a formal issue for this opened, would you like me to for documentation purposes or is this sufficient?