### PR TITLE
Fall back to shutil.copy if shutil.copy2 fails when copying patches

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -646,7 +646,10 @@ def _get_patch_attributes(path, patch_exe, git, src_dir, stdout, stderr, retaine
             for fmt, _ in fmts.items():
                 new_patch = os.path.join(tmpdir, os.path.basename(path) + '.{}'.format(fmt))
                 if fmt == 'native':
-                    shutil.copy2(path, new_patch)
+                    try:
+                        shutil.copy2(path, new_patch)
+                    except:
+                        shutil.copy(path, new_patch)
                 elif fmt == 'lf':
                     _ensure_unix_line_endings(path, new_patch)
                 elif fmt == 'crlf':


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
