### PR TITLE
fix missing "}}" in docs

### DIFF
--- a/docs/source/resources/variants.rst
+++ b/docs/source/resources/variants.rst
@@ -265,7 +265,7 @@ First, the meta.yaml file:
 
        - name: r-xgboost
          requirements:
-             - {{ pin_subpackage('libxgboost', exact=True)
+             - {{ pin_subpackage('libxgboost', exact=True) }}
              - r-base  {{ r_base }}
 
 Next, the conda_build_config.yaml file, specifying our build matrix:


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
fix missing "}}" in docs