### PR TITLE
On ASCII locales, allow UTF-8 text in scripts

### DIFF
--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -26,7 +26,11 @@ def rewrite_script(fn, prefix):
 
     # Load and check the source file for not being a binary
     src = join(prefix, 'Scripts' if ISWIN else 'bin', fn)
-    with io.open(src, encoding=locale.getpreferredencoding()) as fi:
+    encoding = locale.getpreferredencoding()
+    # if default locale is ascii, allow UTF-8 (a reasonably modern ASCII extension)
+    if encoding == "ANSI_X3.4-1968":
+        encoding = "UTF-8"
+    with io.open(src, encoding=encoding) as fi:
         try:
             data = fi.read()
         except UnicodeDecodeError:  # file is binary


### PR DESCRIPTION
The noarch check for binary scripts uses the locale preferred encoding to guess if the script is binary or text based.

On some CI systems, (e.g. gitlab continuous integration using the `conda/miniconda3` docker image), the default encoding is ascii (expressed as "ANSI_X3.4-1968").

In general, in any system with an ascii default encoding conda assumes "if it is not ascii then it is binary". I argue it makes more sense to say "if it is not utf-8 then it is binary". Since ascii is a subset of UTF-8, we will reduce the false positives with this change.

Other encodings are not affected by this.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
