### PR TITLE
Refactor recipe search & conda_build.api.build

### DIFF
--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -872,8 +872,8 @@ def test_build_expands_wildcards(mocker, testing_workdir):
     output = sorted([os.path.join(os.getcwd(), path, 'meta.yaml') for path in files])
 
     build_tree.assert_called_once_with(output,
-                                       mocker.ANY,  # config
-                                       mocker.ANY,  # stats
+                                       config=mocker.ANY,
+                                       stats=mocker.ANY,
                                        build_only=False,
                                        post=None, notest=False,
                                        variants=None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import filelock
 import os
 import subprocess
@@ -7,7 +8,6 @@ import pytest
 
 from conda_build.exceptions import BuildLockError
 import conda_build.utils as utils
-from conda_build.utils import find_recipe
 
 
 def makefile(name, contents=""):
@@ -338,3 +338,126 @@ def test_get_lock(testing_workdir):
     # ...even when not normalized
     lock1_unnormalized = utils.get_lock(os.path.join(testing_workdir, 'foo', '..', 'lock1'))
     assert lock1.lock_file == lock1_unnormalized.lock_file
+
+
+@contextlib.contextmanager
+def _generate_tmp_tree():
+    # dirA
+    # |\- dirB
+    # |   |\- fileA
+    # |   \-- fileB
+    # \-- dirC
+    #     |\- fileA
+    #     \-- fileB
+    import shutil
+    import tempfile
+
+    try:
+        tmp = os.path.realpath(os.path.normpath(tempfile.mkdtemp()))
+
+        dA = os.path.join(tmp, "dirA")
+        dB = os.path.join(dA, "dirB")
+        dC = os.path.join(dA, "dirC")
+        for d in (dA, dB, dC):
+            os.mkdir(d)
+
+        f1 = os.path.join(dB, "fileA")
+        f2 = os.path.join(dB, "fileB")
+        f3 = os.path.join(dC, "fileA")
+        f4 = os.path.join(dC, "fileB")
+        for f in (f1, f2, f3, f4):
+            makefile(f)
+
+        yield tmp, (dA, dB, dC), (f1, f2, f3, f4)
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_rec_glob():
+    with _generate_tmp_tree() as (tmp, _, (f1, f2, f3, f4)):
+        assert sorted(utils.rec_glob(tmp, "fileA")) == [f1, f3]
+        assert sorted(utils.rec_glob(tmp, ("fileA", "fileB"), ignores="dirB")) == [f3, f4]
+        assert sorted(utils.rec_glob(tmp, "fileB", ignores=("dirC",))) == [f2]
+
+
+def test_find_recipe():
+    with _generate_tmp_tree() as (tmp, (dA, dB, dC), (f1, f2, f3, f4)):
+        f5 = os.path.join(tmp, "meta.yaml")
+        f6 = os.path.join(dA, "meta.yml")
+        f7 = os.path.join(dB, "conda.yaml")
+        f8 = os.path.join(dC, "conda.yml")
+
+        # check that each of these are valid recipes
+        for f in (f5, f6, f7, f8):
+            makefile(f)
+            assert utils.find_recipe(tmp) == f
+            os.remove(f)
+
+
+def test_find_recipe_relative():
+    with _generate_tmp_tree() as (tmp, (dA, dB, dC), (f1, f2, f3, f4)):
+        f5 = os.path.join(dA, "meta.yaml")
+        makefile(f5)
+
+        # check that even when given a relative recipe path we still return
+        # the absolute path
+        saved = os.getcwd()
+        os.chdir(tmp)
+        try:
+            assert utils.find_recipe("dirA") == f5
+        finally:
+            os.chdir(saved)
+
+
+def test_find_recipe_no_meta():
+    with _generate_tmp_tree() as (tmp, _, (f1, f2, f3, f4)):
+        # no meta files in tmp
+        with pytest.raises(IOError):
+            utils.find_recipe(tmp)
+
+
+def test_find_recipe_file():
+    with _generate_tmp_tree() as (tmp, _, (f1, f2, f3, f4)):
+        f5 = os.path.join(tmp, "meta.yaml")
+        makefile(f5)
+        # file provided is valid meta
+        assert utils.find_recipe(f5) == f5
+
+
+def test_find_recipe_file_bad():
+    with _generate_tmp_tree() as (tmp, _, (f1, f2, f3, f4)):
+        # file provided is not valid meta
+        with pytest.raises(IOError):
+            utils.find_recipe(f1)
+
+
+def test_find_recipe_multipe_base():
+    with _generate_tmp_tree() as (tmp, (dA, dB, dC), (f1, f2, f3, f4)):
+        f5 = os.path.join(tmp, "meta.yaml")
+        f6 = os.path.join(dB, "meta.yaml")
+        f7 = os.path.join(dC, "conda.yaml")
+        for f in (f5, f6, f7):
+            makefile(f)
+        # multiple meta files, use the one in base level
+        assert utils.find_recipe(tmp) == f5
+
+
+def test_find_recipe_multipe_bad():
+    with _generate_tmp_tree() as (tmp, (dA, dB, dC), (f1, f2, f3, f4)):
+        f5 = os.path.join(dB, "meta.yaml")
+        f6 = os.path.join(dC, "conda.yaml")
+        for f in (f5, f6):
+            makefile(f)
+
+        # nothing in base
+        with pytest.raises(IOError):
+            utils.find_recipe(tmp)
+
+        f7 = os.path.join(tmp, "meta.yaml")
+        f8 = os.path.join(tmp, "conda.yaml")
+        for f in (f7, f8):
+            makefile(f)
+
+        # too many in base
+        with pytest.raises(IOError):
+            utils.find_recipe(tmp)


### PR DESCRIPTION
- Both `conda_build.api.build` and `conda_build.utils.find_recipe` perform checks for *.AppleDouble* and `os.path.isfile`, removed checks from former and rely on `IOErrors` raised in latter.
- Extracted a constant `VALID_METAS` that contains all valid conda recipe meta filenames (I went ahead and included the option to specify both `.yaml` or `.yml` extensions, I understand this doesn't make this possible to use these alternative extensions yet as `meta.yaml` is still hardcoded in a number of places).
- Updated `conda_build.utils.rec_glob` to include the option to pass in an `ignores` argument which removes directories we do not wish to traverse (this simplifies ignoring *.AppleDouble*).
- Updated `conda_build.utils.find_recipe` to better check for base level meta files and ensured that we return the full path to the meta file (not the directory as was previously done if an actual meta file was provided).
- To simplify `conda_build.api.build` make sure recipe paths are absolute prior to searching for meta file such that all recipes returned are already absolute.
- Added ensure_list in `conda_build.utils.expand_globs` such that we can pass in single paths, a minor convenience improvement.
- All of this allows `conda_build.api.build` to be refactored with streamlined and simplified logic and fully harness the duck typing made possible by updates to `conda_build.utils.find_recipe`.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
