### PR TITLE
index by file

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -365,7 +365,7 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
                  subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
-                 hotfix_source_repo=None, current_index_versions=None, **kwargs):
+                 hotfix_source_repo=None, current_index_versions=None, index_file=None, **kwargs):
     import yaml
     from locale import getpreferredencoding
     import os
@@ -385,7 +385,8 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
         update_index(path, check_md5=check_md5, channel_name=channel_name,
                      patch_generator=patch_generator, threads=threads, verbose=verbose,
                      progress=progress, hotfix_source_repo=hotfix_source_repo,
-                     subdirs=ensure_list(subdir), current_index_versions=current_index_versions)
+                     subdirs=ensure_list(subdir), current_index_versions=current_index_versions,
+                     index_file=index_file)
 
 
 def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -365,7 +365,7 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
                  subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
-                 hotfix_source_repo=None, current_index_versions=None, index_file=None, **kwargs):
+                 hotfix_source_repo=None, current_index_versions=None, **kwargs):
     import yaml
     from locale import getpreferredencoding
     import os

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -365,7 +365,7 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
                  subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
-                 hotfix_source_repo=None, current_index_versions=None, index_file=None, **kwargs):
+                 hotfix_source_repo=None, current_index_versions=None, **kwargs):
     import yaml
     from locale import getpreferredencoding
     import os
@@ -386,7 +386,7 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
                      patch_generator=patch_generator, threads=threads, verbose=verbose,
                      progress=progress, hotfix_source_repo=hotfix_source_repo,
                      subdirs=ensure_list(subdir), current_index_versions=current_index_versions,
-                     index_file=index_file)
+                     index_file=kwargs.get('index_file', None))
 
 
 def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,

