### PR TITLE
[CRAN Skeleton] fix when directory indexes are not allowed (e.g., bioconductor)

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -657,7 +657,7 @@ def get_cran_index(cran_url, session, verbose=True):
             records[package.lower()] = (package, line.rstrip().split(' ', 1)[1])
             package = None
     r = session.get(cran_url + "/src/contrib/Archive/")
-    if r.status_code == 403:
+    if r.status_code in (403, 404):
         if verbose:
             print("Cannot fetch an archive index from %s" % cran_url)
         return records


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

This modifies the `get_cran_index` function to parse the `src/contrib/PACAKGES.gz` file instead of relying on the web server's directory index of `src/contrib/` itself. This is necessary to retrieve packages from Bioconductor. To test, try this:
```
conda skeleton cran --cran-url https://www.bioconductor.org/packages/release/bioc biocgenerics
```
Of course we should confirm that direct CRAN packages still work:
```
conda skeleton cran tergm
```
There is more work to make Bioconductor packages skeletonize perfectly—e.g., right now, the default home page for the package defaults to an invalid CRAN url. But this gets a buildable artifact.