### PR TITLE
Try to ensure python stdlib directory is for the correct version

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -977,9 +977,18 @@ def get_stdlib_dir(prefix, py_ver):
         lib_dir = os.path.join(prefix, 'Lib')
     else:
         lib_dir = os.path.join(prefix, 'lib')
-        python_folder = glob(os.path.join(lib_dir, 'python?.*'))
-        if python_folder:
-            lib_dir = os.path.join(lib_dir, python_folder[0])
+        python_folders = glob(os.path.join(lib_dir, 'python?.*'))
+        if python_folders:
+            if len(python_folders) > 1:
+                log = get_logger(__name__)
+                log.warn("Found multiple stdlib directories: {}"
+                         .format(python_folders))
+            for python_folder in python_folders:
+                if py_ver in python_folder:
+                    lib_dir = os.path.join(lib_dir, python_folder)
+                    break
+            else:
+                lib_dir = os.path.join(lib_dir, python_folders[0])
         else:
             lib_dir = os.path.join(lib_dir, 'python{}'.format(py_ver))
     return lib_dir

--- a/news/stdlib-detection
+++ b/news/stdlib-detection
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* Try to ensure the correct Python stdlib directory is detected (#3822)


### PR DESCRIPTION
Currently if the environment contains multiple `lib/pythonX.Y/site-packages` directories the `SP_DIR` environment variable can be set incorrectly. This PR tries to make conda-build more reliable and shows a warning to make it clearer when something is wrong.

More details in: https://github.com/conda-forge/gdk-pixbuf-feedstock/issues/13
PR in conda-forge where this happens: https://github.com/conda-forge/root-feedstock/pull/74#issuecomment-572449839