### PR TITLE
Added missing build error fields in FIELDS

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -502,6 +502,7 @@ FIELDS = {
               'ignore_run_exports', 'requires_features', 'provides_features',
               'force_use_keys', 'force_ignore_keys', 'merge_build_host',
               'pre-link', 'post-link', 'pre-unlink', 'missing_dso_whitelist',
+              'error-overdepending', 'error-overlinking',
               },
     'outputs': {'name', 'version', 'number', 'script', 'script_interpreter', 'build',
                 'requirements', 'test', 'about', 'files', 'type', 'run_exports'},


### PR DESCRIPTION
This PR adds `error_overdepending` and `error_overlinking` to `FIELDS['build']`, mainly to quiet the conda-smithy linter.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
