### PR TITLE
Fix has_prefix detection for Windows.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -199,7 +199,11 @@ def have_prefix_files(files, prefix):
             except subprocess.CalledProcessError:
                 continue
         # HACK: this is basically os.path.relpath, just simpler and faster
-        rg_matches = [rg_match[prefix_len:] for rg_match in rg_matches]
+        # NOTE: path normalization needs to be in sync with create_info_files
+        if utils.on_win:
+            rg_matches = [rg_match.replace('\\', '/')[prefix_len:] for rg_match in rg_matches]
+        else:
+            rg_matches = [rg_match[prefix_len:] for rg_match in rg_matches]
     else:
         print("WARNING: Detecting which files contain PREFIX is slow, installing ripgrep makes it faster."
               " 'conda install ripgrep'")


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

In [`create_info_files`](https://github.com/conda/conda-build/blob/3.18.9/conda_build/build.py#L696-L698), it normalized the file paths into backward slash on Windows. However, the `rg` still outputs the path in forward slash, and the mismatch causes the logic not able to identify the files to patch around the following code block:

https://github.com/conda/conda-build/blob/3.18.9/conda_build/build.py#L213-L217

This fixes #3348.