--- a/conda_build/cli/main_index.py
+++ b/conda_build/cli/main_index.py
@@ -75,6 +75,11 @@ def parse_args(args):
         will keep python 2.7.X and 3.6.Y in the current_index.json, instead of only the very latest python version.
         """
     )
+    p.add_argument(
+        "-f", "--file",
+        help="A file that contains a new line separated list of packages to add to repodata.",
+        action="store"
+    )
 
     args = p.parse_args(args)
     return p, args
@@ -86,7 +91,7 @@ def execute(args):
     api.update_index(args.dir, check_md5=args.check_md5, channel_name=args.channel_name,
                      threads=args.threads, subdir=args.subdir, patch_generator=args.patch_generator,
                      verbose=args.verbose, progress=args.progress, hotfix_source_repo=args.hotfix_source_repo,
-                     current_index_versions=args.current_index_versions_file)
+                     current_index_versions=args.current_index_versions_file, index_file=args.file)
 
 
 def main():

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -868,10 +868,13 @@ class ChannelIndex(object):
         # we'll process these first, because reading their metadata is much faster
         if index_file:
             with open(index_file, 'r') as fin:
-                fns_in_subdir = {line.split(f'{subdir}/')[1] for line in map(lambda line: line.rstrip('\n'), fin) if
-                        line.endswith('.conda') or
-                        line.endswith('.tar.bz2') and
-                        line.startswith(subdir)}
+                fns_in_subdir = set()
+                for line in fin:
+                    fn_subdir, fn = line.strip().split('/')
+                    if fn_subdir != subdir:
+                        continue
+                    if fn.endswith('.conda') or fn.endswith('.tar.bz2'):
+                        fns_in_subdir.add(fn)
         else:
             fns_in_subdir = {fn for fn in os.listdir(subdir_path) if fn.endswith('.conda') or fn.endswith('.tar.bz2')}
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -138,6 +138,110 @@ def test_index_on_single_subdir_1(testing_workdir):
     assert actual_channeldata_json == expected_channeldata_json
 
 
+def test_file_index_on_single_subdir_1(testing_workdir):
+    test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
+    test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
+    download(test_package_url, test_package_path)
+
+    p = os.path.join(testing_workdir, 'index_file')
+    with open(os.path.join(testing_workdir, 'index_file'), 'a+') as fh:
+        fh.write("osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2\n")
+    conda_build.index.update_index(testing_workdir, channel_name='test-channel', index_file=p)
+
+    # #######################################
+    # tests for osx-64 subdir
+    # #######################################
+    assert isfile(join(testing_workdir, 'osx-64', 'index.html'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json.bz2'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json.bz2'))
+
+    with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
+        actual_repodata_json = json.loads(fh.read())
+        assert actual_repodata_json
+    with open(join(testing_workdir, 'osx-64', 'repodata_from_packages.json')) as fh:
+        actual_pkg_repodata_json = json.loads(fh.read())
+    expected_repodata_json = {
+        "info": {
+            'subdir': 'osx-64',
+        },
+        "packages": {
+            "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2": {
+                "build": "py27h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "osx-64",
+                "timestamp": 1508520039632,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    assert actual_repodata_json == expected_repodata_json
+    assert actual_pkg_repodata_json == expected_repodata_json
+
+    # #######################################
+    # tests for full channel
+    # #######################################
+
+    with open(join(testing_workdir, 'channeldata.json')) as fh:
+        actual_channeldata_json = json.loads(fh.read())
+    expected_channeldata_json = {
+        "channeldata_version": 1,
+        "packages": {
+            "conda-index-pkg-a": {
+                "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
+                               "Python is a widely used high-level, general-purpose, interpreted, dynamic "
+                               "programming language. Its design philosophy emphasizes code "
+                               "readability, and its syntax allows programmers to express concepts in "
+                               "fewer lines of code than would be possible in languages such as C++ or "
+                               "Java. The language provides constructs intended to enable clear programs "
+                               "on both a small and large scale.",
+                "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
+                "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
+                "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
+                "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
+                "license": "BSD",
+                "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
+                "subdirs": [
+                    "osx-64",
+                ],
+                "summary": "Summary field for conda-index-pkg-a",
+                "version": "1.0",
+                "activate.d": False,
+                "deactivate.d": False,
+                "post_link": True,
+                "pre_link": False,
+                "pre_unlink": False,
+                "binary_prefix": False,
+                "text_prefix": True,
+                "run_exports": {},
+                'icon_hash': None,
+                'icon_url': None,
+                'identifiers': None,
+                'keywords': None,
+                'recipe_origin': None,
+                'source_url': None,
+                'tags': None,
+                'timestamp': 1508520039,
+            }
+        },
+        "subdirs": [
+            "noarch",
+            "osx-64"
+        ]
+    }
+    assert actual_channeldata_json == expected_channeldata_json
+
+
 def test_index_noarch_osx64_1(testing_workdir):
     test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
     test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
@@ -148,6 +252,125 @@ def test_index_noarch_osx64_1(testing_workdir):
     download(test_package_url, test_package_path)
 
     conda_build.index.update_index(testing_workdir, channel_name='test-channel')
+
+    # #######################################
+    # tests for osx-64 subdir
+    # #######################################
+    assert isfile(join(testing_workdir, 'osx-64', 'index.html'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json'))  # repodata is tested in test_index_on_single_subdir_1
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json.bz2'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json.bz2'))
+
+    # #######################################
+    # tests for noarch subdir
+    # #######################################
+    assert isfile(join(testing_workdir, 'noarch', 'index.html'))
+    assert isfile(join(testing_workdir, 'noarch', 'repodata.json.bz2'))
+    assert isfile(join(testing_workdir, 'noarch', 'repodata_from_packages.json.bz2'))
+
+    with open(join(testing_workdir, 'noarch', 'repodata.json')) as fh:
+        actual_repodata_json = json.loads(fh.read())
+    with open(join(testing_workdir, 'noarch', 'repodata_from_packages.json')) as fh:
+        actual_pkg_repodata_json = json.loads(fh.read())
+    expected_repodata_json = {
+        "info": {
+            'subdir': 'noarch',
+        },
+        "packages": {
+            "conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2": {
+                "build": "pyhed9eced_1",
+                "build_number": 1,
+                "depends": [
+                    "python"
+                ],
+                "license": "BSD",
+                "md5": "56b5f6b7fb5583bccfc4489e7c657484",
+                "name": "conda-index-pkg-a",
+                "noarch": "python",
+                "sha256": "7430743bffd4ac63aa063ae8518e668eac269c783374b589d8078bee5ed4cbc6",
+                "size": 7882,
+                "subdir": "noarch",
+                "timestamp": 1508520204768,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    assert actual_repodata_json == expected_repodata_json
+    assert actual_pkg_repodata_json == expected_repodata_json
+
+    # #######################################
+    # tests for full channel
+    # #######################################
+
+    with open(join(testing_workdir, 'channeldata.json')) as fh:
+        actual_channeldata_json = json.loads(fh.read())
+    expected_channeldata_json = {
+        "channeldata_version": 1,
+        "packages": {
+            "conda-index-pkg-a": {
+                "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
+                               "Python is a widely used high-level, general-purpose, interpreted, dynamic "
+                               "programming language. Its design philosophy emphasizes code "
+                               "readability, and its syntax allows programmers to express concepts in "
+                               "fewer lines of code than would be possible in languages such as C++ or "
+                               "Java. The language provides constructs intended to enable clear programs "
+                               "on both a small and large scale.",
+                "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
+                "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
+                "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
+                "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
+                "license": "BSD",
+                "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
+                'source_url': None,
+                "subdirs": [
+                    "noarch",
+                    "osx-64",
+                ],
+                "summary": "Summary field for conda-index-pkg-a. This is the python noarch version.",  # <- tests that the higher noarch build number is the data collected
+                "version": "1.0",
+                "activate.d": False,
+                "deactivate.d": False,
+                "post_link": True,
+                "pre_link": False,
+                "pre_unlink": False,
+                "binary_prefix": False,
+                "text_prefix": True,
+                "run_exports": {},
+                'icon_hash': None,
+                'icon_url': None,
+                'identifiers': None,
+                'tags': None,
+                'timestamp': 1508520039,
+                'keywords': None,
+                'recipe_origin': None,
+            }
+        },
+        "subdirs": [
+            "noarch",
+            "osx-64",
+        ]
+    }
+    assert actual_channeldata_json == expected_channeldata_json
+
+
+def test_file_index_noarch_osx64_1(testing_workdir):
+    test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
+    test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
+    download(test_package_url, test_package_path)
+
+    test_package_path = join(testing_workdir, 'noarch', 'conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2')
+    test_package_url = 'https://conda.anaconda.org/conda-test/noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2'
+    download(test_package_url, test_package_path)
+
+    p = os.path.join(testing_workdir, 'index_file')
+    with open(os.path.join(testing_workdir, 'index_file'), 'a+') as fh:
+        fh.write('noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2\n')
+        fh.write('osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2\n')
+    conda_build.index.update_index(testing_workdir, channel_name='test-channel', index_file=p)
 
     # #######################################
     # tests for osx-64 subdir


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

This allows a user to pass a new line separated file into `conda index` using the `-f, --file` flag. This will allow a user to pass in a list of packages to be considered for index instead of looking at all of the packages on the file system.
