### PR TITLE
Clarify usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Installation
     # Display information about current conda install
     conda info
 
-    # Install conda-build in the current env
+    # Install conda-build in the current 'root' env
     conda install -n root conda-build
 
 


### PR DESCRIPTION
To use 'root' as an env is a bit confusing, given that it invokes suggestions of admin rights on Unix, and the whole point of conda is to avoid using the system libraries. 

Here making clear that 'root' is just a name.
