### PR TITLE
Make the requirement of `requests` explicit

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - py-lief       # [not win]
     - python
     - pyyaml
+    - requests
     - scandir       # [py<34]
     - setuptools
     - six


### PR DESCRIPTION
Looks like `requests` is listed as a dependency in `setup.py`, but not in the Conda recipe. Plus it appears to be used in the recipe skeleton code like [for PyPI generated recipes]( https://github.com/conda/conda-build/blob/0799ec813a883c274420f9b70277c74d5b25437b/conda_build/skeletons/pypi.py#L22-L23 ). So this adds the requirement to the recipe here as well.

Note: This is [implicitly a requirement from Conda]( https://github.com/conda/conda/blob/e5407fb0cd7e013db01417c32e3822bd0857e427/conda.recipe/meta.yaml#L45 ), but it's worth making it explicit.