### PR TITLE
conda index cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,7 +264,7 @@ jobs:
       python -c "import sys; print(sys.executable)"
       python -c "import sys; print(sys.prefix)"
       call conda update -q --all
-      call conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines
+      call conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines cytoolz
       call conda install -c conda-forge pytest-replay pytest-rerunfailures -y
       echo safety_checks: disabled >> %UserProfile%\.condarc
       echo local_repodata_ttl: 1800 >> %UserProfile%\.condarc

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - conda  >=4.5
     # - conda-verify  >=3.0.2  # optional as of CB 3.12.0
     - contextlib2   # [py<34]
+    - cytoolz
     - enum34        # [py<34]
     - pathlib2      # [py<3]
     - filelock

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -15,7 +15,7 @@ but only use those kwargs in config.  Config must change to support new features
 
 # imports are done locally to keep the api clean and limited strictly
 #    to conda-build's functionality.
-
+from itertools import zip_longest
 import sys as _sys
 
 # make the Config class available in the api namespace
@@ -378,12 +378,12 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
                  subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
-                 hotfix_source_repo=None, current_index_versions=None, **kwargs):
+                 hotfix_source_repo=None, current_index_versions=None, metadata_paths=(), **kwargs):
     import yaml
     from locale import getpreferredencoding
     import os
     from .conda_interface import PY3, string_types
-    from conda_build.index import update_index
+    from conda_build.index import update_index as _update_index
     from conda_build.utils import ensure_list
     dir_paths = [os.path.abspath(path) for path in _ensure_list(dir_paths)]
     # Don't use byte strings in Python 2
@@ -394,11 +394,14 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
         with open(current_index_versions) as f:
             current_index_versions = yaml.safe_load(f)
 
-    for path in dir_paths:
-        update_index(path, check_md5=check_md5, channel_name=channel_name,
-                     patch_generator=patch_generator, threads=threads, verbose=verbose,
-                     progress=progress, hotfix_source_repo=hotfix_source_repo,
-                     subdirs=ensure_list(subdir), current_index_versions=current_index_versions)
+    for path, metadata_path in zip_longest(dir_paths, metadata_paths):
+        _update_index(
+            path, check_md5=check_md5, channel_name=channel_name,
+            patch_generator=patch_generator, threads=threads, verbose=verbose,
+            progress=progress, hotfix_source_repo=hotfix_source_repo,
+            subdirs=ensure_list(subdir), current_index_versions=current_index_versions,
+            metadata_path=metadata_path
+        )
 
 
 def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -15,7 +15,6 @@ but only use those kwargs in config.  Config must change to support new features
 
 # imports are done locally to keep the api clean and limited strictly
 #    to conda-build's functionality.
-from itertools import zip_longest
 import sys as _sys
 
 # make the Config class available in the api namespace
