### PR TITLE
Fix "write() argument must be str, not bytes" error

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -190,7 +190,7 @@ def git_mirror_checkout_recursive(git, mirror_dir, checkout_dir, git_url, git_ca
         stdout = None
         stderr = None
     else:
-        FNULL = open(os.devnull, 'w')
+        FNULL = open(os.devnull, 'wb')
         stdout = FNULL
         stderr = FNULL
 
@@ -348,7 +348,7 @@ def git_info(src_dir, build_prefix, git=None, verbose=True, fo=None):
     if verbose:
         stderr = None
     else:
-        FNULL = open(os.devnull, 'w')
+        FNULL = open(os.devnull, 'wb')
         stderr = FNULL
 
     # Ensure to explicitly set GIT_DIR as some Linux machines will not
@@ -387,7 +387,7 @@ def hg_source(source_dict, src_dir, hg_cache, verbose):
         stdout = None
         stderr = None
     else:
-        FNULL = open(os.devnull, 'w')
+        FNULL = open(os.devnull, 'wb')
         stdout = FNULL
         stderr = FNULL
 
@@ -424,7 +424,7 @@ def svn_source(source_dict, src_dir, svn_cache, verbose=True, timeout=900, locki
         stdout = None
         stderr = None
     else:
-        FNULL = open(os.devnull, 'w')
+        FNULL = open(os.devnull, 'wb')
         stdout = FNULL
         stderr = FNULL
 

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -784,7 +784,7 @@ def apply_one_patch(src_dir, recipe_dir, rel_path, config, git=None):
         stdout = None
         stderr = None
     else:
-        FNULL = open(os.devnull, 'w')
+        FNULL = open(os.devnull, 'wb')
         stdout = FNULL
         stderr = FNULL
 

--- a/news/gh-4118-bytes-like-no-str.rst
+++ b/news/gh-4118-bytes-like-no-str.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Fix printing ``bytes-like object is required, not 'str'`` when applying patches
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
When rendering I see a stream of errors this seems to fix the problem:
```
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
write() argument must be str, not bytes
```

I think this fixes https://github.com/conda/conda-build/issues/4118.