### PR TITLE
default to cos7 distribution on linux-aarch64

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -591,7 +591,7 @@ def linux_vars(m, get_default, prefix):
     # the GNU triplet is powerpc, not ppc. This matters.
     if build_arch.startswith('ppc'):
         build_arch = build_arch.replace('ppc', 'powerpc')
-    if build_arch.startswith('powerpc'):
+    if build_arch.startswith('powerpc') or build_arch.startswith('aarch64'):
         build_distro = 'cos7'
     else:
         build_distro = 'cos6'

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -424,7 +424,7 @@ def cdt(package_name, config, permit_undefined_jinja=False):
 
     cdt_name = 'cos6'
     arch = config.host_arch or config.arch
-    if arch == 'ppc64le':
+    if arch == 'ppc64le' or arch == 'aarch64':
         cdt_name = 'cos7'
         cdt_arch = arch
     else:


### PR DESCRIPTION
Treat the linux-aarch64 platform similar to linux-ppc64le