### PR TITLE
Introduce conda_build.config.get_channel_urls()

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -19,7 +19,8 @@ but only use those kwargs in config.  Config must change to support new features
 import sys as _sys
 
 # make the Config class available in the api namespace
-from conda_build.config import Config, get_or_merge_config, DEFAULT_PREFIX_LENGTH as _prefix_length
+from conda_build.config import (Config, get_or_merge_config, get_channel_urls,
+                                DEFAULT_PREFIX_LENGTH as _prefix_length)
 from conda_build.utils import ensure_list as _ensure_list
 from conda_build.utils import expand_globs as _expand_globs
 from conda_build.utils import get_logger as _get_logger
@@ -414,6 +415,8 @@ def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False, outp
         path = os.path.join(default_config.croot, "debug_{}".format(int(time.time() * 1000)))
     config = get_or_merge_config(config=default_config, croot=path, verbose=verbose, _prefix_length=10,
                                  **args)
+
+    config.channel_urls = get_channel_urls(kwargs)
 
     metadata_tuples = []
 

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -18,12 +18,12 @@ import filelock
 import conda_build.api as api
 import conda_build.build as build
 import conda_build.utils as utils
-from conda_build.conda_interface import (add_parser_channels, url_path, binstar_upload,
+from conda_build.conda_interface import (add_parser_channels, binstar_upload,
                                          cc_conda_build)
 from conda_build.cli.main_render import get_render_parser
 import conda_build.source as source
 from conda_build.utils import LoggingContext
-from conda_build.config import Config
+from conda_build.config import Config, get_channel_urls
 from os.path import abspath, expanduser, expandvars
 
 on_win = (sys.platform == 'win32')
@@ -376,18 +376,7 @@ def execute(args):
     build.check_external()
 
     # change globals in build module, see comment there as well
-    channel_urls = args.__dict__.get('channel') or args.__dict__.get('channels') or ()
-    config.channel_urls = []
-
-    for url in channel_urls:
-        # allow people to specify relative or absolute paths to local channels
-        #    These channels still must follow conda rules - they must have the
-        #    appropriate platform-specific subdir (e.g. win-64)
-        if os.path.isdir(url):
-            if not os.path.isabs(url):
-                url = os.path.normpath(os.path.abspath(os.path.join(os.getcwd(), url)))
-            url = url_path(url)
-        config.channel_urls.append(url)
+    config.channel_urls = get_channel_urls(args.__dict__)
 
     config.override_channels = args.override_channels
     config.verbose = not args.quiet or args.debug

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -9,18 +9,17 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import logging
 import sys
-import os
 from pprint import pprint
 
 import yaml
 from yaml.parser import ParserError
 
-from conda_build.conda_interface import (ArgumentParser, add_parser_channels, cc_conda_build,
-                                         url_path)
+from conda_build.conda_interface import (ArgumentParser, add_parser_channels,
+                                         cc_conda_build)
 
 from conda_build import __version__, api
 
-from conda_build.config import get_or_merge_config
+from conda_build.config import get_or_merge_config, get_channel_urls
 from conda_build.variants import get_package_variants, set_language_env_vars
 from conda_build.utils import LoggingContext
 
@@ -179,18 +178,7 @@ def execute(args, print_results=True):
     variants = get_package_variants(args.recipe, config, variants=args.variants)
     set_language_env_vars(variants)
 
-    channel_urls = args.__dict__.get('channel') or args.__dict__.get('channels') or ()
-    config.channel_urls = []
-
-    for url in channel_urls:
-        # allow people to specify relative or absolute paths to local channels
-        #    These channels still must follow conda rules - they must have the
-        #    appropriate platform-specific subdir (e.g. win-64)
-        if os.path.isdir(url):
-            if not os.path.isabs(url):
-                url = os.path.normpath(os.path.abspath(os.path.join(os.getcwd(), url)))
-            url = url_path(url)
-        config.channel_urls.append(url)
+    config.channel_urls = get_channel_urls(args.__dict__)
 
     config.override_channels = args.override_channels
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -15,7 +15,7 @@ import time
 from .conda_interface import root_dir, root_writable
 from .conda_interface import binstar_upload
 from .variants import get_default_variant
-from .conda_interface import cc_platform, cc_conda_build, subdir
+from .conda_interface import cc_platform, cc_conda_build, subdir, url_path
 
 from .utils import get_build_folders, rm_rf, get_logger, get_conda_operation_locks
 
@@ -803,6 +803,23 @@ def get_or_merge_config(config, variant=None, **kwargs):
     if variant:
         config.variant.update(variant)
     return config
+
+
+def get_channel_urls(args):
+    channel_urls = args.get('channel') or args.get('channels') or ()
+    final_channel_urls = []
+
+    for url in channel_urls:
+        # allow people to specify relative or absolute paths to local channels
+        #    These channels still must follow conda rules - they must have the
+        #    appropriate platform-specific subdir (e.g. win-64)
+        if os.path.isdir(url):
+            if not os.path.isabs(url):
+                url = os.path.normpath(os.path.abspath(os.path.join(os.getcwd(), url)))
+            url = url_path(url)
+        final_channel_urls.append(url)
+
+    return final_channel_urls
 
 
 # legacy exports for conda


### PR DESCRIPTION
This patch introduces a function to reduce duplicate code and makes use
of it in conda_build.api.debug, conda_build.cli.main_render.execute and
conda_build.cli.main_build.execute.

This change makes conda-debug to also honor channels passed with the -c
argument.

Fixes #3433

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
