### PR TITLE
Fix dead link in docs.

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -847,7 +847,7 @@ Specifies the build and runtime requirements. Dependencies of
 these requirements are included automatically.
 
 Versions for requirements must follow the conda match
-specification. See `Package match specifications <https://conda.io/projects/conda/en/latest/user-guide/concepts.html#package-match-specifications>`_.
+specification. See :ref:`build-version-spec`.
 
 
 


### PR DESCRIPTION
This PR replaces a dead hard-coded link to "Package match specifications" with a cross-reference pointed at the desired target.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
