### PR TITLE
allow .tar.bz2 files to use .conda index cache, but not vice versa (a…

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1039,7 +1039,11 @@ class ChannelIndex(object):
             alternate_cache = True
 
         try:
-            if os.path.isfile(index_cache_path):
+            # allow .tar.bz2 files to use the .conda cache, but not vice-versa.
+            #    .conda readup is very fast (essentially free), but .conda files come from
+            #    converting .tar.bz2 files, which can go wrong.  Forcing extraction for
+            #    .conda files gives us a check on the validity of that conversion.
+            if not fn.endswith('.conda') and os.path.isfile(index_cache_path):
                 with open(index_cache_path) as f:
                     index_json = json.load(f)
             elif not alternate_cache and (second_try or not os.path.exists(index_cache_path)):

--- a/news/timestamp_keyerror
+++ b/news/timestamp_keyerror
@@ -7,6 +7,7 @@ Bug fixes:
 ----------
 
 * fix one more keyerror with missing timestamp data
+* when indexing, allow .tar.bz2 files to use .conda cache, but not vice versa.  This acts as a sanity check on the .conda files.
 
 Deprecations:
 -------------


### PR DESCRIPTION
…s sanity check of converted files)

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
