### PR TITLE
Don't trim empty keys

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -874,7 +874,6 @@ else:
 
 def output_yaml(metadata, filename=None, suppress_outputs=False):
     local_metadata = metadata.copy()
-    utils.trim_empty_keys(local_metadata.meta)
     if suppress_outputs and local_metadata.is_output and 'outputs' in local_metadata.meta:
         del local_metadata.meta['outputs']
     output = yaml.dump(_MetaYaml(local_metadata.meta), Dumper=_IndentDumper,


### PR DESCRIPTION
`requirements/host` might get deleted in the resulting package and conda-build will assume `merge_build_host==True` in that case

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
