### PR TITLE
Allow *_has_prefix_files to override the mode

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -471,13 +471,20 @@ def detect_and_record_prefix_files(m, files, prefix):
 
         with open(join(m.config.info_dir, 'has_prefix'), 'w') as fo:
             for pfix, mode, fn in files_with_prefix:
+
+                if fn in binary_has_prefix_files:
+                    if mode != 'binary':
+                        print("Forcing %s to be treated as binary instead of %s" % (fn, mode))
+                        mode = 'binary'
+                    binary_has_prefix_files.remove(fn)
+                elif fn in text_has_prefix_files:
+                    if mode != 'text':
+                        print("Forcing %s to be treated as text instead of %s" % (fn, mode))
+                        mode = 'text'
+                    text_has_prefix_files.remove(fn)
+
                 print("Detected hard-coded path in %s file %s" % (mode, fn))
                 fo.write(fmt_str % (pfix, mode, fn))
-
-                if mode == 'binary' and fn in binary_has_prefix_files:
-                    binary_has_prefix_files.remove(fn)
-                elif mode == 'text' and fn in text_has_prefix_files:
-                    text_has_prefix_files.remove(fn)
 
     # make sure we found all of the files expected
     errstr = ""

--- a/news/override-has_prefix_files.rst
+++ b/news/override-has_prefix_files.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* `binary_has_prefix_files` and `text_has_prefix_files` now override the automatically detected prefix replacement mode
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* Added user-guide index
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
The documentation seems to imply that if a file is automatically detected as `binary` adding it to `text_has_prefix_files` should force it to be treated as `text` when replacing the prefix (and vice versa)

Currently an exception is raised `Did not detect hard-coded path in %s from text_has_prefix_files`.

Perhaps there is a different way of modifying this? If not, this PR modifies the behaviour to match what I expected from the documentation.