### PR TITLE
Add pytest-replay and pytest-rerunfailures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,17 +56,17 @@ jobs:
       pip install --no-deps .
       conda info -a
       mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
-      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]"
       PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]$PYTEST_REPLAY_OPTIONS"
     displayName: Preparing test environment
 
   - script: |
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda install conda-verify -y
-      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
+      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Serial Tests'
 
   - script: |
@@ -79,7 +79,7 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Parallel Tests'
 
   - task: PublishBuildArtifacts@1
@@ -178,12 +178,11 @@ jobs:
       conda info -a
       conda list --show-channel-urls
       mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
-      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]"
       PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
-      echo $PYTEST_REPLAY_OPTIONS
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]$PYTEST_REPLAY_OPTIONS"
     displayName: Preparing test environment
 
   - script: |
@@ -191,9 +190,10 @@ jobs:
       eval "$($(Build.StagingDirectory)/miniconda/bin/python -m conda shell.bash hook)"
       conda activate base
       conda install conda-verify -y
-      echo "Pytest replay: ${PYTEST_REPLAY_OPTIONS}"
-      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
-      ls BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
+      echo "Pytest replay: $PYTEST_REPLAY_OPTIONS"
+      echo $(PYTEST_REPLAY_OPTIONS)
+      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
+      ls $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
     displayName: 'Serial Tests'
 
   - script: |
@@ -206,7 +206,7 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       echo "Pytest replay: ${PYTEST_REPLAY_OPTIONS}"
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
       ls $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
     displayName: 'Parallel Tests'
 
@@ -308,9 +308,9 @@ jobs:
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
       mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay
-      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]"
       set PYTEST_REPLAY_OPTION="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay"
       if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTION%"
     displayName: 'Configuration'
 
   - script: |
@@ -320,7 +320,7 @@ jobs:
       set LUA=
       set R=
       echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
-      py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
+      py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTION)
       dir $(Build.ArtifactStagingDirectory)/pytest-replay
     displayName: 'Serial Tests'
 
@@ -331,7 +331,7 @@ jobs:
       set LUA=
       set R=
       echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
-      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
+      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTION)
       dir $(Build.ArtifactStagingDirectory)/pytest-replay
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,8 @@ jobs:
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
       pip install --no-deps .
       conda info -a
-      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      mkdir $(Build.ArtifactStagingDirectory)/pytest-replay
+      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
@@ -82,7 +83,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)
+      pathToPublish: $(Build.ArtifactStagingDirectory)/pytest-replay
       artifactName: 'Linux-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
 
 
@@ -175,7 +176,8 @@ jobs:
       pip install --no-deps .
       conda info -a
       conda list --show-channel-urls
-      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      mkdir $(Build.ArtifactStagingDirectory)/pytest-replay
+      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
@@ -204,7 +206,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)
+      pathToPublish: $(Build.ArtifactStagingDirectory)/pytest-replay
       artifactName: 'macOS-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
 
 
@@ -299,8 +301,9 @@ jobs:
       conda create -n blarg -yq --download-only python=2.7
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory) --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      mkdir $(Build.ArtifactStagingDirectory)/pytest-replay
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
     displayName: 'Configuration'
 
   - script: |
@@ -309,7 +312,6 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      mkdir -p pytest-replay
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     displayName: 'Serial Tests'
 
