### PR TITLE
don't write bytecode when building noarch: python packages

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1872,6 +1872,9 @@ def write_build_scripts(m, script, build_file):
     # locally, and if we don't, it's a problem.
     env["PIP_NO_INDEX"] = True
 
+    if m.noarch == "python":
+        env["PYTHONDONTWRITEBYTECODE"] = True
+
     work_file = join(m.config.work_dir, 'conda_build.sh')
     env_file = join(m.config.work_dir, 'build_env_setup.sh')
     with open(env_file, 'w') as bf:

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -260,6 +260,8 @@ def _write_bat_activation_text(file_handle, m):
 
 def write_build_scripts(m, env, bld_bat):
     env_script = join(m.config.work_dir, 'build_env_setup.bat')
+    if m.noarch == "python":
+        env["PYTHONDONTWRITEBYTECODE"] = True
     with open(env_script, 'w') as fo:
         # more debuggable with echo on
         fo.write('@echo on\n')


### PR DESCRIPTION
Since we don't want to include this in noarch: python packages, it makes no sense to have python go through with creating pyc files when installing a package.  This cleans it up.  Might save a tiny bit of time.