### PR TITLE
Make lief an optional dependency

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -25,8 +25,9 @@ from conda_build.conda_interface import TemporaryDirectory
 from conda_build.conda_interface import md5_file
 
 from conda_build import utils
-from conda_build.os_utils.liefldd import (get_exports_memoized, get_linkages_memoized,
-                                          get_rpaths_raw, get_runpaths_raw, set_rpath)
+from conda_build.os_utils.liefldd import (have_lief, get_exports_memoized,
+                                          get_linkages_memoized, get_rpaths_raw,
+                                          get_runpaths_raw)
 from conda_build.os_utils.pyldd import codefile_type
 from conda_build.os_utils.ldd import get_package_obj_files
 from conda_build.index import get_build_index
@@ -431,10 +432,11 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
     except CalledProcessError:
         print('patchelf: --print-rpath failed for %s\n' % (elf))
         return
-    existing2, _, _ = get_rpaths_raw(elf)
-    if existing != existing2:
-        print('ERROR :: get_rpaths_raw()={} and patchelf={} disagree for {} :: '.format(
-            existing2, existing, elf))
+    if have_lief:
+        existing2, _, _ = get_rpaths_raw(elf)
+        if existing != existing2:
+            print('ERROR :: get_rpaths_raw()={} and patchelf={} disagree for {} :: '.format(
+                existing2, existing, elf))
     existing = existing.split(os.pathsep)
     new = []
     for old in existing:

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -465,7 +465,8 @@ def mk_relative_linux(f, prefix, rpaths=('lib',)):
             if rpath not in new:
                 new.append(rpath)
     rpath = ':'.join(new)
-    set_rpath(old_matching='*', new_rpath=rpath, file=elf)
+    print('patchelf: file: %s\n    setting rpath to: %s' % (elf, rpath))
+    call([patchelf, '--force-rpath', '--set-rpath', rpath, elf])
 
 
 def assert_relative_osx(path, host_prefix, build_prefix):


### PR DESCRIPTION
Make lief an optional dependency by using patchelf to set the RPATHs and only calling function which depend on lief when it is available.