### PR TITLE
load log prior to calling in post.py

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -397,8 +397,9 @@ def osx_ch_link(path, link_dict, host_prefix, build_prefix, files):
 
 def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
     if sys.platform != 'darwin':
-      log.warn("Found Mach-O file but patching is only supported on macOS, skipping: %s", path)
-      return
+        log = utils.get_logger(__name__)
+        log.warn("Found Mach-O file but patching is only supported on macOS, skipping: %s", path)
+        return
     prefix = build_prefix if exists(build_prefix) else host_prefix
     names = macho.otool(path, prefix)
     s = macho.install_name_change(path, prefix,

--- a/news/fix_ignore_macho.rst
+++ b/news/fix_ignore_macho.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* load log prior to calling warn method (#3925)
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
Load the logger prior to calling the warn method.  Adjust indentation to match the module's style.