### PR TITLE
Optimise use of fnmatch in which_package()

### DIFF
--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import defaultdict
+import fnmatch
 import json
 from operator import itemgetter
 from os.path import abspath, join, dirname, exists, basename
@@ -25,7 +26,6 @@ from conda_build.conda_interface import (iteritems, specs_from_args, is_linked, 
                                          get_index)
 from conda_build.conda_interface import display_actions, install_actions
 from conda_build.conda_interface import memoized
-from fnmatch import fnmatch
 
 
 @memoized
@@ -41,9 +41,10 @@ def which_package(in_prefix_path, prefix):
     only one package.
     """
     norm_ipp = in_prefix_path.replace(os.sep, '/')
+    match = re.compile(fnmatch.translate(norm_ipp)).match
     for dist in linked(prefix):
         dfiles = dist_files(prefix, dist)
-        if any(fnmatch(norm_ipp, w) for w in dfiles):
+        if any(map(match, dfiles)):
             yield dist
 
 


### PR DESCRIPTION
This PR optimises `conda_build.inspec_pkg.which_package()` by only compiling the `fnmatch` once (rather than once per file per package), which significantly speeds up link checking for packages that produce large numbers of binary files.

I'm not sure if this merits a news item, since it doesn't modify any interfaces.

Some timing info. Old:

```
(base) $ python -m timeit -s "import sys; from conda_build.inspect_pkg import which_package" "print(list(which_package('bin/python', sys.prefix)))"
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
1 loop, best of 5: 4.26 sec per loop
```

New:

```
(base) $ python -m timeit -s "import sys; from conda_build.inspect_pkg import which_package" "print(list(which_package('bin/python', sys.prefix)))"
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
[Dist(channel='conda-forge', dist_name='python-3.7.3-h0d93f26_0', name='python', fmt='.tar.bz2', version='3.7.3', build_string='h0d93f26_0', build_number=0, base_url=None, platform=None)]
1 loop, best of 5: 8.13 msec per loop
```
