### PR TITLE
conda skeleton CRAN ignores CRAN's OS_type information (CB-810)

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1115,7 +1115,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
             else:
                 d['homeurl'] = ' https://CRAN.R-project.org/package={}'.format(package)
 
-        if not use_noarch_generic or cran_package.get("NeedsCompilation", 'no') == 'yes' or os_type != '':
+        if not use_noarch_generic or cran_package.get("NeedsCompilation", 'no') == 'yes':
             d['noarch_generic'] = ''
         else:
             d['noarch_generic'] = 'noarch: generic'

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1166,8 +1166,6 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
         if 'R' not in dep_dict:
             dep_dict['R'] = ''
 
-        if 'rJava' in dep_dict:
-            print("Java is in dependencies")
         os_type = cran_package.get("OS_type", '')
         if os_type != 'unix' and os_type != 'windows' and os_type != '':
             print("Unknown OS_type: {} in CRAN package".format(os_type))

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1175,6 +1175,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
             d["noarch_generic"] = ""
         if os_type == 'windows':
             d['skip_os'] = 'skip: True  # [not win]'
+            d["noarch_generic"] = ""
         if os_type == '':
             d['skip_os'] = '# no skip'
 

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1170,10 +1170,6 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
         if os_type != 'unix' and os_type != 'windows' and os_type != '':
             print("Unknown OS_type: {} in CRAN package".format(os_type))
             os_type = ''
-        if 'rJava' in dep_dict:
-            if os_type == '' or os_type == 'unix':
-                d['skip_os'] = 'skip: True  # [not linux]'
-                os_type = 'linux'
         if os_type == 'unix':
             d['skip_os'] = 'skip: True  # [not unix]'
         if os_type == 'windows':

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1172,6 +1172,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
             os_type = ''
         if os_type == 'unix':
             d['skip_os'] = 'skip: True  # [not unix]'
+            d["noarch_generic"] = ""
         if os_type == 'windows':
             d['skip_os'] = 'skip: True  # [not win]'
         if os_type == '':

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -463,3 +463,17 @@ def test_cran_license(package, license_id, license_family, license_files, testin
     license_files = ensure_list(license_files)
     for m_license_file in m_license_files:
         assert os.path.basename(m_license_file) in license_files
+
+# CRAN packages to test skip entry.
+# (package, skip_text)
+cran_os_type_pkgs = [('bigReg', 'skip: True  # [not unix]'),
+                     ('blatr',  'skip: True  # [not win]')
+                    ]
+
+@pytest.mark.parametrize("package, skip_text", cran_os_type_pkgs)
+def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
+    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
+                    config=testing_config)
+    fpath = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml') 
+    with open(fpath) as f:
+        assert skip_text in f.read()


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
