### PR TITLE
Run bash with -e in outputs too

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2353,7 +2353,7 @@ def guess_interpreter(script_filename):
     # Since the MSYS2 installation is probably a set of conda packages we do not
     # need to worry about system environmental pollution here. For that reason I
     # do not pass -l on other OSes.
-    extensions_to_run_commands = {'.sh': ['bash.exe', '-l'] if utils.on_win else ['bash'],
+    extensions_to_run_commands = {'.sh': ['bash.exe', '-el'] if utils.on_win else ['bash', '-e'],
                                   '.bat': [os.environ.get('COMSPEC', 'cmd.exe'), '/d', '/c'],
                                   '.ps1': ['powershell', '-executionpolicy', 'bypass', '-File'],
                                   '.py': ['python']}


### PR DESCRIPTION
`build.sh` is run with `-e`, but scripts in outputs are not. This commit fixes that.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
