### PR TITLE
ENH raise runtimeerror instead of calling sys.exit

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -612,7 +612,7 @@ def apply_patch(src_dir, path, config, git=None):
 
     exception = None
     if not isfile(path):
-        sys.exit('Error: no such patch: %s' % path)
+        raise RuntimeError('Error: no such patch: %s' % path)
 
     if config.verbose:
         stdout = None


### PR DESCRIPTION
Closes #4061 

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
cc @mingwandroid @jjhelmus 