### PR TITLE
output_script.sh/bat: Add . + os.sep to script if it does not begin w…

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1482,7 +1482,10 @@ def bundle_conda(output, metadata, env, stats, **kw):
         script_fn = output.get('script') or 'output_script.{}'.format(suffix)
         with open(os.path.join(metadata.config.work_dir, script_fn), 'w') as f:
             f.write('\n')
-            f.write(script)
+            if not script.startswith('.'):
+                f.write('.' + os.sep + script)
+            else:
+                f.write(script)
             f.write('\n')
         output['script'] = script_fn
 


### PR DESCRIPTION
…ith a .

The current directory is in general, not on PATH on Unix

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
