### PR TITLE
Teake/git describe hash on branches

### DIFF
--- a/news/git-describe-hash-always.rst
+++ b/news/git-describe-hash-always.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* the ``GIT_DESCRIBE_HASH`` variable will be available regardless of whether the sources of the recipe have a git tag or not
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
GIT_DESCRIBE_HASH was not set when there is no tag reachable
from the head of the git repo being build. (This is because
`git describe --tags --long` fails in that case). With this change,
a `git describe --all --long` command is used to fetch the short
hash and store it in GIT_DESCRIBE_HASH. That way,
GIT_DESCRIBE_HASH will be available to use in recipes
also in cases when there is no tag reachable.

I opted to use `git describe --all --long` for this, and not
`git rev-parse --short` because the latter omits the leading `g`
that is prefixed with git-describe.

Note that the resulting `conda_build.environ.get_git_info()` function
is not super DRY.

