### PR TITLE
Fix mercurial TLS failures by switching from system mercurial/python 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
   apt:
     packages:
     - attr
-    - mercurial
 
 install:
   # show which shell we are running
@@ -69,7 +68,7 @@ install:
         popd;
     fi
   - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf python=$TRAVIS_PYTHON_VERSION
-  - conda install -q pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm python-libarchive-c py-lief
+  - conda install -q pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm python-libarchive-c py-lief mercurial
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;


### PR DESCRIPTION
The Travis base image uses Ubuntu 14.04, which supports a maximum system python version of 2.7.6 via apt. Therefore, the version of mercurial installed via apt cannot get access to the TLS improvements available in python 2.7.9+ and will always fail with the following output:
>warning: connecting to bitbucket.org using legacy security technology (TLS 1.0); see https://mercurial-scm.org/wiki/SecureConnections for more info
>abort: error: _ssl.c:510: error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number
>Warning: failed to download source.  If building, will try again after downloading recipe dependencies.
Error was: 
Command '['hg', 'clone', 'https://bitbucket.org/asmeurer/conda-build-hg-test', '/tmp/cb/popen-gw1/test_recipe_builds_source_hg_0/hg_cache/__bitbucket.org_asmeurer_conda-build-hg-test']' returned non-zero exit status 255.

Simply using the `conda`-provided `mercurial` package resolves this issue. The system `mercurial` could be used again once the base Ubuntu image is upgraded to a newer version than 14.04.