### PR TITLE
Actually fix https://github.com/conda/conda-build/issues/3597

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -129,7 +129,7 @@ channel_data = {}
 #    would be nice to fix this at some point.
 MAX_THREADS_DEFAULT = os.cpu_count() if (hasattr(os, "cpu_count") and os.cpu_count() > 1) else 1
 if sys.platform == 'win32':  # see https://github.com/python/cpython/commit/8ea0fd85bc67438f679491fae29dfe0a3961900a
-    MAX_THREADS_DEFAULT = min(61, MAX_THREADS_DEFAULT)
+    MAX_THREADS_DEFAULT = min(48, MAX_THREADS_DEFAULT)
 LOCK_TIMEOUT_SECS = 3 * 3600
 LOCKFILE_NAME = ".lock"
 


### PR DESCRIPTION
Looks like 60 was the magic number in this case. Was basing it off the python change which uses 61. Not sure where the extra thread comes from. Rather than trying to get this exact though, I figure it's better to have plenty of room to spare.