@@ -327,6 +329,6 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)
+      pathToPublish: $(Build.ArtifactStagingDirectory)/pytest-replay
       artifactName: 'Win-$(CONDA_VERSION)-Python$(PYTHON_VERSION)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
       mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
       PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]$PYTEST_REPLAY_OPTIONS"
     displayName: Preparing test environment

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -186,7 +186,8 @@ jobs:
       eval "$($(Build.StagingDirectory)/miniconda/bin/python -m conda shell.bash hook)"
       conda activate base
       conda install conda-verify -y
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      mkdir -p /tmp/pytest-replay
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=/tmp/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
@@ -202,13 +203,13 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      mkdir -p pytest-replay
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=pytest-replay"
+
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=/tmp/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-ParallelTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
-      cp pytest-replay/* $(Build.ArtifactStagingDirectory)
+      cp /tmp/pytest-replay/* $(Build.ArtifactStagingDirectory)
     displayName: 'Parallel Tests'
 
   - task: PublishBuildArtifacts@1
@@ -316,8 +317,9 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory) Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      mkdir -p pytest-replay
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     displayName: 'Serial Tests'
 
@@ -327,11 +329,10 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      mkdir -p pytest-replay
       set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory) --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
-      copy pytest-replay\* $(Build.ArtifactStagingDirectory)
+      copy pytest-replay\\* $(Build.ArtifactStagingDirectory)
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,7 +190,6 @@ jobs:
       eval "$($(Build.StagingDirectory)/miniconda/bin/python -m conda shell.bash hook)"
       conda activate base
       conda install conda-verify -y
-      echo "Pytest replay: $PYTEST_REPLAY_OPTIONS"
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Serial Tests'
 
@@ -203,7 +202,6 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      echo "Pytest replay: ${PYTEST_REPLAY_OPTIONS}"
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Parallel Tests'
 
@@ -305,8 +303,6 @@ jobs:
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
       mkdir $(Build.ArtifactStagingDirectory)\\pytest-replay
-      dir $(Build.ArtifactStagingDirectory)
-      dir $(Build.ArtifactStagingDirectory)\\pytest-replay
       set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay"
       if "%PYTHON_VERSION%" NEQ "2.7" set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTIONS%"
@@ -318,7 +314,6 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      echo "Pytest replay: $(PYTEST_REPLAY_OPTIONS)"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Serial Tests'
 
@@ -328,7 +323,6 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTIONS)
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -305,9 +305,9 @@ jobs:
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
       mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
-      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTION%"
+      set PYTEST_REPLAY_OPTIONS="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTIONS%"
     displayName: 'Configuration'
 
   - script: |
@@ -316,8 +316,8 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      echo "Pytest replay: $(PYTEST_REPLAY_OPTION)"
-      py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTION)
+      echo "Pytest replay: $(PYTEST_REPLAY_OPTIONS)"
+      py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Serial Tests'
 
   - script: |
@@ -326,8 +326,8 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
-      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTION)
+      echo "Pytest replay: %PYTEST_REPLAY_OPTIONS%"
+      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTIONS)
       dir $(Build.ArtifactStagingDirectory)/pytest-replay
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -305,8 +305,10 @@ jobs:
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
       mkdir $(Build.ArtifactStagingDirectory)\\pytest-replay
-      set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      dir $(Build.ArtifactStagingDirectory)
+      dir $(Build.ArtifactStagingDirectory)\\pytest-replay
+      set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTIONS%"
     displayName: 'Configuration'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,8 +55,8 @@ jobs:
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
       pip install --no-deps .
       conda info -a
-      mkdir $(Build.ArtifactStagingDirectory)/pytest-replay
-      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay"
+      mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
+      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
@@ -176,11 +176,12 @@ jobs:
       pip install --no-deps .
       conda info -a
       conda list --show-channel-urls
-      mkdir $(Build.ArtifactStagingDirectory)/pytest-replay
-      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay"
+      mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
+      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
+      echo $PYTEST_REPLAY_OPTIONS
     displayName: Preparing test environment
 
   - script: |
@@ -188,8 +189,9 @@ jobs:
       eval "$($(Build.StagingDirectory)/miniconda/bin/python -m conda shell.bash hook)"
       conda activate base
       conda install conda-verify -y
-      mkdir -p /tmp/pytest-replay
+      echo "Pytest replay: ${PYTEST_REPLAY_OPTIONS}"
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
+      ls BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
     displayName: 'Serial Tests'
 
   - script: |
@@ -201,7 +203,9 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
+      echo "Pytest replay: ${PYTEST_REPLAY_OPTIONS}"
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
+      ls $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
     displayName: 'Parallel Tests'
 
   - task: PublishBuildArtifacts@1
@@ -301,8 +305,8 @@ jobs:
       conda create -n blarg -yq --download-only python=2.7
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
-      mkdir $(Build.ArtifactStagingDirectory)/pytest-replay
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay"
+      mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay"
       if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
     displayName: 'Configuration'
 
@@ -312,7 +316,9 @@ jobs:
       set PERL=
       set LUA=
       set R=
+      echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
+      dir $(Build.ArtifactStagingDirectory)/pytest-replay
     displayName: 'Serial Tests'
 
   - script: |
@@ -321,7 +327,9 @@ jobs:
       set PERL=
       set LUA=
       set R=
+      echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
+      dir $(Build.ArtifactStagingDirectory)/pytest-replay
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -304,9 +304,9 @@ jobs:
       conda create -n blarg -yq --download-only python=2.7
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
-      mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay
-      set PYTEST_REPLAY_OPTIONS="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      mkdir $(Build.ArtifactStagingDirectory)\pytest-replay
+      set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTIONS%"
     displayName: 'Configuration'
 
@@ -326,9 +326,8 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      echo "Pytest replay: %PYTEST_REPLAY_OPTIONS%"
+      echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTIONS)
-      dir $(Build.ArtifactStagingDirectory)/pytest-replay
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:
@@ -336,6 +335,6 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)/pytest-replay
+      pathToPublish: $(Build.ArtifactStagingDirectory)\pytest-replay
       artifactName: 'Win-$(CONDA_VERSION)-Python$(PYTHON_VERSION)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,15 +55,15 @@ jobs:
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
       pip install --no-deps .
       conda info -a
+      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
+      fi
     displayName: Preparing test environment
 
   - script: |
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda install conda-verify -y
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
-      fi
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Serial Tests'
 
@@ -76,10 +76,6 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-parallel-$CONDA_VERSION-Py$PYTHON_VERSION"
-      fi
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Parallel Tests'
@@ -179,6 +175,10 @@ jobs:
       pip install --no-deps .
       conda info -a
       conda list --show-channel-urls
+      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
+      fi
     displayName: Preparing test environment
 
   - script: |
@@ -187,10 +187,6 @@ jobs:
       conda activate base
       conda install conda-verify -y
       mkdir -p /tmp/pytest-replay
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=/tmp/pytest-replay"
-      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
-      fi
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Serial Tests'
 
@@ -203,11 +199,6 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=/tmp/pytest-replay"
-      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-ParallelTests-$CONDA_VERSION-Py$PYTHON_VERSION"
-      fi
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
       cp /tmp/pytest-replay/* $(Build.ArtifactStagingDirectory)
     displayName: 'Parallel Tests'
@@ -309,6 +300,8 @@ jobs:
       conda create -n blarg -yq --download-only python=2.7
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory) --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
     displayName: 'Configuration'
 
   - script: |
@@ -318,8 +311,6 @@ jobs:
       set LUA=
       set R=
       mkdir -p pytest-replay
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     displayName: 'Serial Tests'
 
@@ -329,8 +320,6 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
       copy pytest-replay\\* $(Build.ArtifactStagingDirectory)
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,6 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Parallel Tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
                        ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm  \
                        conda-package-handling py-lief python-libarchive-c perl conda-forge::shellcheck
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock
-      conda install -q pytest-replay -c conda-forge
+      conda install -q pytest-replay pytest-rerunfailures -c conda-forge
       pip install pkginfo
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
       pip install --no-deps .
@@ -166,7 +166,7 @@ jobs:
                        pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling  \
                        py-lief python-libarchive-c perl conda-forge::shellcheck
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock
-      conda install -q pytest-replay -c conda-forge
+      conda install -q pytest-replay pytest-rerunfailures -c conda-forge
       # We should build this, it is easy.
       # conda install -y patchelf
       pip install pkginfo
@@ -282,7 +282,7 @@ jobs:
       python -c "import sys; print(sys.prefix)"
       conda update -q --all
       conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines
-      conda install -c conda-forge pytest-replay -y
+      conda install -c conda-forge pytest-replay pytest-rerunfailures -y
       echo "safety_checks: disabled" >> ~/.condarc
       echo "local_repodata_ttl: 1800" >> ~/.condarc
       if "%PYTHON_VERSION%" == "2.7" conda install -q scandir

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -304,9 +304,9 @@ jobs:
       conda create -n blarg -yq --download-only python=2.7
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
-      mkdir $(Build.ArtifactStagingDirectory)\pytest-replay
-      set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      mkdir $(Build.ArtifactStagingDirectory)\\pytest-replay
+      set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTIONS%"
     displayName: 'Configuration'
 
@@ -335,6 +335,6 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)\pytest-replay
+      pathToPublish: $(Build.ArtifactStagingDirectory)\\pytest-replay
       artifactName: 'Win-$(CONDA_VERSION)-Python$(PYTHON_VERSION)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,10 +81,9 @@ jobs:
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Parallel Tests'
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)/pytest-replay
-      artifactName: 'Linux-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
+  - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
+    artifact: 'Linux-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
+    condition: always()
 
 
 - job: 'macOS'
@@ -204,10 +203,9 @@ jobs:
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
     displayName: 'Parallel Tests'
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)/pytest-replay
-      artifactName: 'macOS-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
+  - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
+    artifact: 'macOS-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
+    condition: always()
 
 
 - job: 'Windows'
@@ -328,8 +326,7 @@ jobs:
       LIB:
     displayName: 'Parallel Tests'
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathToPublish: $(Build.ArtifactStagingDirectory)\\pytest-replay
-      artifactName: 'Win-$(CONDA_VERSION)-Python$(PYTHON_VERSION)'
+  - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
+    artifact: 'Win-$(CONDA_VERSION)-Python$(PYTHON_VERSION)'
+    condition: always()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
-      artifactName: Linux-$CONDA_VERSION-Py$PYTHON_VERSION
+      artifactName: 'Linux-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
 
 
 - job: 'macOS'
@@ -212,7 +212,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
-      artifactName: macOS-$CONDA_VERSION-Py$PYTHON_VERSION
+      artifactName: 'macOS-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
 
 
 - job: 'Windows'
@@ -315,7 +315,7 @@ jobs:
       set LUA=
       set R=
       set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if "%PYTHON_VERSION%" != "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     displayName: 'Serial Tests'
 
@@ -326,7 +326,7 @@ jobs:
       set LUA=
       set R=
       set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if "%PYTHON_VERSION%" != "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
@@ -336,5 +336,5 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: $(Build.ArtifactStagingDirectory)
-      artifactName: Win-%CONDA_VERSION%-Python%PYTHON_VERSION%
+      artifactName: 'Win-$(CONDA_VERSION)-Python$(PYTHON_VERSION)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,8 @@ jobs:
       pip install --no-deps .
       conda info -a
       mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
-      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]"
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
@@ -177,7 +178,8 @@ jobs:
       conda info -a
       conda list --show-channel-urls
       mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
-      export PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]"
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
@@ -306,6 +308,7 @@ jobs:
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
       mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay
+      echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]"
       set PYTEST_REPLAY_OPTION="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay"
       if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
     displayName: 'Configuration'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,7 +200,6 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
-      cp /tmp/pytest-replay/* $(Build.ArtifactStagingDirectory)
     displayName: 'Parallel Tests'
 
   - task: PublishBuildArtifacts@1
@@ -321,7 +320,6 @@ jobs:
       set LUA=
       set R=
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
-      copy pytest-replay\\* $(Build.ArtifactStagingDirectory)
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ jobs:
                        ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm  \
                        conda-package-handling py-lief python-libarchive-c perl conda-forge::shellcheck
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock
+      conda install -q pytest-replay -c conda-forge
       pip install pkginfo
       pushd .. && git clone https://github.com/conda/conda_build_test_recipe && popd;
       pip install --no-deps .
@@ -57,11 +58,17 @@ jobs:
     displayName: Preparing test environment
 
   - script: |
+      source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda install conda-verify -y
-      /usr/share/miniconda/bin/py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION"
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-serial-$CONDA_VERSION-Py$PYTHON_VERSION"
+      fi
+      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Serial Tests'
 
   - script: |
+      source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda remove conda-verify -y
       echo "safety_checks: disabled" >> ~/.condarc
       echo "local_repodata_ttl: 1800" >> ~/.condarc
@@ -69,9 +76,19 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=Linux-parallel-$CONDA_VERSION-Py$PYTHON_VERSION"
+      fi
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION"
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Parallel Tests'
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: Linux-$CONDA_VERSION-Py$PYTHON_VERSION
+
 
 - job: 'macOS'
   pool:
@@ -153,6 +170,7 @@ jobs:
                        pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm conda-package-handling  \
                        py-lief python-libarchive-c perl conda-forge::shellcheck
       conda install -q pytest pip pytest-cov pytest-forked pytest-xdist nomkl numpy mock pytest-mock
+      conda install -q pytest-replay -c conda-forge
       # We should build this, it is easy.
       # conda install -y patchelf
       pip install pkginfo
@@ -168,7 +186,11 @@ jobs:
       eval "$($(Build.StagingDirectory)/miniconda/bin/python -m conda shell.bash hook)"
       conda activate base
       conda install conda-verify -y
-      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION"
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
+      fi
+      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Serial Tests'
 
   - script: |
@@ -180,8 +202,17 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION"
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if [[ "$PYTHON_VERSION" != "2.7" ]]; then
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-ParallelTests-$CONDA_VERSION-Py$PYTHON_VERSION"
+      fi
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
     displayName: 'Parallel Tests'
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: macOS-$CONDA_VERSION-Py$PYTHON_VERSION
 
 
 - job: 'Windows'
@@ -257,8 +288,8 @@ jobs:
       python -c "import sys; print(sys.executable)"
       python -c "import sys; print(sys.prefix)"
       conda update -q --all
-      conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling
-      conda install -c conda-forge pytest-azurepipelines -y
+      conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines
+      conda install -c conda-forge pytest-replay -y
       echo "safety_checks: disabled" >> ~/.condarc
       echo "local_repodata_ttl: 1800" >> ~/.condarc
       if "%PYTHON_VERSION%" == "2.7" conda install -q scandir
@@ -283,7 +314,9 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if "%PYTHON_VERSION%" != "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     displayName: 'Serial Tests'
 
   - script: |
@@ -292,8 +325,16 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      if "%PYTHON_VERSION%" != "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:
     displayName: 'Parallel Tests'
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: Win-%CONDA_VERSION%-Python%PYTHON_VERSION%
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,11 +202,13 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      PYTEST_REPLAY_OPTIONS="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      mkdir -p pytest-replay
+      PYTEST_REPLAY_OPTIONS="--replay-record-dir=pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
         PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-ParallelTests-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $PYTEST_REPLAY_OPTIONS
+      cp pytest-replay/* $(Build.ArtifactStagingDirectory)
     displayName: 'Parallel Tests'
 
   - task: PublishBuildArtifacts@1
@@ -325,9 +327,11 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
+      mkdir -p pytest-replay
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay"
       if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
+      copy pytest-replay\* $(Build.ArtifactStagingDirectory)
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -317,7 +317,7 @@ jobs:
       set LUA=
       set R=
       set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory) Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
     displayName: 'Serial Tests'
 
@@ -329,7 +329,7 @@ jobs:
       set R=
       mkdir -p pytest-replay
       set PYTEST_REPLAY_OPTION="--replay-record-dir=pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="%PYTEST_REPLAY_OPTION% --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory) --replay-base-name=Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%"
       py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTION%
       copy pytest-replay\* $(Build.ArtifactStagingDirectory)
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,10 +177,10 @@ jobs:
       pip install --no-deps .
       conda info -a
       conda list --show-channel-urls
-      mkdir $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
+      mkdir -p $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
       PYTEST_REPLAY_OPTIONS="--replay-record-dir=$BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay"
       if [[ "$PYTHON_VERSION" != "2.7" ]]; then
-        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION"
+        PYTEST_REPLAY_OPTIONS+=" --replay-base-name=macOS-$CONDA_VERSION-Py$PYTHON_VERSION"
       fi
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]$PYTEST_REPLAY_OPTIONS"
     displayName: Preparing test environment
@@ -191,9 +191,7 @@ jobs:
       conda activate base
       conda install conda-verify -y
       echo "Pytest replay: $PYTEST_REPLAY_OPTIONS"
-      echo $(PYTEST_REPLAY_OPTIONS)
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
-      ls $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
     displayName: 'Serial Tests'
 
   - script: |
@@ -207,7 +205,6 @@ jobs:
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       echo "Pytest replay: ${PYTEST_REPLAY_OPTIONS}"
       py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" -k test_recipe_builds tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" $(PYTEST_REPLAY_OPTIONS)
-      ls $BUILD_ARTIFACTSTAGINGDIRECTORY/pytest-replay
     displayName: 'Parallel Tests'
 
   - task: PublishBuildArtifacts@1
@@ -307,9 +304,9 @@ jobs:
       conda create -n blarg -yq --download-only python=2.7
       conda create -n blarg -yq --download-only python=3.7
       conda create -n blarg -yq --download-only python cmake
-      mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay
-      set PYTEST_REPLAY_OPTION="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%/pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)/pytest-replay --replay-base-name=Win-SerialTests-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      mkdir %BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay
+      set PYTEST_REPLAY_OPTION="--replay-record-dir=%BUILD_ARTIFACTSTAGINGDIRECTORY%\\pytest-replay"
+      if "%PYTHON_VERSION%" NEQ "2.7" set PYTEST_REPLAY_OPTION="--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTION%"
     displayName: 'Configuration'
 
@@ -319,9 +316,8 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      echo "Pytest replay: %PYTEST_REPLAY_OPTION%"
+      echo "Pytest replay: $(PYTEST_REPLAY_OPTION)"
       py.test --color=yes -v --cov conda_build --cov-report xml tests --basetemp %UserProfile%\cbtmp_serial -n 0 -m "serial" --test-run-title="Win-SerialTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" $(PYTEST_REPLAY_OPTION)
-      dir $(Build.ArtifactStagingDirectory)/pytest-replay
     displayName: 'Serial Tests'
 
   - script: |

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -458,6 +458,7 @@ cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
 
 @pytest.mark.slow
 @pytest.mark.parametrize("package, license_id, license_family, license_files", cran_packages)
+@pytest.mark.flaky(reruns=5, reruns_delay=1)
 def test_cran_license(package, license_id, license_family, license_files, testing_workdir, testing_config):
     api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
                     config=testing_config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ def test_build():
     main_build.execute(args)
 
 
+@pytest.mark.serial
 def test_build_add_channel():
     """This recipe requires the conda_build_test_requirement package, which is
     only on the conda_build_test channel. This verifies that the -c argument


### PR DESCRIPTION
Add [pytest-replay](https://github.com/ESSS/pytest-replay/) to help us to investigate when a test suddenly fails on CI, which might be related to some race condition. Thereby, we will be able to see which tests were running in parallel.

The only problem here is, the output of ``pytest-replay`` is different between version lower than ``1.0.0`` and versions greater or equal then ``1.0.0`` are available just for Python 3+. 
The release ``1.2.0`` added more information to the output, such as the time which the test started and finished, outcome and node id. Nonetheless, older versions just list the order of the tests which were executed by each worker.

https://github.com/ESSS/pytest-replay/#features

