### PR TITLE
Fixes spurious post build errors/warning messages

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -399,6 +399,7 @@ def inspect_linkages_lief(filename, resolve_filenames=True, recurse=True,
     exedir = os.path.dirname(filename)
     binary = lief.parse(filename)
     todo = [[filename, binary]]
+    sysroot = _trim_sysroot(sysroot)
 
     default_paths = []
     if binary.format == lief.EXE_FORMATS.ELF:

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -491,9 +491,9 @@ def mk_relative_linux(f, prefix, rpaths=('lib',), method='LIEF'):
         return
     if have_lief:
         existing2, _, _ = get_rpaths_raw(elf)
-        if existing != existing2:
+        if [existing] != existing2:
             print('ERROR :: get_rpaths_raw()={} and patchelf={} disagree for {} :: '.format(
-                existing2, existing, elf))
+                existing2, [existing], elf))
     existing = existing.split(os.pathsep)
     new = []
     for old in existing:


### PR DESCRIPTION
This pull requests fixes to two cases where warnings/error messages would be printed by the post build checks when nothing was wrong:

- The check on the difference between the results of get_rpath_raw and patchelf in post.py would always fail because a list (get_rpath_raw) was being compared to a str (output from the subproccess call to pathelf). The first one is a fix for issue #3520 

- get_linkages sometimes throws a warning because the function ```inspect_linkages_lief``` doesn't strip trailing path separators from sysroot, but ```inspect_linkages_pyldd``` does. In cases were sysroot has a trailing separator the comparison of the results fail because some of the results from ```inspect_linkages_lief``` would have double separators. This one is a fix for #3539 