### PR TITLE
Update MACOSX_DEPLOYMENT_TARGET default value

### DIFF
--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -183,7 +183,7 @@ defined only on macOS.
    * - LDFLAGS
      - Same as CFLAGS.
    * - MACOSX_DEPLOYMENT_TARGET
-     - Same as the Anaconda Python macOS deployment target. Currently ``10.6``.
+     - Same as the Anaconda Python macOS deployment target. Currently ``10.9``.
    * - OSX_ARCH
      - ``i386`` or ``x86_64``, depending on Python build.
 


### PR DESCRIPTION
As seen [here](https://github.com/conda/conda-build/blob/32a305208ffe53502e3a2bed8e83279da2cb5a5e/conda_build/environ.py#L575), the default `MACOSX_DEPLOYMENT_TARGET` has drifted since this doc was written.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
