### PR TITLE
Fix Windows build rename error

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -2092,7 +2092,7 @@ def shutil_move_more_retrying(src, dest, debug_name):
             if attempts_left != 5:
                 log.warning("shutil.move({}={}, dest={}) succeeded on attempt number {}".format(debug_name, src, dest,
                                                                                                     6 - attempts_left))
-            attempts_left = -1
+            break
         except:
             attempts_left = attempts_left - 1
         if attempts_left > 0:


### PR DESCRIPTION
Previously it shows "Failed to rename work directory despite sleeping and retrying..." even when the move is successful. This causes the Windows `conda-build` to fail.

Fix: on successful rename, break out of the while loop.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