@@ -24,7 +23,6 @@ from conda_build.config import (Config, get_or_merge_config, get_channel_urls,
 from conda_build.utils import ensure_list as _ensure_list
 from conda_build.utils import expand_globs as _expand_globs
 from conda_build.utils import get_logger as _get_logger
-from os.path import dirname, expanduser, join
 
 
 def render(recipe_path, config=None, variants=None, permit_unsatisfiable_variants=True,
@@ -241,6 +239,7 @@ def list_skeletons():
 
     The returned list is generally the names of supported repositories (pypi, cran, etc.)"""
     import pkgutil
+    from os.path import dirname, join
     modules = pkgutil.iter_modules([join(dirname(__file__), 'skeletons')])
     files = []
     for _, name, _ in modules:
@@ -253,7 +252,7 @@ def skeletonize(packages, repo, output_dir=".", version=None, recursive=False,
                 config=None, **kwargs):
     """Generate a conda recipe from an external repo.  Translates metadata from external
     sources into expected conda recipe format."""
-
+    from os.path import expanduser
     version = getattr(config, "version", version)
     if version:
         kwargs.update({'version': version})
@@ -381,6 +380,10 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
                  hotfix_source_repo=None, current_index_versions=None, metadata_paths=(), **kwargs):
     import yaml
     from locale import getpreferredencoding
+    try:
+        from itertools import zip_longest
+    except ImportError:
+        from itertools import izip_longest as zip_longest
     import os
     from .conda_interface import PY3, string_types
     from conda_build.index import update_index as _update_index

--- a/conda_build/cli/main_index.py
+++ b/conda_build/cli/main_index.py
@@ -75,6 +75,13 @@ def parse_args(args):
         will keep python 2.7.X and 3.6.Y in the current_index.json, instead of only the very latest python version.
         """
     )
+    p.add_argument(
+        "--metadata-dir",
+        action="append",
+        help="Locate generated indexing and metadata files (repodata.json, .cache directories, etc.) "
+             "in a location different than `dir`.",
+        default=[],
+    )
 
     args = p.parse_args(args)
     return p, args
@@ -82,12 +89,16 @@ def parse_args(args):
 
 def execute(args):
     _, args = parse_args(args)
-
+    assert len(args.dir) >= len(args.metadata_dir)
     api.update_index(args.dir, check_md5=args.check_md5, channel_name=args.channel_name,
                      threads=args.threads, subdir=args.subdir, patch_generator=args.patch_generator,
                      verbose=args.verbose, progress=args.progress, hotfix_source_repo=args.hotfix_source_repo,
-                     current_index_versions=args.current_index_versions_file)
+                     current_index_versions=args.current_index_versions_file, metadata_paths=args.metadata_dir)
 
 
 def main():
     return execute(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -7,7 +7,7 @@ from base64 import urlsafe_b64encode
 import bz2
 from collections import OrderedDict
 import copy
-from datetime import datetime, timezone
+from datetime import datetime
 import json
 from numbers import Number
 import os
@@ -65,7 +65,7 @@ from .utils import glob, get_logger, FileNotFoundError, JSONDecodeError, sha256_
 
 # TODO: better to define this in conda; doing it here because we're implementing it in conda-build first
 CONDA_TARBALL_EXTENSIONS = ('.conda', '.tar.bz2')
-
+UTC = pytz.timezone("UTC")
 
 log = get_logger(__name__)
 
@@ -397,7 +397,7 @@ def _get_jinja2_environment():
         if isinstance(dt, Number):
             if dt > 253402300799:  # 9999-12-31
                 dt //= 1000  # convert milliseconds to seconds; see #1988
-            dt = datetime.utcfromtimestamp(dt).replace(tzinfo=pytz.timezone("UTC"))
+            dt = datetime.utcfromtimestamp(dt).replace(tzinfo=UTC)
         return dt.strftime(dt_format)
 
     def _filter_add_href(text, link, **kwargs):
@@ -579,7 +579,7 @@ def _make_subdir_index_html(channel_name, subdir, repodata_packages, extra_paths
     rendered_html = template.render(
         title="%s/%s" % (channel_name or '', subdir),
         packages=repodata_packages,
-        current_time=datetime.utcnow().replace(tzinfo=pytz.timezone("UTC")),
+        current_time=datetime.utcnow().replace(tzinfo=UTC),
         extra_paths=extra_paths,
     )
     return rendered_html
@@ -592,7 +592,7 @@ def _make_channeldata_index_html(channel_name, channeldata):
         title=channel_name,
         packages=channeldata['packages'],
         subdirs=channeldata['subdirs'],
-        current_time=datetime.utcnow().replace(tzinfo=pytz.timezone("UTC")),
+        current_time=datetime.utcnow().replace(tzinfo=UTC),
     )
     return rendered_html
 
@@ -743,7 +743,7 @@ def _build_current_repodata(subdir, repodata, pins):
 
 
 def timestamp_to_dt(timestamp):
-    return datetime.fromtimestamp(_make_seconds(timestamp), timezone.utc)
+    return datetime.fromtimestamp(_make_seconds(timestamp), UTC)
 
 
 def dt_to_timestamp(dt):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -582,7 +582,7 @@ def _build_current_repodata(subdir, repodata, pins):
 def json_dumps_compact(obj):
     return json.dumps(
         obj,
-        ensure_ascii=False,
+        ensure_ascii=True,
         indent=None,
         sort_keys=True,
         separators=(",", ":"),

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1081,8 +1081,7 @@ class ChannelIndex(object):
 
         # gather conda package filenames in subdir
         # we'll process these first, because reading their metadata is much faster
-        with scandir(subdir_path) as sd_it:
-            groups = groupby(lambda fn: fn[-6:], (entry.name for entry in sd_it))
+        groups = groupby(lambda fn: fn[-6:], (entry.name for entry in scandir(subdir_path)))
         conda_fns = set(groups.get(".conda", ()))
         tar_bz2_fns = set(groups.get("ar.bz2", ()))
         fns_in_subdir = conda_fns | tar_bz2_fns
@@ -1195,13 +1194,14 @@ class ChannelIndex(object):
         #                           "a valid package." % os.path.join(subdir_path, fn))
 
         new_repodata = {
-            'packages': new_repodata_packages,
-            'packages.conda': new_repodata_conda_packages,
-            'info': {
-                'subdir': subdir,
+            "$schema": "https://schemas.conda.io/repodata-1.schema.json",
+            "repodata_version": REPODATA_VERSION,
+            "info": {
+                "subdir": subdir,
             },
-            'repodata_version': REPODATA_VERSION,
-            'removed': sorted(all_removed)
+            "packages": new_repodata_packages,
+            "packages.conda": new_repodata_conda_packages,
+            "removed": sorted(all_removed)
         }
         return new_repodata
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1152,7 +1152,7 @@ class ChannelIndex(object):
         # Extract and cache update_set and add_set, then add to new_repodata_packages.
         extract_fns = sorted(concatv(add_set, update_set))
         num_extract_fns = len(extract_fns)
-        for q, fn in enumerate(tqdm(extract_fns)):
+        for q, fn in enumerate(tqdm(extract_fns, desc="extracting metadata", disable=verbose or not progress)):
             log.debug("extracting metadata [%s/%s] %s/%s", q + 1, num_extract_fns, subdir, fn)
             repodata_record = self._extract_to_cache2(self.channel_root, subdir, fn)
             if repodata_record is None:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -270,12 +270,12 @@ def update_index(dir_path, check_md5=False, channel_name=None, patch_generator=N
                             threads=threads, verbose=verbose, progress=progress,
                             hotfix_source_repo=hotfix_source_repo,
                             current_index_versions=current_index_versions)
-    return ChannelIndex(dir_path, channel_name, subdirs=subdirs, threads=threads,
-                        deep_integrity_check=check_md5, debug=debug).index(
-                            patch_generator=patch_generator, verbose=verbose,
-                            progress=progress,
-                            hotfix_source_repo=hotfix_source_repo,
-                            current_index_versions=current_index_versions)
+    return ChannelIndex(
+        dir_path, channel_name, subdirs=subdirs, threads=threads, deep_integrity_check=check_md5, debug=debug
+    ).index(
+        patch_generator=patch_generator, verbose=verbose, progress=progress,
+        hotfix_source_repo=hotfix_source_repo, current_index_versions=current_index_versions
+    )
 
 
 def _determine_namespace(info):
@@ -935,12 +935,14 @@ def _extract_info_directory(channel_root, subdir, fn, check_hash=False):
     timestamp = _make_seconds(repodata_record.get("timestamp", st.st_mtime))
     sha256 = sha256 or sha256_checksum(package_path)
     md5 = md5_file(package_path)
-    subdir = repodata_record.get("subdir", subdir)
 
     derived_fn = "{0}-{1}-{2}{3}".format(
         repodata_record["name"], repodata_record["version"], repodata_record["build"], ext
     )
     assert derived_fn == fn, (derived_fn, fn)
+    derived_subdir = repodata_record.get("subdir")
+    if derived_subdir and derived_subdir != subdir:
+        log.warning("subdir mismatch in info/index.json (%s != %s) for %s", derived_subdir, subdir, package_path)
     repodata_record.update({
         "fn": fn,
         "md5": md5,

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1074,7 +1074,7 @@ class ChannelIndex(object):
                 copy_from_cache = False
             if copy_from_cache:
                 log.debug("writing icon to %s", icon_channel_path)
-                icon_binary = urlsafe_b64decode(all_metadata["icon"]["icon_base64"])
+                icon_binary = urlsafe_b64decode(all_metadata["icon"]["icon_base64"].encode("utf-8"))
                 try:
                     os.makedirs(dirname(icon_channel_path))
                 except EnvironmentError:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -8,17 +8,21 @@ import bz2
 from collections import OrderedDict
 import copy
 from datetime import datetime
+from functools import partial
 import json
+import logging
 from numbers import Number
 import os
-from os import scandir, lstat, utime
+from os import lstat, utime
 from os.path import abspath, basename, getmtime, getsize, isdir, isfile, join, dirname, lexists
 import sys
 import time
 from uuid import uuid4
 
-# Lots of conda internals here.  Should refactor to use exports.
-from conda.common.compat import ensure_binary
+try:
+    from os import scandir
+except ImportError:
+    from scandir import scandir
 
 import pytz
 from jinja2 import Environment, PackageLoader
@@ -37,8 +41,6 @@ from ruamel_yaml.reader import ReaderError
 
 from cytoolz.itertoolz import concat, concatv, groupby
 
-from functools import partial
-import logging
 import conda_package_handling.api
 from conda_package_handling.api import InvalidArchiveError
 
@@ -46,6 +48,8 @@ from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import Executor
 
 #  BAD BAD BAD - conda internals
+# Lots of conda internals here.  Should refactor to use exports.
+from conda.common.compat import ensure_binary
 from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
 
@@ -1012,7 +1016,6 @@ class ChannelIndex(object):
                 #         channel_data = json.load(f)
                 # Step 2. Collect repodata from packages, save to pkg_repodata.json file
                 repodatas = {}
-                # TODO: add cytoolz and scandir to conda-build requirements
                 with tqdm(total=len(subdirs), disable=(verbose or not progress), leave=False) as t:
                     for subdir in subdirs:
                         t.set_description("Subdir: %s" % subdir)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -54,7 +54,7 @@ from .conda_interface import MatchSpec, VersionOrder, human_bytes, context, md5_
 from .conda_interface import CondaError, CondaHTTPError, get_index, url_path
 from .conda_interface import TemporaryDirectory
 from .conda_interface import Resolve
-from .utils import glob, get_logger, FileNotFoundError, JSONDecodeError, sha256_checksum, rm_rf
+from .utils import get_logger, FileNotFoundError, JSONDecodeError, sha256_checksum, rm_rf
 
 # try:
 #     from conda.base.constants import CONDA_TARBALL_EXTENSIONS
@@ -738,7 +738,6 @@ def _build_current_repodata(subdir, repodata, pins):
     return new_repodata
 
 
-
 def timestamp_to_dt(timestamp):
     return datetime.fromtimestamp(_make_seconds(timestamp), UTC)
 
@@ -1118,9 +1117,7 @@ class ChannelIndex(object):
         # add_set: filenames that aren't in the current/old repodata, but exist in the subdir
         add_set = fns_in_subdir - old_repodata_fns
         remove_set = old_repodata_fns - fns_in_subdir
-        all_removed =  (old_repodata_fns | set(old_repodata.get('removed', ()))) - fns_in_subdir
-        # ignore_set = set(old_repodata.get('removed', []))
-        # add_set -= ignore_set  # this seems wrong
+        all_removed = (old_repodata_fns | set(old_repodata.get('removed', ()))) - fns_in_subdir
 
         # update_set: Filenames that are in both old repodata and new repodata,
         #     and whose contents have changed based on file size or mtime. We're
@@ -1132,7 +1129,6 @@ class ChannelIndex(object):
         )
         # unchanged_set: packages in old repodata whose information can carry straight
         #     across to new repodata
-        # unchanged_set = sorted(old_repodata_fns - update_set - remove_set - ignore_set)
         unchanged_set = candidate_fns - update_set
 
         log.debug(
@@ -1152,7 +1148,7 @@ class ChannelIndex(object):
         extract_fns = sorted(concatv(add_set, update_set))
         num_extract_fns = len(extract_fns)
         for q, fn in enumerate(tqdm(extract_fns)):
-            log.debug("extracting metadata [%s/%s] %s/%s", q+1, num_extract_fns, subdir, fn)
+            log.debug("extracting metadata [%s/%s] %s/%s", q + 1, num_extract_fns, subdir, fn)
             repodata_record = self._extract_to_cache2(self.channel_root, subdir, fn)
             if repodata_record is None:
                 # extraction error

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -847,7 +847,7 @@ class ChannelIndex(object):
         try:
             with open(join(metadata_dir_path, "info", "index.json")) as fh:
                 repodata_record = json.load(fh)
-        except FileNotFoundError:
+        except EnvironmentError:
             log.error("Corrupt package at %s", package_path)
             return None
 

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -27,17 +27,11 @@ except ImportError:
 import pytz
 from jinja2 import Environment, PackageLoader
 from tqdm import tqdm
-# import yaml
-# from yaml.constructor import ConstructorError
-# from yaml.parser import ParserError
-# from yaml.scanner import ScannerError
-# from yaml.reader import ReaderError
-
-from ruamel_yaml import safe_load as yaml_safe_load
-from ruamel_yaml.constructor import ConstructorError
-from ruamel_yaml.parser import ParserError
-from ruamel_yaml.scanner import ScannerError
-from ruamel_yaml.reader import ReaderError
+from yaml import safe_load as yaml_safe_load
+from yaml.constructor import ConstructorError
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
+from yaml.reader import ReaderError
 
 from cytoolz.itertoolz import concat, concatv, groupby
 
@@ -58,7 +52,7 @@ from .conda_interface import MatchSpec, VersionOrder, human_bytes, context, md5_
 from .conda_interface import CondaError, CondaHTTPError, get_index, url_path
 from .conda_interface import TemporaryDirectory
 from .conda_interface import Resolve
-from .utils import get_logger, FileNotFoundError, JSONDecodeError, sha256_checksum, rm_rf
+from .utils import get_logger, JSONDecodeError, sha256_checksum, rm_rf
 
 # try:
 #     from conda.base.constants import CONDA_TARBALL_EXTENSIONS

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1565,6 +1565,10 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
     log = logging.getLogger(name)
     log.setLevel(level)
     if dedupe:
+        # This is a really bad idea. The implementation messes up proper use of python log invocations
+        # with parameter interpolation.
+        #   e.g.  log.debug("extracting metadata [%s/%s] %s/%s", q + 1, num_extract_fns, subdir, fn)
+        # in a loop will only output the first iteration of the loop.
         log.addFilter(dedupe_filter)
 
     # these are defaults.  They can be overridden by configuring a log config yaml file.

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1218,7 +1218,10 @@ def find_recipe(path):
                                       "will be used.")
             results = [base_recipe]
         else:
-            raise IOError("More than one meta.yaml files found in %s" % path)
+            # filter out any .cache directories
+            results = [p for p in rec_glob(path, ["meta.yaml", "conda.yaml"]) if ".cache" not in p.split(os.sep)]
+            if len(results) > 1:
+                raise IOError("More than one meta.yaml files found in %s" % path)
     elif not results:
         raise IOError("No meta.yaml or conda.yaml files found in %s" % path)
     return results[0]

--- a/tests/index_data/.gitignore
+++ b/tests/index_data/.gitignore
@@ -1,0 +1,4 @@
+*/.cache/
+index.html
+channeldata.json
+

--- a/tests/index_data/corrupt/.gitignore
+++ b/tests/index_data/corrupt/.gitignore
@@ -1,0 +1,2 @@
+*repodata*
+

--- a/tests/index_data/packages/.gitignore
+++ b/tests/index_data/packages/.gitignore
@@ -1,0 +1,2 @@
+*repodata*
+

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -120,5 +120,5 @@ def test_api_update_index():
     argspec = getargspec(api.update_index)
     assert argspec.args == ['dir_paths', 'config', 'force', 'check_md5', 'remove', 'channel_name', 'subdir',
                             'threads', 'patch_generator', "verbose", "progress", "hotfix_source_repo",
-                            'current_index_versions']
-    assert argspec.defaults == (None, False, False, False, None, None, None, None, False, False, None, None)
+                            'current_index_versions', 'metadata_paths']
+    assert argspec.defaults == (None, False, False, False, None, None, None, None, False, False, None, None, ())

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -48,8 +48,8 @@ def test_index_on_single_subdir_1(testing_workdir):
     # tests for osx-64 subdir
     # #######################################
     assert isfile(join(testing_workdir, 'osx-64', 'index.html'))
-    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json.bz2'))
-    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json.bz2'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json'))
 
     with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
         actual_repodata_json = json.loads(fh.read())
@@ -83,6 +83,8 @@ def test_index_on_single_subdir_1(testing_workdir):
         "repodata_version": 1,
     }
     assert actual_repodata_json == expected_repodata_json
