### PR TITLE
Remove deprecated ``sudo: false`` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,6 @@ notifications:
 git:
   depth: 10000
 
-sudo: false
-
 after_success:
   - pip install codecov
   - codecov --env TRAVIS_PYTHON_VERSION


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration