### PR TITLE
Added dependency on setuptools

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - python
     - pyyaml
     - scandir       # [py<34]
+    - setuptools
     - six
     - glob2  >=0.6
     - pytz

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -4,8 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from functools import partial
 import os
 from os import lstat
-from pkg_resources import parse_version
 from importlib import import_module
+
+from pkg_resources import parse_version
 
 from conda import __version__ as CONDA_VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ if version_dict['error']:
     raise RuntimeError(version_dict["error"])
 
 deps = ['conda', 'requests', 'filelock', 'pyyaml', 'jinja2', 'pkginfo',
-        'beautifulsoup4', 'chardet', 'pytz', 'tqdm', 'psutil', 'six', 'libarchive-c']
+        'beautifulsoup4', 'chardet', 'pytz', 'tqdm', 'psutil', 'six',
+        'libarchive-c', 'setuptools']
 
 # We cannot build lief for Python 2.7 on Windows (unless we use mingw-w64 for it, which
 # would be a non-trivial amount of work).


### PR DESCRIPTION
This PR adds an explicit dependency on `setuptools`, since `pkg_resources` module is a module-level import. I have not added a news entry, since this is a packaging-only change. 