+    any(rec.pop("mtime", None) for rec in actual_pkg_repodata_json["packages"].values())
+    any(rec.pop("mtime", None) for rec in actual_pkg_repodata_json["packages.conda"].values())
     assert actual_pkg_repodata_json == expected_repodata_json
 
     # #######################################
@@ -142,16 +144,14 @@ def test_index_noarch_osx64_1(testing_workdir):
     # #######################################
     assert isfile(join(testing_workdir, 'osx-64', 'index.html'))
     assert isfile(join(testing_workdir, 'osx-64', 'repodata.json'))  # repodata is tested in test_index_on_single_subdir_1
-    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json.bz2'))
     assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json'))
-    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json.bz2'))
 
     # #######################################
     # tests for noarch subdir
     # #######################################
     assert isfile(join(testing_workdir, 'noarch', 'index.html'))
-    assert isfile(join(testing_workdir, 'noarch', 'repodata.json.bz2'))
-    assert isfile(join(testing_workdir, 'noarch', 'repodata_from_packages.json.bz2'))
+    assert isfile(join(testing_workdir, 'noarch', 'repodata.json'))
+    assert isfile(join(testing_workdir, 'noarch', 'repodata_from_packages.json'))
 
     with open(join(testing_workdir, 'noarch', 'repodata.json')) as fh:
         actual_repodata_json = json.loads(fh.read())
