### PR TITLE
Fix pkg_format 2 (.conda) package builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - conda info
   # avoids a python 3.7 problem
   - conda install -q cytoolz
-  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief
+  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief python-libarchive-c
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Additionally, you need to install a few extra packages:
 
 .. code-block:: bash
 
-  conda install anaconda-client pytest pytest-cov mock pytest-mock conda-package-handling
+  conda install anaconda-client pytest pytest-cov mock pytest-mock conda-package-handling python-libarchive-c
 
 The test suite runs with py.test. Some useful commands to run select tests,
 assuming you are in the conda-build root folder:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling
+  - conda install -q pip pytest pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling python-libarchive-c
   - if "%SYS_PYTHON_VERSION%" == "2.7" conda install -q scandir
   - if "%SYS_PYTHON_VERSION%" == "3.7" conda install -q py-lief
   # this is to ensure dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
       if [[ "$PYTHON_VERSION" == "2.7" ]]; then
         conda install -q futures scandir;
       fi
-      conda install -q pytest-azurepipelines anaconda-client git requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief
+      conda install -q pytest-azurepipelines anaconda-client git requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief python-libarchive-c
       pip install pkginfo
       conda install -c c3i_test -q perl;
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock;

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - pytz
     - tqdm
     - conda-package-handling  >=1.3
+    - python-libarchive-c
 
 test:
   requires:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -27,11 +27,6 @@ import encodings.idna  # NOQA
 from bs4 import UnicodeDammit
 import yaml
 
-try:
-    from conda.base.constants import CONDA_TARBALL_EXTENSIONS
-except Exception:
-    from conda.base.constants import CONDA_TARBALL_EXTENSION
-    CONDA_TARBALL_EXTENSIONS = (CONDA_TARBALL_EXTENSION,)
 import conda_package_handling.api
 
 # used to get version
@@ -55,7 +50,7 @@ from .conda_interface import UnsatisfiableError
 from .conda_interface import NoPackagesFoundError
 from .conda_interface import CondaError
 from .conda_interface import pkgs_dirs
-from .utils import env_var, glob, tmp_chdir
+from .utils import env_var, glob, tmp_chdir, CONDA_TARBALL_EXTENSIONS
 
 from conda_build import environ, source, tarcheck, utils
 from conda_build.index import get_build_index, update_index

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1133,6 +1133,7 @@ def scan_metadata(path):
 
 bundlers = {
     'conda': bundle_conda,
+    'conda_v2': bundle_conda,
     'wheel': bundle_wheel,
 }
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -35,10 +35,11 @@ import filelock
 import conda_package_handling.api
 
 try:
-    from conda.base.constants import CONDA_TARBALL_EXTENSIONS
+    from conda.base.constants import CONDA_PACKAGE_EXTENSIONS
 except Exception:
     from conda.base.constants import CONDA_TARBALL_EXTENSION
-    CONDA_TARBALL_EXTENSIONS = (CONDA_TARBALL_EXTENSION,)
+    CONDA_PACKAGE_EXTENSIONS = (CONDA_TARBALL_EXTENSION,)
+CONDA_TARBALL_EXTENSIONS = CONDA_PACKAGE_EXTENSIONS # noqa: shim for previous interface
 
 from conda.api import PackageCacheData
 
@@ -432,7 +433,11 @@ def get_recipe_abspath(recipe):
     if isfile(recipe):
         if recipe.lower().endswith(decompressible_exts) or recipe.lower().endswith(CONDA_TARBALL_EXTENSIONS):
             recipe_dir = tempfile.mkdtemp()
-            tar_xf(recipe, recipe_dir)
+            if recipe.lower().endswith(CONDA_TARBALL_EXTENSIONS):
+                import conda_package_handling.api
+                conda_package_handling.api.extract(recipe, recipe_dir)
+            else:
+                tar_xf(recipe, recipe_dir)
             # At some stage the old build system started to tar up recipes.
             recipe_tarfile = os.path.join(recipe_dir, 'info', 'recipe.tar')
             if isfile(recipe_tarfile):

--- a/news/pkg_2_build.rst
+++ b/news/pkg_2_build.rst
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* Fixed build of '.conda' packages enabled via 'conda config --set conda_build.pkg_format 2'.

--- a/tests/test_api_build_conda_v2.py
+++ b/tests/test_api_build_conda_v2.py
@@ -1,18 +1,20 @@
 import os
+
 import pytest
 
 from conda_build import api
 
-from .utils import metadata_dir
+from .utils import fail_dir, metadata_dir
 
-@pytest.fixture()
-def recipe():
-    # Build the "entry_points" recipe, which contains a test pass for package.
-    return os.path.join(metadata_dir, "entry_points")
 
 @pytest.mark.parametrize("pkg_format,pkg_ext", [(None, ".tar.bz2"), ("2", ".conda")])
-def test_conda_pkg_format(recipe, pkg_format, pkg_ext, testing_config, testing_workdir, monkeypatch):
+def test_conda_pkg_format(
+    pkg_format, pkg_ext, testing_config, testing_workdir, monkeypatch, capfd
+):
     """Conda package format "2" builds .conda packages."""
+
+    # Build the "entry_points" recipe, which contains a test pass for package.
+    recipe = os.path.join(metadata_dir, "entry_points")
 
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts
@@ -26,3 +28,9 @@ def test_conda_pkg_format(recipe, pkg_format, pkg_ext, testing_config, testing_w
 
     api.build(recipe, config=testing_config)
     assert os.path.exists(output_file)
+
+    out, err = capfd.readouterr()
+
+    # Verify that test pass ran through api
+    assert "Manual entry point" in out
+    assert "TEST END: %s" % output_file in out

--- a/tests/test_api_build_conda_v2.py
+++ b/tests/test_api_build_conda_v2.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+from conda_build import api
+
+from .utils import metadata_dir
+
+@pytest.fixture()
+def recipe():
+    # Build the "entry_points" recipe, which contains a test pass for package.
+    return os.path.join(metadata_dir, "entry_points")
+
+@pytest.mark.parametrize("pkg_format,pkg_ext", [(None, ".tar.bz2"), ("2", ".conda")])
+def test_conda_pkg_format(recipe, pkg_format, pkg_ext, testing_config, testing_workdir, monkeypatch):
+    """Conda package format "2" builds .conda packages."""
+
+    # These variables are defined solely for testing purposes,
+    # so they can be checked within build scripts
+    testing_config.activate = True
+    testing_config.conda_pkg_format = pkg_format
+    monkeypatch.setenv("CONDA_TEST_VAR", "conda_test")
+    monkeypatch.setenv("CONDA_TEST_VAR_2", "conda_test_2")
+
+    output_file, = api.get_output_file_paths(recipe, config=testing_config)
+    assert output_file.endswith(pkg_ext)
+
+    api.build(recipe, config=testing_config)
+    assert os.path.exists(output_file)


### PR DESCRIPTION
_Based off #3743 for ci fix._

- [x] Add an api test covering direct builds of v2 (`.conda`) format packages, specified via `conda config --set conda_build.pkg_format 2`.
- [x] Fix error in v2 format package builds, explicitly specifying the proper bundler for `conda_v2` type packages.
- [x] Fix detection and extraction of `.conda` packages in the test phase, enabling test execution for `.conda` packages.