### PR TITLE
remove docs on features from bdist_conda and env vars

### DIFF
--- a/bdist_conda.py
+++ b/bdist_conda.py
@@ -66,14 +66,6 @@ class CondaDistribution(Distribution):
       setuptools or has a setuptools entry_points other than console_scripts
       and gui_scripts.
 
-    - conda_features: List of features for the package. See the features
-      section of the conda build documentation for more information about
-      features in conda.
-
-    - conda_track_features: List of features that this package should track
-      (enable when installed).  See the features section of the conda build
-      documentation for more information about features in conda.
-
     Command line options:
 
     --buildnum: Set the build number. Defaults to the conda_buildnum passed to

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -311,28 +311,6 @@ Environment variables that affect the build process
        usually labeled ``-p`` or ``--prefix``.
 
 
-.. _build-features:
-
-Environment variables to set build features
-===========================================
-
-The environment variables listed in the following table are
-inherited from the process running conda-build. 
-
-.. list-table::
-   :widths: 15 43 42
-
-   * - FEATURE_NOMKL
-     - Adds the ``nomkl`` feature to the built package.
-     - Accepts ``0`` for off and ``1`` for on.
-   * - FEATURE_DEBUG
-     - Adds the ``debug`` feature to the built package.
-     - Accepts ``0`` for off and ``1`` for on.
-   * - FEATURE_OPT
-     - Adds the ``opt`` feature to the built package.
-     - Accepts ``0`` for off and ``1`` for on.
-
-
 .. _test-envs:
 
 Environment variables that affect the test process

--- a/docs/source/user-guide/recipes/build-without-recipe.rst
+++ b/docs/source/user-guide/recipes/build-without-recipe.rst
@@ -32,7 +32,6 @@ EXAMPLE: A minimal ``setup.py`` file using the setup options
       version="1.0",
       distclass=distutils.command.bdist_conda.CondaDistribution,
       conda_buildnum=1,
-      conda_features=['mkl'],
   )
 
 
@@ -117,30 +116,6 @@ gui_scripts.
 
    conda_preserve_egg_dir=False
 
-
-Features
---------
-
-A list of features for the package.
-
-.. code::
-
-   conda_features=['mkl']
-
-.. note::
-   Replace ``mkl`` with the features that you want to list.
-
-
-
-Track features
------------------
-
-List of features that this package should track---enable---when
-installed.
-
-.. code::
-
-   conda_track_features=['mkl']
 
 Command line options
 ====================


### PR DESCRIPTION
Leave code intact, but no docs

Mutex metapackages are the documented preferred approach: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html#mutex-metapackages