### PR TITLE
Make build.sh files of skeletons shellcheck clean

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       source /usr/share/miniconda/bin/activate
-      /usr/share/miniconda/bin/py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION"
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION"
     displayName: 'Parallel Tests'
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,7 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
+      source /usr/share/miniconda/bin/activate
       /usr/share/miniconda/bin/py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION"
     displayName: 'Parallel Tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
       if [[ "$PYTHON_VERSION" == "2.7" ]]; then
         conda install -q futures scandir;
       fi
-      conda install -q pytest-azurepipelines anaconda-client git requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief python-libarchive-c
+      conda install -q pytest-azurepipelines anaconda-client git requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief python-libarchive-c conda-forge::shellcheck
       pip install pkginfo
       conda install -c c3i_test -q perl;
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock;

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1467,7 +1467,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
                 if isfile(build_file) or script:
                     work_file, _ = write_build_scripts(m, script, build_file)
                     if not provision_only:
-                        cmd = [shell_path] + (['-x'] if m.config.debug else []) + ['-e', work_file]
+                        cmd = [shell_path] + (['-x'] if m.config.debug else []) + ['-o', 'errexit', work_file]
 
                         # rewrite long paths in stdout back to their env variables
                         if m.config.debug or m.config.no_rewrite_stdout_env:
@@ -2173,7 +2173,7 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True, prov
     if utils.on_win:
         cmd = [os.environ.get('COMSPEC', 'cmd.exe'), "/d", "/c", test_script]
     else:
-        cmd = [shell_path] + (['-x'] if metadata.config.debug else []) + ['-e', test_script]
+        cmd = [shell_path] + (['-x'] if metadata.config.debug else []) + ['-o', 'errexit', test_script]
     try:
         test_stats = {}
         if not provision_only:

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -74,6 +74,8 @@ about:
 CPAN_BUILD_SH = """\
 #!/bin/bash
 
+set -o errexit
+
 # If it has Build.PL use that, otherwise use Makefile.PL
 if [ -f Build.PL ]; then
     perl Build.PL

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -74,7 +74,7 @@ about:
 CPAN_BUILD_SH = """\
 #!/bin/bash
 
-set -o errexit
+set -o errexit -o pipefail
 
 # If it has Build.PL use that, otherwise use Makefile.PL
 if [ -f Build.PL ]; then

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -150,33 +150,34 @@ if {source_pf_bash}; then
   export DISABLE_AUTOBREW=1
   mv DESCRIPTION DESCRIPTION.old
   grep -va '^Priority: ' DESCRIPTION.old > DESCRIPTION
-  $R CMD INSTALL --build .
+  ${{R}} CMD INSTALL --build .
 else
