### PR TITLE
macos: Delete build_prefix rpath

### DIFF
--- a/conda_build/os_utils/macho.py
+++ b/conda_build/os_utils/macho.py
@@ -218,10 +218,10 @@ def get_id(path, build_prefix=None):
         return ''
 
 
-def get_rpaths(path):
+def get_rpaths(path, build_prefix=None):
     """Return a list of the dylib rpaths"""
-    res_pyldd = inspect_rpaths(path, resolve_dirnames=False, use_os_varnames=True)
-    return res_pyldd
+    dylib_loads = otool(path, build_prefix, is_rpath)
+    return [dylib_load['path'] for dylib_load in dylib_loads]
 
 
 def _chmod(filename, mode):

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -407,6 +407,7 @@ def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
                                   dylibs=names)
 
     if names:
+        existing_rpaths = macho.get_rpaths(path, build_prefix=prefix)
         # Add an rpath to every executable to increase the chances of it
         # being found.
         for rpath in rpaths:
@@ -417,7 +418,13 @@ def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
                              relpath(join(host_prefix, rpath), dirname(path)),
                              '').replace('/./', '/')
             macho.add_rpath(path, rpath_new, build_prefix=prefix, verbose=True)
-            macho.delete_rpath(path, join(host_prefix, rpath), build_prefix=prefix, verbose=True)
+            if join(host_prefix, rpath) in existing_rpaths:
+                macho.delete_rpath(path, join(host_prefix, rpath), build_prefix=prefix, verbose=True)
+
+        if build_prefix != host_prefix:
+            for rpath in existing_rpaths:
+                if rpath.startswith(build_prefix):
+                    macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be
         # made relocatable.


### PR DESCRIPTION
Leaving invalid build_prefix rpath entries is fine in general but
may confuse tools such as delocate.

cc @isuruf 