### PR TITLE
Revert to using corelist and LooseVersion

### DIFF
--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -176,6 +176,7 @@ class PerlTmpDownload(TmpDownload):
 
             return dst
 
+
 def LooseVersion(version):
     """
     Wrap distutils.version.LooseVersion, coercing passed version into str
@@ -314,7 +315,7 @@ def skeletonize(packages, output_dir=".", version=None,
 
         # Add Perl version to core module requirements, since these are empty
         # packages, unless we're newer than what's in core
-        if (core_version is not None and 
+        if (core_version is not None and
            ((version in [None, '']) or (core_version >= LooseVersion(version)))):
             if not write_core:
                 print('We found core module %s. Skipping recipe creation.' %
@@ -490,7 +491,6 @@ def core_module_version(module, version, config):
               the module is actually part of the Perl core, the version of Perl
               passed in will be used as the module version.
     '''
-
 
     # In case we were given a dist, convert to module
     module = module.replace('-', '::')
@@ -733,9 +733,9 @@ def get_release_info(cpan_url, package, version, perl_version, config,
     # request
 
     version_str = str(version)
-    if (version is not None and 
-        LooseVersion('0') != LooseVersion(version_str) and
-        LooseVersion(rel_dict['version']) != LooseVersion(version_str)):
+    if (version is not None and
+            LooseVersion('0') != LooseVersion(version_str) and
+            LooseVersion(rel_dict['version']) != LooseVersion(version_str)):
         author = rel_dict['author']
         try:
             new_rel_dict = get_cpan_api_url('{0}/release/{1}/{2}-{3}'.format(cpan_url,

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -303,12 +303,12 @@ def skeletonize(packages, output_dir=".", version=None,
 
         # Fetch all metadata from CPAN
         core_version = core_module_version(package, perl_version, config=config)
-        if version in [None, ''] and core_version is None:
+        if not version and not core_version:
             release_data = latest_release_data
         else:
             release_data = get_release_info(meta_cpan_url, package,
                                             (LooseVersion(version) if
-                                             version not in [None, ''] else
+                                             version else
                                              core_version),
                                              perl_version,
                                              config=config)
@@ -316,7 +316,7 @@ def skeletonize(packages, output_dir=".", version=None,
         # Add Perl version to core module requirements, since these are empty
         # packages, unless we're newer than what's in core
         if (core_version is not None and
-           ((version in [None, '']) or (core_version >= LooseVersion(version)))):
+           (not version or core_version >= LooseVersion(version))):
             if not write_core:
                 print('We found core module %s. Skipping recipe creation.' %
                       packagename)
@@ -494,7 +494,7 @@ def core_module_version(module, version, config):
 
     # In case we were given a dist, convert to module
     module = module.replace('-', '::')
-    if version in [None, '']:
+    if not version:
         version = LooseVersion(config.variant['perl'])
     else:
         version = LooseVersion(version)
@@ -580,7 +580,7 @@ def deps_for_package(package, release_data, perl_version, output_dir,
     for dep_dict in release_data['dependency']:
         # Only care about requirements outside the develop phase
         try:
-            if dep_dict['relationship'] == 'requires' and dep_dict['phase'] not in ['develop']:
+            if dep_dict['relationship'] == 'requires' and dep_dict['phase'] != 'develop':
                 print('.', end='')
                 sys.stdout.flush()
                 # Format dependency string (with Perl trailing dist comment)

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -191,9 +191,7 @@ def LooseVersion(version):
     :param version: version string or number
     :return: distutils.version.LooseVersion(str(version).lstrip('v'))
     """
-    if version is None:
-        return version
-    else:
+    if version:
         return distutils.version.LooseVersion(str(version).lstrip('v'))
 
 

--- a/tests/test_cpan_skeleton.py
+++ b/tests/test_cpan_skeleton.py
@@ -1,0 +1,84 @@
+from textwrap import dedent
+
+import pytest
+
+from conda_build.config import Config
+from conda_build.skeletons import cpan
+
+
+@pytest.mark.parametrize('module,perl_version,config,corelist_mock_outputs,expected',
+        [
+            ('List::Util',
+             None,
+             Config(variant={'perl': '5.26.0'}),
+             [
+                 "List::Util 1.46_02\n",
+                 dedent("""
+                    Data for 2018-04-14
+                    List::Util was first released with perl v5.7.3
+                    """.lstrip())
+             ],
+             '1.46_02',
+             ),
+            ('List::Util',
+             '5.15.0',
+             Config(variant={'perl': '5.26.0'}),
+             [
+                 "List::Util 1.23\n",
+                 dedent("""
+                    Data for 2018-04-14
+                    List::Util was first released with perl v5.7.3
+                    """.lstrip())
+             ],
+             '1.23',
+             ),
+            ('Sys::Syslog::Win32',
+             None,
+             Config(variant={'perl': '5.26.0'}),
+             [
+                 "Sys::Syslog::Win32 undef\n",
+                 dedent("""
+                    Data for 2018-04-14
+                    Sys::Syslog::Win32 was first released with perl v5.15.1
+                    """.lstrip())
+             ],
+             '5.26.0',
+             ),
+            ('Sys::Syslog::Win32',
+             '5.15.0',
+             Config(variant={'perl': '5.26.0'}),
+             [
+                 "Sys::Syslog::Win32 undef\n",
+                 dedent("""
+                    Data for 2018-04-14
+                    Sys::Syslog::Win32 was first released with perl v5.15.1
+                    """.lstrip())
+             ],
+             None,
+             ),
+            ('LWP',
+             None,
+             Config(variant={'perl': '5.26.0'}),
+             [
+                 "LWP undef\n",
+                 dedent("""
+                    LWP was not in CORE (or so I think)
+                    """.lstrip())
+             ],
+             None,
+             ),
+        ],
+        ids=[
+                'simple_in_core',
+                'pv_param_wins',
+                'undef_after_in_core',
+                'undef_before_in_core',
+                'not_in_core',
+             ])
+def test_core_model_version(module, perl_version, config, corelist_mock_outputs, expected, mocker):
+    check_output = mocker.patch('subprocess.check_output')
+    check_output.side_effect = corelist_mock_outputs
+
+    cmv = cpan.core_module_version(module, perl_version, config)
+    check_output.assert_called()
+    assert(cmv == expected)


### PR DESCRIPTION
corelist is the cannonical method for determining whether
a perl module is included in the perl core library. The
metacpan community does not have a method for their API
to convey whether a module is in the core or not (
see metacpan/metacpan-api#925).  Until metacpan can
tell us whether a module is in the core, revert back to
using the corelist script that ships with perl.

Also revert to using distutils.version.LooseVersion for
version comparisons.  LooseVersion implements versioning
that is free-form like Perl and the pkg_resources.parse_version
will incorrectly sort versions compared that align with
PEP-440 against those that don't.  (Reading the code
pkg_resources assumes that all versions that do not comply
with PEP-440 occur before those that do. Since nothing in
the Perl world will intentionally comply with PEP-440
using pkg_resources will lead to confusing results.

When moving back to LooseVersion, we must fix issues like
the one reported in #994:
  TypeError: expected string or buffer
and it's Python3 equivalent that uses bytes instead of buffer.
This TypeError is encountered when we pass an int into
LooseVersion instead of a string or bytes.  Metacpan has
an open issue (metacpan/metacpan-api#789) that reports
inconsistancy in the returned type of versions in the json.

To address this, we now wrap distutils.version.LooseVersion
in our own LooseVersion helper that coerces the supplied
version parameter into a string.  We also strip any leading
'v' to avoid TypeError about comparing int against str.

fixes #3661 