### PR TITLE
Set R_USER when building R packages

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -394,12 +394,15 @@ def r_vars(metadata, prefix, escape_backslash):
     if any(r_pkg in deps for r_pkg in R_PACKAGES) or \
             metadata.name(fail_ok=True) in R_PACKAGES:
         r_bin = metadata.config.r_bin(prefix, metadata.config.host_subdir)
+        # set R_USER explicitly to prevent crosstalk with existing R_LIBS_USER packages
+        r_user = join(prefix, 'Libs', 'R')
 
         if utils.on_win and escape_backslash:
             r_bin = r_bin.replace('\\', '\\\\')
 
         vars_.update({
             'R': r_bin,
+            'R_USER': r_user,
         })
     return vars_
 


### PR DESCRIPTION
If the machine already has an existing R installation, the `R_LIBS_USER`
environment value (defaults to
%USERPROFILE%\Documents\R\win-library\{r.major}.{r.minor}) location will
exist, and commands like `R CMD INSTALL --build .` will install the
generated package into this location rather than the build environment.
This prevents conda-build from seeing the added files, and results in an
empty package. Setting the `R_USER` environment variable fixes the R
installation exclusively to that spot, and it will be prefered over the
per-user library directory.

Scenario where this was affecting the package build: A machine with an 
existing R 3.5 installation, and installed packages. When building 
`r-base` packages, it worked without issue, but building `mro-base` 
targeting packages failed as the extracted package contents ended up in 
the `R_LIBS_USER` directory.

To reproduce:

1. Install an R package into the `R_LIBS_USER` directory
2. `conda build` on a package which targets `mro-base`
3. Note the resulting package contents in `R_LIBS_USER`, but nothing but 
   metadata in the package file.

Also note that (perversely) the test will succeed -- because `R_LIBS_USER`
is being used, it will show up as the first entry in `.libPaths()` and the
package will successfully import, despite not being in the created archive.