### PR TITLE
render: Permit --file and --output to be used simultaneously

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -51,6 +51,7 @@ test:
   requires:
     - pytest
     - pytest-cov
+    - pytest-mock
     # Optional: you can use pytest-xdist to run the tests in parallel
     # - pytest-env  # [win]
     # - pytest-xdist

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -24,6 +24,7 @@ from conda_build.variants import get_package_variants, set_language_env_vars
 from conda_build.utils import LoggingContext
 
 on_win = (sys.platform == 'win32')
+log = logging.getLogger(__name__)
 
 
 # see: https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
@@ -196,11 +197,18 @@ def execute(args, print_results=True):
                                  no_download_source=args.no_source,
                                  variants=args.variants)
 
+    if args.file and len(metadata_tuples) > 1:
+        log.warning("Multiple variants rendered. "
+                    "Only one will be written to the file you specified ({}).".format(args.file))
+
     if print_results:
         if args.output:
             with LoggingContext(logging.CRITICAL + 1):
                 paths = api.get_output_file_paths(metadata_tuples, config=config)
                 print('\n'.join(sorted(paths)))
+            if args.file:
+                m = metadata_tuples[-1][0]
+                api.output_yaml(m, args.file, suppress_outputs=True)
         else:
             logging.basicConfig(level=logging.INFO)
             for (m, _, _) in metadata_tuples:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,20 @@ def test_render_output_build_path(testing_workdir, testing_metadata, capfd, capl
     assert error == ""
 
 
+def test_render_output_build_path_and_file(testing_workdir, testing_metadata, capfd, caplog):
+    api.output_yaml(testing_metadata, 'meta.yaml')
+    rendered_filename = 'out.yaml'
+    args = ['--output', '--file', rendered_filename, os.path.join(testing_workdir)]
+    main_render.execute(args)
+    test_path = os.path.join(sys.prefix, "conda-bld", testing_metadata.config.host_subdir,
+                             "test_render_output_build_path_and_file-1.0-1.tar.bz2")
+    output, error = capfd.readouterr()
+    assert output.rstrip() == test_path, error
+    assert error == ""
+    rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
+    assert rendered_meta['package']['name'] == 'test_render_output_build_path_and_file'
+
+
 def test_build_output_build_path(testing_workdir, testing_metadata, testing_config, capfd):
     api.output_yaml(testing_metadata, 'meta.yaml')
     testing_config.verbose = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,7 +107,7 @@ def test_no_filename_hash(testing_workdir, testing_metadata, capfd):
 
 def test_render_output_build_path(testing_workdir, testing_metadata, capfd, caplog):
     api.output_yaml(testing_metadata, 'meta.yaml')
-    args = ['--output', os.path.join(testing_workdir)]
+    args = ['--output', testing_workdir]
     main_render.execute(args)
     test_path = os.path.join(sys.prefix, "conda-bld", testing_metadata.config.host_subdir,
                              "test_render_output_build_path-1.0-1.tar.bz2")
@@ -119,7 +119,7 @@ def test_render_output_build_path(testing_workdir, testing_metadata, capfd, capl
 def test_render_output_build_path_and_file(testing_workdir, testing_metadata, capfd, caplog):
     api.output_yaml(testing_metadata, 'meta.yaml')
     rendered_filename = 'out.yaml'
-    args = ['--output', '--file', rendered_filename, os.path.join(testing_workdir)]
+    args = ['--output', '--file', rendered_filename, testing_workdir]
     main_render.execute(args)
     test_path = os.path.join(sys.prefix, "conda-bld", testing_metadata.config.host_subdir,
                              "test_render_output_build_path_and_file-1.0-1.tar.bz2")
@@ -134,7 +134,7 @@ def test_build_output_build_path(testing_workdir, testing_metadata, testing_conf
     api.output_yaml(testing_metadata, 'meta.yaml')
     testing_config.verbose = False
     testing_config.debug = False
-    args = ['--output', os.path.join(testing_workdir)]
+    args = ['--output', testing_workdir]
     main_build.execute(args)
     test_path = os.path.join(sys.prefix, "conda-bld", testing_config.host_subdir,
                                   "test_build_output_build_path-1.0-1.tar.bz2")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,8 @@ def test_render_add_channel():
         args = ['-c', 'conda_build_test', os.path.join(metadata_dir,
                             "_recipe_requiring_external_channel"), '--file', rendered_filename]
         main_render.execute(args)
-        rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
+        with open(rendered_filename, 'r') as rendered_file:
+            rendered_meta = yaml.safe_load(rendered_file)
         required_package_string = [pkg for pkg in rendered_meta['requirements']['build'] if
                                    'conda_build_test_requirement' in pkg][0]
         required_package_details = required_package_string.split(' ')
@@ -83,7 +84,8 @@ def test_render_without_channel_fails():
         rendered_filename = os.path.join(tmpdir, 'out.yaml')
         args = ['--override-channels', os.path.join(metadata_dir, "_recipe_requiring_external_channel"), '--file', rendered_filename]
         main_render.execute(args)
-        rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
+        with open(rendered_filename, 'r') as rendered_file:
+            rendered_meta = yaml.safe_load(rendered_file)
         required_package_string = [pkg for pkg in
                                    rendered_meta.get('requirements', {}).get('build', [])
                                    if 'conda_build_test_requirement' in pkg][0]
@@ -126,7 +128,8 @@ def test_render_output_build_path_and_file(testing_workdir, testing_metadata, ca
     output, error = capfd.readouterr()
     assert output.rstrip() == test_path, error
     assert error == ""
-    rendered_meta = yaml.safe_load(open(rendered_filename, 'r'))
+    with open(rendered_filename, 'r') as rendered_file:
+        rendered_meta = yaml.safe_load(rendered_file)
     assert rendered_meta['package']['name'] == 'test_render_output_build_path_and_file'
 
 
@@ -420,11 +423,12 @@ def test_develop(testing_env):
     args = ['-p', testing_env, extract_folder]
     main_develop.execute(args)
     py_ver = '.'.join((str(sys.version_info.major), str(sys.version_info.minor)))
-    assert cwd in open(os.path.join(get_site_packages(testing_env, py_ver), 'conda.pth')).read()
+    with open(os.path.join(get_site_packages(testing_env, py_ver), 'conda.pth')) as f_pth:
+        assert cwd in f_pth.read()
     args = ['--uninstall', '-p', testing_env, extract_folder]
     main_develop.execute(args)
-    assert (cwd not in open(os.path.join(get_site_packages(testing_env, py_ver),
-                                         'conda.pth')).read())
+    with open(os.path.join(get_site_packages(testing_env, py_ver), 'conda.pth')) as f_pth:
+        assert cwd not in f_pth.read()
 
 
 def test_convert(testing_workdir, testing_config):


### PR DESCRIPTION
The following command does not behave as expected because `conda render` does not respect both `--file` and `--output` simultaneously.  (If `--output` is present, then `--file` is ignored.)

```
conda render --output --file=rendered-meta.yaml myrecipe > rendered-tarball-name.txt
```

With this PR, both options can be used at the same time.