### PR TITLE
Drop `/usr` from CDT skeleton path

### DIFF
--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -105,8 +105,8 @@ BUILDSH = """\
 #!/bin/bash
 
 RPM=$(find ${PWD}/binary -name "*.rpm")
-mkdir -p ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot/usr
-pushd ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot/usr > /dev/null 2>&1
+mkdir -p ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot
+pushd ${PREFIX}/x86_64-conda_cos6-linux-gnu/sysroot > /dev/null 2>&1
 if [[ -n "${RPM}" ]]; then
   "${RECIPE_DIR}"/rpm2cpio "${RPM}" | cpio -idmv
   popd > /dev/null 2>&1


### PR DESCRIPTION
This seems to already exist in RPMs. So by default will result in the `usr` directory being created again within `usr`, which causes problems for CDTs and anything using them. This fixes that by dropping `usr` from the path.

cc @mingwandroid

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
