### PR TITLE
no longer run tests on Python 2.7

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,12 +12,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      py27-release:
-        PYTHON_VERSION: '2.7'
-        CONDA_VERSION: 'release'
-     #py27-canary:
-     #  PYTHON_VERSION: '2.7'
-     #  CONDA_VERSION: 'canary'
      #py37-canary:
      #  PYTHON_VERSION: '3.7'
      #  CONDA_VERSION: 'release'
@@ -82,7 +76,7 @@ jobs:
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
     artifact: 'Linux-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
-    condition: and(always(), ne(variables['PYTHON_VERSION'], '2.7'))
+    condition: always()
 
 
 - job: 'macOS'
@@ -91,15 +85,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      # Some tests are done with Xcode others without.
-      py27-release-xcode:
-        PYTHON_VERSION: '2.7'
-        CONDA_VERSION: 'release'
-        INSTALL_XCODE: '1'
-     #py27-canary:
-     #  PYTHON_VERSION: '2.7'
-     #  CONDA_VERSION: 'canary'
-     #  INSTALL_XCODE: '0'
       py37-release-xcode:
         PYTHON_VERSION: '3.7'
         CONDA_VERSION: 'release'
@@ -196,7 +181,7 @@ jobs:
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
     artifact: 'macOS-$(CONDA_VERSION)-Py$(PYTHON_VERSION)'
-    condition: and(always(), ne(variables['PYTHON_VERSION'], '2.7'))
+    condition: always()
 
 
 - job: 'Windows'
@@ -205,12 +190,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      py27-release:
-        PYTHON_VERSION: '2.7'
-        CONDA_VERSION: 'release'
-     #py27-canary:
-     #  PYTHON_VERSION: '2.7'
-     #  CONDA_VERSION: 'canary'
       py37-release:
         PYTHON_VERSION: '3.7'
         CONDA_VERSION: 'release'
@@ -285,12 +264,10 @@ jobs:
       python -c "import sys; print(sys.prefix)"
       call conda update -q --all
       call conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines
-      if "%PYTHON_VERSION%" == "2.7" call conda install -c defaults -c conda-forge pytest-replay pytest-rerunfailures -y
-      if "%PYTHON_VERSION%" NEQ "2.7" call conda install pytest-replay pytest-rerunfailures -y
+      call conda install -q pytest-replay pytest-rerunfailures -y
       echo safety_checks: disabled >> %UserProfile%\.condarc
       echo local_repodata_ttl: 1800 >> %UserProfile%\.condarc
-      if "%PYTHON_VERSION%" == "2.7" call conda install -q scandir pathlib2
-      if "%PYTHON_VERSION%" NEQ "2.7" call conda install -q py-lief
+      call conda install -q py-lief
       python --version
       python -c "import struct; print(struct.calcsize('P') * 8)"
       pip install --no-deps .
@@ -304,8 +281,7 @@ jobs:
       call conda create -n blarg -yq --download-only python=3.7
       call conda create -n blarg -yq --download-only python cmake
       mkdir $(Build.ArtifactStagingDirectory)\\pytest-replay
-      set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay"
-      if "%PYTHON_VERSION%" NEQ "2.7" set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
+      set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
       echo "##vso[task.setvariable variable=PYTEST_REPLAY_OPTIONS]%PYTEST_REPLAY_OPTIONS%"
     displayName: 'Configuration'
 

--- a/ci/azurepipelines/install_conda_build_test_deps
+++ b/ci/azurepipelines/install_conda_build_test_deps
@@ -4,14 +4,9 @@ function install_conda_build_test_deps_fn()
 {
   # avoids a python 3.7 problem
   local -a _PKGS=(cytoolz)
-  if [[ "$PYTHON_VERSION" == "2.7" ]]; then
-    _PKGS+=(futures scandir pathlib2)
-  fi
-  _PKGS+=("pytest<6" pytest-azurepipelines pytest-cov pytest-forked pytest-xdist)
+  _PKGS+=(pytest pytest-azurepipelines pytest-cov pytest-forked pytest-xdist)
   _PKGS+=(py-lief pytest-mock)
-  if [[ "$PYTHON_VERSION" != "2.7" ]] || [[ ! $(uname) =~ M* ]]; then
-    _PKGS+=(pytest-replay pytest-rerunfailures)
-  fi
+  _PKGS+=(pytest-replay pytest-rerunfailures)
   _PKGS+=(anaconda-client git requests filelock contextlib2 jinja2 flaky)
   _PKGS+=(ripgrep pyflakes beautifulsoup4 chardet pycrypto glob2 psutil pytz tqdm)
   _PKGS+=(conda-package-handling perl python-libarchive-c)


### PR DESCRIPTION
Support for running conda-build in a Python 2.7 environment will be
dropped in the 4.0.0 release.

See #4024

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
