### PR TITLE
Split tests on CI

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -21,8 +21,8 @@ engine:
 ## The envvars param is an environment variable list
 env:
   - PYTHON_VERSION=2.7
-  - PYTHON_VERSION=3.4
-  - PYTHON_VERSION=3.5
+  - PYTHON_VERSION=3.6
+  - PYTHON_VERSION=3.7
 
 #===============================================================================
 # Script options

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ python:
   - 2.7
   - 3.7
 env:
-  - CONDA_VERSION=release
-  - CONDA_VERSION=canary
+  - CONDA_VERSION=release SLOW_TESTS=true SANITY=false
+  - CONDA_VERSION=release SLOW_TESTS=false SANITY=false
+  - CONDA_VERSION=release SANITY=true
+  - CONDA_VERSION=canary SLOW_TESTS=false SANITY=false
+  - CONDA_VERSION=canary SLOW_TESTS=true SANITY=false
+  - CONDA_VERSION=canary SANITY=true
 matrix:
   fast_finish: true
   exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,16 +10,49 @@ environment:
       SYS_PYTHON_VERSION: "3.7"
       SYS_PYTHON_ARCH: "64"
       CONDA_CANARY: "False"
+      SLOW_TESTS: "True"
+
+    - SYS_PYTHON: "C:\\Miniconda37-x64"
+      SYS_PYTHON_VERSION: "3.7"
+      SYS_PYTHON_ARCH: "64"
+      CONDA_CANARY: "False"
+      SANITY: "True"
+
+    - SYS_PYTHON: "C:\\Miniconda37-x64"
+      SYS_PYTHON_VERSION: "3.7"
+      SYS_PYTHON_ARCH: "64"
+      CONDA_CANARY: "False"
+      SLOW_TESTS: "False"
 
     - SYS_PYTHON: "C:\\Miniconda-x64"
       SYS_PYTHON_VERSION: "2.7"
       SYS_PYTHON_ARCH: "64"
       CONDA_CANARY: "False"
+      SANITY: "True"
+
+    - SYS_PYTHON: "C:\\Miniconda-x64"
+      SYS_PYTHON_VERSION: "2.7"
+      SYS_PYTHON_ARCH: "64"
+      CONDA_CANARY: "False"
+      SLOW_TESTS: "False"
+
+    - SYS_PYTHON: "C:\\Miniconda-x64"
+      SYS_PYTHON_VERSION: "2.7"
+      SYS_PYTHON_ARCH: "64"
+      CONDA_CANARY: "False"
+      SLOW_TESTS: "True"
 
     - SYS_PYTHON: "C:\\Miniconda37-x64"
       SYS_PYTHON_VERSION: "3.7"
       SYS_PYTHON_ARCH: "64"
       CONDA_CANARY: "True"
+      SLOW_TESTS: "False"
+
+    - SYS_PYTHON: "C:\\Miniconda37-x64"
+      SYS_PYTHON_VERSION: "3.7"
+      SYS_PYTHON_ARCH: "64"
+      CONDA_CANARY: "True"
+      SLOW_TESTS: "True"
 
 skip_commits:
   files:
@@ -80,6 +113,7 @@ test_script:
   - set "PATH=%CONDA_ROOT%;%CONDA_ROOT%\Scripts;%CONDA_ROOT%\Library\bin;%PATH%"
   - set PATH
   - mkdir C:\cbtmp
+  - mkdir C:\cbtmp_serial
   # unset other language env vars - we only want to test if conda-build sets them itself
   - set PERL=
   - set LUA=
@@ -93,10 +127,19 @@ test_script:
   - conda create -n blarg -yq --download-only python cmake
   # remove all folders to avoid permission errors.  Leave root files (may have coverage info there)
   - for /d %%F in (c:\cbtmp\*) do rd /s /q "%%F"
-  - py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n 2 -m "not serial"
+  - for /d %%F in (c:\cbtmp_serial\*) do rd /s /q "%%F"
   # install conda-verify later, so we are ignoring checks in most tests
