### PR TITLE
Respect PEP440 ~= 'Compatible release clause'

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -266,6 +266,13 @@ def test_skeleton_pypi(testing_workdir, testing_config):
     main_build.execute(('peppercorn',))
 
 
+@pytest.mark.sanity
+def test_skeleton_pypi_compatible_versions(testing_workdir, testing_config):
+    args = ['pypi', 'openshift']
+    main_skeleton.execute(args)
+    assert os.path.isdir('openshift')
+
+
 @pytest.mark.slow
 def test_skeleton_pypi_arguments_work(testing_workdir):
     """


### PR DESCRIPTION
    .. we expand this to >=X.Y.Z,==X.Y.* as per the PEP

Test with openshift which uses 'Compatible release' specs
Add commented out code to compare with conda-build's old
handling of this which differed:

`kubernetes >=11.0.0,<11.1 vs kubernetes >=11.0.0,==11.0.*`

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
