### PR TITLE
Fix parsing UnsatisfiableError from conda>=4.7.8

### DIFF
--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -67,7 +67,7 @@ class DependencyNeedsBuildingError(CondaBuildException):
         else:
             self.packages = packages or []
             for line in str(conda_exception).splitlines():
-                if not line.startswith('  - '):
+                if not line.startswith('  - ') and (':' in line or ' -> ' not in line):
                     continue
                 pkg = line.lstrip('  - ').split(' -> ')[-1]
                 self.matchspecs.append(pkg)

--- a/news/fix-parsing-UnsatisfiableError.rst
+++ b/news/fix-parsing-UnsatisfiableError.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Fix parsing UnsatisfiableError from conda>=4.7.8
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
This has been broken since
https://github.com/conda/conda/commit/1dff3526c2ca2574a56e2352d7b8de86441fbd8b#diff-1f2230f9e987e7b066381cf7e00e9d21R697

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
