### PR TITLE
Make list_of_dicts_to_dict_of_lists preserver the original order

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1161,12 +1161,16 @@ def package_has_file(package_path, file_path, refresh=False):
 
 
 def ensure_list(arg):
-    if (isinstance(arg, string_types) or not hasattr(arg, '__iter__')):
-        if arg is not None:
-            arg = [arg]
-        else:
-            arg = []
-    return arg
+    if arg is None:
+        return []
+
+    if isinstance(arg, string_types):
+        return [arg]
+
+    if not hasattr(arg, '__iter__'):
+        return [arg]
+
+    return list(arg)
 
 
 @contextlib.contextmanager

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -446,7 +446,8 @@ def dict_of_lists_to_list_of_dicts(dict_of_lists, extend_keys=None):
 
 
 def list_of_dicts_to_dict_of_lists(list_of_dicts):
-    """Opposite of dict_of_lists_to_list_of_dicts function.
+    r"""
+    Inverse of `dict_of_lists_to_list_of_dicts`.
 
     Take broken out collection of variants, and squish it into a dict, where each value is a list.
     Only squishes string/int values; does "update" for dict keys
@@ -475,18 +476,14 @@ def list_of_dicts_to_dict_of_lists(list_of_dicts):
                 existing_value = squished.get(k, OrderedDict())
                 existing_value.update(v)
                 squished[k] = existing_value
-            elif isinstance(v, list):
-                squished[k] = set(squished.get(k, set())) | set(v)
             else:
-                squished[k] = list(squished.get(k, [])) + ensure_list(v)
+                squished[k] = squished.get(k, []) + ensure_list(v)
                 if k not in all_zip_keys:
-                    squished[k] = list(set(squished[k]))
+                    squished[k] = list(OrderedDict.fromkeys(squished[k]))
     # reduce the combinatoric space of the zipped keys, too:
     if groups:
         for group in groups:
-            values = list(zip(*set(zip(*(squished[key] for key in group)))))
-            for idx, key in enumerate(group):
-                squished[key] = values[idx]
+            squished.update({key: value for (key, value) in zip(group, zip(*OrderedDict.fromkeys(zip(*[squished[key] for key in group]))))})
     squished['zip_keys'] = zip_key_groups
     return squished
 

--- a/news/inverse.rst
+++ b/news/inverse.rst
@@ -1,0 +1,7 @@
+Enhancements:
+-------------
+
+* `list_of_dicts_to_dict_of_lists` and `dict_of_lists_to_list_of_dicts` are now
+  iverse to each other, in particular they do not randomize ordering of entries
+  anymore. This usually makes no big difference but it makes the build order
+  more predictable when building many variants of a package with conda-build.


### PR DESCRIPTION
`list_of_dicts_to_dict_of_lists()` was not actually inverse to
`dict_of_lists_to_list_of_dicts()` since its use of set() changed the
original ordering in lists.

This is part of the reason for https://github.com/conda-forge/conda-smithy/issues/1183.

TODO:

* [ ] Add tests