### PR TITLE
Filter out *.conda_trash files when packaging

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1365,7 +1365,8 @@ def filter_files(files_list, prefix, filter_patterns=('(.*[\\\\/])?\.git[\\\\/].
                                                       '(.*[\\\\/])?\.git$',
                                                       '(.*)?\.DS_Store.*',
                                                       '.*\.la$',
-                                                      'conda-meta.*')):
+                                                      'conda-meta.*',
+                                                      '.*\.conda_trash$')):
     """Remove things like the .git directory from the list of files to be copied"""
     for pattern in filter_patterns:
         r = re.compile(pattern)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1366,7 +1366,7 @@ def filter_files(files_list, prefix, filter_patterns=('(.*[\\\\/])?\.git[\\\\/].
                                                       '(.*)?\.DS_Store.*',
                                                       '.*\.la$',
                                                       'conda-meta.*',
-                                                      '.*\.conda_trash$')):
+                                                      '.*\.conda_trash(?:_\d+)*$')):
     """Remove things like the .git directory from the list of files to be copied"""
     for pattern in filter_patterns:
         r = re.compile(pattern)

--- a/news/update-filter_files.rst
+++ b/news/update-filter_files.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Update utils.filter_files to filter out generated .conda_trash files
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -197,7 +197,8 @@ def test_expand_globs(testing_workdir):
 def test_filter_files():
     # Files that should be filtered out.
     files_list = ['.git/a', 'something/.git/a', '.git\\a', 'something\\.git\\a',
-                 'file.la', 'something/file.la']
+                  'file.la', 'something/file.la', 'python.exe.conda_trash', 
+                  'bla.dll.conda_trash_1', 'bla.dll.conda_trash.conda_trash']
     assert not utils.filter_files(files_list, '')
 
     # Files that should *not* be filtered out.
@@ -205,7 +206,8 @@ def test_filter_files():
     #    lib/python3.4/site-packages/craftr/stl/craftr.utils.git/Craftrfile
     files_list = ['a', 'x.git/a', 'something/x.git/a',
                   'x.git\\a', 'something\\x.git\\a', 'something/.gitmodules',
-                  'some/template/directory/.gitignore', 'another.lab']
+                  'some/template/directory/.gitignore', 'another.lab',
+                  'miniconda_trashcan.py', 'conda_trash_avoider.py']
     assert len(utils.filter_files(files_list, '')) == len(files_list)
 
 


### PR DESCRIPTION
Make sure to filter out *.conda_trash files when packaging.
Closes #3455.

@msarahan please review.
