### PR TITLE
Optionally add full unit tests to cran recipes

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -66,6 +66,7 @@ TEST_META_WITH_UNIT = """\
   commands:
     - cp -r tests $PREFIX/lib/R/library/{cran_packagename}/  # [not win]
     - $R -e "tools::testInstalledPackage('{cran_packagename}')"  # [not win]
+    - xcopy /E tests %PREFIX%\\lib\\R\\library\\{cran_packagename}\\tests\\  # [win]
     - "\\"%R%\\" -e \\"tools::testInstalledPackage('{cran_packagename}')\\""  # [win]
   {test_source}
   {test_depends}

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -62,11 +62,15 @@ TEST_META_NO_UNIT = """\
     # Put any additional test requirements here.
 """
 
-TEST_META_WITH_UNIT = """\
-  commands:
+
+TEST_META_FILES = """
     - cp -r tests $PREFIX/lib/R/library/{cran_packagename}/  # [not win]
+    - xcopy /E tests %PREFIX%\\lib\\R\\library\\{cran_packagename}\\tests\\  # [win]"""
+
+
+TEST_META_WITH_UNIT = """\
+  commands:{test_copy_files}
     - $R -e "tools::testInstalledPackage('{cran_packagename}')"  # [not win]
-    - xcopy /E tests %PREFIX%\\lib\\R\\library\\{cran_packagename}\\tests\\  # [win]
     - "\\"%R%\\" -e \\"tools::testInstalledPackage('{cran_packagename}')\\""  # [win]
   {test_source}
   {test_depends}
@@ -956,6 +960,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
                 'run_depends': '',
                 'test_depends': '',
                 'test_source': '',
+                'test_copy_files': '',
                 # CRAN doesn't seem to have this metadata :(
                 'home_comment': '#',
                 'homeurl': '',
@@ -1404,6 +1409,8 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
             pass
         print("Writing recipe for %s" % package.lower())
         if include_tests:
+            if has_tests:
+                d['test_copy_files'] = TEST_META_FILES.format(**d)
             if d.get('test_depends'):
                 d['test_depends'] = 'requires:' + d['test_depends']
             d['test_section'] = TEST_META_WITH_UNIT.format(**d)

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1363,7 +1363,7 @@ def skeletonize(in_packages, output_dir=".", output_suffix="", add_maintainer=No
 
                         if ddict[name]:
                             deps.append('{indent}{name} {version}'.format(name=conda_name,
-                                version=dep_dict[name], indent=INDENT))
+                                version=ddict[name], indent=INDENT))
                         else:
                             deps.append('{indent}{name}'.format(name=conda_name,
                                 indent=INDENT))


### PR DESCRIPTION
This implements an `--include-tests` option for `conda skeleton cran`, which adds the full unit tests to CRAN package builds. This is done by
- copying the contents of the source package's `tests/` directory into the R path
- adding the `Suggests:` dependencies to the test phase
- calling `tools::testInstalledPackage` instead of just importing the package

Windows isn't finished yet, hence the WIP