### PR TITLE
Remove old rpath when loader_path is used

### DIFF
--- a/conda_build/os_utils/macho.py
+++ b/conda_build/os_utils/macho.py
@@ -267,10 +267,10 @@ def add_rpath(path, rpath, build_prefix=None, verbose=False):
         % code)
 
 
-def delete_rpath(path, rpath, verbose=False):
+def delete_rpath(path, rpath, build_prefix=None, verbose=False):
     """Delete an `rpath` from the Mach-O file at `path`"""
     args = ['-delete_rpath', rpath, path]
-    code, _, stderr = install_name_tool(args)
+    code, _, stderr = install_name_tool(args, build_prefix)
     if "Mach-O dynamic shared library stub file" in stderr:
         print("Skipping Mach-O dynamic shared library stub file %s\n" % path)
         return

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -417,6 +417,7 @@ def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
                              relpath(join(host_prefix, rpath), dirname(path)),
                              '').replace('/./', '/')
             macho.add_rpath(path, rpath_new, build_prefix=prefix, verbose=True)
+            macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be
         # made relocatable.


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
