### PR TITLE
Change behaviour of build/binary_has_prefix_files

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -947,8 +947,9 @@ def get_files_with_prefix(m, files_in, prefix):
 
 def record_prefix_files(m, files_with_prefix):
 
+    filtered = []
     if not files_with_prefix:
-        return
+        return filtered
 
     # Copies are made to ease debugging. Sorry.
     binary_has_prefix_files = m.binary_has_prefix_files()[:]
@@ -971,16 +972,16 @@ def record_prefix_files(m, files_with_prefix):
 
         print("Files containing CONDA_PREFIX")
         print("-----------------------------")
+        detect_binary_files_with_prefix = m.get_value('build/detect_binary_files_with_prefix', False)
         with open(join(m.config.info_dir, 'has_prefix'), 'w') as fo:
             for pfix, mode, fn in files_with_prefix:
-                print('{} :: {} :: {}'.format(pfix, mode, fn))
                 ignored_because = None
                 if (fn in binary_has_prefix_files or (not len_binary_has_prefix_files or
-                   m.get_value('build/detect_binary_files_with_prefix', False) and mode == 'binary')):
+                   detect_binary_files_with_prefix and mode == 'binary')):
                     if fn in binary_has_prefix_files:
                         if mode != 'binary':
                             mode = 'binary'
-                        elif fn in binary_has_prefix_files:
+                        elif fn in binary_has_prefix_files and detect_binary_files_with_prefix:
                             print("File {} force-identified as 'binary', "
                                   "But it is 'binary' anyway, suggest removing it from "
                                   "`build/binary_has_prefix_files`".format(fn))
@@ -1003,6 +1004,7 @@ def record_prefix_files(m, files_with_prefix):
                                                                reason=ignored_because if ignored_because else ""))
                 if ignored_because is None:
                     fo.write(fmt_str % (pfix, mode, fn))
+                    filtered.append((pfix, mode, fn))
 
     # make sure we found all of the files expected
     errstr = ""
@@ -1012,6 +1014,8 @@ def record_prefix_files(m, files_with_prefix):
         errstr += "Did not detect hard-coded path in %s from binary_has_prefix_files\n" % f
     if errstr:
         raise RuntimeError(errstr)
+
+    return filtered
 
 
 def sanitize_channel(channel):
@@ -1194,9 +1198,9 @@ def create_info_files(m, files, prefix):
     write_info_files_file(m, files)
 
     files_with_prefix = get_files_with_prefix(m, files, prefix)
+    files_with_prefix = record_prefix_files(m, files_with_prefix)
     checksums = create_info_files_json_v1(m, m.config.info_dir, prefix, files, files_with_prefix)
 
-    record_prefix_files(m, files_with_prefix)
     write_no_link(m, files)
 
     sources = m.get_section('source')

--- a/tests/test-recipes/metadata/binary_has_prefix_files_list/bld.bat
+++ b/tests/test-recipes/metadata/binary_has_prefix_files_list/bld.bat
@@ -1,0 +1,2 @@
+%PYTHON% %RECIPE_DIR%\write_binary_has_prefix.py binary-has-prefix
+%PYTHON% %RECIPE_DIR%\write_binary_has_prefix.py binary-has-prefix-ignored

--- a/tests/test-recipes/metadata/binary_has_prefix_files_list/build.sh
+++ b/tests/test-recipes/metadata/binary_has_prefix_files_list/build.sh
@@ -1,0 +1,2 @@
+${PYTHON} ${RECIPE_DIR}/write_binary_has_prefix.py binary-has-prefix
+${PYTHON} ${RECIPE_DIR}/write_binary_has_prefix.py binary-has-prefix-ignored

--- a/tests/test-recipes/metadata/binary_has_prefix_files_list/meta.yaml
+++ b/tests/test-recipes/metadata/binary_has_prefix_files_list/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: conda-build-test-binary_has_prefix_files_list
+  version: 1.0
+
+build:
+  binary_has_prefix_files:
+    - binary-has-prefix
+
+requirements:
+  build:
+    - python

--- a/tests/test-recipes/metadata/binary_has_prefix_files_list/run_test.sh
+++ b/tests/test-recipes/metadata/binary_has_prefix_files_list/run_test.sh
@@ -1,0 +1,8 @@
+set -x
+
+cd $PREFIX
+cat binary-has-prefix
+cat binary-has-prefix | grep $PREFIX
+
+cat binary-has-prefix-ignored
+cat binary-has-prefix-ignored | grep --invert-match $PREFIX

--- a/tests/test-recipes/metadata/binary_has_prefix_files_list/write_binary_has_prefix.py
+++ b/tests/test-recipes/metadata/binary_has_prefix_files_list/write_binary_has_prefix.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+prefix = os.environ['PREFIX']
+fn = '%s/%s' % (prefix, sys.argv[1])
+
+if not os.path.isdir(prefix):
+    os.makedirs(prefix)
+
+with open(fn, 'wb') as f:
+    f.write(prefix.encode('utf-8') + b'\x00')


### PR DESCRIPTION
If specified as a list, then only those files in that list are
considered eligible for binary prefix replacement.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
