### PR TITLE
Add `extra` to `outputs` in `FIELDS`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -504,7 +504,7 @@ FIELDS = {
               'pre-link', 'post-link', 'pre-unlink', 'missing_dso_whitelist',
               },
     'outputs': {'name', 'version', 'number', 'script', 'script_interpreter', 'build',
-                'requirements', 'test', 'about', 'files', 'type', 'run_exports'},
+                'requirements', 'test', 'about', 'extra', 'files', 'type', 'run_exports'},
     'requirements': {'build', 'host', 'run', 'conflicts', 'run_constrained'},
     'app': {'entry', 'icon', 'summary', 'type', 'cli_opts',
             'own_environment'},

--- a/tests/test-recipes/split-packages/_extra_metadata/meta.yaml
+++ b/tests/test-recipes/split-packages/_extra_metadata/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: subpackage_has_about_metadata
+  version: 1.0
+
+outputs:
+  - name: abc
+    extra:
+      enthusiasm: weee
+  - name: def
+    extra:
+      dummy_url: http://not.a.url


### PR DESCRIPTION
Adding it here should also avoid some lint that I'm [running into]( https://github.com/conda-forge/ucx-split-feedstock/pull/14#issuecomment-533550603 ).

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
