### PR TITLE
Be robust against spaces in %SRC_DIR%.

### DIFF
--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -234,7 +234,7 @@ def write_build_scripts(m, env, bld_bat):
             data = fi.read()
         with codecs.getwriter('utf-8')(open(work_script, 'wb')) as fo:
             fo.write('IF "%CONDA_BUILD%" == "" (\n')
-            fo.write("    call {}\n".format(env_script))
+            fo.write('    call "{}"\n'.format(env_script))
             fo.write(')\n')
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)

--- a/news/spaces-in-path.rst
+++ b/news/spaces-in-path.rst
@@ -1,0 +1,5 @@
+Bug fixes:
+----------
+
+* Improved support for cases where conda is installed on Windows in a path that
+  contains a space.


### PR DESCRIPTION
The build directory simply needs to be quoted.
This can be tested by trying to build any recipe after installing conda
in a path that contains spaces (e.g., if your username contains spaces).

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
