### PR TITLE
Get run_exports the slow way

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -357,16 +357,12 @@ def get_upstream_pins(m, actions, env):
     run_exports = {}
     empty_run_exports = False
     for pkg in linked_packages:
-        channeldata = utils.download_channeldata(pkg.channel)
-        if channeldata:
-            pkg_data = channeldata.get('packages', {}).get(pkg.name, {})
-            run_exports = pkg_data.get('run_exports', {}).get(pkg.version, {})
-            empty_run_exports = run_exports == {}
-        if not run_exports and not empty_run_exports:
-            locs_and_dists = execute_download_actions(m, actions, env=env,
-                                                      package_subset=linked_packages)
-            locs_and_dists = [v for k, v in locs_and_dists.items() if k == pkg]
-            run_exports = _read_specs_from_package(*next(iter(locs_and_dists)))
+        # here we can't use channeldata.json, because it doesn't
+        # handle multiple builds of packages for the same version
+        locs_and_dists = execute_download_actions(m, actions, env=env,
+                                                  package_subset=linked_packages)
+        locs_and_dists = [v for k, v in locs_and_dists.items() if k == pkg]
+        run_exports = _read_specs_from_package(*next(iter(locs_and_dists)))
         specs = _filter_run_exports(run_exports, ignore_list)
         if specs:
             additional_specs = utils.merge_dicts_of_lists(additional_specs, specs)


### PR DESCRIPTION
`channeldata.json` only contains one `run_exports` entry for each version of each package; some packages (looking at you `fftw`) have multiple builds of the same version with different `run_exports`. This PR naively undoes some recent work to force recipe rendering to use the slow, but robust method of accessing `run_exports`.

I'm not sure if this PR is well-motivated, or if there is a better solution to the `run_exports` problem, so I haven't added news entries, but will do if this change is acceptable.
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
