### PR TITLE
test_api_debug: don't modify global variable

### DIFF
--- a/tests/test_api_debug.py
+++ b/tests/test_api_debug.py
@@ -51,8 +51,8 @@ def test_debug_recipe_default_path(testing_config):
     activation_string = api.debug(recipe_path, config=testing_config)
     assert activation_string and "debug_1" in activation_string
     _, work_dir, _, src_command, env_activation_script = activation_string.split()
-    shell_cmd.append(' '.join((src_command, env_activation_script)))
-    subprocess.check_call(shell_cmd, cwd=work_dir)
+    _shell_cmd = shell_cmd + [' '.join((src_command, env_activation_script))]
+    subprocess.check_call(_shell_cmd, cwd=work_dir)
     check_build_files_present(work_dir, True)
     check_test_files_present(work_dir, False)
     assert_correct_folders(work_dir)
@@ -61,8 +61,8 @@ def test_debug_recipe_default_path(testing_config):
 def test_debug_package_default_path(testing_config):
     activation_string = api.debug(tarball_path, config=testing_config)
     _, work_dir, _, src_command, env_activation_script = activation_string.split()
-    shell_cmd.append(' '.join((src_command, env_activation_script)))
-    subprocess.check_call(shell_cmd, cwd=work_dir)
+    _shell_cmd = shell_cmd + [' '.join((src_command, env_activation_script))]
+    subprocess.check_call(_shell_cmd, cwd=work_dir)
     check_build_files_present(work_dir, False)
     check_test_files_present(work_dir, True)
     assert_correct_folders(work_dir, build=False)
@@ -72,8 +72,8 @@ def test_debug_recipe_custom_path(testing_workdir):
     activation_string = api.debug(recipe_path, path=testing_workdir)
     assert activation_string and "debug_1" not in activation_string
     _, work_dir, _, src_command, env_activation_script = activation_string.split()
-    shell_cmd.append(' '.join((src_command, env_activation_script)))
-    subprocess.check_call(shell_cmd, cwd=work_dir)
+    _shell_cmd = shell_cmd + [' '.join((src_command, env_activation_script))]
+    subprocess.check_call(_shell_cmd, cwd=work_dir)
     check_build_files_present(work_dir, True)
     check_test_files_present(work_dir, False)
     assert_correct_folders(work_dir)
@@ -82,8 +82,8 @@ def test_debug_recipe_custom_path(testing_workdir):
 def test_debug_package_custom_path(testing_workdir):
     activation_string = api.debug(tarball_path, path=testing_workdir)
     _, work_dir, _, src_command, env_activation_script = activation_string.split()
-    shell_cmd.append(' '.join((src_command, env_activation_script)))
-    subprocess.check_call(shell_cmd, cwd=work_dir)
+    _shell_cmd = shell_cmd + [' '.join((src_command, env_activation_script))]
+    subprocess.check_call(_shell_cmd, cwd=work_dir)
     check_build_files_present(work_dir, False)
     check_test_files_present(work_dir, True)
     assert_correct_folders(work_dir, build=False)
@@ -92,8 +92,8 @@ def test_debug_package_custom_path(testing_workdir):
 def test_specific_output():
     activation_string = api.debug(ambiguous_recipe_path, output_id="output1*")
     _, work_dir, _, src_command, env_activation_script = activation_string.split()
-    shell_cmd.append(' '.join((src_command, env_activation_script)))
-    subprocess.check_call(shell_cmd, cwd=work_dir)
+    _shell_cmd = shell_cmd + [' '.join((src_command, env_activation_script))]
+    subprocess.check_call(_shell_cmd, cwd=work_dir)
     check_build_files_present(work_dir, True)
     check_test_files_present(work_dir, False)
     assert_correct_folders(work_dir, build=True)


### PR DESCRIPTION
shell_cmd kept getting modified in subsequent calls, leading to test
failures on Windows.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
