### PR TITLE
Allow python=3.8 for pypi skeletons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Other:
 ------
 
 * Enable ppc64 support (#3921)
+* Allow python=3.8 for pypi skeletons
 
 Docs:
 -----

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -490,7 +490,7 @@ def add_parser(repos):
         action='store',
         default=default_python,
         help="""Version of Python to use to run setup.py. Default is %(default)s.""",
-        choices=['2.7', '3.5', '3.6', '3.7'],
+        choices=['2.7', '3.5', '3.6', '3.7', '3.8'],
     )
 
     pypi.add_argument(


### PR DESCRIPTION
Just what it says on the lid.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
