### PR TITLE
Skeleton pypi quoting only version, summary, script and description

### DIFF
--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -209,8 +209,9 @@ def _formating_value(attribute_name, attribute_value):
     :return string: Value quoted if need
     """
     pattern_search = re.compile('[@_!#$%^&*()<>?/\|}{~:]')
-    if isinstance(attribute_value, string_types) and pattern_search.search(attribute_value) \
-        or attribute_name in ["summary", "description", "version", "script"] :
+    if isinstance(attribute_value, string_types) \
+            and pattern_search.search(attribute_value) \
+            or attribute_name in ["summary", "description", "version", "script"]:
         return ' "' + str(attribute_value) + '"\n'
     return ' ' + str(attribute_value) + '\n'
 

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -209,7 +209,7 @@ def _formating_value(attribute_name, attribute_value):
     :return string: Value quoted if need
     """
     pattern_search = re.compile('[@_!#$%^&*()<>?/\|}{~:]')
-    if pattern_search.search(attribute_value) \
+    if isinstance(attribute_value, string_types) and pattern_search.search(attribute_value) \
         or attribute_name in ["summary", "description", "version", "script"] :
         return ' "' + str(attribute_value) + '"\n'
     return ' ' + str(attribute_value) + '\n'

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -162,29 +162,38 @@ def __print_with_indent(line, prefix='', suffix='', level=0, newline=True):
     return output + prefix + line + suffix + ('\n' if newline else '')
 
 
-def _print_dict(d, order=None, level=0, indent=2):
+def _print_dict(recipe_metadata, order=None, level=0, indent=2):
+    """Free function responsible to get the metadata which represents the
+    recipe and convert it to the yaml format.
+
+    :param OrderedDict recipe_metadata:
+    :param list order: Order to be write each section
+    :param int level:
+    :param int indent: Indentation - Number of empty spaces for each level
+    :return string: Recipe rendered with the metadata
+    """
     rendered_recipe = ''
     if not order:
-        order = sorted(list(d.keys()))
-    for k in order:
-        if k in d and d[k]:
-            rendered_recipe += __print_with_indent(k, suffix=':')
-            for _k, _v in d[k].items():
-                if _v is None:
+        order = sorted(list(recipe_metadata.keys()))
+    for section_name in order:
+        if section_name in recipe_metadata and recipe_metadata[section_name]:
+            rendered_recipe += __print_with_indent(section_name, suffix=':')
+            for attribute_name, attribute_value in recipe_metadata[section_name].items():
+                if attribute_value is None:
                     continue
