### PR TITLE
cran-skeleton: support optional licenses

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1442,7 +1442,7 @@ def get_license_info(license_text, allowed_license_families):
                  'bsd2': ['BSD_2_clause', 'BSD_2_Clause', 'BSD 2-clause License'],
                  'bsd3': ['BSD_3_clause', 'BSD_3_Clause', 'BSD 3-clause License'],
                  'mit': ['MIT'],
-                }
+                 }
 
     license_file_template = '\'{{{{ environ["PREFIX"] }}}}/lib/R/share/licenses/{license_id}\''
 

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1455,7 +1455,7 @@ def get_license_info(license_text, allowed_license_families):
         # the file case
         if l_opt.startswith("file "):
             license_files.append(l_opt[5:])
-            break
+            continue
 
         # license id string to match
         for license_id in d_license.keys():

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1409,7 +1409,7 @@ def up_to_date(cran_metadata, package):
 
 
 def get_license_info(license_text, allowed_license_families):
-    '''
+    """
     Most R packages on CRAN do not include a license file. Instead, to avoid
     duplication, R base ships with common software licenses:
 
@@ -1420,17 +1420,12 @@ def get_license_info(license_text, allowed_license_families):
     license file shipped with R base. The template files are more complicated
     because they would need to be combined with the license information provided
     by the package authors. In this case, the template file and the license
-    information file are both packaged.
+    information file are both packaged. All optional ('|' seperated) licenses
+    are included, if they are matching.
 
     This function returns the path to the license file for the unambiguous
     cases.
-    '''
-
-    license_extra_file = None
-    if '+ file' in license_text:
-        idx = license_text.index(" + file ")
-        license_extra_file = license_text[idx+8:]
-        license_text = license_text[:idx]
+    """
 
     # The list order matters. The first element should be the name of the
     # license file shipped with r-base.
@@ -1449,18 +1444,34 @@ def get_license_info(license_text, allowed_license_families):
                  'mit': ['MIT'],
                 }
 
-    license_file_template = 'license_file:\n    - \'{{{{ environ["PREFIX"] }}}}/lib/R/share/licenses/{license_id}\''
+    license_file_template = '\'{{{{ environ["PREFIX"] }}}}/lib/R/share/licenses/{license_id}\''
 
-    for license_id in d_license.keys():
-        if license_text in d_license[license_id]:
-            license_text = d_license[license_id][0]
-            license_file = license_file_template.format(license_id=license_text)
-            break
-    else:
-        license_file = ''
+    license_texts = []
+    license_files = []
 
-    if license_extra_file is not None and license_file != '':
-        license_file = license_file + '\n    - ' + license_extra_file
+    license_text_parts = [l_opt.strip() for l_opt in license_text.split("|")]
+    for l_opt in license_text_parts:
+        license_extra_file = None
+        if "+ file" in l_opt:
+            idx = license_text.index(" + file ")
+            license_extra_file = l_opt[idx+8:]
+            l_opt = l_opt[:idx]
+        for license_id in d_license.keys():
+            if l_opt in d_license[license_id]:
+                l_opt_text = d_license[license_id][0]
 
+                license_texts.append(l_opt_text)
+                license_files.append(license_file_template.format(license_id=l_opt_text))
+                if license_extra_file:
+                    license_files.append(license_extra_file)
+
+    # Fallback to original license_text if matched license_texts is empty
+    license_text = " | ".join(license_texts) or license_text
+
+    # Build the license_file entry and ensure it is empty if no license file
+    license_file = "license_file:\n    - " + "\n    - ".join(license_files) if license_files else ""
+
+    # Only one family is allowed, so guessing it once
     license_family = guess_license_family(license_text, allowed_license_families)
+
     return license_text, license_file, license_family

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1449,23 +1449,24 @@ def get_license_info(license_text, allowed_license_families):
     license_texts = []
     license_files = []
 
-    license_text_parts = [l_opt.strip() for l_opt in license_text.split("|")]
+    # split license_text by "|" and "+" into parts for further matching
+    license_text_parts = [l_opt.strip() for l_opt in re.split('\||\+', license_text)]
     for l_opt in license_text_parts:
-        license_extra_file = None
-        if "+ file" in l_opt:
-            idx = license_text.index(" + file ")
-            license_extra_file = l_opt[idx+8:]
-            l_opt = l_opt[:idx]
+        # the file case
+        if l_opt.startswith("file "):
+            license_files.append(l_opt[5:])
+            break
+
+        # license id string to match
         for license_id in d_license.keys():
             if l_opt in d_license[license_id]:
                 l_opt_text = d_license[license_id][0]
 
                 license_texts.append(l_opt_text)
                 license_files.append(license_file_template.format(license_id=l_opt_text))
-                if license_extra_file:
-                    license_files.append(license_extra_file)
+                break
 
-    # Fallback to original license_text if matched license_texts is empty
+    # Join or fallback to original license_text if matched license_texts is empty
     license_text = " | ".join(license_texts) or license_text
 
     # Build the license_file entry and ensure it is empty if no license file

--- a/news/cran_skeleton_match_optional_licenses
+++ b/news/cran_skeleton_match_optional_licenses
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* Update cran skeleton to match supported optional licenses for license file
+  derivation.
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -347,6 +347,8 @@ cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),
                  ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),
                  ('r-meanr', 'BSD_2_clause', 'BSD', ['BSD_2_clause', 'LICENSE']),
                  ('r-rsed', 'BSD_3_clause', 'BSD', ['BSD_3_clause', 'LICENSE']),
+                 ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),
+                 ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),
                  ]
 
 

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -341,16 +341,16 @@ def test_pypi_section_order_preserved(testing_workdir):
 
 # CRAN packages to test license_file entry.
 # (package, license_id, license_family, license_files)
-cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),
-                 ('r-cortools', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),
-                 ('r-udpipe', 'MPL-2.0', 'OTHER', ''),
-                 ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),
-                 ('r-meanr', 'BSD_2_clause', 'BSD', ['BSD_2_clause', 'LICENSE']),
-                 ('r-rsed', 'BSD_3_clause', 'BSD', ['BSD_3_clause', 'LICENSE']),
-                 ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),
-                 ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),
-                 ('r-dt', 'GPL-3', 'GPL3', 'GPL-3'),
-                 ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),
+cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
+                 ('r-cortools', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),  # cran: 'Artistic License 2.0'
+                 ('r-udpipe', 'MPL-2.0', 'OTHER', ''),  # cran: 'MPL-2.0'
+                 ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),  # cran: 'MIT + file LICENSE'
+                 ('r-meanr', 'BSD_2_clause', 'BSD', ['BSD_2_clause', 'LICENSE']),  # cran: 'BSD 2-clause License + file LICENSE'
+                 ('r-rsed', 'BSD_3_clause', 'BSD', ['BSD_3_clause', 'LICENSE']),  # cran: 'BSD_3_clause + file LICENSE'
+                 ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),  # cran: 'GPL-2 | GPL-3'
+                 ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),  # cran: 'GPL-3 | GPL-2'
+                 ('r-dt', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3 | file LICENSE'
+                 ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),  # cran: 'GPL (>= 2)'
                  ]
 
 

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -349,6 +349,7 @@ cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),
                  ('r-rsed', 'BSD_3_clause', 'BSD', ['BSD_3_clause', 'LICENSE']),
                  ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),
                  ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),
+                 ('r-dt', 'GPL-3', 'GPL3', 'GPL-3'),
                  ]
 
 

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -349,7 +349,7 @@ cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
                  ('r-rsed', 'BSD_3_clause', 'BSD', ['BSD_3_clause', 'LICENSE']),  # cran: 'BSD_3_clause + file LICENSE'
                  ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),  # cran: 'GPL-2 | GPL-3'
                  ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),  # cran: 'GPL-3 | GPL-2'
-                 ('r-dt', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3 | file LICENSE'
+                 ('r-dt', 'GPL-3', 'GPL3', ['GPL-3', 'LICENSE']),  # cran: 'GPL-3 | file LICENSE'
                  ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),  # cran: 'GPL (>= 2)'
                  ]
 

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -350,6 +350,7 @@ cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),
                  ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),
                  ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),
                  ('r-dt', 'GPL-3', 'GPL3', 'GPL-3'),
+                 ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),
                  ]
 
 


### PR DESCRIPTION
This is a bit tricky. Ideas welcome to improve it or do it in a different way.

Still I believe, that this gives some skeleton generated recipes a valid license file, which they
currently miss. This is not only helpful for new recipes, but also for existing ones, that get re-generated as part of an update process.

@jdblischak updated the license handling before, maybe you want to take a look.

This can be tested with e.g. r-dt or r-zoo.

Thanks

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
