### PR TITLE
[WIP] Add content to Metapackage

### DIFF
--- a/conda_build/metapackage.py
+++ b/conda_build/metapackage.py
@@ -5,7 +5,7 @@ from conda_build.metadata import MetaData
 
 def create_metapackage(name, version, entry_points=(), build_string=None, build_number=0,
                        dependencies=(), home=None, license_name=None, summary=None, config=None):
-    # local import to avoid circular import, we provid create_metapackage in api
+    # local import to avoid circular import, we provide create_metapackage in api
     from conda_build.api import build
 
     if not config:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,6 +327,40 @@ def test_metapackage_metadata(testing_config, testing_workdir):
     assert info['summary'] == 'wee'
 
 
+def test_metapackage_content(testing_config, testing_workdir):
+    # generate a simple content txt file
+    nested_dir = os.makedirs(os.path.join(testing_workdir, [ 'conda', 'nested', 'dir' ]))
+
+    for basedir in [testing_workdir, nested_dir]:
+        dest_file = os.path.join(testing_workdir, 'content.txt')
+        with open(dest_file, 'w') as f:
+            f.write('content in metapackage')
+        assert os.path.isfile(dest_file)
+
+
+    args = ['metapackage_content', '1.0',
+            '--content', 'content.txt', '/',
+            '--content', 'content.txt', '/renamed.txt',
+            '--content', 'content.txt', '/abc/',
+            '--content', 'conda', '/',
+            '--content', 'conda/nested', '/',
+            '--content', 'conda', '/my',
+            '--content', 'conda', '/your/',
+            '--no-anaconda-upload']
+    main_metapackage.execute(args)
+
+    test_path = glob(os.path.join(sys.prefix, "conda-bld", testing_config.host_subdir,
+                             'metapackage_content-1.0-0.tar.bz2'))[0]
+    assert os.path.isfile(test_path)
+    assert package_has_file(test_path, 'content.txt')
+    assert package_has_file(test_path, 'renamed.txt')
+    assert package_has_file(test_path, 'abc/content.txt')
+    assert package_has_file(test_path, 'conda/nested/dir//content.txt')
+    assert package_has_file(test_path, 'nested/dir/content.txt')
+    assert package_has_file(test_path, 'my/nested/dir/content.txt')
+    assert package_has_file(test_path, 'your/conda/nested/dir/content.txt')
+
+
 def testing_index(testing_workdir):
     args = ['.']
     main_index.execute(args)


### PR DESCRIPTION
### Use Case
Data Scientist finished training a model, e.g. a Tensorflow graph or some other pickle file. They want to store that model for either sharing or posterior use. Since they are already using conda, it would be nice to store those model files as conda packages and upload then to a repo, with proper dependency management and versioning.

### Actual Behavior

We reinvent the wheel and create our own mini package manager.

### Expected Behavior

I would like to be able to:
1. Using the command line generate a conda package similar to how `conda metapackage` works, but allow us to include content, e.g. 
```
# To create a package my-model-0.1.1 with model.pk at $PREFIX/model/model.pkl
conda metapackage --content model.pkl:/model/ my-model 0.1.1

# To create a package my-conf-0.2 with config folder at $PREFIX/etc/my
conda metapackage --content config:/etc/my my-conf 0.2
```

2. Generate the same conda package from step 1 but calling a simple API. This use case would include the API call right after the model is trained.
```python
from conda_build import metapackage

# Single file case
create_metapackage("my-model", "0.1.1", content=[('model.pkl', '/model/')])

# Directory tree case
create_metapackage("my-conf", "0.2", content=[('config', '/etc/my')])
```

Any feedback is welcome