### PR TITLE
Update test of CRAN license

### DIFF
--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -187,7 +187,7 @@ def test_pypi_section_order_preserved(testing_workdir):
 cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),
                  ('r-abf2', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),
                  ('r-cortools', 'Artistic License 2.0', 'OTHER', 'Artistic-2.0'),
-                 ('r-ruchardet', 'MPL', 'OTHER', ''),
+                 ('r-udpipe', 'MPL-2.0', 'OTHER', ''),
                  ]
 
 


### PR DESCRIPTION
The CRAN package [Ruchardet](https://cran.r-project.org/package=Ruchardet) was archived, which broke one of the [tests of the CRAN skeleton](https://github.com/jdblischak/conda-build/blob/9e6bc448090acd118d51872bcb700a504837cd3d/tests/test_api_skeleton.py#L190). This PR replaces Ruchardet with [udpipe](https://cran.r-project.org/package=udpipe).



Thanks to @bilderbuchi for reporting this in PR #3460.



