### PR TITLE
Fix sphinx warnings

### DIFF
--- a/docs/source/concepts/features.rst
+++ b/docs/source/concepts/features.rst
@@ -1,3 +1,5 @@
+.. _concepts_features:
+
 ========
 Features
 ========

--- a/docs/source/concepts/recipe.rst
+++ b/docs/source/concepts/recipe.rst
@@ -2,7 +2,7 @@
 Conda build recipes
 ===================
 
-To enable building conda packages, :doc:`install and update conda
+To enable building conda packages, :ref:`install and update conda
 and conda build <install-conda-build>`.
 
 Building a conda package requires a recipe. A conda build recipe
@@ -65,7 +65,7 @@ Conda build process
    conda package metadata.
 
 #. Tests the new conda package if the recipe includes tests:
-  
+
    #. Deletes the build environment.
 
    #. Creates a test environment with the package and its

--- a/docs/source/resources/compiler-tools.rst
+++ b/docs/source/resources/compiler-tools.rst
@@ -1,3 +1,5 @@
+.. _compiler-tools:
+
 =======================
 Anaconda compiler tools
 =======================

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -10,7 +10,7 @@ Defining metadata (meta.yaml)
 
 
 All the metadata in the conda build recipe is specified in the
-``meta.yaml`` file. See the example below: 
+``meta.yaml`` file. See the example below:
 
 .. code-block:: Python
 
@@ -311,7 +311,7 @@ Features
 --------
 
 Defines what features a package has. For more information, see
-:doc:`features`.
+:ref:`features<concepts_features>`.
 
 .. code-block:: yaml
 
@@ -327,7 +327,7 @@ To enable a feature, install a package that tracks that feature.
 A package can have a feature, track that feature, or both, or
 neither. Usually it is best for the package that tracks a
 feature to be a metapackage that does not have the feature. For
-more information, see :doc:`features`.
+more information, see :ref:`features<concepts_features>`.
 
 .. code-block:: yaml
 
@@ -651,7 +651,7 @@ undefined.
    others to reproduce binaries from source with your recipe. Use
    this feature with caution or avoid it.
 
-.. note:: 
+.. note::
    If you split your build and test phases with ``--no-test`` and ``--test``,
    you need to ensure that the environment variables present at build time and test
    time match. If you do not, the package hashes may use different values, and your
@@ -1508,8 +1508,8 @@ practice means changing the conda build source code. See the
 
 For more information, see the `Jinja2 template
 documentation <http://jinja.pocoo.org/docs/dev/templates/>`_
-and :doc:`the list of available environment
-variables <environment-variables>`.
+and :ref:`the list of available environment
+variables <env-vars>`.
 
 Jinja templates are evaluated during the build process. To
 retrieve a fully rendered ``meta.yaml`` use the
@@ -1648,8 +1648,8 @@ variables are booleans.
      - The NumPy version as an integer such as ``111``. See the
        CONDA_NPY :ref:`environment variable <build-envs>`.
 
-The use of the Python version selectors, `py27`, `py34`, etc is discouraged in 
-favor of the more general comparison operators.  Additional selectors in this 
+The use of the Python version selectors, `py27`, `py34`, etc is discouraged in
+favor of the more general comparison operators.  Additional selectors in this
 series will not be added to conda-build.
 
 Because the selector is any valid Python expression, complicated

--- a/docs/source/resources/make-relocatable.rst
+++ b/docs/source/resources/make-relocatable.rst
@@ -1,3 +1,5 @@
+.. _make-relocatable:
+
 ===========================
 Making packages relocatable
 ===========================

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -316,7 +316,7 @@ Environment variables to set build features
 
 The environment variables listed in the following table are
 inherited from the process running conda build. These variables
-control :doc:`features`.
+control :ref:`features<concepts_features>`.
 
 .. list-table::
    :widths: 15 43 42

--- a/docs/source/user-guide/recipes/build-without-recipe.rst
+++ b/docs/source/user-guide/recipes/build-without-recipe.rst
@@ -101,7 +101,7 @@ install_name_tool on macOS or patchelf on Linux. The default is
 
    conda_binary_relocation=False
 
-For more information, see :doc:`make-relocatable`.
+For more information, see :ref:`make-relocatable <make-relocatable>`.
 
 
 Preserve egg directory
@@ -128,7 +128,7 @@ A list of features for the package.
 
 NOTE: Replace ``mkl`` with the features that you want to list.
 
-For more information, see :doc:`features`.
+For more information, see :ref:`features<concepts_features>`.
 
 
 Track features
@@ -141,7 +141,7 @@ installed.
 
    conda_track_features=['mkl']
 
-For more information, see :doc:`features`.
+For more information, see :ref:`features<concepts_features>`.
 
 
 Command line options

--- a/docs/source/user-guide/tutorials/building-conda-packages.rst
+++ b/docs/source/user-guide/tutorials/building-conda-packages.rst
@@ -167,7 +167,7 @@ named ``run_test.bat`` on Windows, or ``run_test.sh`` on macOS or Linux,
 or ``run_test.py`` on any platform, the file runs to test the package,
 and any errors are reported.
 
-.. note:: 
+.. note::
    Use the :ref:`Test section of the meta.yaml file
    <meta-test>` to move data files from the recipe directory to the
    test directory when the test is run.
@@ -231,7 +231,7 @@ For this package, ``bld.bat`` and ``build.sh`` need no changes.
 You need to edit the ``meta.yaml`` file to add the dependency on
 NumPy and add an optional test for the built package by importing
 It. For more information about what can be specified in meta.yaml,
-see :doc:`../resources/define-metadata`.
+see :ref:`define-metadata<meta-yaml>`.
 
 #. In the requirements section of the ``meta.yaml`` file, add a
    line that adds NumPy as a requirement to build the package.
@@ -425,7 +425,7 @@ Notice that the C compilers are pulled into the recipe using the syntax
 function ``compiler()`` to specify compiler packages dynamically. So, using
 the ``compiler(‘c’)`` function in a conda recipe will pull in the correct
 compiler for any build platform. For more information about compilers with
-conda build see :doc:`../resources/compiler-tools`.
+conda build see :ref:`compiler-tools<compiler-tools>`.
 
 Also note that the compilers used by conda build can be specified using
 a conda_build_config.yaml. For more information about how to do that,
@@ -463,4 +463,3 @@ Or explicitly set the location of the conda build variant matrix
 If you want to know more about build variants and conda_build_config.yaml,
 including how to specify a config file and what can go into it, take a look
 at :ref:`conda-build-variant-config-files`.
-

--- a/docs/source/user-guide/tutorials/index.rst
+++ b/docs/source/user-guide/tutorials/index.rst
@@ -5,6 +5,5 @@ Tutorials
 .. toctree::
    :maxdepth: 1
 
-  building-conda-packages
-  add-win-start-menu-items
-  
+   building-conda-packages
+   add-win-start-menu-items


### PR DESCRIPTION
Hi!

There are some warnings/errors when building HTML docs. This PR fixes all those errors, including:

- Broken links
- Bad indentation on doc tree

Regards!