### PR TITLE
variants: remove hard-coded default path for CONDA_BUILD_SYSROOT

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -33,7 +33,6 @@ DEFAULT_VARIANTS = {
     'ignore_build_only_deps': ['python', 'numpy'],
     'extend_keys': ['pin_run_as_build', 'ignore_version', 'ignore_build_only_deps', 'extend_keys'],
     'cran_mirror': "https://cran.r-project.org",
-    'CONDA_BUILD_SYSROOT': '/opt/MacOSX10.10.sdk',
 }
 
 # set this outside the initialization because of the dash in the key

--- a/news/remove-default-variants-sysroot
+++ b/news/remove-default-variants-sysroot
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* variants: remove hard-coded default path for CONDA_BUILD_SYSROOT
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
In https://github.com/conda/conda-build/commit/8a326413e1f7fc2441a9668027977ecb2e2fdfe0#diff-593f4997b372b8d4a4fe630de1e497adR36 a hard-coded path was added as a default value for `CONDA_BUILD_SYSROOT`.
The commit message from that commit is
> Set CONDA_BUILD_SYSROOT during tests to /opt/MacOSX10.10.sdk 

. So, supposedly, this also wasn't meant to be added as a general default value, but just for tests.
If it is still needed to be set for some tests, feel free to add it to the appropriate place and commit to this branch (meaning, "Allow edits from maintainers." is enabled).