### PR TITLE
Add more information to error about pip version usage

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1189,9 +1189,9 @@ class MetaData(object):
                 ms = MatchSpec(spec)
             except AssertionError:
                 raise RuntimeError("Invalid package specification: %r" % spec)
-            except (AttributeError, ValueError):
+            except (AttributeError, ValueError) as e:
                 raise RuntimeError("Received dictionary as spec.  Note that pip requirements are "
-                                   "not supported in conda-build meta.yaml.")
+                                   "not supported in conda-build meta.yaml.  Error message: " + str(e))
             if ms.name == self.name():
                 raise RuntimeError("%s cannot depend on itself" % self.name())
             for name, ver in name_ver_list:

--- a/news/add-more-info-to-error.rst
+++ b/news/add-more-info-to-error.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* Added the error message when an invalid pip dependency version expression is used
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
Related to #3544 I think.

Was creating a new recipe using the `staged-recipes` template. Had already created one, so was doing it faster this time as I needed to go to a meeting.

Unfortunately whenever you are in a hurry you make simple mistakes. I copied everything similar to the other recipe, but did not notice that I had used the dependency version from the project `setup.py` without translating to what conda expects.

I used `- graphql-core >=2.0<3` while it should be `- graphql-core >=2.0,<3`. But haste never helps to spot issues like this. It exited the process with exit code `1`, and the following message:

```bash
$ conda build .
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Received dictionary as spec.  Note that pip requirements are not supported in conda-build meta.yaml.
```

As I don't have much experience with conda recipes, I didn't associate it could be an issue with my dependency version syntax. Looking up on the Internet, didn't find any simple solution. So `grep`ed that in my local installed `conda-build`, and changed the module as in this PR. That gave me:

```bash
$ conda build .
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Received dictionary as spec.  Note that pip requirements are not supported in conda-build meta.yaml.  Error message: Invalid version '2.0<3': invalid character(s)
```

Now it was clear to me where the error was. I think something like this could save others time, by being more explicit about the error. I tried with `--debug` too with no luck. But maybe there are other ways of giving users more information other than changing the error message as in this PR.

If so, happy to update the PR with whatever works best :+1: 

Thanks
Bruno