@@ -186,6 +186,8 @@ def test_index_noarch_osx64_1(testing_workdir):
         "repodata_version": 1,
     }
     assert actual_repodata_json == expected_repodata_json
+    any(rec.pop("mtime", None) for rec in actual_pkg_repodata_json["packages"].values())
+    any(rec.pop("mtime", None) for rec in actual_pkg_repodata_json["packages.conda"].values())
     assert actual_pkg_repodata_json == expected_repodata_json
 
     # #######################################
@@ -595,11 +597,11 @@ def test_new_pkg_format_stat_cache_used(testing_workdir, mocker):
     test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0')
     copy_into(os.path.join(archive_dir, 'conda-index-pkg-a-1.0-py27h5e241af_0' + '.tar.bz2'), test_package_path + '.tar.bz2')
     conda_build.index.update_index(testing_workdir, channel_name='test-channel')
-    assert cph_extract.call_count == 1  # if there's no .conda file, we have to extract the .tar.bz2
+    assert cph_extract.call_count == 0  # if there's no .conda file, we have to extract the .tar.bz2
 
     copy_into(os.path.join(archive_dir, 'conda-index-pkg-a-1.0-py27h5e241af_0' + '.conda'), test_package_path + '.conda')
     conda_build.index.update_index(testing_workdir, channel_name='test-channel', debug=True)
