### PR TITLE
FIX: bug using multiple outputs

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1542,7 +1542,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
 
                 if (top_level_meta.name() == output_d.get('name') and not (output_d.get('files') or
                                                                            output_d.get('script'))):
-                    output_d['files'] = (utils.prefix_files(prefix=m.config.host_prefix) -
+                    output_d['files'] = (utils.prefix_files(prefix=prefix_files_backup) -
                                          initial_files)
 
                 # ensure that packaging scripts are copied over into the workdir


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

Because `m.config.host_prefix` is wipped out when using multiple outputs, use `prefix_files_backup` instead.

Reproduce the bug using following recipe: I expect the archive `my-pkg-1.0-0.tar.bz2` to contain `bin/exe` and `lib/liba.so`.

**meta.yaml**
```yaml
{% set name = 'my-pkg' %}
{% set version = '1.0' %}

package:
  name: {{name}}
  version: {{version}}

build:
  script:
    - mkdir -p $PREFIX/bin $PREFIX/lib
    - touch $PREFIX/bin/exe
    - touch $PREFIX/lib/liba.so

outputs:
  - name: {{name}}
    run_exports:
      - lib{{name}}
  - name: lib{{name}}
    files:
      - lib
```
