### PR TITLE
Fix post.py when SDK has install names surrounded by single qoutes

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -1121,6 +1121,9 @@ def check_overlinking_impl(pkg_name, pkg_version, build_str, build_number, subdi
                         install_names = [re.match('^install-name:\s+(.*)$', line) for line in lines]
                         install_names = [insname.groups(1)[0] for insname in install_names]
                         replaced = install_names[0][1:]
+                        if replaced.endswith("'"):
+                            # Some SDKs have install name surrounded by single qoutes
+                            replaced = replaced[1:-1]
                 sysroot_files.append(replaced)
             diffs = set(orig_sysroot_files) - set(sysroot_files)
             if diffs:

--- a/news/linking_tbd.rst
+++ b/news/linking_tbd.rst
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* Fix post linking for SDKs with tapi-tbd-v4 (MacOS 11.0 and upwards)


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