-  - conda install -y conda-verify
-  - py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp -n 0 -m "serial"
+  - set "SLOW_MARK=and not slow"
+  - if "%SLOW_TESTS%" == "True" set "SLOW_MARK=and slow"
+  - if "%SANITY%" == "True" (
+        conda install -y conda-verify &
+        py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n auto -m "sanity and not slow and not serial" &
+        py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp_serial -n 0 -m "sanity and not slow and serial"
+    ) else (
+        py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp C:\cbtmp -n auto -m "not serial %SLOW_MARK% and not sanity" &
+        conda install -y conda-verify &
+        if "%SLOW_MARK%" == "and not slow" ( py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp C:\cbtmp_serial -n 0 -m "serial %SLOW_MARK% and not sanity" )
+    )
 
 # For debugging, this is helpful - zip up the test environment and make it available for later download.
 #    However, it eats up a fair amount of time.  Better to disable until you need it.
@@ -105,5 +148,5 @@ test_script:
 #   - appveyor PushArtifact cbtmp.7z
 
 on_success:
-  - pip install codecov
+  - conda install -c conda-forge codecov -y
   - codecov --env SYS_PYTHON_VERSION --file C:\projects\conda-build\coverage.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,13 @@ addopts =
     --tb native
     --strict
     --durations=0
+log_level = DEBUG
 env =
     PYTHONHASHSEED=0
 markers =
     serial: execute test serially (to avoid race conditions)
+    slow: execute the slow tests if active
+    sanity: execute the sanity tests
 
 [versioneer]
 VCS = git

--- a/tests/test_api_build_dll_package.py
+++ b/tests/test_api_build_dll_package.py
@@ -9,6 +9,7 @@ from .utils import thisdir
 def recipe():
     return os.path.join(thisdir, 'test-recipes', 'dll-package')
 
+@pytest.mark.sanity
 def test_recipe_build(recipe, testing_config, testing_workdir, monkeypatch):
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts

--- a/tests/test_api_build_go_package.py
+++ b/tests/test_api_build_go_package.py
@@ -9,6 +9,7 @@ from .utils import thisdir
 def recipe():
     return os.path.join(thisdir, 'test-recipes', 'go-package')
 
+@pytest.mark.sanity
 def test_recipe_build(recipe, testing_config, testing_workdir, monkeypatch):
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -173,6 +173,7 @@ def test_convert_platform_to_others(testing_workdir, base_platform, package):
                 assert_package_paths_matches_files(package)
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(on_win, reason="we create the pkg to be converted in *nix; don't run on win.")
 def test_convert_from_unix_to_win_creates_entry_points(testing_config):
     recipe_dir = os.path.join(metadata_dir, "entry_points")

--- a/tests/test_api_debug.py
+++ b/tests/test_api_debug.py
@@ -47,6 +47,7 @@ def check_test_files_present(work_dir, test=True):
         assert os.path.exists(os.path.join(work_dir, "conda_test_runner.sh")) == test
 
 
+@pytest.mark.slow
 def test_debug_recipe_default_path(testing_config):
     activation_string = api.debug(recipe_path, config=testing_config)
     assert activation_string and "debug_1" in activation_string
@@ -68,6 +69,7 @@ def test_debug_package_default_path(testing_config):
     assert_correct_folders(work_dir, build=False)
 
 
+@pytest.mark.slow
 def test_debug_recipe_custom_path(testing_workdir):
     activation_string = api.debug(recipe_path, path=testing_workdir)
     assert activation_string and "debug_1" not in activation_string
@@ -99,11 +101,13 @@ def test_specific_output():
     assert_correct_folders(work_dir, build=True)
 
 
+@pytest.mark.sanity
 def test_error_on_ambiguous_output():
     with pytest.raises(ValueError):
         api.debug(ambiguous_recipe_path)
 
 
+@pytest.mark.sanity
 def test_error_on_unmatched_output():
     with pytest.raises(ValueError):
         api.debug(ambiguous_recipe_path, output_id="frank")

--- a/tests/test_api_inspect.py
+++ b/tests/test_api_inspect.py
@@ -1,11 +1,14 @@
 import os
 