-  mkdir -p $PREFIX/lib/R/library/{cran_packagename}
-  mv * $PREFIX/lib/R/library/{cran_packagename}
+  mkdir -p "${{PREFIX}}"/lib/R/library/{cran_packagename}
+  mv ./* "${{PREFIX}}"/lib/R/library/{cran_packagename}
 
-  if [[ $target_platform == osx-64 ]]; then
-    pushd $PREFIX
+  if [[ ${{target_platform}} == osx-64 ]]; then
+    pushd "${{PREFIX}}"
       for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
-        pushd $libdir || exit 1
-          for SHARED_LIB in $(find . -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R"); do
-            echo "fixing SHARED_LIB $SHARED_LIB"
-            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
-            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "$PREFIX"/lib/libomp.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
-            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
-            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libgcc_s.1.dylib "$PREFIX"/lib/libgcc_s.1.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libiconv.2.dylib "$PREFIX"/sysroot/usr/lib/libiconv.2.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libncurses.5.4.dylib "$PREFIX"/sysroot/usr/lib/libncurses.5.4.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libicucore.A.dylib "$PREFIX"/sysroot/usr/lib/libicucore.A.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libexpat.1.dylib "$PREFIX"/lib/libexpat.1.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libcurl.4.dylib "$PREFIX"/lib/libcurl.4.dylib $SHARED_LIB || true
-            install_name_tool -change /usr/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
-            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
-          done
+        pushd "${{libdir}}" || exit 1
+          while IFS= read -r -d '' SHARED_LIB
+          do
+            echo "fixing SHARED_LIB ${{SHARED_LIB}}"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "${{PREFIX}}"/lib/R/lib/libR.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "${{PREFIX}}"/lib/R/lib/libR.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "${{PREFIX}}"/lib/libomp.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "${{PREFIX}}"/lib/libgfortran.3.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "${{PREFIX}}"/lib/libquadmath.0.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "${{PREFIX}}"/lib/libquadmath.0.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "${{PREFIX}}"/lib/libgfortran.3.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "${{PREFIX}}"/lib/libgcc_s.1.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "${{PREFIX}}"/sysroot/usr/lib/libiconv.2.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "${{PREFIX}}"/sysroot/usr/lib/libncurses.5.4.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "${{PREFIX}}"/sysroot/usr/lib/libicucore.A.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "${{PREFIX}}"/lib/libexpat.1.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "${{PREFIX}}"/lib/libcurl.4.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "${{PREFIX}}"/lib/libc++.1.dylib "${{SHARED_LIB}}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "${{PREFIX}}"/lib/libc++.1.dylib "${{SHARED_LIB}}" || true
+          done <   <(find . \( -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R" \) -print0)
         popd
       done
     popd
@@ -189,9 +190,8 @@ CRAN_BUILD_SH_BINARY = """\
 
 set -o errexit
 
-mkdir -p $PREFIX/lib/R/library/{cran_packagename}
-mv * $PREFIX/lib/R/library/{cran_packagename}
-fi
+mkdir -p "${{PREFIX}}"/lib/R/library/{cran_packagename}
+mv ./* "${{PREFIX}}"/lib/R/library/{cran_packagename}
 """
 
 CRAN_BLD_BAT_SOURCE = """\
@@ -1383,7 +1383,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                     f.write(CRAN_BUILD_SH_BINARY.format(**d))
                 else:
                     tpbt = [target_platform_bash_test_by_sel[t] for t in from_sources]
-                    d['source_pf_bash'] = ' || '.join(['[[ $target_platform ' + s + ' ]]'
+                    d['source_pf_bash'] = ' || '.join(['[[ ${target_platform} ' + s + ' ]]'
                                                   for s in tpbt])
                     f.write(CRAN_BUILD_SH_MIXED.format(**d))
 

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -144,6 +144,8 @@ $R CMD INSTALL --build .
 CRAN_BUILD_SH_MIXED = """\
 #!/bin/bash
 
+set -o errexit
+
 if {source_pf_bash}; then
   export DISABLE_AUTOBREW=1
   mv DESCRIPTION DESCRIPTION.old
@@ -184,6 +186,9 @@ fi
 
 CRAN_BUILD_SH_BINARY = """\
 #!/bin/bash
+
+set -o errexit
+
 mkdir -p $PREFIX/lib/R/library/{cran_packagename}
 mv * $PREFIX/lib/R/library/{cran_packagename}
 fi

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -144,7 +144,7 @@ $R CMD INSTALL --build .
 CRAN_BUILD_SH_MIXED = """\
 #!/bin/bash
 
-set -o errexit
+set -o errexit -o pipefail
 
 if {source_pf_bash}; then
   export DISABLE_AUTOBREW=1
@@ -188,7 +188,7 @@ fi
 CRAN_BUILD_SH_BINARY = """\
 #!/bin/bash
 
-set -o errexit
+set -o errexit -o pipefail
 
 mkdir -p "${{PREFIX}}"/lib/R/library/{cran_packagename}
 mv ./* "${{PREFIX}}"/lib/R/library/{cran_packagename}

--- a/conda_build/skeletons/luarocks.py
+++ b/conda_build/skeletons/luarocks.py
@@ -103,7 +103,7 @@ about:
 LUAROCKS_BUILD_SH = """\
 #!/bin/bash
 
-set -o errexit
+set -o errexit -o pipefail
 
 # Make sure luarocks can see all local dependencies
 "${{PREFIX}}"/bin/luarocks-admin make_manifest --local-tree

--- a/conda_build/skeletons/luarocks.py
+++ b/conda_build/skeletons/luarocks.py
@@ -106,7 +106,7 @@ LUAROCKS_BUILD_SH = """\
 set -o errexit
 
 # Make sure luarocks can see all local dependencies
-$PREFIX/bin/luarocks-admin make_manifest --local-tree
+"${{PREFIX}}"/bin/luarocks-admin make_manifest --local-tree
 
 # Install
 # Rocks aren't located in a standard location, although
@@ -114,7 +114,7 @@ $PREFIX/bin/luarocks-admin make_manifest --local-tree
 # NOTE: we're just picking the first rock we find. If there's
 # more than one, specify it manually.
 ROCK=$(find . -name "*.rockspec" | sort -n -r | head -n 1)
-$PREFIX/bin/luarocks install "$ROCK" --local-tree
+"${{PREFIX}}"/bin/luarocks install "${{ROCK}}" --local-tree
 
 # Add more build steps here, if they are necessary.
 

--- a/conda_build/skeletons/luarocks.py
+++ b/conda_build/skeletons/luarocks.py
@@ -103,6 +103,8 @@ about:
 LUAROCKS_BUILD_SH = """\
 #!/bin/bash
 
+set -o errexit
+
 # Make sure luarocks can see all local dependencies
 $PREFIX/bin/luarocks-admin make_manifest --local-tree
 

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -63,8 +63,8 @@ BUILDSH = """\
 
 set -o errexit
 
-mkdir -p ${PREFIX}/{hostmachine}/sysroot
-pushd ${PREFIX}/{hostmachine}/sysroot > /dev/null 2>&1
+mkdir -p "${PREFIX}"/{hostmachine}/sysroot
+pushd "${PREFIX}"/{hostmachine}/sysroot > /dev/null 2>&1
 cp -Rf "${SRC_DIR}"/binary/* .
 """
 

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -61,6 +61,8 @@ about:
 BUILDSH = """\
 #!/bin/bash
 
+set -o errexit
+
 mkdir -p ${PREFIX}/{hostmachine}/sysroot
 pushd ${PREFIX}/{hostmachine}/sysroot > /dev/null 2>&1
 cp -Rf "${SRC_DIR}"/binary/* .

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -61,7 +61,7 @@ about:
 BUILDSH = """\
 #!/bin/bash
 
-set -o errexit
+set -o errexit -o pipefail
 
 mkdir -p "${PREFIX}"/{hostmachine}/sysroot
 pushd "${PREFIX}"/{hostmachine}/sysroot > /dev/null 2>&1

--- a/news/skeleton_build_sh_shellcheck_clean.rst
+++ b/news/skeleton_build_sh_shellcheck_clean.rst
@@ -1,0 +1,27 @@
+Enhancements:
+-------------
+
+* Update build.sh files of skeletons to be shellcheck clean including test to
+  lint future updates. Also adding `set -o errexit -o pipefail` to build.sh
+  files to make those settings transparent for better linting, while errexit was
+  anyway already the default used the call the build script.
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -1,4 +1,6 @@
+import fnmatch
 import os
+import subprocess
 import sys
 
 from pkg_resources import parse_version
@@ -20,6 +22,7 @@ except ImportError:
 
 from conda_build import api
 from conda_build.exceptions import DependencyNeedsBuildingError
+import conda_build.os_utils.external as external
 from conda_build.utils import on_win, ensure_list
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
@@ -468,6 +471,7 @@ def test_cran_license(package, license_id, license_family, license_files, testin
     for m_license_file in m_license_files:
         assert os.path.basename(m_license_file) in license_files
 
+
 # CRAN packages to test skip entry.
 # (package, skip_text)
 cran_os_type_pkgs = [('bigReg', 'skip: True  # [not unix]'),
@@ -481,3 +485,32 @@ def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
     fpath = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml') 
     with open(fpath) as f:
         assert skip_text in f.read()
+
+
+@pytest.mark.skipif(not external.find_executable("shellcheck"), reason="requires shellcheck >=0.7.0")
+@pytest.mark.parametrize(
+    "package, repo", [("r-usethis", "cran"), ("Perl::Lint", "cpan"), ("screen", "rpm")]
+)
+def test_build_sh_shellcheck_clean(package, repo, testing_workdir, testing_config):
+    api.skeletonize(packages=package, repo=repo, output_dir=testing_workdir, config=testing_config)
+
+    matches = []
+    for root, dirnames, filenames in os.walk(testing_workdir):
+        for filename in fnmatch.filter(filenames, "build.sh"):
+            matches.append(os.path.join(root, filename))
+
+    build_sh = matches[0]
+    cmd = [
+        "shellcheck",
+        "--enable=all",
+        # SC2154: var is referenced but not assigned,
+        #         see https://github.com/koalaman/shellcheck/wiki/SC2154
+        "--exclude=SC2154",
+        build_sh,
+    ]
+
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    sc_stdout, _ = p.communicate()
+    findings = sc_stdout.decode(sys.stdout.encoding).replace("\r\n", "\n").splitlines()
+    assert findings == []
+    assert p.returncode == 0

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -487,6 +487,7 @@ def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
         assert skip_text in f.read()
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not external.find_executable("shellcheck"), reason="requires shellcheck >=0.7.0")
 @pytest.mark.parametrize(
     "package, repo", [("r-usethis", "cran"), ("Perl::Lint", "cpan"), ("screen", "rpm")]


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

This is done in context of https://github.com/conda-forge/conda-smithy/pull/1122 where the conda-forge linter is learning shellcheck, potentially activated for new recipes brought via conda-forge/staged-recipes or later also for updates of existing recipes. By reducing the findings in the existing skeletons the linter will then only have findings in custom added code.

This is all done in 4 steps:
1. Make the already applied `errexit` bash setting more explicit by 1. turning it from the short form `-e` into the long form `-o errexit` and 2. by adding it also to the build.sh files itself. The last steps may seem redundant, but is important to provide `shellcheck` the information under which settings the build.sh script is actually running (that changes the required error handling). Also the explicit form allows to e.g. do a `git grep errexit` to find all relevant places in the code where this is applied.
2. Adding a test for various skeletons linting their build.sh files to be shellcheck clean.
3. Fixing all findings to ensure all build.sh templates produce shellcheck clean code (don't be confused about single and double braces, that depends on the map in string.format(map)).
4. Enabling also `-o pipefail` in the skeletons, which in theory is the only real `functional` change here for a more reliable style in newly created recipes. (Enabling that as bash settings for all build.sh as part of the conda-build calls would be more fundamentally, but maybe also helpful).

To execute the added test, shellcheck >=0.7.0 has to be installed, that is why the test skips itself, if that is not available.

Step 1-3 should be just polishing for better applyablity of shellcheck, step 4 could also be removed.


