### PR TITLE
add --use-channeldata arg which determines if channeldata is used to find run_exports

### DIFF
--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -137,12 +137,18 @@ source to try fill in related template variables.",
               "yours to handle. Any variants with overlapping names within a "
               "build will clobber each other.")
     )
+    p.add_argument(
+        '--use-channeldata',
+        action='store_true',
+        dest='use_channeldata',
+        help=("Use channeldata, if available, to determine run_exports. Otherwise packages "
+              "are downloaded to determine this information")
+    )
     p.add_argument('--variants',
                    nargs=1,
                    action=ParseYAMLArgument,
                    help=('Variants to extend the build matrix. Must be a valid YAML instance, '
                          'such as "{python: [3.6, 3.7]}"'))
-
     add_parser_channels(p)
     return p
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -100,6 +100,11 @@ def _get_default_settings():
             # should rendering cut out any skipped metadata?
             Setting('trim_skip', True),
 
+            # Use channeldata.json for run_export information during rendering.
+            # Falls back to downloading packages if False or channeldata does
+            # not exist for the channel.
+            Setting('use_channeldata', False),
+
             # Disable the overlinking test for this package. This test checks that transitive DSOs
             # are not referenced by DSOs in the package being built. When this happens something
             # has gone wrong with:


### PR DESCRIPTION
Add a --use-channeldata argument which determines if channeldata is used to determine run_exports when rendering (and builds) a recipe.  The default is False which will use run_export information from the packages directly.