### PR TITLE
fix indexing by file

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -896,6 +896,8 @@ class ChannelIndex(object):
 
         stat_cache_original = stat_cache.copy()
 
+        remove_set = old_repodata_fns - fns_in_subdir
+        ignore_set = set(old_repodata.get('removed', []))
         try:
             # calculate all the paths and figure out what we're going to do with them
             # add_set: filenames that aren't in the current/old repodata, but exist in the subdir
@@ -908,12 +910,10 @@ class ChannelIndex(object):
                             continue
                         if fn.endswith('.conda') or fn.endswith('.tar.bz2'):
                             add_set.add(fn)
-                remove_set = ignore_set = set()
             else:
                 add_set = fns_in_subdir - old_repodata_fns
-                remove_set = old_repodata_fns - fns_in_subdir
-                ignore_set = set(old_repodata.get('removed', []))
-                add_set -= ignore_set
+
+            add_set -= ignore_set
 
             # update_set: Filenames that are in both old repodata and new repodata,
             #     and whose contents have changed based on file size or mtime. We're


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

This should fix indexing by file. The previous way would effectively truncate the existing repodata.json and create a new one with only the artifacts in the file.
I am deliberately making the ignore and remove set empty here. If there's a better approach, I'm open to suggestions.
