### PR TITLE
Fix missing package names in index.html

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1196,7 +1196,7 @@ class ChannelIndex(object):
         return write_result
 
     def _write_subdir_index_html(self, subdir, repodata):
-        repodata_packages = repodata["packages"].values()
+        repodata_packages = repodata["packages"]
         subdir_path = join(self.channel_root, subdir)
 
         def _add_extra_path(extra_paths, path):

--- a/conda_build/templates/subdir-index.html.j2
+++ b/conda_build/templates/subdir-index.html.j2
@@ -49,6 +49,7 @@
       <th>Filename</th>
       <th>Size</th>
       <th>Last Modified</th>
+      <th>SHA256</th>
       <th>MD5</th>
     </tr>
 {% for path in extra_paths %}
@@ -61,11 +62,12 @@
       <td>{{ record.md5 }}</td>
     </tr>
 {%- endfor %}
-{% for record in packages %}
+{% for fn, record in packages|dictsort() %}
     <tr>
-      <td>{{ record.fn | add_href(record.fn) }}</td>
+      <td>{{ fn | add_href(fn) }}</td>
       <td class="s">{{ record.size | human_bytes }}</td>
       <td>{% if record.timestamp %}{{ record.timestamp|strftime("%Y-%m-%d %H:%M:%S %z") }}{% endif %}</td>
+      <td>{{ record.sha256 }}</td>
       <td>{{ record.md5 }}</td>
     </tr>
 {%- endfor %}

--- a/news/fix_html_fnames
+++ b/news/fix_html_fnames
@@ -1,0 +1,9 @@
+Enhancements:
+-------------
+
+* package sha256 sums are includex in index.html
+
+Bug fixes:
+----------
+
+* fix bug where package filenames were not included in the index.html


### PR DESCRIPTION
Fix issue where filenames and links where missing from the index.html
files created by conda-index.

Adds a SHA256 column which was already being recorded for the extra files.