-                if isinstance(_v, string_types) or not hasattr(_v, "__iter__"):
-                    rendered_recipe += __print_with_indent(_k, suffix=':', level=level + indent,
+                if isinstance(attribute_value, string_types) or not hasattr(attribute_value, "__iter__"):
+                    rendered_recipe += __print_with_indent(attribute_name, suffix=':', level=level + indent,
                                                           newline=False)
-                    if isinstance(_v, string_types):
-                        rendered_recipe += ' "' + _v + '"\n'
+                    if attribute_name in ["summary", "description", "version"]:
+                        rendered_recipe += ' "' + attribute_value + '"\n'
                     else:
-                        rendered_recipe += ' ' + str(_v) + '\n'
-                elif hasattr(_v, 'keys'):
-                    rendered_recipe += _print_dict(_v, sorted(list(_v.keys())))
+                        rendered_recipe += ' ' + str(attribute_value) + '\n'
+                elif hasattr(attribute_value, 'keys'):
+                    rendered_recipe += _print_dict(attribute_value, sorted(list(attribute_value.keys())))
                 # assume that it's a list if it exists at all
-                elif _v:
-                    rendered_recipe += __print_with_indent(_k, suffix=':', level=level + indent)
-                    for item in _v:
+                elif attribute_value:
+                    rendered_recipe += __print_with_indent(attribute_name, suffix=':', level=level + indent)
+                    for item in attribute_value:
                         rendered_recipe += __print_with_indent(item, prefix='- ',
                                                                level=level + indent)
             # add a newline in between sections

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -184,10 +184,7 @@ def _print_dict(recipe_metadata, order=None, level=0, indent=2):
                 if isinstance(attribute_value, string_types) or not hasattr(attribute_value, "__iter__"):
                     rendered_recipe += __print_with_indent(attribute_name, suffix=':', level=level + indent,
                                                           newline=False)
-                    if attribute_name in ["summary", "description", "version", "script"]:
-                        rendered_recipe += ' "' + str(attribute_value) + '"\n'
-                    else:
-                        rendered_recipe += ' ' + str(attribute_value) + '\n'
+                    rendered_recipe += _formating_value(attribute_name, attribute_value)
                 elif hasattr(attribute_value, 'keys'):
                     rendered_recipe += _print_dict(attribute_value, sorted(list(attribute_value.keys())))
                 # assume that it's a list if it exists at all
@@ -201,6 +198,21 @@ def _print_dict(recipe_metadata, order=None, level=0, indent=2):
                 rendered_recipe += '\n'
 
     return rendered_recipe
+
+
+def _formating_value(attribute_name, attribute_value):
+    """Format the value of the yaml file. This function will quote the
+    attribute value if needed.
+
+    :param string attribute_name: Attribute name
+    :param string attribute_value: Attribute value
+    :return string: Value quoted if need
+    """
+    pattern_search = re.compile('[@_!#$%^&*()<>?/\|}{~:]')
+    if pattern_search.search(attribute_value) \
+        or attribute_name in ["summary", "description", "version", "script"] :
+        return ' "' + str(attribute_value) + '"\n'
+    return ' ' + str(attribute_value) + '\n'
 
 
 def skeletonize(packages, output_dir=".", version=None, recursive=False,

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -353,9 +353,8 @@ def skeletonize(packages, output_dir=".", version=None, recursive=False,
             if noarch_python:
                 ordered_recipe['build']['noarch'] = 'python'
 
-            ordered_recipe['build']['script'] = (
-                    '{{ PYTHON }} -m pip install . -vv ' + ' '.join(setup_options)
-                )
+            py_install_cmd = ["{{ PYTHON }} -m pip install . -vv"]
+            ordered_recipe['build']['script'] = ' '.join(py_install_cmd + setup_options)
 
             # Always require python as a dependency.  Pip is because we use pip for
             #    the install line.

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -184,8 +184,8 @@ def _print_dict(recipe_metadata, order=None, level=0, indent=2):
                 if isinstance(attribute_value, string_types) or not hasattr(attribute_value, "__iter__"):
                     rendered_recipe += __print_with_indent(attribute_name, suffix=':', level=level + indent,
                                                           newline=False)
-                    if attribute_name in ["summary", "description", "version"]:
-                        rendered_recipe += ' "' + attribute_value + '"\n'
+                    if attribute_name in ["summary", "description", "version", "script"]:
+                        rendered_recipe += ' "' + str(attribute_value) + '"\n'
                     else:
                         rendered_recipe += ' ' + str(attribute_value) + '\n'
                 elif hasattr(attribute_value, 'keys'):

--- a/news/bug-3718-unquote-entries.rst
+++ b/news/bug-3718-unquote-entries.rst
@@ -1,0 +1,5 @@
+Enhancements:
+-------------
+
+* Conda skeleton pypi quoting just `version`, `summary`` and `description`
+

--- a/news/bug-3718-unquote-entries.rst
+++ b/news/bug-3718-unquote-entries.rst
@@ -1,5 +1,5 @@
 Enhancements:
 -------------
 
-* Conda skeleton pypi quoting just `version`, `summary`` and `description`
+* Conda skeleton pypi quoting just `version`, `summary`` and `description` or attributes with special characters
 

--- a/tests/test_pypi_skeleton.py
+++ b/tests/test_pypi_skeleton.py
@@ -1,4 +1,7 @@
+from collections import OrderedDict
+
 from conda_build.skeletons import pypi
+from conda_build.skeletons.pypi import _print_dict
 
 
 def test_version_compare():
@@ -21,3 +24,48 @@ def test_version_compare():
     assert pypi.convert_version(rc_version) == ' >=1.4.5rc4,<1.5'
     assert pypi.convert_version(padding_version_short) == ' >=2.2.0,<2.3'
     assert pypi.convert_version(padding_version_long) == ' >=1.4.5.0,<1.4.6'
+
+
+def test_print_dict():
+    recipe_metadata = OrderedDict(
+        {
+            "about": OrderedDict(
+                {
+                    "home": "https://conda.io",
+                    "license": "MIT",
+                    "license_family": "MIT",
+                    "summary": "SUMMARY SUMMARY SUMMARY",
+                    "description": "DESCRIPTION DESCRIPTION DESCRIPTION",
+                }
+            ),
+            "source": OrderedDict(
+                {
+                    "sha256": "4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732",
+                    "url": "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz",
+                }
+            ),
+            "package": OrderedDict(
+                {"name": "{{ name|lower }}", "version": "{{ version }}"}
+            ),
+        }
+    )
+
+    assert (
+        _print_dict(recipe_metadata, order=["package", "source", "about"])
+        == """package:
+  name: {{ name|lower }}
+  version: "{{ version }}"
+
+source:
+  sha256: 4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+
+about:
+  home: https://conda.io
+  license: MIT
+  license_family: MIT
+  summary: "SUMMARY SUMMARY SUMMARY"
+  description: "DESCRIPTION DESCRIPTION DESCRIPTION"
+
+"""
+    )

--- a/tests/test_pypi_skeleton.py
+++ b/tests/test_pypi_skeleton.py
@@ -27,31 +27,35 @@ def test_version_compare():
 
 
 def test_print_dict():
-    recipe_metadata = OrderedDict(
-        {
+    recipe_metadata = {
             "about": OrderedDict(
-                {
-                    "home": "https://conda.io",
-                    "license": "MIT",
-                    "license_family": "MIT",
-                    "summary": "SUMMARY SUMMARY SUMMARY",
-                    "description": "DESCRIPTION DESCRIPTION DESCRIPTION",
-                }
+                [
+                    ("home", "https://conda.io"),
+                    ("license", "MIT"),
+                    ("license_family", "MIT"),
+                    ("summary", "SUMMARY SUMMARY SUMMARY"),
+                    ("description", "DESCRIPTION DESCRIPTION DESCRIPTION"),
+                ]
             ),
             "source": OrderedDict(
-                {
-                    "sha256": "4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732",
-                    "url": "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz",
-                }
+                [
+                    ("sha256", "4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732"),
+                    ("url", "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"),
+                ]
             ),
             "package": OrderedDict(
-                {"name": "{{ name|lower }}", "version": "{{ version }}"}
+                [("name", "{{ name|lower }}"), ("version", "{{ version }}")]
+            ),
+            "build": OrderedDict(
+                [
+                    ("number", 0),
+                    ("script", "{{ PYTHON }} -m pip install . -vv"),
+                ]
             ),
         }
-    )
 
     assert (
-        _print_dict(recipe_metadata, order=["package", "source", "about"])
+        _print_dict(recipe_metadata, order=["package", "source", "build", "about"])
         == """package:
   name: {{ name|lower }}
   version: "{{ version }}"
@@ -59,6 +63,10 @@ def test_print_dict():
 source:
   sha256: 4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 about:
   home: https://conda.io

--- a/tests/test_pypi_skeleton.py
+++ b/tests/test_pypi_skeleton.py
@@ -65,19 +65,19 @@ def test_print_dict():
     assert (
         _print_dict(recipe_metadata, order=["package", "source", "build", "about"])
         == """package:
-  name: {{ name|lower }}
+  name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
   sha256: 4d24b03ffa67638a3fa931c09fd9e0273ffa904e95ebebe7d4b1a54c93d7b732
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
 
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 
 about:
-  home: https://conda.io
+  home: "https://conda.io"
   license: MIT
   license_family: MIT
   summary: "SUMMARY SUMMARY SUMMARY"

--- a/tests/test_pypi_skeleton.py
+++ b/tests/test_pypi_skeleton.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from conda_build.skeletons import pypi
-from conda_build.skeletons.pypi import _print_dict
+from conda_build.skeletons.pypi import _print_dict, _formating_value
 
 
 def test_version_compare():
@@ -24,6 +24,14 @@ def test_version_compare():
     assert pypi.convert_version(rc_version) == ' >=1.4.5rc4,<1.5'
     assert pypi.convert_version(padding_version_short) == ' >=2.2.0,<2.3'
     assert pypi.convert_version(padding_version_long) == ' >=1.4.5.0,<1.4.6'
+
+
+def test_formating_value():
+    assert _formating_value("summary", "SUMMARY SUMMARY") == " \"SUMMARY SUMMARY\"\n"
+    assert _formating_value("description", "DESCRIPTION DESCRIPTION") == " \"DESCRIPTION DESCRIPTION\"\n"
+    assert _formating_value("script", "SCRIPT VALUE") == " \"SCRIPT VALUE\"\n"
+    assert _formating_value("name", "{{name|lower}}") == " \"{{name|lower}}\"\n"
+    assert _formating_value("name", "NORMAL NAME") == " NORMAL NAME\n"
 
 
 def test_print_dict():


### PR DESCRIPTION
Related to #3718 

Quoting only ``version``, ``summary``, ``script`` and ``description`` or attributes which contains special characters.

cc: @ocefpaf 

