### PR TITLE
Clarify 'deletes the build env' in concepts/recipe

### DIFF
--- a/docs/source/concepts/recipe.rst
+++ b/docs/source/concepts/recipe.rst
@@ -69,7 +69,7 @@ Conda-build performs the following steps:
 
 #. Tests the new conda package if the recipe includes tests:
 
-   #. Deletes the build environment.
+   #. Deletes the build environment and source directory to ensure that the new conda package does not inadvertantly depend on artifacts not included in the package.
 
    #. Creates a test environment with the package and its
       dependencies.

--- a/news/clarify_rm_build_env_in_recipe_concepts.rst
+++ b/news/clarify_rm_build_env_in_recipe_concepts.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* clarified 'deletes the build environment' in concepts/recipe.rst (#3901)
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
I don't see anywhere in the docs where it is explained why the SOURCE_DIR, and build/host environments are deleted at the beginning of test phase (or in between build and test phase).  This commit captures that reasoning so that I can point here for new people learning about conda-build.

- [x] I'll push a NEWS file in just a sec.  I made this edit with the web ui and I don't see an easy way to create a new news file there.