### PR TITLE
Reduce length of test environement prefix

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -604,7 +604,9 @@ class Config(object):
         """The temporary folder where the test environment is created"""
         if on_win or not self.long_test_prefix:
             return self._short_test_prefix
-        return self._long_prefix(self._short_test_prefix)
+        # Reduce the length of the prefix by 2 characters to check if the null
+        # byte padding causes issues
+        return self._long_prefix(self._short_test_prefix)[:-2]
 
     @property
     def build_python(self):

--- a/news/shorter-testing-prefix.rst
+++ b/news/shorter-testing-prefix.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* Use a shorter environment prefix when testing on unix-like platforms
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* Added user-guide index
+
+Other:
+------
+
+* <news item>
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,9 +40,9 @@ def test_long_test_prefix_length(config):
     assert config.long_test_prefix
     assert '_plac' in config.test_prefix
     config.long_test_prefix = True
-    config.prefix_length = 80
+    config.prefix_length = 78
     assert len(config.test_prefix) == config.prefix_length
-    config.prefix_length = 255
+    config.prefix_length = 253
     assert len(config.test_prefix) == config.prefix_length
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,10 +40,12 @@ def test_long_test_prefix_length(config):
     assert config.long_test_prefix
     assert '_plac' in config.test_prefix
     config.long_test_prefix = True
-    config.prefix_length = 78
-    assert len(config.test_prefix) == config.prefix_length
-    config.prefix_length = 253
-    assert len(config.test_prefix) == config.prefix_length
+    # The length of the testing prefix is reduced by 2 characters to check if the null
+    # byte padding causes issues
+    config.prefix_length = 80
+    assert len(config.test_prefix) == config.prefix_length - 2
+    config.prefix_length = 255
+    assert len(config.test_prefix) == config.prefix_length - 2
 
 
 def test_build_id_at_end_of_long_build_prefix(config):


### PR DESCRIPTION
I've seen a couple errors caused by the prefix replacement failing when the install path is shorter than the build path. This has been caused by the null bytes that are appended on the strings and could be fixed using `has_prefix_files` to explicitly mark them as text files.

I propose reducing the length of the testing environment path by 2 characters so these cases can be noticed by `conda-build`'s testing step.