-    assert cph_extract.call_count == 2
+    assert cph_extract.call_count == 1
 
     with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
         actual_repodata_json = json.loads(fh.read())

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,7 +10,6 @@ import shutil
 import tarfile
 
 import pytest
-import mock
 import conda_package_handling.api
 
 from conda_build import api
@@ -67,13 +66,14 @@ def test_index_on_single_subdir_1(testing_workdir):
                 "depends": [
                     "python >=2.7,<2.8.0a0"
                 ],
+                "fn": "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2",
                 "license": "BSD",
                 "md5": "37861df8111170f5eed4bff27868df59",
                 "name": "conda-index-pkg-a",
                 "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
                 "size": 8733,
                 "subdir": "osx-64",
-                "timestamp": 1508520039632,
+                "timestamp": 1508520039,
                 "version": "1.0",
             },
         },
@@ -91,7 +91,8 @@ def test_index_on_single_subdir_1(testing_workdir):
     with open(join(testing_workdir, 'channeldata.json')) as fh:
         actual_channeldata_json = json.loads(fh.read())
     expected_channeldata_json = {
-        "channeldata_version": 1,
+        "$schema": "https://schemas.conda.io/channeldata-1.schema.json",
+        "schema_version": 1,
         "packages": {
             "conda-index-pkg-a": {
                 "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
@@ -106,27 +107,13 @@ def test_index_on_single_subdir_1(testing_workdir):
                 "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
                 "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
                 "license": "BSD",
+                "reference_package": "osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2",
                 "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
                 "subdirs": [
                     "osx-64",
                 ],
                 "summary": "Summary field for conda-index-pkg-a",
                 "version": "1.0",
-                "activate.d": False,
-                "deactivate.d": False,
-                "post_link": True,
-                "pre_link": False,
-                "pre_unlink": False,
-                "binary_prefix": False,
-                "text_prefix": True,
-                "run_exports": {},
-                'icon_hash': None,
-                'icon_url': None,
-                'identifiers': None,
-                'keywords': None,
-                'recipe_origin': None,
-                'source_url': None,
-                'tags': None,
                 'timestamp': 1508520039,
             }
         },
@@ -180,6 +167,7 @@ def test_index_noarch_osx64_1(testing_workdir):
                 "depends": [
                     "python"
                 ],
+                "fn": "conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2",
                 "license": "BSD",
                 "md5": "56b5f6b7fb5583bccfc4489e7c657484",
                 "name": "conda-index-pkg-a",
@@ -187,7 +175,7 @@ def test_index_noarch_osx64_1(testing_workdir):
                 "sha256": "7430743bffd4ac63aa063ae8518e668eac269c783374b589d8078bee5ed4cbc6",
                 "size": 7882,
                 "subdir": "noarch",
-                "timestamp": 1508520204768,
+                "timestamp": 1508520204,
                 "version": "1.0",
             },
         },
