### PR TITLE
Ignore patching Mach-O files if not running on macOS

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -396,7 +396,9 @@ def osx_ch_link(path, link_dict, host_prefix, build_prefix, files):
 
 
 def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
-    assert sys.platform == 'darwin'
+    if sys.platform != 'darwin':
+      log.warn("Found Mach-O file but patching is only supported on macOS, skipping: %s", path)
+      return
     prefix = build_prefix if exists(build_prefix) else host_prefix
     names = macho.otool(path, prefix)
     s = macho.install_name_change(path, prefix,

--- a/news/dont-fix-macho-files-on-other-platforms.rst
+++ b/news/dont-fix-macho-files-on-other-platforms.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Show a warning instead of failing if a Mach-O file is prouduced by a build running on a platform other than macOS.
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

As found in https://github.com/conda-forge/cmake-feedstock/pull/115#issuecomment-603472268 the Linux CMake build produces a Mach-O binary which then triggers this assertion and causes the build to fail.

This is a regression in 3.18 as this function used to never be called on other platforms: https://github.com/conda/conda-build/pull/3808/files#diff-60400bbbdb51124a0a8a06ca17ecec5cL1105

cc @jakirkham 