### PR TITLE
Activate the environments even when building conda

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -2270,7 +2270,7 @@ class MetaData(object):
     def activate_build_script(self):
         b = self.meta.get('build', {}) or {}
         should_activate = (self.uses_new_style_compiler_activation or b.get('activate_in_script') is not False)
-        return bool(self.config.activate and should_activate) and not self.name() == 'conda'
+        return bool(self.config.activate and should_activate)
 
     @property
     def build_is_host(self):


### PR DESCRIPTION
Looks like this was disabled in https://github.com/conda/conda-build/commit/c546a3b2a9a04cefe67afa3f4ed4ad7041ece519
because conda used to symlink itself into each conda environment. conda doesn't do this anymore, so it's
safe to disable this now.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
