### PR TITLE
Fix inconsistency in computation of changed files

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1117,7 +1117,7 @@ class ChannelIndex(object):
             #     not using md5 here because it takes too long. If needing to do full md5 checks,
             #     use the --deep-integrity-check flag / self.deep_integrity_check option.
             update_set = self._calculate_update_set(
-                subdir, add_set, old_repodata_fns, stat_cache,
+                subdir, fns_in_subdir, old_repodata_fns, stat_cache,
                 verbose=verbose, progress=progress
             )
             # unchanged_set: packages in old repodata whose information can carry straight


### PR DESCRIPTION
When updating a file in channel with different build time and/or disk size `_calculate_update_set` incorrectly returns a zero length `update_set`.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
