### PR TITLE
Version support for CRAN skeleton

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -147,7 +147,7 @@ CRAN_BUILD_SH_MIXED = """\
 if {source_pf_bash}; then
   export DISABLE_AUTOBREW=1
   mv DESCRIPTION DESCRIPTION.old
-  grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+  grep -va '^Priority: ' DESCRIPTION.old > DESCRIPTION
   $R CMD INSTALL --build .
 else
   mkdir -p $PREFIX/lib/R/library/{cran_packagename}
@@ -937,7 +937,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                 'summary': '',
                 'binary1': '',
                 'binary2': ''
-            })
+                })
 
         if version_compare:
             sys.exit(not version_compare(dir_path, d['conda_version']))


### PR DESCRIPTION
Adding support for version selection for `conda skeleton cran`.

To do this, we've replaced the internal index `conda_metadata` with a simpler index `conda_index`. We never used most of the information in `conda_metadata`; it really exists just to provide a lowercase-to-fullycased package map. The new `conda_index` keys are lowercase names of packages as before, and the values are `(name, version)` pairs, where `name` is the fully-cased package name, and `version` is the active version of the package. What is important is that _archived_ packages are included in this list, with `version = None`. Because the `PACKAGES` file does not include information about archived packages or older versions, this index is constructed by scraping the HTML from `/src/contrib/` and `/src/contrib/Archive`.

If a specific version is requested, and that version is not in the current package set, the function `get_cran_archive_versions` retrieves that from a directory listing of `/src/contrib/Archive/<package>`.

The metadata for the package is fetched by downloading the source package into the source cache, and extracted from there, using the `get_archive_metadata` function.