### PR TITLE
Document run_constrained

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -944,6 +944,21 @@ The line in the ``meta.yaml`` file should literally say
    sections with :ref:`run_exports <run_exports>` which are then automatically
    added to the run requirements for you.
 
+Run_constrained
+---------------
+
+Packages that are optional at runtime but must obey the supplied additional constraint if they are installed.
+
+Package names should follow the `package match specifications <https://conda.io/projects/conda/en/latest/user-guide/concepts.html#package-match-specifications>`_.
+
+
+.. code-block:: yaml
+
+   requirements:
+     run_constrained:
+       - optional-subpackage =={{ version }}
+
+
 .. _meta-test:
 
 Test section


### PR DESCRIPTION
Add short section about requirements.run_constrained to define-metadata.rst

fixes #3739

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
