### PR TITLE
More helpful error message if an empty hash field is given

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -51,6 +51,8 @@ def download_to_cache(cache_folder, recipe_path, source_dict, verbose=False):
     hash_added = False
     for hash_type in ('md5', 'sha1', 'sha256'):
         if hash_type in source_dict:
+            if source_dict[hash_type] in (None, ""):
+                raise ValueError('Empty %s hash provided for %s'.format(hash_type, fn))
             fn = append_hash_to_fn(fn, source_dict[hash_type])
             hash_added = True
             break

--- a/news/hash-check.rst
+++ b/news/hash-check.rst
@@ -1,0 +1,5 @@
+Enhancements:
+-------------
+
+* More helpful error message if an empty string is passed as the hash ('md5',
+  'sha1' or 'sha256' fields)


### PR DESCRIPTION
I forgot to enter an sha256 hash in an input file, but left had the field there. I found the error uninformative (copied below), so added a check to raise a more helpful exception.

```
Traceback (most recent call last):
  File "/home/conda/.ci_support/build_all.py", line 133, in <module>
    build_all(args.recipes_dir, args.arch)
  File "/home/conda/.ci_support/build_all.py", line 66, in build_all
    build_folders(recipes_dir, new_comp_folders, arch, channel_urls)
  File "/home/conda/.ci_support/build_all.py", line 123, in build_folders
    conda_build.api.build([recipe], config=get_config(arch, channel_urls))
  File "/opt/conda/lib/python3.7/site-packages/conda_build/api.py", line 209, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/build.py", line 2864, in build_tree
    notest=notest,
  File "/opt/conda/lib/python3.7/site-packages/conda_build/build.py", line 1921, in build
    try_download(m, no_download_source=False, raise_error=True)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/render.py", line 639, in try_download
    source.provide(metadata)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/source.py", line 654, in provide
    timeout=metadata.config.timeout, locking=metadata.config.locking)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/source.py", line 139, in unpack
    src_path, unhashed_fn = download_to_cache(cache_folder, recipe_path, source_dict, verbose)
  File "/opt/conda/lib/python3.7/site-packages/conda_build/source.py", line 54, in download_to_cache
    fn = append_hash_to_fn(fn, source_dict[hash_type])
  File "/opt/conda/lib/python3.7/site-packages/conda_build/source.py", line 36, in append_hash_to_fn
    return ext_re.sub(r"\1_{}\2".format(hash_value[:10]), fn)
TypeError: 'NoneType' object is not subscriptable
```