### PR TITLE
Add noarch regression test for gh-3916

### DIFF
--- a/tests/test-recipes/metadata/entry_points_have_prefix/conda_build_config.yaml
+++ b/tests/test-recipes/metadata/entry_points_have_prefix/conda_build_config.yaml
@@ -1,0 +1,3 @@
+noarch:
+  - false
+  - python

--- a/tests/test-recipes/metadata/entry_points_have_prefix/meta.yaml
+++ b/tests/test-recipes/metadata/entry_points_have_prefix/meta.yaml
@@ -12,6 +12,7 @@ build:
   number: 0
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  noarch: {{ noarch }}
 
 requirements:
   host:


### PR DESCRIPTION
gh-3932 / b6f9b438339281c899da0b15cfbdb302eaa4f11e regressed gh-3916 for `noarch` packages.
(Looks like it is not `noarch: python`-specific but also fails for `noarch: generic`; I just chose `noarch: python` because the test package is a Python one.)