### PR TITLE
add py37 and py38 selectors

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -105,7 +105,9 @@ def ns_cfg(config):
                     py33=bool(py == 33),
                     py34=bool(py == 34),
                     py35=bool(py == 35),
-                    py36=bool(py == 36),))
+                    py36=bool(py == 36),
+                    py37=bool(py == 37),
+                    py38=bool(py == 38),))
 
     np = config.variant.get('numpy')
     if not np:

--- a/docs/source/define-metadata.rst
+++ b/docs/source/define-metadata.rst
@@ -1594,6 +1594,10 @@ variables are booleans.
      - True if the Python version is 3.5.
    * - py36
      - True if the Python version is 3.6.
+   * - py37
+     - True if the Python version is 3.7.
+   * - py38
+     - True if the Python version is 3.8.
    * - np
      - The NumPy version as an integer such as ``111``. See the
        CONDA_NPY :ref:`environment variable <build-envs>`.

--- a/news/add_py37_py38_selector
+++ b/news/add_py37_py38_selector
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* add py37 and py38 selectors
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
Add support for the py37 and py38 selectors.  These behave in the same manner
as other Python version selectors like py36.

closes #3361