### PR TITLE
Fix rendering fails if package/build not at top

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1672,7 +1672,9 @@ class MetaData(object):
             r'(\s*source:.*?)(?=^build:|^requirements:|^test:|^extra:|^about:|^outputs:|\Z)')
 
     def extract_package_and_build_text(self):
-        return self.get_recipe_text(r'(^.*?)(?=^requirements:|^test:|^extra:|^about:|^outputs:|\Z)')
+        return self.get_recipe_text(
+          r'(^(?:package|build:).*?)'
+          r'(?=^requirements:|^test:|^extra:|^about:|^outputs:|^source:|\Z)')
 
     def extract_single_output_text(self, output_name, output_type, apply_selectors=True):
         # first, need to figure out which index in our list of outputs the name matches.


### PR DESCRIPTION
The regular expression used in `metadata.MetaData.extract_package_and_build_text()` stalls with no characters consumed if the recipe starts with any of the excluded sections (e.g. `about:`). The result is then empty and api.render() raises an exception.

The regex also did not exclude the `source` section, leading to longer fragments than expected.

Honestly, I'm not sure the regex parsing is such a good idea - pretty hard to read and fragile. This bug looks like a copy/paste error from `extract_source_text` that "kind of worked" the way recipes are "commonly written".