### PR TITLE
Drop source RPMs (as they are unused currently)

### DIFF
--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -38,8 +38,6 @@ source:
   - url: {rpmurl}
     {checksum_name}: {checksum}
     folder: binary
-  - url: {srcrpmurl}
-    folder: source
 
 build:
   number: 0
@@ -521,7 +519,6 @@ def write_conda_recipes(recursive, repo_primary, package, architectures,
               'hostsubdir': cdt['host_subdir'],
               'depends': dependsstr,
               'rpmurl': rpm_url,
-              'srcrpmurl': srpm_url,
               'home': entry['home'],
               'license': license,
               'license_family': license_family,


### PR DESCRIPTION
Also community members have requested having checksums for the source RPMs as well. While there is some rough idea as to how this might be done, it appears to be a fair bit of work that no one has volunteered to take on. To streamline usage a bit, the suggestion here is to leave source RPMs out of the skeleton until we have solved this checksum issue.

cc @mingwandroid

xref: https://github.com/conda/conda-build/issues/3552
xref: https://github.com/conda-forge/staged-recipes/pull/8633#discussion_r296949547
xref: https://github.com/conda-forge/conda-forge.github.io/issues/783

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->