### PR TITLE
Do not consider .ignore files when searching with ripgrep

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -187,6 +187,7 @@ def have_prefix_files(files, prefix):
         for rep_prefix, _ in searches.items():
             try:
                 args = [rg,
+                        '--unrestricted',
                         '--no-heading',
                         '--with-filename',
                         '--files-with-matches',


### PR DESCRIPTION
Under some special conditions, for example installing miniconda in a folder that contains `.gitignore`, behavior of ripgrep can change during builds.
Adding the `--unrestricted` flag avoids this.
```
    -u, --unrestricted                      
            Reduce the level of "smart" searching. A single -u won't respect .gitignore
            (etc.) files. Two -u flags will additionally search hidden files and
            directories. Three -u flags will additionally search binary files.
            
            'rg -uuu' is roughly equivalent to 'grep -r'.
```


<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
