### PR TITLE
Rename ccache method from mklink to symlinks

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1820,7 +1820,7 @@ def _write_sh_activation_text(file_handle, m):
             ccache = ccache[0]
         ccache_methods = {}
         ccache_methods['env_vars'] = False
-        ccache_methods['mklink'] = False
+        ccache_methods['symlinks'] = False
         ccache_methods['native'] = False
         if hasattr(m.config, 'ccache_method'):
             ccache_methods[m.config.ccache_method] = True
@@ -1832,7 +1832,7 @@ def _write_sh_activation_text(file_handle, m):
                     #     'export CCACHE_SLOPPINESS="pch_defines,time_macros${CCACHE_SLOPPINESS+,$CCACHE_SLOPPINESS}"\n')
                     # file_handle.write('export CCACHE_CPP2=true\n')
                     done_necessary_env = True
-                if method == 'mklink':
+                if method == 'symlinks':
                     dirname_ccache_ln_bin = join(m.config.build_prefix, 'ccache-ln-bin')
                     file_handle.write('mkdir {}\n'.format(dirname_ccache_ln_bin))
                     file_handle.write('pushd {}\n'.format(dirname_ccache_ln_bin))

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1898,7 +1898,7 @@ def write_bat_activation_text(file_handle, m):
             ccache = ccache[0]
         ccache_methods = {}
         ccache_methods['env_vars'] = False
-        ccache_methods['mklink'] = False
+        ccache_methods['symlinks'] = False
         ccache_methods['native'] = False
         if hasattr(m.config, 'ccache_method'):
             ccache_methods[m.config.ccache_method] = True
@@ -1907,7 +1907,7 @@ def write_bat_activation_text(file_handle, m):
                 if method == 'env_vars':
                     file_handle.write('set "CC={ccache} %CC%"\n'.format(ccache=ccache))
                     file_handle.write('set "CXX={ccache} %CXX%"\n'.format(ccache=ccache))
-                elif method == 'mklink':
+                elif method == 'symlinks':
                     dirname_ccache_ln_bin = join(m.config.build_prefix, 'ccache-ln-bin')
                     file_handle.write('mkdir {}\n'.format(dirname_ccache_ln_bin))
                     file_handle.write('pushd {}\n'.format(dirname_ccache_ln_bin))


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
