### PR TITLE
Fix noarch get_shlib_ext for osx

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -504,7 +504,7 @@ def get_shlib_ext(host_platform):
     # Return the shared library extension.
     if host_platform.startswith('win'):
         return '.dll'
-    elif host_platform.startswith('osx'):
+    elif host_platform in ['osx', 'darwin']:
         return '.dylib'
     elif host_platform.startswith('linux'):
         return '.so'


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
