### PR TITLE
Add flaky to testing dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Additionally, you need to install a few extra packages:
 
 .. code-block:: bash
 
-  conda install anaconda-client pytest pytest-cov mock pytest-mock conda-package-handling python-libarchive-c
+  conda install anaconda-client pytest pytest-cov mock pytest-mock conda-package-handling python-libarchive-c flaky
 
 The test suite runs with py.test. Some useful commands to run select tests,
 assuming you are in the conda-build root folder:


### PR DESCRIPTION
This error occurs without `flaky`:
```
==== test session starts ====
platform linux -- Python 3.8.0, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: [...]/conda-build/conda-build, configfile: setup.cfg
plugins: cov-2.10.1, mock-3.3.1
collected 558 items / 1 error / 557 selected                                                                                                                           

==== ERRORS =====
____ ERROR collecting tests/test_api_skeleton.py ____
'flaky' not found in `markers` configuration option
==== warnings summary ====
```

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
