### PR TITLE
Tar: Extract Fallback

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -791,7 +791,7 @@ def tar_xf(tarball, dir_path):
         # try again, maybe we are on Windows and the archive contains symlinks
         # https://github.com/conda/conda-build/issues/3351
         # https://github.com/libarchive/libarchive/pull/1030
-        if tarball.endswith(('.tar', '.tar.gz', '.tgz', '.tar.bz2')):
+        if tarball.endswith(('.tar', '.tar.gz', '.tgz', '.tar.bz2', '.tar.z', '.tar.xz')):
             _tar_xf_fallback(tarball, dir_path)
         else:
             raise

--- a/news/ax3l-fix-tarFallback.rst
+++ b/news/ax3l-fix-tarFallback.rst
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* provide fallback from libarchive back to python tarfile handling for handling tarfiles containing symlinks on windows


### PR DESCRIPTION
Try to re-introduce the tarball extractor from conda-build 3.15.0.
Trying to fix #3351

Shamelessly taken from https://github.com/conda/conda-build/compare/3.15.0...3.16.0

fixes #3351 

### To do

- [ ] I don't have a windows and cannot test this
- [ ] maybe add a test in CI?
- [x] add to changelog