### PR TITLE
Fix for globbing test files on Windows

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -27,7 +27,7 @@ def create_files(m, test_dir=None):
 
     for pattern in ensure_list(m.get_value('test/files', [])):
         has_files = True
-        files = glob(join(m.path, pattern))
+        files = glob(join(m.path, pattern.replace('/', os.sep)))
         for f in files:
             copy_into(f, f.replace(m.path, test_dir), m.config.timeout, locking=False,
                     clobber=True)


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
