### PR TITLE
Split variant parsing function so that users can get an order preserving combined variant spec.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -70,7 +70,8 @@ from conda_build.post import (post_process, post_build,
 
 from conda_build.exceptions import indent, DependencyNeedsBuildingError, CondaBuildException
 from conda_build.variants import (set_language_env_vars, dict_of_lists_to_list_of_dicts,
-                                  get_package_variants)
+                                  get_package_variants, get_package_combined_spec, 
+                                  filter_combined_spec_to_used_keys)
 from conda_build.create_test import create_all_test_files
 
 import conda_build.noarch_python as noarch_python

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -746,7 +746,7 @@ class Config(object):
 
     @post_variant_combine_hook.setter
     def post_variant_combine_hook(self, fn):
-        if not callable(fn):
+        if fn and not callable(fn):
             raise ValueError("fn is expected to be a callable of the form:"
                              "\ndef post_variant_combine_hook("
                              "\n        specs, combined_spec, config=config, log_output=log_output):"

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -187,6 +187,11 @@ def _get_default_settings():
 
             # this can be set to different values (currently only 2 means anything) to use package formats
             Setting('conda_pkg_format', cc_conda_build.get('pkg_format', None))
+
+            # This allows build orchestrators to introspect and change variant spec parsing behavior.
+            # This is an advanced feature only intended when using conda-build as a library.
+            Setting("post_variant_combine_hook", None)
+
             ]
 
 
@@ -734,6 +739,20 @@ class Config(object):
     @pip_cache_dir.setter
     def pip_cache_dir(self, path):
         self._pip_cache_dir = path
+
+    @property
+    def post_variant_combine_hook(self):
+        return self._post_variant_combine_hook
+
+    @post_variant_combine_hook.setter
+    def post_variant_combine_hook(self, fn):
+        if not callable(fn):
+            raise ValueError("{} is expected to be a callable of the form:"
+                             "\ndef post_variant_combine_hook(
+                             "\n        specs, combined_spec, config=config, log_output=log_output):"
+                             "\n     ..."
+                             "\n     return combined_specs") 
+        self._post_variant_combine_hook = fn
 
     @property
     def test_dir(self):

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -186,7 +186,7 @@ def _get_default_settings():
             Setting('compression_tuple', ('.tar.zst', 'zstd', 'zstd:compression-level=22')),
 
             # this can be set to different values (currently only 2 means anything) to use package formats
-            Setting('conda_pkg_format', cc_conda_build.get('pkg_format', None))
+            Setting('conda_pkg_format', cc_conda_build.get('pkg_format', None)),
 
             # This allows build orchestrators to introspect and change variant spec parsing behavior.
             # This is an advanced feature only intended when using conda-build as a library.

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -747,11 +747,11 @@ class Config(object):
     @post_variant_combine_hook.setter
     def post_variant_combine_hook(self, fn):
         if not callable(fn):
-            raise ValueError("{} is expected to be a callable of the form:"
-                             "\ndef post_variant_combine_hook(
+            raise ValueError("fn is expected to be a callable of the form:"
+                             "\ndef post_variant_combine_hook("
                              "\n        specs, combined_spec, config=config, log_output=log_output):"
                              "\n     ..."
-                             "\n     return combined_specs") 
+                             "\n     return combined_specs")
         self._post_variant_combine_hook = fn
 
     @property

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -190,7 +190,7 @@ def _get_default_settings():
 
             # This allows build orchestrators to introspect and change variant spec parsing behavior.
             # This is an advanced feature only intended when using conda-build as a library.
-            Setting("post_variant_combine_hook", None)
+            Setting("post_variant_combine_hook", None),
 
             ]
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -188,10 +188,6 @@ def _get_default_settings():
             # this can be set to different values (currently only 2 means anything) to use package formats
             Setting('conda_pkg_format', cc_conda_build.get('pkg_format', None)),
 
-            # This allows build orchestrators to introspect and change variant spec parsing behavior.
-            # This is an advanced feature only intended when using conda-build as a library.
-            Setting("post_variant_combine_hook", None),
-
             ]
 
 
@@ -739,20 +735,6 @@ class Config(object):
     @pip_cache_dir.setter
     def pip_cache_dir(self, path):
         self._pip_cache_dir = path
