### PR TITLE
rework index nesting for better responsiveness, fix some small indexi…

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -378,7 +378,7 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
                  subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
-                 hotfix_source_repo=None, shared_format_cache=True, current_index_versions=None, **kwargs):
+                 hotfix_source_repo=None, current_index_versions=None, **kwargs):
     import yaml
     from locale import getpreferredencoding
     import os
@@ -398,8 +398,7 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
         update_index(path, check_md5=check_md5, channel_name=channel_name,
                      patch_generator=patch_generator, threads=threads, verbose=verbose,
                      progress=progress, hotfix_source_repo=hotfix_source_repo,
-                     subdirs=ensure_list(subdir), shared_format_cache=shared_format_cache,
-                     current_index_versions=current_index_versions)
+                     subdirs=ensure_list(subdir), current_index_versions=current_index_versions)
 
 
 def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,

--- a/conda_build/cli/main_index.py
+++ b/conda_build/cli/main_index.py
@@ -60,12 +60,6 @@ def parse_args(args):
         "--no-progress", help="Hide progress bars", action="store_false", dest="progress"
     )
     p.add_argument(
-        "--no-shared-format-cache", action="store_false", dest="shared_format_cache",
-        help=("Do not share a cache between .tar.bz2 and .conda files.  By default, "
-              "we assume that two files that differ only by extension can be treated "
-              "as similar for the purposes of caching metadata.  This flag disables that assumption.")
-    )
-    p.add_argument(
         "--current-index-versions-file", "-m",
         help="""
         YAML file containing name of package as key, and list of versions as values.  The current_index.json
@@ -89,7 +83,7 @@ def execute(args):
     api.update_index(args.dir, check_md5=args.check_md5, channel_name=args.channel_name,
                      threads=args.threads, subdir=args.subdir, patch_generator=args.patch_generator,
                      verbose=args.verbose, progress=args.progress, hotfix_source_repo=args.hotfix_source_repo,
-                     shared_format_cache=args.shared_format_cache, current_index_versions=args.current_index_versions_file)
+                     current_index_versions=args.current_index_versions_file)
 
 
 def main():

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -10,8 +10,8 @@ from datetime import datetime
 import json
 from numbers import Number
 import os
-from os.path import abspath, basename, getmtime, getsize, isdir, isfile, join, lexists, splitext, dirname
-from shutil import copy2, move
+from os.path import abspath, basename, getmtime, getsize, isdir, isfile, join, splitext, dirname
+from shutil import move
 import subprocess
 import tarfile
 from tempfile import gettempdir
@@ -1367,11 +1367,8 @@ class ChannelIndex(object):
             icon_md5 = utils.md5_file(icon_cache_path)
             icon_hash = "md5:%s:%s" % (icon_md5, getsize(icon_cache_path))
             data.update(icon_hash=icon_hash, icon_url=icon_url)
-            if lexists(icon_channel_path) and utils.md5_file(icon_channel_path) != icon_md5:
-                os.unlink(icon_channel_path)
-            if not lexists(icon_channel_path):
-                # log.info("writing icon from %s to %s", icon_cache_path, icon_channel_path)
-                copy2(icon_cache_path, icon_channel_path)
+            # log.info("writing icon from %s to %s", icon_cache_path, icon_channel_path)
+            utils.copy_into(icon_cache_path, icon_channel_path)
 
         # have to stat again, because we don't have access to the stat cache here
         data['mtime'] = mtime

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1294,6 +1294,9 @@ class ChannelIndex(object):
                 return ChannelIndex._extract_to_cache(channel_root, subdir, fn, shared_format_cache, second_try=True)
             log.error("Package %s appears to be corrupt.  Please remove it and re-download it" % abs_fn)
             log.error(str(e))
+        except FileNotFoundError as e:
+            log.error("Package %s appears to be corrupt.  Please remove it and re-download it" % abs_fn)
+            log.error(str(e))
         return retval
 
     def _load_index_from_cache(self, subdir, fn, stat_cache, shared_format_cache):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1275,22 +1275,18 @@ class ChannelIndex(object):
                 for field_name in filter_fields & set(index_json):
                     del index_json[field_name]
 
-                # calculate extra stuff to add to index.json cache, size, md5, sha256
-                #    This is done for both the old and possibly the new file format.
-                #    The old one is the one that shows up in repodata.json.  The new
-                #    one makes up the stat cache.
-                index_json.update(conda_package_handling.api.get_pkg_details(abs_fn))
-
                 with open(index_cache_path, 'w') as fh:
                     json.dump(index_json, fh)
+
             else:
                 with open(index_cache_path) as f:
                     index_json = json.load(f)
 
-                # if we are sharing the cache, the filename of the thing in the cache is
-                #    ambiguous.  We need to update the md5, sha256, and size for the actual
-                #    file we have here
-                index_json.update(conda_package_handling.api.get_pkg_details(abs_fn))
+            # calculate extra stuff to add to index.json cache, size, md5, sha256
+            #    This is done always for all files, whether the cache is loaded or not,
+            #    because the cache may be from the other file type.  We don't store this
+            #    info in the cache to avoid confusion.
+            index_json.update(conda_package_handling.api.get_pkg_details(abs_fn))
             retval = fn, mtime, size, index_json
         except (libarchive.exception.ArchiveError, tarfile.ReadError, KeyError,
                 EOFError, JSONDecodeError) as e:

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -120,5 +120,5 @@ def test_api_update_index():
     argspec = getargspec(api.update_index)
     assert argspec.args == ['dir_paths', 'config', 'force', 'check_md5', 'remove', 'channel_name', 'subdir',
                             'threads', 'patch_generator', "verbose", "progress", "hotfix_source_repo",
-                            'shared_format_cache', 'current_index_versions']
-    assert argspec.defaults == (None, False, False, False, None, None, None, None, False, False, None, True, None)
+                            'current_index_versions']
+    assert argspec.defaults == (None, False, False, False, None, None, None, None, False, False, None, None)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -236,7 +236,10 @@ def test_index_noarch_osx64_1(testing_workdir):
 
 
 def _build_test_index(workdir):
-    api.build(os.path.join(metadata_dir, "_index_hotfix_pkgs"), croot=workdir)
+    pkgs = api.build(os.path.join(metadata_dir, "_index_hotfix_pkgs"), croot=workdir)
+    for pkg in pkgs:
+        conda_package_handling.api.transmute(pkg, '.conda')
+    api.update_index(workdir)
 
     with open(os.path.join(workdir, subdir, 'repodata.json')) as f:
         original_metadata = json.load(f)
@@ -374,37 +377,40 @@ def test_channel_patch_instructions_json(testing_workdir):
     with open(os.path.join(testing_workdir, subdir, 'repodata.json')) as f:
         patched_metadata = json.load(f)
 
-    pkg_list = patched_metadata['packages']
-    assert "track_features_test-1.0-0.tar.bz2" in pkg_list
-    assert "track_features" not in pkg_list["track_features_test-1.0-0.tar.bz2"]
+    formats = (('packages', '.tar.bz2'), ('packages.conda', '.conda'))
 
-    assert "hotfix_depends_test-1.0-dummy_0.tar.bz2" in pkg_list
-    assert "features" not in pkg_list["hotfix_depends_test-1.0-dummy_0.tar.bz2"]
-    assert "zlib" in pkg_list["hotfix_depends_test-1.0-dummy_0.tar.bz2"]["depends"]
-    assert "dummy" in pkg_list["hotfix_depends_test-1.0-dummy_0.tar.bz2"]["depends"]
+    for key, ext in formats:
+        pkg_list = patched_metadata[key]
+        assert "track_features_test-1.0-0" + ext in pkg_list
+        assert "track_features" not in pkg_list["track_features_test-1.0-0" + ext]
 
-    assert "revoke_test-1.0-0.tar.bz2" in pkg_list
-    assert "zlib" in pkg_list["revoke_test-1.0-0.tar.bz2"]["depends"]
-    assert "package_has_been_revoked" in pkg_list["revoke_test-1.0-0.tar.bz2"]["depends"]
+        assert "hotfix_depends_test-1.0-dummy_0" + ext in pkg_list
+        assert "features" not in pkg_list["hotfix_depends_test-1.0-dummy_0" + ext]
+        assert "zlib" in pkg_list["hotfix_depends_test-1.0-dummy_0" + ext]["depends"]
+        assert "dummy" in pkg_list["hotfix_depends_test-1.0-dummy_0" + ext]["depends"]
 
-    assert "remove_test-1.0-0.tar.bz2" not in pkg_list
+        assert "revoke_test-1.0-0" + ext in pkg_list
+        assert "zlib" in pkg_list["revoke_test-1.0-0" + ext]["depends"]
+        assert "package_has_been_revoked" in pkg_list["revoke_test-1.0-0" + ext]["depends"]
 
-    with open(os.path.join(testing_workdir, subdir, 'repodata_from_packages.json')) as f:
-        pkg_repodata = json.load(f)
+        assert "remove_test-1.0-0" + ext not in pkg_list
 
-    pkg_list = pkg_repodata['packages']
-    assert "track_features_test-1.0-0.tar.bz2" in pkg_list
-    assert pkg_list["track_features_test-1.0-0.tar.bz2"]["track_features"] == "dummy"
+        with open(os.path.join(testing_workdir, subdir, 'repodata_from_packages.json')) as f:
+            pkg_repodata = json.load(f)
 
-    assert "hotfix_depends_test-1.0-dummy_0.tar.bz2" in pkg_list
-    assert pkg_list["hotfix_depends_test-1.0-dummy_0.tar.bz2"]["features"] == "dummy"
-    assert "zlib" in pkg_list["hotfix_depends_test-1.0-dummy_0.tar.bz2"]["depends"]
+        pkg_list = pkg_repodata[key]
+        assert "track_features_test-1.0-0" + ext in pkg_list
+        assert pkg_list["track_features_test-1.0-0" + ext]["track_features"] == "dummy"
 
-    assert "revoke_test-1.0-0.tar.bz2" in pkg_list
-    assert "zlib" in pkg_list["revoke_test-1.0-0.tar.bz2"]["depends"]
-    assert "package_has_been_revoked" not in pkg_list["revoke_test-1.0-0.tar.bz2"]["depends"]
+        assert "hotfix_depends_test-1.0-dummy_0" + ext in pkg_list
+        assert pkg_list["hotfix_depends_test-1.0-dummy_0" + ext]["features"] == "dummy"
+        assert "zlib" in pkg_list["hotfix_depends_test-1.0-dummy_0" + ext]["depends"]
 
-    assert "remove_test-1.0-0.tar.bz2" in pkg_list
+        assert "revoke_test-1.0-0" + ext in pkg_list
+        assert "zlib" in pkg_list["revoke_test-1.0-0" + ext]["depends"]
+        assert "package_has_been_revoked" not in pkg_list["revoke_test-1.0-0" + ext]["depends"]
+
+        assert "remove_test-1.0-0" + ext in pkg_list
 
 
 def test_patch_from_tarball(testing_workdir):


### PR DESCRIPTION
…ng issues

This reinterprets channeldata a bit.  Rather than representing a single snapshot of one version on the channel, channeldata is a superset of all packages.  For different metadata, this means different things.  For most metadata, it just takes the newest value.  For run_exports, we accumulate results by version, since you really want to know run_exports for a particular version, and these vary over time.