### PR TITLE
Smarter build_numbers

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -491,7 +491,7 @@ def meta_vars(meta, skip_build_id=False):
     # use `get_value` to prevent early exit while name is still unresolved during rendering
     d['PKG_NAME'] = meta.get_value('package/name')
     d['PKG_VERSION'] = meta.version()
-    d['PKG_BUILDNUM'] = str(meta.build_number() or 0)
+    d['PKG_BUILDNUM'] = str(meta.build_number())
     if meta.final and not skip_build_id:
         d['PKG_BUILD_STRING'] = str(meta.build_id())
         d['PKG_HASH'] = meta.hash_dependencies()

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1173,12 +1173,15 @@ class MetaData(object):
 
     def build_number(self):
         number = self.get_value('build/number')
+
         # build number can come back as None if no setting (or jinja intermediate)
+        if not number:
+            return 0
+
         try:
-            build_int = int(number)
+            return int(number)
         except (ValueError, TypeError):
-            build_int = ""
-        return build_int
+            raise ValueError("Build number was invalid value '{}'. Must be an integer.".format(number))
 
     def get_depends_top_and_out(self, typ):
         meta_requirements = ensure_list(self.get_value('requirements/' + typ, []))[:]

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -591,7 +591,7 @@ def build_string_from_metadata(metadata):
             res.append('_')
         if features:
             res.extend(('_'.join(features), '_'))
-        res.append('{0}'.format(metadata.build_number() if metadata.build_number() else 0))
+        res.append(str(metadata.build_number()))
         build_str = "".join(res)
     return build_str
 
@@ -1373,7 +1373,7 @@ class MetaData(object):
             name=self.name(),
             version=self.version(),
             build=self.build_id(),
-            build_number=self.build_number() if self.build_number() else 0,
+            build_number=self.build_number(),
             platform=self.config.host_platform if (self.config.host_platform != 'noarch' and
                                                    arch != 'noarch') else None,
             arch=ARCH_MAP.get(arch, arch),

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1898,7 +1898,7 @@ def match_peer_job(target_matchspec, other_m, this_m=None):
                                               match_dict['build'])),
                           version=match_dict['version'],
                           build_string=match_dict['build'],
-                          build_number=int(other_m.build_number() or 0),
+                          build_number=other_m.build_number(),
                           channel=None)
     matchspec_matches = target_matchspec.match(match_dict)
 


### PR DESCRIPTION
In order to decrease duplicate code and to make the build_number method "smarter" we explicitly check for falsy build numbers and otherwise raise a ValueError for otherwise bad values (e.g. "abba").

Resolves #4146

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