@@ -205,7 +193,8 @@ def test_index_noarch_osx64_1(testing_workdir):
     with open(join(testing_workdir, 'channeldata.json')) as fh:
         actual_channeldata_json = json.loads(fh.read())
     expected_channeldata_json = {
-        "channeldata_version": 1,
+        "$schema": "https://schemas.conda.io/channeldata-1.schema.json",
+        "schema_version": 1,
         "packages": {
             "conda-index-pkg-a": {
                 "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
@@ -220,29 +209,15 @@ def test_index_noarch_osx64_1(testing_workdir):
                 "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
                 "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
                 "license": "BSD",
+                "reference_package": "noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2",
                 "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
-                'source_url': None,
                 "subdirs": [
                     "noarch",
                     "osx-64",
                 ],
                 "summary": "Summary field for conda-index-pkg-a. This is the python noarch version.",  # <- tests that the higher noarch build number is the data collected
                 "version": "1.0",
-                "activate.d": False,
-                "deactivate.d": False,
-                "post_link": True,
-                "pre_link": False,
-                "pre_unlink": False,
-                "binary_prefix": False,
-                "text_prefix": True,
-                "run_exports": {},
-                'icon_hash': None,
-                'icon_url': None,
-                'identifiers': None,
-                'tags': None,
-                'timestamp': 1508520039,
-                'keywords': None,
-                'recipe_origin': None,
+                'timestamp': 1508520204,
             }
         },
         "subdirs": [
@@ -521,6 +496,8 @@ def test_patch_instructions_with_missing_subdir(testing_workdir):
 
 
 def test_stat_cache_used(testing_workdir, mocker):
+    # There is no longer a stat cache, but this test remains unchanged.
+    # The important part of this test is the last line: `cph_extract.assert_not_called()`
     test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
     test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
     download(test_package_url, test_package_path)
@@ -541,8 +518,13 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
     #     with the .tar.bz2, because the .conda should be preferred
     cph_extract = mocker.spy(conda_package_handling.api, 'extract')
     conda_build.index.update_index(testing_workdir, channel_name='test-channel', debug=True)
-    # extract should get called once by default.  Within a channel, we assume that a .tar.bz2 and .conda have the same contents.
-    cph_extract.assert_called_once_with(test_package_path + '.conda', mock.ANY, 'info')
+    # Both .tar.bz2 and .conda packages exist, so .extract() should be called twice, but both times for the .conda
+    # package. Within a channel, we assume that a .tar.bz2 and .conda have the same contents.
+    assert cph_extract.call_count == 2
+    assert cph_extract.call_args_list[0][0][0].endswith("conda-index-pkg-a-1.0-py27h5e241af_0.conda")
+    assert cph_extract.call_args_list[0][1]["dest_dir"].endswith("conda-index-pkg-a-1.0-py27h5e241af_0.conda.metadata")
+    assert cph_extract.call_args_list[1][0][0].endswith("conda-index-pkg-a-1.0-py27h5e241af_0.conda")
+    assert cph_extract.call_args_list[1][1]["dest_dir"].endswith("conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2.metadata")
 
     with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
         actual_repodata_json = json.loads(fh.read())
@@ -558,13 +540,14 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
                 "depends": [
                     "python >=2.7,<2.8.0a0"
                 ],
+                "fn": "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2",
                 "license": "BSD",
                 "md5": "37861df8111170f5eed4bff27868df59",
                 "name": "conda-index-pkg-a",
                 "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
                 "size": 8733,
                 "subdir": "osx-64",
-                "timestamp": 1508520039632,
+                "timestamp": 1508520039,
                 "version": "1.0",
             },
         },
