### PR TITLE
force target_platform as used when not noarch

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -2162,9 +2162,7 @@ class MetaData(object):
 
             used_vars = meta_yaml_reqs | script_reqs
             # force target_platform to always be included, because it determines behavior
-            if ('target_platform' in self.config.variant and
-                    any(plat != self.config.subdir for plat in
-                        self.get_variants_as_dict_of_lists()['target_platform'])):
+            if ('target_platform' in self.config.variant and not self.noarch):
                 used_vars.add('target_platform')
 
             if self.force_use_keys or self.force_ignore_keys:


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
Follow up to https://github.com/conda/conda-build/pull/4065