### PR TITLE
docs: remove bzip2 package from build toolkit description

### DIFF
--- a/docs/source/user-guide/tutorials/building-conda-packages.rst
+++ b/docs/source/user-guide/tutorials/building-conda-packages.rst
@@ -122,13 +122,13 @@ built on Windows 10.
 Other tools
 ------------
 
-Some environments initially lack tools such as bzip2, patch, or Git
+Some environments initially lack tools such as patch or Git
 that may be needed for some build workflows.
 
 On Windows these can be installed with conda:
 
 ```
-conda install bzip2 git m2-patch
+conda install git m2-patch
 ```
 
 On macOS and Linux replace `m2-patch` with patch

--- a/news/docs-remove-bzip2.rst
+++ b/news/docs-remove-bzip2.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* Remove bzip2 package from build toolkit description.
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
`docs/source/user-guide/tutorials/building-conda-packages.rst ` mentions `bzip2` as one of the "other tools" of the "building toolkit" but -- in contrast to patch and Git -- does not reference it later anywhere.
For consistency, `bzip2` could/should be removed in that document.
(It is also no "optional dependency" for `conda-build` like `git` and `patch` are, so no hurt in not mentioning it.)

xref: https://github.com/conda-forge/docker-images/pull/103