### PR TITLE
Respect context.offline setting

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -275,10 +275,11 @@ def get_build_index(subdir, bldpkgs_dir, output_folder=None, clear_cache=False,
                             retry += 1
                 else:
                     # download channeldata.json for url
-                    try:
-                        channel_data[channel.name] = _download_channeldata(channel.base_url + '/channeldata.json')
-                    except CondaHTTPError:
-                        continue
+                    if not context.offline:
+                        try:
+                            channel_data[channel.name] = _download_channeldata(channel.base_url + '/channeldata.json')
+                        except CondaHTTPError:
+                            continue
                 # collapse defaults metachannel back into one superchannel, merging channeldata
                 if channel.base_url in context.default_channels and channel_data.get(channel.name):
                     packages = superchannel.get('packages', {})

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -131,6 +131,12 @@ def test_no_anaconda_upload_condarc(service_name, testing_workdir, testing_confi
     assert "Automatic uploading is disabled" in output, error
 
 
+@pytest.mark.parametrize("service_name", ["binstar", "anaconda"])
+def test_offline(service_name, testing_workdir, testing_config, capfd, monkeypatch):
+    with env_var('CONDA_OFFLINE', 'True', reset_context):
+        api.build(empty_sections, config=testing_config)
+
+
 def test_git_describe_info_on_branch(testing_config):
     recipe_path = os.path.join(metadata_dir, "_git_describe_number_branch")
     m = api.render(recipe_path, config=testing_config)[0][0]


### PR DESCRIPTION
While `conda-build` does not have an `--offline` flag like other conda commands (see https://github.com/conda/conda-build/issues/282 and 
https://github.com/conda/conda-build/issues/695), it *does* respect the equivalent environment variable `$CONDA_OFFLINE`. This is due to the `conda.common.configuration.Configuration` class, which pulls in environment variables to the `conda.context` module.

The `asv` test suite runs a number of builds inside test cases to ensure its `conda` integration is working; those tests have been failing due to `conda-build` exiting with exit code 1 and the following message in stdout:
```
EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/channeldata.json
This command is using a remote connection in offline mode.
```
The intent behind running with `$CONDA_OFFLINE=True` is to ensure all dependencies have been specified and downloaded prior to the tests starting (and I have confirmed that's the case).

As this is supported in much of the `conda` tooling, it appears like it could be a minimal change to extend this support by simply skipping downloading `channeldata.json` (which doesn't appear to directly make it into the build). If having `channeldata.json` accessible is necessary, a simple cache akin to `repodata.json` would also solve this case.

Additionally, this PR adds a test case that runs a build under `$CONDA_OFFLINE=True` for regression purposes.