### PR TITLE
fix pip build isolation

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1877,7 +1877,7 @@ def write_build_scripts(m, script, build_file):
     env_file = join(m.config.work_dir, 'build_env_setup.sh')
     with open(env_file, 'w') as bf:
         for k, v in env.items():
-            if v:
+            if v != '':  # do not write empty strings
                 bf.write('export {0}="{1}"\n'.format(k, v))
 
         if m.activate_build_script:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1876,7 +1876,7 @@ def write_build_scripts(m, script, build_file):
     env_file = join(m.config.work_dir, 'build_env_setup.sh')
     with open(env_file, 'w') as bf:
         for k, v in env.items():
-            if v != '':  # do not write empty strings
+            if v != '' and v is not None:
                 bf.write('export {0}="{1}"\n'.format(k, v))
 
         if m.activate_build_script:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1856,7 +1856,6 @@ def write_build_scripts(m, script, build_file):
     # Note that pip env "NO" variables are inverted logic.
     #      PIP_NO_BUILD_ISOLATION=False means don't use build isolation.
     #
-    # This needs to be a string, falsey values are not written to the env file
     env["PIP_NO_BUILD_ISOLATION"] = 'False'
     # some other env vars to have pip ignore dependencies.
     # we supply them ourselves instead.

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1856,7 +1856,8 @@ def write_build_scripts(m, script, build_file):
     # Note that pip env "NO" variables are inverted logic.
     #      PIP_NO_BUILD_ISOLATION=False means don't use build isolation.
     #
-    env["PIP_NO_BUILD_ISOLATION"] = False
+    # This needs to be a string, falsey values are not written to the env file
+    env["PIP_NO_BUILD_ISOLATION"] = 'False'
     # some other env vars to have pip ignore dependencies.
     # we supply them ourselves instead.
     env["PIP_NO_DEPENDENCIES"] = True

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -305,7 +305,7 @@ def build(m, bld_bat, stats, provision_only=False):
     # some other env vars to have pip ignore dependencies.
     # we supply them ourselves instead.
     #    See note above about inverted logic on "NO" variables
-    env["PIP_NO_DEPENDENCIES"] = False
+    env["PIP_NO_DEPENDENCIES"] = True
     env["PIP_IGNORE_INSTALLED"] = True
 
     # pip's cache directory (PIP_NO_CACHE_DIR) should not be

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -301,7 +301,6 @@ def build(m, bld_bat, stats, provision_only=False):
     # Note that pip env "NO" variables are inverted logic.
     #      PIP_NO_BUILD_ISOLATION=False means don't use build isolation.
     #
-    # This needs to be a string, falsey values are not written to the env file
     env["PIP_NO_BUILD_ISOLATION"] = 'False'
     # some other env vars to have pip ignore dependencies.
     # we supply them ourselves instead.

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -264,7 +264,7 @@ def write_build_scripts(m, env, bld_bat):
         # more debuggable with echo on
         fo.write('@echo on\n')
         for key, value in env.items():
-            if value:
+            if value != '':
                 fo.write('set "{key}={value}"\n'.format(key=key, value=value))
         if not m.uses_new_style_compiler_activation:
             fo.write(msvc_env_cmd(bits=m.config.host_arch, config=m.config,

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -301,7 +301,8 @@ def build(m, bld_bat, stats, provision_only=False):
     # Note that pip env "NO" variables are inverted logic.
     #      PIP_NO_BUILD_ISOLATION=False means don't use build isolation.
     #
-    env["PIP_NO_BUILD_ISOLATION"] = False
+    # This needs to be a string, falsey values are not written to the env file
+    env["PIP_NO_BUILD_ISOLATION"] = 'False'
     # some other env vars to have pip ignore dependencies.
     # we supply them ourselves instead.
     #    See note above about inverted logic on "NO" variables

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -264,7 +264,7 @@ def write_build_scripts(m, env, bld_bat):
         # more debuggable with echo on
         fo.write('@echo on\n')
         for key, value in env.items():
-            if value != '':
+            if value != '' and value is not None:
                 fo.write('set "{key}={value}"\n'.format(key=key, value=value))
         if not m.uses_new_style_compiler_activation:
             fo.write(msvc_env_cmd(bits=m.config.host_arch, config=m.config,


### PR DESCRIPTION
The environment variable PIP_NO_BUILD_ISOLATION is set to 'False' in the
build environment.  Previously this variable was not set in the environment
due to it having a falsey value. It is now set to the string 'False' so that it
has a truethy value in Python which results in in being included in the
environment file.

closes #3318