+import pytest
+
 from conda_build import api
 from .utils import metadata_dir
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
 
 
+@pytest.mark.sanity
 def test_check_recipe():
     """Technically not inspect, but close enough to belong here"""
     assert api.check(os.path.join(metadata_dir, "source_git_jinja2"))

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -107,6 +107,7 @@ def test_pin_compatible_semver(testing_config):
     assert 'zlib >=1.2.11,<2.0a0' in metadata.get_value('requirements/run')
 
 
+@pytest.mark.slow
 def test_resolved_packages_recipe(testing_config):
     recipe_dir = os.path.join(metadata_dir, '_resolved_packages_host_build')
     metadata = api.render(recipe_dir, config=testing_config)[0][0]
@@ -121,6 +122,7 @@ def test_resolved_packages_recipe(testing_config):
         assert package in run_requirements
 
 
+@pytest.mark.slow
 def test_host_entries_finalized(testing_config):
     recipe = os.path.join(metadata_dir, '_host_entries_finalized')
     metadata = api.render(recipe, config=testing_config)
@@ -222,6 +224,7 @@ def test_merge_build_host_empty_host_section(testing_config):
 
 
 @pytest.mark.skipif(sys.platform != "linux2", reason="package on remote end is only on linux")
+@pytest.mark.xfail(reason="It needs to be fixed for Python v2.7. #3681")
 def test_run_exports_from_repo_without_channeldata(testing_config):
     ms = api.render(os.path.join(metadata_dir, '_run_export_no_channeldata'), config=testing_config)
     assert ms[0][0].meta['requirements']['build'] == ["exporty"]

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -4,7 +4,7 @@ import sys
 from pkg_resources import parse_version
 import pytest
 
-from conda_build.skeletons.pypi import get_package_metadata, get_pkginfo, \
+from conda_build.skeletons.pypi import get_package_metadata, \
     get_entry_points, is_setuptools_enabled, convert_to_flat_list, \
     get_dependencies, get_import_tests, get_tests_require, get_home, \
     get_summary, get_license_name, clean_license_name
@@ -53,6 +53,7 @@ def test_repo(prefix, repo, package, version, testing_workdir, testing_config):
         raise
 
 
+@pytest.mark.slow
 def test_name_with_version_specified(testing_workdir, testing_config):
     api.skeletonize(packages='sympy', repo='pypi', version='0.7.5',
                     config=testing_config)
@@ -297,6 +298,7 @@ def test_get_package_metadata(
     assert mock_metada_pylint == result_metadata_pylint
 
 
+@pytest.mark.slow
 def test_pypi_with_setup_options(testing_workdir, testing_config):
     # Use photutils package below because skeleton will fail unless the setup.py is given
     # the flag --offline because of a bootstrapping a helper file that
@@ -349,6 +351,7 @@ def test_pypi_with_version_arg(testing_workdir):
     assert parse_version(m.version()) == parse_version("0.7.2")
 
 
+@pytest.mark.slow
 def test_pypi_with_extra_specs(testing_workdir, testing_config):
     # regression test for https://github.com/conda/conda-build/issues/1697
     # For mpi4py:
@@ -364,6 +367,7 @@ def test_pypi_with_extra_specs(testing_workdir, testing_config):
     assert any('mpi4py' in req for req in m.meta['requirements']['host'])
 
 
+@pytest.mark.slow
 def test_pypi_with_version_inconsistency(testing_workdir, testing_config):
     # regression test for https://github.com/conda/conda-build/issues/189
     # For mpi4py:
@@ -449,7 +453,7 @@ cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
                  ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),  # cran: 'GPL (>= 2)'
                  ]
 
-
+@pytest.mark.slow
 @pytest.mark.parametrize("package, license_id, license_family, license_files", cran_packages)
 def test_cran_license(package, license_id, license_family, license_files, testing_workdir, testing_config):
     api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,

--- a/tests/test_api_test.py
+++ b/tests/test_api_test.py
@@ -10,6 +10,7 @@ from conda_build import api
 from .utils import metadata_dir
 
 
+@pytest.mark.sanity
 def test_recipe_test(testing_workdir, testing_config):
     """Test calling conda build -t <recipe dir>"""
     recipe = os.path.join(metadata_dir, 'has_prefix_files')
@@ -18,6 +19,7 @@ def test_recipe_test(testing_workdir, testing_config):
     api.test(recipe, config=metadata.config)
 
 
