### PR TITLE
Fix typo in: build-pkgs.rst

### DIFF
--- a/docs/source/user-guide/tutorials/build-pkgs.rst
+++ b/docs/source/user-guide/tutorials/build-pkgs.rst
@@ -172,7 +172,7 @@ on your local computer.
 
       conda-build click
 
-   If you are already in the click folder, you can type ``conda build .``.
+   If you are already in the click folder, you can type ``conda-build .``.
 
 
 


### PR DESCRIPTION
Fix typo: `conda-build` instead of `conda build`