### PR TITLE
Update cran skeleton to not use toolchain for win

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1197,12 +1197,18 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                 if need_c:
                     deps.append("{indent}{{{{ compiler('c') }}}}      {sel}".format(
                         indent=INDENT, sel=sel_src_not_win))
+                    deps.append("{indent}{{{{ compiler('m2w64_c') }}}}{sel}".format(
+                        indent=INDENT, sel=sel_src_and_win))
                 if need_cxx:
                     deps.append("{indent}{{{{ compiler('cxx') }}}}    {sel}".format(
                         indent=INDENT, sel=sel_src_not_win))
+                    deps.append("{indent}{{{{ compiler('m2w64_cxx') }}}}{sel}".format(
+                        indent=INDENT, sel=sel_src_and_win))
                 if need_f:
                     deps.append("{indent}{{{{ compiler('fortran') }}}}{sel}".format(
                         indent=INDENT, sel=sel_src_not_win))
+                    deps.append("{indent}{{{{ compiler('m2w64_fortran') }}}}{sel}".format(
+                        indent=INDENT, sel=sel_src_and_win))
                 if use_rtools_win:
                     need_c = need_cxx = need_f = need_autotools = need_make = False
                     deps.append("{indent}rtools                   {sel}".format(
@@ -1212,9 +1218,6 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                     # for non-MRO builds or maybe switch to Jeroen's toolchain?)
                     # deps.append("{indent}{{{{native}}}}extsoft     {sel}".format(
                     #     indent=INDENT, sel=sel_src_and_win))
-                if need_c or need_cxx or need_f:
-                    deps.append("{indent}{{{{native}}}}toolchain      {sel}".format(
-                        indent=INDENT, sel=sel_src_and_win))
                 if need_autotools or need_make or need_git:
                     deps.append("{indent}{{{{posix}}}}filesystem      {sel}".format(
                         indent=INDENT, sel=sel_src_and_win))

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1195,17 +1195,17 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
             # Put non-R dependencies first.
             if dep_type == 'build':
                 if need_c:
-                    deps.append("{indent}{{{{ compiler('c') }}}}      {sel}".format(
+                    deps.append("{indent}{{{{ compiler('c') }}}}            {sel}".format(
                         indent=INDENT, sel=sel_src_not_win))
-                    deps.append("{indent}{{{{ compiler('m2w64_c') }}}}{sel}".format(
+                    deps.append("{indent}{{{{ compiler('m2w64_c') }}}}      {sel}".format(
                         indent=INDENT, sel=sel_src_and_win))
                 if need_cxx:
-                    deps.append("{indent}{{{{ compiler('cxx') }}}}    {sel}".format(
+                    deps.append("{indent}{{{{ compiler('cxx') }}}}          {sel}".format(
                         indent=INDENT, sel=sel_src_not_win))
-                    deps.append("{indent}{{{{ compiler('m2w64_cxx') }}}}{sel}".format(
+                    deps.append("{indent}{{{{ compiler('m2w64_cxx') }}}}    {sel}".format(
                         indent=INDENT, sel=sel_src_and_win))
                 if need_f:
-                    deps.append("{indent}{{{{ compiler('fortran') }}}}{sel}".format(
+                    deps.append("{indent}{{{{ compiler('fortran') }}}}      {sel}".format(
                         indent=INDENT, sel=sel_src_not_win))
                     deps.append("{indent}{{{{ compiler('m2w64_fortran') }}}}{sel}".format(
                         indent=INDENT, sel=sel_src_and_win))

--- a/news/cran_skeleton_win_compilers
+++ b/news/cran_skeleton_win_compilers
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* Update cran skeleton to use m2w64 compilers for windows instead of toolchain.
+  The linter is telling since long: Using toolchain directly in this manner is deprecated.
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

Update cran skeleton to use m2w64 compilers for windows instead of toolchain.

The linter is telling since long: Using toolchain directly in this manner is deprecated.

(Instead of updating the liner: https://github.com/conda-forge/conda-smithy/pull/1062)