### PR TITLE
WIP: fix CRAN url in recipe; fetch all packages

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1183,8 +1183,8 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
             d['home_comment'] = ''
             if is_github_url:
                 d['homeurl'] = ' {}'.format(location)
-            else:
-                d['homeurl'] = ' https://CRAN.R-project.org/package={}'.format(package)
+            elif fix_cran_url:
+                d['homeurl'] = ' {}/html/{}.html'.format(cran_url, package)
 
         if not use_noarch_generic or cran_package.get("NeedsCompilation", 'no') == 'yes':
             d['noarch_generic'] = ''


### PR DESCRIPTION
I was taking a look at Bioconductor and noted that each "epoch" is structured identically to CRAN, with one significant exception: it doesn't serve a directory index for the `/src/contrib/` path. So I had to drop back to grabbing the PACKAGES file to build the CRAN index again—but at least I still only need the name and version; no need to parse the entire file. Interestingly, `/src/contrib/Archive/` _does_ provide a simple directory index so the `--version` command still works.

And then I realized I might at least want to optionally fix the CRAN URL in the recipe for these cases, instead of building a variant file, so I added a `--fix-cran-url` option.

Finally, I thought, "why not create all of the recipes in one go?" So I added a `--fetch-all` option. To be used with caution. But if anyone wants a complete set of skeletons for Bioconductor 3.9  (@katietz, perhaps?), I know someone who has one.