### PR TITLE
Fix in render.py::_read_specs_from_package

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -253,7 +253,7 @@ def _read_specs_from_package(pkg_loc, pkg_dist):
         elif os.path.isfile(downstream_file + '.json'):
             with open(downstream_file + '.json') as f:
                 specs = json.load(f)
-    if not specs and os.path.isfile(pkg_loc):
+    if not specs and pkg_loc and os.path.isfile(pkg_loc):
         # switching to json for consistency in conda-build 4
         specs_yaml = utils.package_has_file(pkg_loc, 'info/run_exports.yaml')
         specs_json = utils.package_has_file(pkg_loc, 'info/run_exports.json')


### PR DESCRIPTION
This PR adds check on `pkg_loc` as explained in the following note privately sent to @msarahan:

<hr>
<p>
In A Travis’s PR job for Pull Request by @ogrisel to daal4py fails with conda build error:

https://github.com/IntelPython/daal4py/pull/111/checks?check_run_id=159357667

Failures manifest itself on Py2 on Linux, and Py 3 on OSX, i.e. work fine on Py3/Linux and Py2/OSX.
The failure happens during rendering of the recipe being built.

The trailing backtrace:

```
  File "/home/travis/miniconda/lib/python2.7/site-packages/conda_build/render.py", line 234, in _read_specs_from_package
    if not specs and os.path.isfile(pkg_loc):
  File "/home/travis/miniconda/lib/python2.7/genericpath.py", line 37, in isfile
    st = os.stat(path)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

It appears as if the argument `pkg_loc` to `_read_specs_from_package` is `None`.

I suspect  that line 256, https://github.com/conda/conda-build/blob/master/conda_build/render.py#L256  should check that pkg_loc is not None:

if not specs and pkg_loc and os.path.isfile(pkg_loc):

Similar to how L244 does a block above.
</p>