### PR TITLE
Include target_platform in hash

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1259,7 +1259,7 @@ class MetaData(object):
         trim_build_only_deps(self, dependencies)
 
         # filter out ignored versions
-        build_string_excludes = ['python', 'r_base', 'perl', 'lua', 'target_platform']
+        build_string_excludes = ['python', 'r_base', 'perl', 'lua']
         build_string_excludes.extend(ensure_list(self.config.variant.get('ignore_version', [])))
         if 'numpy' in dependencies:
             pin_compatible, not_xx = self.uses_numpy_pin_compatible_without_xx


### PR DESCRIPTION
cc @chenghlee, @jjhelmus, @msarahan, @beckermr 

Note that this will change the hash for all packages and people relying on skipping existing builds might not like this.