@@ -575,13 +558,14 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
                 "depends": [
                     "python >=2.7,<2.8.0a0"
                 ],
+                "fn": "conda-index-pkg-a-1.0-py27h5e241af_0.conda",
                 "license": "BSD",
                 "md5": "4ed4b435f400dac1aabdc1fff06f78ff",
                 "name": "conda-index-pkg-a",
                 "sha256": "67b07b644105439515cc5c8c22c86939514cacf30c8c574cd70f5f1267a40f19",
                 "size": 9296,
                 "subdir": "osx-64",
-                "timestamp": 1508520039632,
+                "timestamp": 1508520039,
                 "version": "1.0",
             },
         },
@@ -590,12 +574,10 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
     }
     assert actual_repodata_json == expected_repodata_json
 
-    # if we clear the stat cache, we force a re-examination.  This re-examination will load files
-    #     from the cache.  This has been a source of bugs in the past, where the wrong cached file
-    #     being loaded resulted in incorrect hashes/sizes for either the .tar.bz2 or .conda, depending
-    #     on which of those 2 existed in the cache.
-    rm_rf(os.path.join(testing_workdir, 'osx-64', 'stat.json'))
+    # Calling update_index() again should load all files from the cache.
+    cph_extract.reset_mock()
     conda_build.index.update_index(testing_workdir, channel_name='test-channel', debug=True)
+    cph_extract.assert_not_called()
 
     with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
         actual_repodata_json = json.loads(fh.read())
@@ -604,19 +586,17 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
 
 
 def test_new_pkg_format_stat_cache_used(testing_workdir, mocker):
+    cph_extract = mocker.spy(conda_package_handling.api, 'extract')
+
     # if we have old .tar.bz2 index cache stuff, assert that we pick up correct md5, sha26 and size for .conda
     test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0')
     copy_into(os.path.join(archive_dir, 'conda-index-pkg-a-1.0-py27h5e241af_0' + '.tar.bz2'), test_package_path + '.tar.bz2')
     conda_build.index.update_index(testing_workdir, channel_name='test-channel')
+    assert cph_extract.call_count == 1  # if there's no .conda file, we have to extract the .tar.bz2
 
-    # mock the extract function, so that we can assert that it is not called, because the stat cache should exist
-    #    if this doesn't work, something about the stat cache is confused.  It's a little convoluted, because
-    #    the index has keys for .tar.bz2's, but the stat cache comes from .conda files when they are available
-    #    because extracting them is much, much faster.
     copy_into(os.path.join(archive_dir, 'conda-index-pkg-a-1.0-py27h5e241af_0' + '.conda'), test_package_path + '.conda')