+@pytest.mark.sanity
 def test_package_test(testing_workdir, testing_config):
     """Test calling conda build -t <package file> - rather than <recipe dir>"""
     recipe = os.path.join(metadata_dir, 'has_prefix_files')
@@ -45,6 +47,7 @@ def test_package_with_jinja2_does_not_redownload_source(testing_workdir, testing
     assert not provide.called
 
 
+@pytest.mark.sanity
 def test_api_extra_dep(testing_metadata):
     testing_metadata.meta['test']['imports'] = ['click']
     output = api.build(testing_metadata, notest=True, anaconda_upload=False)[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,7 @@ import conda_build.cli.main_inspect as main_inspect
 import conda_build.cli.main_index as main_index
 
 
+@pytest.mark.sanity
 def test_build():
     args = ['--no-anaconda-upload', os.path.join(metadata_dir, "empty_sections"), '--no-activate',
             '--no-anaconda-upload']
@@ -156,6 +157,7 @@ def test_slash_in_recipe_arg_keeps_build_id(testing_workdir, testing_config):
     assert 'conda-build-test-has-prefix-files_1' in data
 
 
+@pytest.mark.sanity
 @pytest.mark.skipif(on_win, reason="prefix is always short on win.")
 def test_build_long_test_prefix_default_enabled(mocker, testing_workdir):
     recipe_path = os.path.join(metadata_dir, '_test_long_test_prefix')
@@ -178,6 +180,7 @@ def test_build_no_build_id(testing_workdir, testing_config):
     assert 'has_prefix_files_1' not in data
 
 
+@pytest.mark.sanity
 def test_build_multiple_recipes(testing_metadata, testing_workdir, testing_config):
     """Test that building two recipes in one CLI call separates the build environment for each"""
     os.makedirs('recipe1')
@@ -236,6 +239,7 @@ def test_render_output_build_path_set_python(testing_workdir, testing_metadata, 
     assert os.path.basename(output.rstrip()) == test_path, error
 
 
+@pytest.mark.sanity
 def test_skeleton_pypi(testing_workdir, testing_config):
     args = ['pypi', 'peppercorn']
     main_skeleton.execute(args)
@@ -243,13 +247,9 @@ def test_skeleton_pypi(testing_workdir, testing_config):
 
     # ensure that recipe generated is buildable
     main_build.execute(('peppercorn',))
-    # output, error = capfd.readouterr()
-    # if hasattr(output, 'decode'):
-    #     output = output.decode()
-    # assert 'Nothing to test for' not in output
-    # assert 'Nothing to test for' not in error
 
 
+@pytest.mark.slow
 def test_skeleton_pypi_arguments_work(testing_workdir):
     """
     These checks whether skeleton executes without error when these
@@ -486,6 +486,7 @@ def test_no_force_upload(mocker, testing_workdir, testing_metadata):
     assert call.called_once_with(['anaconda', 'upload', '--force', pkg])
 
 
+@pytest.mark.slow
 def test_conda_py_no_period(testing_workdir, testing_metadata, monkeypatch):
     monkeypatch.setenv('CONDA_PY', '36')
     testing_metadata.meta['requirements'] = {'host': ['python'],
@@ -520,6 +521,7 @@ def test_build_skip_existing_croot(testing_workdir, capfd):
     assert "are already built" in output
 
 
+@pytest.mark.sanity
 def test_package_test(testing_workdir, testing_metadata):
     """Test calling conda build -t <package file> - rather than <recipe dir>"""
     api.output_yaml(testing_metadata, 'recipe/meta.yaml')
@@ -591,6 +593,7 @@ def test_relative_path_test_recipe():
     main_build.execute(args)
 
 
+@pytest.mark.slow
 def test_render_with_python_arg_reduces_subspace(capfd):
     recipe = os.path.join(metadata_dir, "..", "variants", "20_subspace_selection_cli")
     # build the package
@@ -630,6 +633,7 @@ def test_render_with_python_arg_CLI_reduces_subspace(capfd):
     assert(len(out.splitlines()) == 1)
 
 
+@pytest.mark.sanity
 def test_test_extra_dep(testing_metadata):
     testing_metadata.meta['test']['imports'] = ['imagesize']
     api.output_yaml(testing_metadata, 'meta.yaml')

--- a/tests/test_published_examples.py
+++ b/tests/test_published_examples.py
@@ -11,6 +11,7 @@ from .utils import metadata_dir, is_valid_dir
 published_examples = os.path.join(os.path.dirname(metadata_dir), 'published_code')
 
 
+@pytest.mark.sanity
 def test_skeleton_pypi(testing_workdir):
     """published in docs at http://conda.pydata.org/docs/build_tutorials/pkgs.html"""
     conda_path = os.path.join(sys.prefix, 'Scripts' if sys.platform == 'win32' else 'bin', 'conda')
@@ -27,6 +28,7 @@ def recipe(request):
 
 
 # This tests any of the folders in the test-recipes/published_code folder that don't start with _
+@pytest.mark.sanity
 def test_recipe_builds(recipe, testing_config, testing_workdir):
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,9 +1,7 @@
 import os
-import sys
+
 from conda_build import api
 from conda_build import render
-
-import pytest
 
 
 def test_output_with_noarch_says_noarch(testing_metadata):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -97,6 +97,7 @@ def test_git_repo_with_single_subdir_does_not_enter_subdir(testing_metadata):
     assert os.path.basename(testing_metadata.config.work_dir) != 'one_folder'
 
 
+@pytest.mark.sanity
 def test_source_user_expand(testing_workdir):
     with TemporaryDirectory(dir=os.path.expanduser('~')) as tmp:
         with TemporaryDirectory() as tbz_srcdir:

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -18,10 +18,12 @@ def recipe(request):
     return os.path.join(subpackage_dir, request.param)
 
 
+@pytest.mark.slow
 def test_subpackage_recipes(recipe, testing_config):
     api.build(recipe, config=testing_config)
 
 
+@pytest.mark.sanity
 def test_autodetect_raises_on_invalid_extension(testing_config):
     with pytest.raises(NotImplementedError):
         api.build(os.path.join(subpackage_dir, '_invalid_script_extension'), config=testing_config)
@@ -158,6 +160,7 @@ def test_about_metadata(testing_config):
             assert info['home'] == 'http://not.a.url'
 
 
+@pytest.mark.slow
 def test_toplevel_entry_points_do_not_apply_to_subpackages(testing_config):
     recipe_dir = os.path.join(subpackage_dir, '_entry_points')
     outputs = api.build(recipe_dir, config=testing_config)
@@ -216,6 +219,7 @@ def test_overlapping_files(testing_config, caplog):
     assert sum(int("Exact overlap" in rec.message) for rec in caplog.records) == 1
 
 
+@pytest.mark.sanity
 def test_per_output_tests(testing_config):
     recipe_dir = os.path.join(subpackage_dir, '_per_output_tests')
     api.build(recipe_dir, config=testing_config)
@@ -226,6 +230,7 @@ def test_per_output_tests(testing_config):
     # assert out.count("top-level test") == count, out
 
 
+@pytest.mark.sanity
 def test_per_output_tests_script(testing_config):
     recipe_dir = os.path.join(subpackage_dir, '_output_test_script')
     with pytest.raises(SystemExit):
@@ -263,12 +268,14 @@ def test_subpackage_order_bad(testing_config):
     assert len(outputs) == 2
 
 
+@pytest.mark.sanity
 def test_build_script_and_script_env(testing_config):
     recipe = os.path.join(subpackage_dir, '_build_script')
     os.environ['TEST_FN'] = 'test'
     api.build(recipe, config=testing_config)
 
 
+@pytest.mark.sanity
 @pytest.mark.skipif(sys.platform != 'darwin', reason="only implemented for mac")
 def test_strong_run_exports_from_build_applies_to_host(testing_config):
     recipe = os.path.join(subpackage_dir, '_strong_run_exports_applies_from_build_to_host')
@@ -314,6 +321,7 @@ def test_merge_build_host_applies_in_outputs(testing_config):
     api.build(recipe, config=testing_config)
 
 
+@pytest.mark.sanity
 def test_activation_in_output_scripts(testing_config):
     recipe = os.path.join(subpackage_dir, '_output_activation')
     testing_config.activate = True
@@ -328,6 +336,7 @@ def test_inherit_build_number(testing_config):
         assert int(m.meta['build']['number']) == 1, "build number should have been inherited as '1'"
 
 
+@pytest.mark.slow
 def test_loops_do_not_remove_earlier_packages(testing_config):
     recipe = os.path.join(subpackage_dir, '_xgboost_example')
     output_files = api.get_output_file_paths(recipe, config=testing_config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,6 +63,7 @@ def namespace_setup(testing_workdir, request):
     return testing_workdir
 
 
+@pytest.mark.sanity
 def test_disallow_merge_conflicts(namespace_setup, testing_config):
     duplicate = os.path.join(namespace_setup, 'dupe', 'namespace', 'package', 'module.py')
     makefile(duplicate)
@@ -71,6 +72,7 @@ def test_disallow_merge_conflicts(namespace_setup, testing_config):
                                                  'package'))
 
 
+@pytest.mark.sanity
 def test_disallow_in_tree_merge(testing_workdir):
     with open('testfile', 'w') as f:
         f.write("test")
@@ -230,6 +232,9 @@ def test_logger_filtering(caplog, capfd):
     assert 'test warn message' in err
     assert 'test error message' in err
     assert caplog.text.count('duplicate') == 1
+
+    log.removeHandler(logging.StreamHandler(sys.stdout))
+    log.removeHandler(logging.StreamHandler(sys.stderr))
 
 
 def test_logger_config_from_file(testing_workdir, caplog, capfd, mocker):

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -93,6 +93,7 @@ def test_pinning_in_build_requirements():
     assert all(len(req.split(' ')) == 3 for req in build_requirements)
 
 
+@pytest.mark.sanity
 def test_no_satisfiable_variants_raises_error():
     recipe = os.path.join(recipe_dir, '01_basic_templating')
     with pytest.raises(exceptions.DependencyNeedsBuildingError):
@@ -182,6 +183,7 @@ def test_variant_input_with_zip_keys_keeps_zip_keys_list():
     assert 'zip_keys' in variant_list[0] and variant_list[0]['zip_keys']
 
 
+@pytest.mark.serial
 @pytest.mark.xfail(sys.platform=='win32', reason="console readout issues on appveyor")
 def test_ensure_valid_spec_on_run_and_test(testing_workdir, testing_config, caplog):
     testing_config.debug = True
@@ -356,7 +358,6 @@ def test_target_platform_looping(testing_config):
     assert len(outputs) == 2
 
 
-@pytest.mark.serial
 def test_numpy_used_variable_looping(testing_config):
     outputs = api.get_output_file_paths(os.path.join(recipe_dir, 'numpy_used'))
     assert len(outputs) == 4
@@ -409,7 +410,6 @@ def test_exclusive_config_file(testing_workdir):
     assert variant['abc'] == '123'
 
 
-@pytest.mark.serial
 def test_inner_python_loop_with_output(testing_config):
     outputs = api.get_output_file_paths(os.path.join(recipe_dir, 'test_python_as_subpackage_loop'),
                                         config=testing_config)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,9 +8,16 @@ import pytest
 
 from conda_build.conda_interface import PY3
 from conda_build.metadata import MetaData
-from conda_build.utils import on_win, FileNotFoundError
+from conda_build.utils import on_win
 
-thisdir = os.path.dirname(os.path.realpath(__file__))
+
+def get_root_dir():
+    import conda_build
+    conda_build_dir = os.path.realpath(os.path.dirname(conda_build.__file__))
+    return os.path.abspath(os.path.join(conda_build_dir, ".."))
+
+
+thisdir = os.path.join(get_root_dir(), "tests")
 metadata_dir = os.path.join(thisdir, "test-recipes", "metadata")
 subpackage_dir = os.path.join(thisdir, "test-recipes", "split-packages")
 fail_dir = os.path.join(thisdir, "test-recipes", "fail")


### PR DESCRIPTION
Added slow and sanity marks to tests. Some tests are taking too much time to finish and because of that, the CI is failing due to timeout.

The goal of this PR is to separate the tests in three jobs, each job will execute one "type" of tests such as ``slow`` tests, ``sanity`` tests and another one to execute the rest of them
