### PR TITLE
make pins for current_repodata additive - always newest, and pins are…

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -722,14 +722,13 @@ def _shard_newest_packages(subdir, r, pins=None):
     groups = {}
     pins = pins or {}
     for g_name, g_recs in r.groups.items():
+        # always do the latest implicitly
+        version = r.groups[g_name][0].version
+        matches = set(r.find_matches(MatchSpec('%s=%s' % (g_name, version))))
         if g_name in pins:
-            matches = set()
-            for pin in pins[g_name]:
-                version = r.find_matches(MatchSpec('%s=%s' % (g_name, pin)))[0].version
+            for pin_value in pins[g_name]:
+                version = r.find_matches(MatchSpec('%s=%s' % (g_name, pin_value)))[0].version
                 matches.update(r.find_matches(MatchSpec('%s=%s' % (g_name, version))))
-        else:
-            version = r.groups[g_name][0].version
-            matches = set(r.find_matches(MatchSpec('%s=%s' % (g_name, version))))
         groups[g_name] = matches
     new_r = _get_resolve_object(subdir, precs=[pkg for group in groups.values() for pkg in group])
     return set(_add_missing_deps(new_r, r))

--- a/news/additive_pins
+++ b/news/additive_pins
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* make pins for current_repodata additive - always newest, and pins are additions to that
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/news/run_exports
+++ b/news/run_exports
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* add fallback to run_exports determination for channels that don't have channeldata.json
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
… additions to that

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
