### PR TITLE
Removing extra line in metadata.sanitize docstring

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -419,7 +419,6 @@ default_structs = {
 def sanitize(meta):
     """
     Sanitize the meta-data to remove aliases/handle deprecation
-
     """
     sanitize_funs = {'source': [_git_clean], 'package': [_str_version], 'build': [_str_version]}
     for section, funs in sanitize_funs.items():


### PR DESCRIPTION
I feel a little weird proposing such a small change, but I was reading through this file and the extra line caught my eye.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
