### PR TITLE
Add tests for non-utf-8 charsets

### DIFF
--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/bld.bat
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/bld.bat
@@ -1,0 +1,1 @@
+python "%RECIPE_DIR%\write_binary_has_prefix.py"

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/build.sh
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/build.sh
@@ -1,0 +1,1 @@
+python $RECIPE_DIR/write_binary_has_prefix.py

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/meta.yaml
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: conda-build-test-binary-has-prefix-files
+  version: 1.0
+
+build:
+  binary_has_prefix_files:
+    - binary-has-prefix

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/meta.yaml
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/meta.yaml
@@ -4,4 +4,8 @@ package:
 
 build:
   binary_has_prefix_files:
-    - binary-has-prefix
+    - binary-has-prefix-utf-8
+    - binary-has-prefix-utf-16-le
+    - binary-has-prefix-utf-16-be
+    - binary-has-prefix-utf-32-le
+    - binary-has-prefix-utf-32-be

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/run_test.py
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/run_test.py
@@ -1,16 +1,25 @@
 import os
 
+supported_encodings = [
+    'utf-8',
+    # Make sure to specify -le and -be so that the UTF endian prefix
+    # doesn't show up in the string
+    'utf-16-le', 'utf-16-be',
+    'utf-32-le', 'utf-32-be'
+]
+
 
 def main():
-    prefix = os.environ['PREFIX']
-    fn = os.path.join(prefix, 'binary-has-prefix')
-    prefix = prefix.encode('utf-8')
+    for encoding in supported_encodings:
+        prefix = os.environ['PREFIX']
+        prefix = prefix.encode(encoding)
+        fn = os.path.join(
+            prefix, 'binary-has-prefix-{encoding}'.format(encoding=encoding)
+        with open(fn, 'rb') as f:
+            data = f.read()
+        print(data)
 
-    with open(fn, 'rb') as f:
-        data = f.read()
-
-    print(data)
-    assert prefix in data, prefix + b" not found in " + data
+        assert prefix in data, prefix + b" not found in " + data
 
 if __name__ == '__main__':
     main()

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/run_test.py
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/run_test.py
@@ -1,0 +1,16 @@
+import os
+
+
+def main():
+    prefix = os.environ['PREFIX']
+    fn = os.path.join(prefix, 'binary-has-prefix')
+    prefix = prefix.encode('utf-8')
+
+    with open(fn, 'rb') as f:
+        data = f.read()
+
+    print(data)
+    assert prefix in data, prefix + b" not found in " + data
+
+if __name__ == '__main__':
+    main()

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/write_binary_has_prefix.py
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/write_binary_has_prefix.py
@@ -9,11 +9,12 @@ supported_encodings = [
 ]
 
 prefix = os.environ['PREFIX']
-fn = os.path.join(prefix, 'binary-has-prefix')
 
 if not os.path.isdir(prefix):
     os.makedirs(prefix)
 
-with open(fn, 'wb') as f:
-    for encoding in supported_encodings:
+for encoding in supported_encodings:
+    fn = os.path.join(
+        prefix, 'binary-has-prefix-{encoding}'.format(encoding=encoding)
+    with open(fn, 'wb') as f:
         f.write(prefix.encode(encoding) + b'\x00\x00\x00\x00')

--- a/tests/test-recipes/metadata/_binary_has_utf_non_8/write_binary_has_prefix.py
+++ b/tests/test-recipes/metadata/_binary_has_utf_non_8/write_binary_has_prefix.py
@@ -1,0 +1,19 @@
+import os
+
+supported_encodings = [
+    'utf-8',
+    # Make sure to specify -le and -be so that the UTF endian prefix
+    # doesn't show up in the string
+    'utf-16-le', 'utf-16-be',
+    'utf-32-le', 'utf-32-be'
+]
+
+prefix = os.environ['PREFIX']
+fn = os.path.join(prefix, 'binary-has-prefix')
+
+if not os.path.isdir(prefix):
+    os.makedirs(prefix)
+
+with open(fn, 'wb') as f:
+    for encoding in supported_encodings:
+        f.write(prefix.encode(encoding) + b'\x00\x00\x00\x00')

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -237,6 +237,14 @@ def test_binary_has_prefix_files(testing_workdir, testing_config):
     api.build(os.path.join(metadata_dir, '_binary_has_prefix_files'), config=testing_config)
 
 
+# @pytest.mark.xfail
+@pytest.mark.sanity
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="no binary prefix manipulation done on windows.")
+def test_binary_has_prefix_files_non_utf8(testing_workdir, testing_config):
+    api.build(os.path.join(metadata_dir, '_binary_has_utf_non_8'), config=testing_config)
+
+
 def test_relative_path_git_versioning(testing_workdir, testing_config):
     # conda_build_test_recipe is a manual step.  Clone it at the same level as
     #    your conda-build source.


### PR DESCRIPTION
Adds tests for binary files that contain many charsets, utf16 and utf32

xref: https://github.com/conda/conda/pull/9946
xref: https://github.com/conda/conda/issues/4298