-
-    @property
-    def post_variant_combine_hook(self):
-        return self._post_variant_combine_hook
-
-    @post_variant_combine_hook.setter
-    def post_variant_combine_hook(self, fn):
-        if fn and not callable(fn):
-            raise ValueError("fn is expected to be a callable of the form:"
-                             "\ndef post_variant_combine_hook("
-                             "\n        specs, combined_spec, config=config, log_output=log_output):"
-                             "\n     ..."
-                             "\n     return combined_specs")
-        self._post_variant_combine_hook = fn
 
     @property
     def test_dir(self):

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -34,7 +34,7 @@ from conda_build import exceptions, utils, environ
 from conda_build.metadata import MetaData, combine_top_level_metadata_with_output
 import conda_build.source as source
 from conda_build.variants import (get_package_variants, list_of_dicts_to_dict_of_lists,
-                                  filter_by_key_value)
+                                  filter_by_key_value, filter_combined_spec_to_used_keys)
 from conda_build.exceptions import DependencyNeedsBuildingError
 from conda_build.index import get_build_index
 # from conda_build.jinja_context import pin_subpackage_against_outputs

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -520,8 +520,9 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
     # provide a hook so that more complex build systems have a place during which they can modify
     # the variant that gets generated.
     if config.post_variant_combine_hook is not None:
-        combined_spec = config.post_variant_combine_hook(specs, combined_spec, 
-                                                         config=config, log_output=log_output)
+        combined_spec = config.post_variant_combine_hook(specs, combined_spec,
+                                                         config=config,
+                                                         log_output=config.verbose)
 
     extend_keys = set(ensure_list(combined_spec.get('extend_keys')))
     extend_keys.update({'zip_keys', 'extend_keys'})

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -517,6 +517,12 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
     #      by a later spec
     combined_spec = combine_specs(specs, log_output=config.verbose)
 
+    # provide a hook so that more complex build systems have a place during which they can modify
+    # the variant that gets generated.
+    if config.post_variant_combine_hook is not None:
+        combined_spec = config.post_variant_combine_hook(specs, combined_spec, 
+                                                         config=config, log_output=log_output)
+
     extend_keys = set(ensure_list(combined_spec.get('extend_keys')))
     extend_keys.update({'zip_keys', 'extend_keys'})
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -486,7 +486,10 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
     return squished
 
 
-def get_package_variants(recipedir_or_metadata, config=None, variants=None):
+def get_package_combined_spec(recipedir_or_metadata, config=None, variants=None):
+    # outputs a tuple of (combined_spec_dict_of_lists, used_spec_file_dict)
+    #
+    # The output of this function is order preserving, unlike get_package_variants
     if hasattr(recipedir_or_metadata, 'config'):
         config = recipedir_or_metadata.config
     if not config:
@@ -516,13 +519,10 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
     # this merges each of the specs, providing a debug message when a given setting is overridden
     #      by a later spec
     combined_spec = combine_specs(specs, log_output=config.verbose)
+    return combined_spec, specs
 
-    # provide a hook so that more complex build systems have a place during which they can modify
-    # the variant that gets generated.
-    if config.post_variant_combine_hook is not None:
-        combined_spec = config.post_variant_combine_hook(specs, combined_spec,
-                                                         config=config,
-                                                         log_output=config.verbose)
+
+def filter_combined_spec_to_used_keys(combined_spec, specs):
 
     extend_keys = set(ensure_list(combined_spec.get('extend_keys')))
     extend_keys.update({'zip_keys', 'extend_keys'})
@@ -531,6 +531,7 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
     specs = specs.copy()
     del specs['internal_defaults']
 
+    # TODO: act here? 
     combined_spec = dict_of_lists_to_list_of_dicts(combined_spec, extend_keys=extend_keys)
     for source, source_specs in reversed(specs.items()):
         for k, vs in source_specs.items():
@@ -541,6 +542,11 @@ def get_package_variants(recipedir_or_metadata, config=None, variants=None):
                 combined_spec = (filter_by_key_value(combined_spec, k, vs, source_name=source) or
                                  combined_spec)
     return combined_spec
+
+
+def get_package_variants(recipedir_or_metadata, config=None, variants=None):
+    combined_spec, specs = get_package_combined_spec(recipedir_or_metadata, config=config, variants=variants)
+    return filter_combined_spec_to_used_keys(combined_spec, specs=specs)
 
 
 def get_vars(variants, loop_only=False):


### PR DESCRIPTION
For complex build systems that rely heavily on variant specs to produce
and update a large set of packages (such as conda-forge or c3i), it is
useful to have some means of overriding the behavior that is used by
conda render when generating package variants.

Alternatively we could just provide a config value allowing an override for `combined_spec` to be specified at the config level.

cc @msarahan 

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
