### PR TITLE
Refactor dict_of_lists_to_lists_of_dict

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1175,12 +1175,74 @@ def package_has_file(package_path, file_path, refresh=False):
 
 
 def ensure_list(arg):
-    if (isinstance(arg, string_types) or not hasattr(arg, '__iter__')):
-        if arg is not None:
-            arg = [arg]
-        else:
-            arg = []
-    return arg
+    """
+    Ensure the object is a list. If not return it in a list.
+
+    :param arg: Object to ensure is a list
+    :type arg: any
+    :return: `arg` as a `list`
+    :rtype: `list`
+    """
+    if arg is None:
+        return []
+    elif islist(arg):
+        return arg
+    else:
+        return [arg]
+
+
+def islist(arg, uniform=False):
+    """
+    Check whether `arg` is a `list`. Optionally determine whether the list elements
+    are all uniform.
+
+    When checking for generic uniformity (`uniform=True`) we check to see if all
+    elements are of the first element's type (`type(arg[0]) == type(arg[1])`). For
+    any other kinds of uniformity checks are desired provide a uniformity function:
+
+    .. code-block:: python
+        # uniformity function checking if elements are str and not empty
+        >>> truthy_str = lambda e: isinstance(e, str) and e
+        >>> islist(["foo", "bar"], uniform=truthy_str)
+        True
+        >>> islist(["", "bar"], uniform=truthy_str)
+        False
+        >>> islist([0, "bar"], uniform=truthy_str)
+        False
+
+    NOTE: Testing for uniformity will consume generators.
+
+    :param arg: Object to ensure is a `list`
+    :type arg: any
+    :param uniform: Whether to check for uniform or uniformity function
+    :type uniform: `bool` or `function`
+    :return: Whether `arg` is a `list`
+    :rtype: `bool`
+    """
+    if isinstance(arg, string_types) or not hasattr(arg, '__iter__'):
+        # str and non-iterables are not lists
+        return False
+    elif not uniform:
+        # short circuit for non-uniformity
+        return True
+
+    # NOTE: not checking for Falsy arg since arg may be a generator
+
+    if uniform is True:
+        arg = iter(arg)
+        try:
+            etype = type(next(arg))
+        except StopIteration:
+            # StopIteration: list is empty, an empty list is still uniform
+            return True
+        # check for explicit type match, do not allow the ambiguity of isinstance
+        uniform = lambda e: type(e) == etype
+
+    try:
+        return all(uniform(e) for e in arg)
+    except (ValueError, TypeError):
+        # ValueError, TypeError: uniform function failed
+        return False
 
 
 @contextlib.contextmanager

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1186,7 +1186,7 @@ def ensure_list(arg):
     if arg is None:
         return []
     elif islist(arg):
-        return arg
+        return list(arg)
     else:
         return [arg]
 

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -128,18 +128,54 @@ def test_zip_fields():
     assert ld[1]['python'] == '2.7'
     assert ld[1]['vc'] == '14'
 
-    # mismatched lengths should raise an error
-    v = {'python': ['2.7', '3.5', '3.4'], 'vc': ['9', '14'], 'zip_keys': [('python', 'vc')]}
+
+def test_validate_spec():
+    """
+    Basic spec validation checking for bad characters, bad zip_keys, missing keys,
+    duplicate keys, and zip_key fields length mismatch.
+    """
+    spec = {
+        # normal expansions
+        "foo": [2.7, 3.7, 3.8],
+        # zip_keys are the values that need to be expanded as a set
+        "zip_keys": [["bar", "baz"], ["qux", "quux", "quuz"]],
+        "bar": [1, 2, 3],
+        "baz": [2, 4, 6],
+        "qux": [4, 5],
+        "quux": [8, 10],
+        "quuz": [12, 15],
+        # extend_keys are those values which we do not expand
+        "extend_keys": ["corge"],
+        "corge": 42,
+    }
+    # valid spec
+    variants.validate_spec("spec", spec)
+
+    spec2 = dict(spec)
+    spec2["bad-char"] = "bad-char"
+    # invalid characters
     with pytest.raises(ValueError):
-        ld = variants.dict_of_lists_to_list_of_dicts(v)
+        variants.validate_spec("spec[bad_char]", spec2)
 
