### PR TITLE
Add --r-interp-build argument

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -354,6 +354,11 @@ def add_parser(repos):
         help="Declare R interpreter package",
     )
     cran.add_argument(
+        "--r-interp-build",
+        default=None,
+        help="Declare R interpreter package for the build step only. Defaults to the same as --r-interp",
+    )
+    cran.add_argument(
         "--use-binaries-ver",
         help=("Repackage binaries from version provided by argument instead of building "
               "from source."),
@@ -784,7 +789,7 @@ def get_available_binaries(cran_url, details):
 
 def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=None, version=None,
                 git_tag=None, cran_url=None, recursive=False, archive=True,
-                version_compare=False, update_policy='', r_interp='r-base', use_binaries_ver=None,
+                version_compare=False, update_policy='', r_interp='r-base', r_interp_build=None, use_binaries_ver=None,
                 use_noarch_generic=False, use_when_no_binary='src', use_rtools_win=False, config=None,
                 variant_config_files=None):
 
@@ -1322,7 +1327,8 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                         # that are in the recommended group.
                         # We don't include any R version restrictions because
                         # conda-build always pins r-base and mro-base version.
-                        deps.insert(0, '{indent}{r_name}'.format(indent=INDENT, r_name=r_interp))
+                        r_int = r_interp_build if dep_type == 'host' and r_interp_build else r_interp
+                        deps.insert(0, '{indent}{r_name}'.format(indent=INDENT, r_name=r_int))
                     else:
                         conda_name = 'r-' + name.lower()
 


### PR DESCRIPTION
Adds a new argument to `conda skeleton cran`, `--r-interp-build`. This argument has the same format as `--r-interp`, except that it is applied only to the build step.

This is useful for R because if we build for the earliest `x.x` release of R, it is generally compatible with all `x.x.y` sub-versions of R. For instance, building a package for `R 3.5.0` allows it to be compatible for all `R 3.5.*` interpreters.

If not supplied, it defaults to using the same value as `--r-interp`.