### PR TITLE
Replace stdlib glob with utils.glob

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 
 from collections import deque, OrderedDict
 import fnmatch
-from glob import glob
 import io
 import json
 import os
@@ -56,7 +55,7 @@ from .conda_interface import UnsatisfiableError
 from .conda_interface import NoPackagesFoundError
 from .conda_interface import CondaError
 from .conda_interface import pkgs_dirs
-from .utils import env_var, tmp_chdir
+from .utils import env_var, glob, tmp_chdir
 
 from conda_build import __version__
 from conda_build import environ, source, tarcheck, utils


### PR DESCRIPTION
The stdlib glob doesn't use recursion (`**`) by default, but utils.glob
does. Note that `**` is only supported since Python 3.5, but since
anything older is already EOL (and because we fall back on glob2 for
Python 2) this isn't a problem.

Closes #3504.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
