### PR TITLE
Escape quotes in env variables.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1841,7 +1841,7 @@ def write_build_scripts(m, script, build_file):
     with open(env_file, 'w') as bf:
         for k, v in env.items():
             if v != '' and v is not None:
-                bf.write('export {0}="{1}"\n'.format(k, v))
+                bf.write('export {0}="{1}"\n'.format(k, v.replace('"', '\\"')))
 
         if m.activate_build_script:
             _write_sh_activation_text(bf, m)


### PR DESCRIPTION
Quotes are not escaped when forwarding env variables.