### PR TITLE
Fix index.json:"platform" in cross-platform builds

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1371,8 +1371,8 @@ class MetaData(object):
             version=self.version(),
             build=self.build_id(),
             build_number=self.build_number() if self.build_number() else 0,
-            platform=self.config.platform if (self.config.platform != 'noarch' and
-                                              arch != 'noarch') else None,
+            platform=self.config.host_platform if (self.config.host_platform != 'noarch' and
+                                                   arch != 'noarch') else None,
             arch=ARCH_MAP.get(arch, arch),
             subdir=self.config.target_subdir,
             depends=sorted(' '.join(ms.spec.split())

--- a/news/gh-4124-info_index-host_platform.rst
+++ b/news/gh-4124-info_index-host_platform.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Set "platform" in index.json to the target platform for cross-platform builds.
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/tests/test-recipes/metadata/_cross_build_unix_windows/conda_build_config.yaml
+++ b/tests/test-recipes/metadata/_cross_build_unix_windows/conda_build_config.yaml
@@ -1,0 +1,3 @@
+target_platform:
+  - win-64    # [not win]
+  - linux-64  # [win]

--- a/tests/test-recipes/metadata/_cross_build_unix_windows/meta.yaml
+++ b/tests/test-recipes/metadata/_cross_build_unix_windows/meta.yaml
@@ -1,0 +1,5 @@
+# Empty package that gets cross-built on Unix for Windows and vice versa.
+
+package:
+  name: test_cross_unix_windows
+  version: 1.0

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -163,6 +163,16 @@ def test_cross_recipe_with_only_build_section(testing_config):
     assert not metadata.build_is_host
 
 
+def test_cross_info_index_platform(testing_config):
+    recipe = os.path.join(metadata_dir, '_cross_build_unix_windows')
+    metadata = api.render(recipe, config=testing_config, bypass_env_check=True)[0][0]
+    info_index = metadata.info_index()
+    assert metadata.config.host_subdir != subdir
+    assert metadata.config.host_subdir == info_index['subdir']
+    assert metadata.config.host_platform != metadata.config.platform
+    assert metadata.config.host_platform == info_index['platform']
+
+
 def test_setting_condarc_vars_with_env_var_expansion(testing_workdir):
     os.makedirs('config')
     # python won't be used - the stuff in the recipe folder will override it


### PR DESCRIPTION
If we cross-build on different platforms and not just different architectures of the same platform, the `platform` key in `index.json` is not set to the target platform.
refs:
  - https://gitter.im/conda-forge/conda-forge.github.io?at=5faa7d4b8a236947ba9813eb
    > I'm having an odd upload issue at https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=237099 .
    > The build went fine and uploads for `linux-64` and `osx-64` were successful. But the `win-64` one does not upload (restarted once).
    > There is one peculiarity I did: The `win-64` one is built on `linux-64` -- but that shouldn't cause any issues, shouldn't it? (Given that we upload `osx-arm64` packages built from `osx-64`.)
  - https://gitter.im/conda-forge/conda-forge.github.io?at=5faad739c6fe0131d4e912df
    > I got it:
    > I replaced `"platform": "linux",` with `"platform": "win",` in `info/index.json` and then the upload worked.
    > This would also explain why we didn't see this with other cross-compiles before since we had `osx-arm64` on `osx-64`, i.e., unchanged `"platform": "osx",`. So, `conda-build` needs a little change to do this then.

