### PR TITLE
fix regexes to aovid ReDos

### DIFF
--- a/conda_build/os_utils/ldd.py
+++ b/conda_build/os_utils/ldd.py
@@ -12,8 +12,11 @@ from conda_build.conda_interface import linked_data
 from conda_build.os_utils.macho import otool
 from conda_build.os_utils.pyldd import codefile_class, inspect_linkages, machofile, is_codefile
 
-LDD_RE = re.compile(r'\s*(.*?)\s*=>\s*(.*?)\s*\(.*\)')
-LDD_NOT_FOUND_RE = re.compile(r'\s*(.*?)\s*=>\s*not found')
+# LDD_RE = re.compile(r'\s*(.*?)\s*=>\s*(.*?)\s*\(.*\)')
+LDD_RE = re.compile(r'\s*(\S+\s*)?=>\s*(.+\s*)?\(.*\)')
+
+# LDD_NOT_FOUND_RE = re.compile(r'\s*(.*?)\s*=>\s*not found')
+LDD_NOT_FOUND_RE = re.compile(r'\s*(\S+\s*)?=>\s*not found')
 
 
 def ldd(path):

--- a/conda_build/os_utils/ldd.py
+++ b/conda_build/os_utils/ldd.py
@@ -13,10 +13,10 @@ from conda_build.os_utils.macho import otool
 from conda_build.os_utils.pyldd import codefile_class, inspect_linkages, machofile, is_codefile
 
 # LDD_RE = re.compile(r'\s*(.*?)\s*=>\s*(.*?)\s*\(.*\)')
-LDD_RE = re.compile(r'\s*(\S+\s*)?=>\s*(.+\s*)?\(.*\)')
+LDD_RE = re.compile(r'\s*((.+?)\s*)?=>\s*((.+?)\s*)?\(.*\)')
 
 # LDD_NOT_FOUND_RE = re.compile(r'\s*(.*?)\s*=>\s*not found')
-LDD_NOT_FOUND_RE = re.compile(r'\s*(\S+\s*)?=>\s*not found')
+LDD_NOT_FOUND_RE = re.compile(r'\s*((.+?)\s*)?=>\s*not found')
 
 
 def ldd(path):
@@ -30,11 +30,13 @@ def ldd(path):
         assert line[0] == '\t', (path, line)
         m = LDD_RE.match(line)
         if m:
+            # res.append(m.groups())
+            _, group1, _, group2 = m.groups()
             res.append(m.groups())
             continue
         m = LDD_NOT_FOUND_RE.match(line)
         if m:
-            res.append((m.group(1), 'not found'))
+            res.append((m.group(2), 'not found'))
             continue
         if 'ld-linux' in line:
             continue


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

Regexes which can match over long parts of strings but then be rejected by nonmatching at the end can be used for
denial-of-service. This addresses #4039
