### PR TITLE
[WIP] Allow to specify channels in a recipe

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -506,7 +506,7 @@ FIELDS = {
               },
     'outputs': {'name', 'version', 'number', 'script', 'script_interpreter', 'build',
                 'requirements', 'test', 'about', 'files', 'type'},
-    'requirements': {'requirements', 'build', 'host', 'run', 'conflicts', 'run_constrained'},
+    'requirements': {'channels', 'build', 'host', 'run', 'conflicts', 'run_constrained'},
     'app': {'entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'},
     'test': {'requires', 'commands', 'files', 'imports', 'source_files', 'downstreams'},

--- a/news/allow-channels-in-recipes.rst
+++ b/news/allow-channels-in-recipes.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* Channels can now be added to recipes (at requirements > channels).
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/tests/test-recipes/metadata/_recipe_requiring_external_channel_in_yaml/meta.yaml
+++ b/tests/test-recipes/metadata/_recipe_requiring_external_channel_in_yaml/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: requires_external_channel
+  version: 1.0
+
+requirements:
+  channels:
+    - conda_build_test
+
+  build:
+    # package that does not exist on defaults, but only on our test channel
+    - conda_build_test_requirement

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,11 +48,21 @@ def test_build_add_channel():
             os.path.join(metadata_dir, "_recipe_requiring_external_channel")]
     main_build.execute(args)
 
-def test_build_yaml_channel():
+
+def test_build_add_channel_from_yaml():
     """This recipe requires the conda_build_test_requirement package, which is
     only on the conda_build_test channel. This verifies that specifying channels in the meta.yaml file works."""
 
     args = [os.path.join(metadata_dir, "_recipe_requiring_external_channel_in_yaml")]
+    main_build.execute(args)
+
+
+def test_build_duplicate_channel():
+    """This recipe requires the conda_build_test_requirement package, which is
+    only on the conda_build_test channel. This verifies that specifying channels in the meta.yaml and using the -c argument simultaneously does not cause problems."""
+
+    args = ['-c', 'conda_build_test', '--no-activate', '--no-anaconda-upload', 
+            os.path.join(metadata_dir, "_recipe_requiring_external_channel_in_yaml")]
     main_build.execute(args)
 
 
@@ -83,7 +93,7 @@ def test_render_add_channel():
         assert required_package_details[1] == '1.0', "Expected version number 1.0 on successful rendering, but got {}".format(required_package_details[1])
 
 
-def test_render_yaml_channel():
+def test_render_add_channel_from_yaml():
     """This recipe requires the conda_build_test_requirement package, which is
     only on the conda_build_test channel. This verifies specifying channels in the meta.yaml file works for rendering."""
     with TemporaryDirectory() as tmpdir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,13 @@ def test_build_add_channel():
             os.path.join(metadata_dir, "_recipe_requiring_external_channel")]
     main_build.execute(args)
 
+def test_build_yaml_channel():
+    """This recipe requires the conda_build_test_requirement package, which is
+    only on the conda_build_test channel. This verifies that specifying channels in the meta.yaml file works."""
+
+    args = [os.path.join(metadata_dir, "_recipe_requiring_external_channel_in_yaml")]
+    main_build.execute(args)
+
 
 def test_build_without_channel_fails(testing_workdir):
     # remove the conda forge channel from the arguments and make sure that we fail.  If we don't,
@@ -66,6 +73,22 @@ def test_render_add_channel():
         rendered_filename = os.path.join(tmpdir, 'out.yaml')
         args = ['-c', 'conda_build_test', os.path.join(metadata_dir,
                             "_recipe_requiring_external_channel"), '--file', rendered_filename]
+        main_render.execute(args)
+        rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
+        required_package_string = [pkg for pkg in rendered_meta['requirements']['build'] if
+                                   'conda_build_test_requirement' in pkg][0]
+        required_package_details = required_package_string.split(' ')
+        assert len(required_package_details) > 1, ("Expected version number on successful "
+                                    "rendering, but got only {}".format(required_package_details))
+        assert required_package_details[1] == '1.0', "Expected version number 1.0 on successful rendering, but got {}".format(required_package_details[1])
+
+
+def test_render_yaml_channel():
+    """This recipe requires the conda_build_test_requirement package, which is
+    only on the conda_build_test channel. This verifies specifying channels in the meta.yaml file works for rendering."""
+    with TemporaryDirectory() as tmpdir:
+        rendered_filename = os.path.join(tmpdir, 'out.yaml')
+        args = [os.path.join(metadata_dir, "_recipe_requiring_external_channel_in_yaml"), '--file', rendered_filename]
         main_render.execute(args)
         rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
         required_package_string = [pkg for pkg in rendered_meta['requirements']['build'] if


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
Adds support for channels to meta.yaml recipes as discussed in #532 . This is achieved by adding the channels specified in the meta.yaml file to those given by the -c argument.

Example usage:
```
package:
  name: test
  version: "0.1"

requirements:
  channels:
    - anaconda
    - cdat-forge
  host:
    - cdat-forge::pylint
    - python=3.6
```
This will (in this case) install pylint from cdat-forge and all other dependencies (including python) from anaconda. This is effectively the same as calling
`conda build -c anaconda -c cdat-forge .`
on the same meta.yaml minus the channels section.

I noticed some failures in unrelated (?) tests locally. I'll take another look at this when the tests for this PR complete.