-    cph_extract = mocker.spy(conda_package_handling.api, 'extract')
     conda_build.index.update_index(testing_workdir, channel_name='test-channel', debug=True)
-    cph_extract.assert_not_called()
+    assert cph_extract.call_count == 2
 
     with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
         actual_repodata_json = json.loads(fh.read())
@@ -632,13 +612,14 @@ def test_new_pkg_format_stat_cache_used(testing_workdir, mocker):
                 "depends": [
                     "python >=2.7,<2.8.0a0"
                 ],
+                "fn": "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2",
                 "license": "BSD",
                 "md5": "37861df8111170f5eed4bff27868df59",
                 "name": "conda-index-pkg-a",
                 "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
                 "size": 8733,
                 "subdir": "osx-64",
-                "timestamp": 1508520039632,
+                "timestamp": 1508520039,
                 "version": "1.0",
             },
         },
@@ -649,13 +630,14 @@ def test_new_pkg_format_stat_cache_used(testing_workdir, mocker):
                 "depends": [
                     "python >=2.7,<2.8.0a0"
                 ],
+                "fn": "conda-index-pkg-a-1.0-py27h5e241af_0.conda",
                 "license": "BSD",
                 "md5": "4ed4b435f400dac1aabdc1fff06f78ff",
                 "name": "conda-index-pkg-a",
                 "sha256": "67b07b644105439515cc5c8c22c86939514cacf30c8c574cd70f5f1267a40f19",
                 "size": 9296,
                 "subdir": "osx-64",
-                "timestamp": 1508520039632,
+                "timestamp": 1508520039,
                 "version": "1.0",
             },
         },
@@ -721,17 +703,6 @@ def test_current_index_version_keys_keep_older_packages(testing_workdir):
     with open(os.path.join(pkg_dir, 'osx-64', 'current_repodata.json')) as f:
         repodata = json.load(f)
     assert list(repodata['packages'].values())[0]['version'] == "1.0"
-
-
-def test_channeldata_picks_up_all_versions_of_run_exports():
-    pkg_dir = os.path.join(os.path.dirname(__file__), 'index_data', 'packages')
-    api.update_index(pkg_dir)
-    with open(os.path.join(pkg_dir, 'channeldata.json')) as f:
-        repodata = json.load(f)
-    run_exports = repodata['packages']['run_exports_versions']['run_exports']
-    assert len(run_exports) == 2
-    assert "1.0" in run_exports
-    assert "2.0" in run_exports
 
 
 def test_index_invalid_packages():

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -56,6 +56,7 @@ def test_index_on_single_subdir_1(testing_workdir):
     with open(join(testing_workdir, 'osx-64', 'repodata_from_packages.json')) as fh:
         actual_pkg_repodata_json = json.loads(fh.read())
     expected_repodata_json = {
+        "$schema": "https://schemas.conda.io/repodata-1.schema.json",
         "info": {
             'subdir': 'osx-64',
         },
@@ -157,6 +158,7 @@ def test_index_noarch_osx64_1(testing_workdir):
     with open(join(testing_workdir, 'noarch', 'repodata_from_packages.json')) as fh:
         actual_pkg_repodata_json = json.loads(fh.read())
     expected_repodata_json = {
+        "$schema": "https://schemas.conda.io/repodata-1.schema.json",
         "info": {
             'subdir': 'noarch',
         },
@@ -530,6 +532,7 @@ def test_new_pkg_format_preferred(testing_workdir, mocker):
         actual_repodata_json = json.loads(fh.read())
 
     expected_repodata_json = {
+        "$schema": "https://schemas.conda.io/repodata-1.schema.json",
         "info": {
             'subdir': 'osx-64',
         },
@@ -602,6 +605,7 @@ def test_new_pkg_format_stat_cache_used(testing_workdir, mocker):
         actual_repodata_json = json.loads(fh.read())
 
     expected_repodata_json = {
+        "$schema": "https://schemas.conda.io/repodata-1.schema.json",
         "info": {
             'subdir': 'osx-64',
         },


### PR DESCRIPTION
Refactors the conda index cache to create a single cache directory per package, rather that splitting individual metadata files out among multiple disparate directories.

Makes `cytoolz` and `scandir` (py27) hard dependencies of conda-build for performance reasons.

Once released, this PR will induce a one-time re-caching for all existing long-lived conda-index caches. One mitigating factor is that now, we extract and cache the _whole_ `info/` directory, so that within the cache we have access to the full metadata of a package. Even if we need to add extra information into an aggregate file like repodata.json or channeldata.json (or a new one) in the future, we won't have to re-extract all packages ever again.