-    # WHEN one is completely missing, it's OK.  The zip_field for the set gets ignored.
-    v = {'python': ['2.7', '3.5'], 'zip_keys': [('python', 'vc')]}
-    ld = variants.dict_of_lists_to_list_of_dicts(v)
-    assert len(ld) == 2
-    assert 'vc' not in ld[0].keys()
-    assert 'vc' not in ld[1].keys()
+    spec3 = dict(spec, zip_keys="bad_zip_keys")
+    # bad zip_keys
+    with pytest.raises(ValueError):
+        variants.validate_spec("spec[bad_zip_keys]", spec3)
 
+    spec4 = dict(spec, zip_keys=[["bar", "baz"], ["qux", "quux"], ["quuz", "missing"]])
+    # zip_keys' zip_group has key missing from spec
+    with pytest.raises(ValueError):
+        variants.validate_spec("spec[missing_key]", spec4)
+
+    spec5 = dict(spec, zip_keys=[["bar", "baz"], ["qux", "quux", "quuz"], ["quuz"]])
+    # zip_keys' zip_group has duplicate key
+    with pytest.raises(ValueError):
+        variants.validate_spec("spec[duplicate_key]", spec5)
+
+    spec6 = dict(spec, baz=[4, 6])
+    # zip_keys' zip_group key fields have same length
+    with pytest.raises(ValueError):
+        variants.validate_spec("spec[duplicate_key]", spec6)
 
 def test_cross_compilers():
     recipe = os.path.join(recipe_dir, '09_cross')
@@ -173,14 +209,17 @@ def test_git_variables_with_variants(testing_workdir, testing_config):
 
 
 def test_variant_input_with_zip_keys_keeps_zip_keys_list():
-    variants_ = {'scipy': ['0.17', '0.19'], 'sqlite': ['3'], 'zlib': ['1.2'], 'xz': ['5'],
-                 'zip_keys': ['macos_min_version', 'macos_machine', 'MACOSX_DEPLOYMENT_TARGET',
-                              'CONDA_BUILD_SYSROOT'],
-                 'pin_run_as_build': {'python': {'min_pin': 'x.x', 'max_pin': 'x.x'}}}
-    variant_list = variants.dict_of_lists_to_list_of_dicts(variants_,
-                        extend_keys=variants.DEFAULT_VARIANTS['extend_keys'])
-    assert len(variant_list) == 2
-    assert 'zip_keys' in variant_list[0] and variant_list[0]['zip_keys']
+    spec = {
+        'scipy': ['0.17', '0.19'],
+        'sqlite': ['3'],
+        'zlib': ['1.2'],
+        'xz': ['5'],
+        'zip_keys': ['sqlite', 'zlib', 'xz'],
+        'pin_run_as_build': {'python': {'min_pin': 'x.x', 'max_pin': 'x.x'}}
+    }
+    vrnts = variants.dict_of_lists_to_list_of_dicts(spec)
+    assert len(vrnts) == 2
+    assert vrnts[0].get("zip_keys") == spec["zip_keys"]
 
 
 @pytest.mark.serial


### PR DESCRIPTION
Refactor code to eliminate overly verbose and complex code. 6-12 times faster implementation.

I sought to eliminate a number of private helper functions that did not aid in simplifying the code. I also ended up adding a new function `conda_build.utils.islist` which we may find valuable to use elsewhere.

Yes, I like using list/dictionary comprehension and when formatted properly I believe they are easier to read - I totally understand how subjective this is so let me know if you disagree and want it coded differently.

I personally wish to rename `dict_of_lists_to_lists_of_dict` to `expand_variants` (and `lists_of_dict_to_dict_of_lists` to `collapse_spec`) in order to make the functions more self documented as well as making them less of a mouthful. @mingwandroid what do you think? I have no problem reverting this change.

I also moved all spec validation checks to the `validate_spec` function instead of having them spread out in various locations. This may require that `validate_spec` is rerun after combining specs in places like this:
https://github.com/conda/conda-build/blob/d8fa0b3e4edf3d98452f8fcfc381853e9955a47f/conda_build/variants.py#L517-L525

Not 100% sure some of the assumptions I made are valid, need to dig a little further into corner cases. For example, instead of joining zip_keys on some special char ("#") and then splitting the keys after the Cartesian Product, I opted to use `tuples` as the keys and at least with my test cases I get the correct result but this is likely only safe to do if all of specs keys are strings to start with.