### PR TITLE
Add 37 to list of CONDA_PY

### DIFF
--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -298,7 +298,7 @@ Environment variables that affect the build process
 
    * - CONDA_PY
      - The Python version used to build the package. Should
-       be ``27``, ``34``, ``35`` or ``36``.
+       be ``27``, ``34``, ``35``, ``36`` or ``37``.
    * - CONDA_NPY
      - The NumPy version used to build the package, such as
        ``19``, ``110`` or ``111``.


### PR DESCRIPTION
I figured that `37` is probably supported for this environment variable, since Anaconda now ships with python 3.7

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
