### PR TITLE
LIEF: Allow parsing static libs to fail

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -833,7 +833,11 @@ def get_exports(filename, arch='native', enable_static=False):
                 # Sorry, LIEF does not handle COFF (only PECOFF) and object files are COFF.
                 exports2 = exports
             else:
-                exports2, flags2, exports2_all, flags2_all = get_static_lib_exports(filename)
+                try:
+                    exports2, flags2, exports2_all, flags2_all = get_static_lib_exports(filename)
+                except:
+                    print("WARNING :: Failed to get_static_lib_exports({})".format(filename))
+                    exports2 = exports2
             result = exports2
             if debug_static_archives:
                 if exports and set(exports) != set(exports2):


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
