### PR TITLE
Switch to using CONDA_PACKAGE_EXTENSIONS

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -399,7 +399,7 @@ def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,
     import time
     from conda_build.conda_interface import string_types
     from conda_build.build import test as run_test, build as run_build
-    from conda_build.utils import CONDA_TARBALL_EXTENSIONS, on_win, LoggingContext
+    from conda_build.utils import CONDA_PACKAGE_EXTENSIONS, on_win, LoggingContext
     is_package = False
     default_config = get_or_merge_config(config, **kwargs)
     args = {"set_build_id": False}
@@ -434,7 +434,7 @@ def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,
                 metadata_tuples.append((metadata, False, True))
         else:
             ext = os.path.splitext(recipe_or_package_path_or_metadata_tuples)[1]
-            if not ext or not any(ext in _ for _ in CONDA_TARBALL_EXTENSIONS):
+            if not ext or not any(ext in _ for _ in CONDA_PACKAGE_EXTENSIONS):
                 metadata_tuples = render(recipe_or_package_path_or_metadata_tuples, config=config, **kwargs)
             else:
                 # this is a package, we only support testing

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 from conda_build import api
-from conda_build.utils import CONDA_TARBALL_EXTENSIONS, on_win
+from conda_build.utils import CONDA_PACKAGE_EXTENSIONS, on_win
 # we extend the render parser because we basically need to render the recipe before
 #       we can say what env to create.  This is not really true for debugging tests, but meh...
 from conda_build.cli.main_render import get_render_parser
@@ -61,7 +61,7 @@ def execute(args):
     test = True
 
     try:
-        if not any(os.path.splitext(_args.recipe_or_package_file_path)[1] in ext for ext in CONDA_TARBALL_EXTENSIONS):
+        if not any(os.path.splitext(_args.recipe_or_package_file_path)[1] in ext for ext in CONDA_PACKAGE_EXTENSIONS):
             # --output silences console output here
             thing_to_debug = render_execute(args, print_results=False)
             test = False

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -29,6 +29,7 @@ from .conda_interface import pkgs_dirs
 from .conda_interface import conda_43
 from .conda_interface import specs_from_url
 from .conda_interface import memoized
+from .utils import CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2
 
 from conda_build import exceptions, utils, environ
 from conda_build.metadata import MetaData, combine_top_level_metadata_with_output
@@ -38,12 +39,6 @@ from conda_build.variants import (get_package_variants, list_of_dicts_to_dict_of
 from conda_build.exceptions import DependencyNeedsBuildingError
 from conda_build.index import get_build_index
 # from conda_build.jinja_context import pin_subpackage_against_outputs
-
-try:
-    from conda.base.constants import CONDA_TARBALL_EXTENSIONS
-except Exception:
-    from conda.base.constants import CONDA_TARBALL_EXTENSION
-    CONDA_TARBALL_EXTENSIONS = (CONDA_TARBALL_EXTENSION,)
 
 
 def odict_representer(dumper, data):
@@ -71,9 +66,9 @@ def bldpkg_path(m):
 
     # the default case will switch over to conda_v2 at some point
     if pkg_type == "conda":
-        path = os.path.join(m.config.output_folder, subdir, '%s%s' % (m.dist(), CONDA_TARBALL_EXTENSIONS[0]))
+        path = os.path.join(m.config.output_folder, subdir, '%s%s' % (m.dist(), CONDA_PACKAGE_EXTENSION_V1))
     elif pkg_type == "conda_v2":
-        path = os.path.join(m.config.output_folder, subdir, '%s%s' % (m.dist(), '.conda'))
+        path = os.path.join(m.config.output_folder, subdir, '%s%s' % (m.dist(), CONDA_PACKAGE_EXTENSION_V2))
     else:
         path = '{} file for {} in: {}'.format(m.type, m.name(), os.path.join(m.config.output_folder, subdir))
     return path
@@ -219,7 +214,7 @@ def find_pkg_dir_or_file_in_pkgs_dirs(pkg_dist, m, files_only=False):
     pkg_loc = None
     for pkgs_dir in _pkgs_dirs:
         pkg_dir = os.path.join(pkgs_dir, pkg_dist)
-        pkg_file = os.path.join(pkgs_dir, pkg_dist + CONDA_TARBALL_EXTENSIONS[0])
+        pkg_file = os.path.join(pkgs_dir, pkg_dist + CONDA_PACKAGE_EXTENSION_V1)
         if not files_only and os.path.isdir(pkg_dir):
             pkg_loc = pkg_dir
             break

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -35,11 +35,11 @@ import filelock
 import conda_package_handling.api
 
 try:
-    from conda.base.constants import CONDA_PACKAGE_EXTENSIONS
+    from conda.base.constants import CONDA_PACKAGE_EXTENSIONS, CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2
 except Exception:
-    from conda.base.constants import CONDA_TARBALL_EXTENSION
-    CONDA_PACKAGE_EXTENSIONS = (CONDA_TARBALL_EXTENSION,)
-CONDA_TARBALL_EXTENSIONS = CONDA_PACKAGE_EXTENSIONS # noqa: shim for previous interface
+    from conda.base.constants import CONDA_TARBALL_EXTENSION as CONDA_PACKAGE_EXTENSION_V1
+    CONDA_PACKAGE_EXTENSION_V2 = ".conda"
+    CONDA_PACKAGE_EXTENSIONS = (CONDA_PACKAGE_EXTENSION_V2, CONDA_PACKAGE_EXTENSION_V1)
 
 from conda.api import PackageCacheData # noqa
 
@@ -443,9 +443,9 @@ def get_recipe_abspath(recipe):
     if not PY3:
         recipe = recipe.decode(getpreferredencoding() or 'utf-8')
     if isfile(recipe):
-        if recipe.lower().endswith(decompressible_exts) or recipe.lower().endswith(CONDA_TARBALL_EXTENSIONS):
+        if recipe.lower().endswith(decompressible_exts) or recipe.lower().endswith(CONDA_PACKAGE_EXTENSIONS):
             recipe_dir = tempfile.mkdtemp()
-            if recipe.lower().endswith(CONDA_TARBALL_EXTENSIONS):
+            if recipe.lower().endswith(CONDA_PACKAGE_EXTENSIONS):
                 import conda_package_handling.api
                 conda_package_handling.api.extract(recipe, recipe_dir)
             else:


### PR DESCRIPTION
I see that `conda` switched from using `CONDA_TARBALL_EXTENSIONS` to `CONDA_PACKAGE_EXTENSIONS` over a year ago.

This change doesn't alter anything in `conda_build` beyond renaming the old `CONDA_TARBALL_EXTENSIONS` variables and removing duplicate code.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
