### PR TITLE
fix conda debug output being suppressed

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -724,11 +724,10 @@ def get_install_actions(prefix, specs, env, retries=0, subdir=None,
     specs = list(specs)
     if specs:
         specs.extend(create_default_packages)
-    if verbose:
+    if verbose or debug:
         capture = contextlib.contextmanager(lambda: (yield))
-    elif debug:
-        capture = contextlib.contextmanager(lambda: (yield))
-        conda_log_level = logging.DEBUG
+        if debug:
+            conda_log_level = logging.DEBUG
     else:
         capture = utils.capture
     for feature, value in feature_list:

--- a/news/fix-conda-debug
+++ b/news/fix-conda-debug
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* fix conda debug output being suppressed


### PR DESCRIPTION
fix conda debug output being suppressed

`config.verbose` is set to `True` if `--debug` is used in https://github.com/conda/conda-build/blob/3.18.6/conda_build/cli/main_build.py#L382. Thus the first `if` condition is `True` when the `elif` condition is `True`, ergo the latter isn't executed.