### PR TITLE
fix caching using move instead of copy, resulting in missing .conda data

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1086,7 +1086,7 @@ class ChannelIndex(object):
                             os.makedirs(os.path.dirname(dest))
                         except:
                             pass
-                        utils.move_with_fallback(src, dest)
+                        utils.copy_into(src, dest)
 
                 with open(index_cache_path) as f:
                     index_json = json.load(f)


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
