### PR TITLE
Fix auth in aboutjson

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -52,6 +52,7 @@ from .conda_interface import UnsatisfiableError
 from .conda_interface import NoPackagesFoundError
 from .conda_interface import CondaError
 from .conda_interface import pkgs_dirs
+from .conda_interface import get_conda_channel
 from .utils import (CONDA_PACKAGE_EXTENSION_V1, CONDA_PACKAGE_EXTENSION_V2,
                     CONDA_PACKAGE_EXTENSIONS, env_var, glob,
                     shutil_move_more_retrying, tmp_chdir)
@@ -1077,7 +1078,7 @@ def record_prefix_files(m, files_with_prefix):
 
 
 def sanitize_channel(channel):
-    return re.sub(r'\/t\/[a-zA-Z0-9\-]*\/', '/t/<TOKEN>/', channel)
+    return get_conda_channel(channel).urls(with_credentials=False, subdirs=[''])[0]
 
 
 def write_info_files_file(m, files):

--- a/news/fix-auth-in-aboutjson.rst
+++ b/news/fix-auth-in-aboutjson.rst
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* about.json leaks credentials  (#3991)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -50,7 +50,9 @@ def test_build_preserves_PATH(testing_workdir, testing_config):
 
 def test_sanitize_channel():
     test_url = 'https://conda.anaconda.org/t/ms-534991f2-4123-473a-b512-42025291b927/somechannel'
-    assert build.sanitize_channel(test_url) == 'https://conda.anaconda.org/t/<TOKEN>/somechannel'
+    assert build.sanitize_channel(test_url) == 'https://conda.anaconda.org/somechannel'
+    test_url_auth = 'https://myuser:mypass@conda.anaconda.org/somechannel'
+    assert build.sanitize_channel(test_url_auth) == 'https://conda.anaconda.org/somechannel'
 
 
 def test_get_short_path(testing_metadata):


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
Closes #3991 

This uses the Channel class from conda to sanitize the channel url, instead of relying on a regular expression.

This does mean that the channel format in `about.json` now is different. E.g. see these test urls:
```
https://conda.anaconda.org/t/ms-534991f2-4123-473a-b512-42025291b927/somechannel
https://myuser:mypass@conda.anaconda.org/somechannel
```
Previously these would become
```
https://conda.anaconda.org/t/<TOKEN>/somechannel
https://myuser:mypass@conda.anaconda.org/somechannel
```
Now they are both
```
https://conda.anaconda.org/somechannel
https://conda.anaconda.org/somechannel
```
This is better, because
* it is standardized with how conda itself does things
* it should not matter how the channel is authenticated.

[Edit: removed something about clahub.com being down; apparently I signed the CLA already in the past]