### PR TITLE
Add python-libarchive-c to package and CI dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - conda info
   # avoids a python 3.7 problem
   - conda install -q cytoolz
-  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief
+  - conda install -q anaconda-client requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief python-libarchive-c
   - pip install pkginfo
   - if [[ "$FLAKE8" == "true" ]]; then
       conda install -q flake8;

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Additionally, you need to install a few extra packages:
 
 .. code-block:: bash
 
-  conda install anaconda-client pytest pytest-cov mock pytest-mock conda-package-handling
+  conda install anaconda-client pytest pytest-cov mock pytest-mock conda-package-handling python-libarchive-c
 
 The test suite runs with py.test. Some useful commands to run select tests,
 assuming you are in the conda-build root folder:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ install:
   - python -c "import sys; print(sys.executable)"
   - python -c "import sys; print(sys.prefix)"
   - conda update -q --all
-  - conda install -q pip pytest pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling
+  - conda install -q pip pytest pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling python-libarchive-c
   - if "%SYS_PYTHON_VERSION%" == "2.7" conda install -q scandir
   - if "%SYS_PYTHON_VERSION%" == "3.7" conda install -q py-lief
   # this is to ensure dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
       if [[ "$PYTHON_VERSION" == "2.7" ]]; then
         conda install -q futures scandir;
       fi
-      conda install -q pytest-azurepipelines anaconda-client git requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief
+      conda install -q pytest-azurepipelines anaconda-client git requests filelock contextlib2 jinja2 patchelf ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling py-lief python-libarchive-c
       pip install pkginfo
       conda install -c c3i_test -q perl;
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock;

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - pytz
     - tqdm
     - conda-package-handling  >=1.3
+    - python-libarchive-c
 
 test:
   requires:


### PR DESCRIPTION
It appears that python-libarchive-c was previously being pulled in as a transitive dependency during CI test runs, but is not longer being implicitly installed in the test environment. 

Adds python-libarchive-c, which is a hard requirement for conda-build, into the conda recipe run requirements, matching the existing dependency specified in setup.py.