### PR TITLE
Reduce get_rpaths_raw/patchelf disagree warnings

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -121,7 +121,10 @@ def _get_elf_rpathy_thing(binary, attribute, dyn_tag):
     dynamic_entries = binary.dynamic_entries
     rpaths_colons = [getattr(e, attribute)
                      for e in dynamic_entries if e.tag == dyn_tag]
-    return rpaths_colons
+    rpaths = []
+    for rpath in rpaths_colons:
+        rpaths.extend(rpath.split(':'))
+    return rpaths
 
 
 def _set_elf_rpathy_thing(binary, old_matching, new_rpath, set_rpath, set_runpath):
@@ -219,11 +222,6 @@ def get_rpaths(file, exe_dirname, envroot, windows_root=''):
             rpaths.extend(list(_get_path_dirs(envroot)))
     elif binary_format == lief.EXE_FORMATS.MACHO:
         rpaths = [rpath.rstrip('/') for rpath in rpaths]
-    elif binary_format == lief.EXE_FORMATS.ELF:
-        result = []
-        for rpath in rpaths:
-            result.extend(rpath.split(':'))
-        rpaths = result
     return [from_os_varnames(binary_format, binary_type, rpath) for rpath in rpaths]
 
 

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -508,9 +508,9 @@ def mk_relative_linux(f, prefix, rpaths=('lib',), method=None):
     existing = existing_pe
     if have_lief:
         existing2, _, _ = get_rpaths_raw(elf)
-        if existing_pe and [existing_pe] != existing2:
+        if existing_pe and existing_pe != existing2:
             print('WARNING :: get_rpaths_raw()={} and patchelf={} disagree for {} :: '.format(
-                      existing2, [existing_pe], elf))
+                      existing2, existing_pe, elf))
         # Use LIEF if method is LIEF to get the initial value?
         if method == 'LIEF':
             existing = existing2

--- a/news/gh-4131-split-patchelf-rpath.rst
+++ b/news/gh-4131-split-patchelf-rpath.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Reduce get_rpaths_raw/patchelf disagree warnings
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
Reduce amount of warnings like
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=235715&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=715
> WARNING :: get_rpaths_raw()=['/home/conda/feedstock_root/build_artifacts/slirp4netns_1604525000330/_build_env/lib:/home/conda/feedstock_root/build_artifacts/slirp4netns_1604525000330/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib'] and patchelf=[['/home/conda/feedstock_root/build_artifacts/slirp4netns_1604525000330/_build_env/lib', '/home/conda/feedstock_root/build_artifacts/slirp4netns_1604525000330/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib']] disagree for /home/conda/feedstock_root/build_artifacts/slirp4netns_1604525000330/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/bin/slirp4netns :: 

Which just happen because patchelf's RPATH entries are split but LIEF's are still concatenated by `:`.