### PR TITLE
Fix skeleton URLs for CentOS 6 (EOL) and various CI fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -296,7 +296,8 @@ jobs:
       set PATH
       call %UserProfile%\Miniconda3\condabin\activate.bat base||exit 1
       set PATH
-      call conda install python="%PYTHON_VERSION%" -y||exit 1
+      :: No Python 2.7 builds after conda=4.8.4 available.
+      if "%PYTHON_VERSION%" == "2.7" (call conda install python="%PYTHON_VERSION%" "conda<=4.8.4" -y||exit 1) else (call conda install python="%PYTHON_VERSION%" -y||exit 1)
       if "%CONDA_VERSION%" == "canary" (call conda update -c conda-canary conda||exit 1) else (call conda update -q conda||exit 1)
       call conda config --set always_yes yes
       call conda config --set auto_update_conda no

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       fi
       mkdir -p /usr/share/miniconda/locks
       mkdir -p /usr/share/miniconda/bin
-      chmod -w /usr/share/miniconda/locks
+      chmod a-w /usr/share/miniconda/locks
       if [ "$CONDA_VERSION" = "release" ]; then
         conda update -y conda
       else

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ jobs:
   timeoutInMinutes: 480
   steps:
   - script: |
+      set -e -u
       sudo apt update
       sudo apt install attr -y
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
@@ -62,12 +63,14 @@ jobs:
     displayName: Preparing test environment
 
   - script: |
+      set -e -u
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda install conda-verify -y
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]}"
     displayName: 'Serial Tests'
 
   - script: |
+      set -e -u
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda remove conda-verify -y
       echo "safety_checks: disabled" >> ~/.condarc
@@ -123,6 +126,7 @@ jobs:
       echo "Fast Finish"
   - script: |
       echo "Removing homebrew from Azure to avoid conflicts."
+      set -e -u
       curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
       chmod +x ~/uninstall_homebrew
       ~/uninstall_homebrew -fq
@@ -131,7 +135,7 @@ jobs:
 
   - script: |
       echo "Installing Miniconda"
-      set -x -e
+      set -x -e -u
       curl -o $(Build.StagingDirectory)/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
       chmod +x $(Build.StagingDirectory)/miniconda.sh
       $(Build.StagingDirectory)/miniconda.sh -b -p $(Build.StagingDirectory)/miniconda
@@ -141,7 +145,7 @@ jobs:
 
   - script: |
       echo "Setup CF macOS bits and select Xcode"
-      set -x -e
+      set -x -e -u
       source ci/azurepipelines/activate_conda "$(Build.StagingDirectory)/miniconda/bin/python"
       echo "PWD is $PWD"
       find $PWD
@@ -149,6 +153,7 @@ jobs:
     displayName: 'Setup CF macOS bits and select Xcode'
 
   - script: |
+      set -e -u
       source ci/azurepipelines/activate_conda "$(Build.StagingDirectory)/miniconda/bin/python"
       conda info
       conda install python=$PYTHON_VERSION -y
@@ -177,12 +182,14 @@ jobs:
     displayName: Preparing test environment
 
   - script: |
+      set -e -u
       source ci/azurepipelines/activate_conda "$(Build.StagingDirectory)/miniconda/bin/python"
       conda install conda-verify -y
       py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]}"
     displayName: 'Serial Tests'
 
   - script: |
+      set -e -u
       source ci/azurepipelines/activate_conda "$(Build.StagingDirectory)/miniconda/bin/python"
       conda remove conda-verify -y
       echo "safety_checks: disabled" >> ~/.condarc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,8 +87,7 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
-      pytest_nproc="$(( 2 * $( nproc ) ))"
-      py.test --color=yes -v -n "${pytest_nproc}" --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Parallel Tests'
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
@@ -213,8 +212,7 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      pytest_nproc="$(( 2 * $( sysctl -n hw.ncpu ) ))"
-      py.test --color=yes -v -n "${pytest_nproc}" --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Parallel Tests'
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
@@ -353,9 +351,7 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      set "pytest_nproc=%NUMBER_OF_PROCESSORS%"
-      set /A pytest_nproc*=2
-      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n "%pytest_nproc%" -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTIONS%
+      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTIONS%
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,8 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
+      pytest_nproc="$(( 2 * $( nproc ) ))"
+      py.test --color=yes -v -n "${pytest_nproc}" --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Parallel Tests'
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
@@ -212,7 +213,8 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
+      pytest_nproc="$(( 2 * $( sysctl -n hw.ncpu ) ))"
+      py.test --color=yes -v -n "${pytest_nproc}" --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Parallel Tests'
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
@@ -351,7 +353,9 @@ jobs:
       set PERL=
       set LUA=
       set R=
-      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n auto -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTIONS%
+      set "pytest_nproc=%NUMBER_OF_PROCESSORS%"
+      set /A pytest_nproc*=2
+      py.test --color=yes -v --cov conda_build --cov-report xml --cov-append tests --basetemp %UserProfile%\cbtmp -n "%pytest_nproc%" -m "not serial" --test-run-title="Win-ParallelTests-%CONDA_VERSION%-Python%PYTHON_VERSION%" %PYTEST_REPLAY_OPTIONS%
     env:
       VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
       LIB:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,12 @@ jobs:
       ps -ef | grep $$
       conda list
       grep '^#' "${CONDA_PREFIX}/conda-meta/history"
-      conda install python=$PYTHON_VERSION -y
+      if [ "$PYTHON_VERSION" = "2.7" ]; then
+        # No Python 2.7 builds after conda=4.8.4 available.
+        conda install python=$PYTHON_VERSION conda\<=4.8.4 -y
+      else
+        conda install python=$PYTHON_VERSION -y
+      fi
       mkdir -p /usr/share/miniconda/locks
       mkdir -p /usr/share/miniconda/bin
       chmod -w /usr/share/miniconda/locks
@@ -160,7 +165,12 @@ jobs:
       conda info
       conda list
       grep '^#' "${CONDA_PREFIX}/conda-meta/history"
-      conda install python=$PYTHON_VERSION -y
+      if [ "$PYTHON_VERSION" = "2.7" ]; then
+        # No Python 2.7 builds after conda=4.8.4 available.
+        conda install python=$PYTHON_VERSION conda\<=4.8.4 -y
+      else
+        conda install python=$PYTHON_VERSION -y
+      fi
       mkdir -p $(Build.StagingDirectory)/miniconda/locks
       mkdir -p $(Build.StagingDirectory)/miniconda/bin
       chmod -w $(Build.StagingDirectory)/miniconda/locks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
       set -e -u
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda install conda-verify -y
-      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]}"
+      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="Linux-SerialTests-$CONDA_VERSION-Py$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Serial Tests'
 
   - script: |
@@ -87,7 +87,7 @@ jobs:
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]}"
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="Linux-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Parallel Tests'
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay
@@ -199,7 +199,7 @@ jobs:
       set -e -u
       source ci/azurepipelines/activate_conda "$(Build.StagingDirectory)/miniconda/bin/python"
       conda install conda-verify -y
-      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]}"
+      py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests --test-run-title="macOS-SerialTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Serial Tests'
 
   - script: |
@@ -212,7 +212,7 @@ jobs:
       conda create -n blarg1 -yq python=2.7
       conda create -n blarg3 -yq python=3.7
       conda create -n blarg4 -yq python nomkl numpy pandas svn
-      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]}"
+      py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests --test-run-title="macOS-ParallelTests-$CONDA_VERSION-Python$PYTHON_VERSION" "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
     displayName: 'Parallel Tests'
 
   - publish: $(Build.ArtifactStagingDirectory)/pytest-replay

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
       set -e -u
       curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
       chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
+      ~/uninstall_homebrew -f -q
       rm ~/uninstall_homebrew
     displayName: Remove homebrew
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -294,24 +294,24 @@ jobs:
   - script: |
       echo on
       set PATH
-      call %UserProfile%\Miniconda3\condabin\activate.bat base
+      call %UserProfile%\Miniconda3\condabin\activate.bat base||exit 1
       set PATH
-      call conda install python="%PYTHON_VERSION%" -y
-      if "%CONDA_VERSION%" == "canary" (call conda update -c conda-canary conda) else (call conda update -q conda)
+      call conda install python="%PYTHON_VERSION%" -y||exit 1
+      if "%CONDA_VERSION%" == "canary" (call conda update -c conda-canary conda||exit 1) else (call conda update -q conda||exit 1)
       call conda config --set always_yes yes
       call conda config --set auto_update_conda no
       call conda info
       python -c "import sys; print(sys.version)"
       python -c "import sys; print(sys.executable)"
       python -c "import sys; print(sys.prefix)"
-      call conda update -q --all
-      call conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines
-      if "%PYTHON_VERSION%" == "2.7" call conda install -c defaults -c conda-forge pytest-replay pytest-rerunfailures -y
-      if "%PYTHON_VERSION%" NEQ "2.7" call conda install pytest-replay pytest-rerunfailures -y
+      call conda update -q --all||exit 1
+      call conda install -q pip python-libarchive-c pytest git pytest-cov jinja2 m2-patch flake8 mock requests contextlib2 chardet glob2 perl pyflakes pycrypto posix m2-git anaconda-client numpy beautifulsoup4 pytest-xdist pytest-mock filelock pkginfo psutil pytz tqdm conda-package-handling pytest-azurepipelines||exit 1
+      if "%PYTHON_VERSION%" == "2.7" call conda install -c defaults -c conda-forge pytest-replay pytest-rerunfailures -y||exit 1
+      if "%PYTHON_VERSION%" NEQ "2.7" call conda install pytest-replay pytest-rerunfailures -y||exit 1
       echo safety_checks: disabled >> %UserProfile%\.condarc
       echo local_repodata_ttl: 1800 >> %UserProfile%\.condarc
-      if "%PYTHON_VERSION%" == "2.7" call conda install -q scandir pathlib2
-      if "%PYTHON_VERSION%" NEQ "2.7" call conda install -q py-lief
+      if "%PYTHON_VERSION%" == "2.7" call conda install -q scandir pathlib2||exit 1
+      if "%PYTHON_VERSION%" NEQ "2.7" call conda install -q py-lief||exit 1
       python --version
       python -c "import struct; print(struct.calcsize('P') * 8)"
       pip install --no-deps .
@@ -321,9 +321,9 @@ jobs:
       mkdir %UserProfile%\cbtmp
       for /d %%F in (%UserProfile%\cbtmp_serial\*) do rd /s /q "%%F"
       for /d %%F in (%UserProfile%\cbtmp\*) do rd /s /q "%%F"
-      call conda create -n blarg -yq --download-only python=2.7
-      call conda create -n blarg -yq --download-only python=3.7
-      call conda create -n blarg -yq --download-only python cmake
+      call conda create -n blarg -yq --download-only python=2.7||exit 1
+      call conda create -n blarg -yq --download-only python=3.7||exit 1
+      call conda create -n blarg -yq --download-only python cmake||exit 1
       mkdir $(Build.ArtifactStagingDirectory)\\pytest-replay
       set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay"
       if "%PYTHON_VERSION%" NEQ "2.7" set "PYTEST_REPLAY_OPTIONS=--replay-record-dir=$(Build.ArtifactStagingDirectory)\\pytest-replay --replay-base-name=Win-%CONDA_VERSION%-Py%PYTHON_VERSION%"
@@ -333,9 +333,9 @@ jobs:
   - script: |
       echo on
       set PATH
-      call %UserProfile%\Miniconda3\condabin\activate.bat base
+      call %UserProfile%\Miniconda3\condabin\activate.bat base||exit 1
       set PATH
-      call conda install -y conda-verify
+      call conda install -y conda-verify||exit 1
       set PERL=
       set LUA=
       set R=
@@ -345,9 +345,9 @@ jobs:
   - script: |
       echo on
       set PATH
-      call %UserProfile%\Miniconda3\condabin\activate.bat base
+      call %UserProfile%\Miniconda3\condabin\activate.bat base||exit 1
       set PATH
-      call conda remove -y conda-verify
+      call conda remove -y conda-verify||exit 1
       set PERL=
       set LUA=
       set R=

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,8 @@ jobs:
       source ci/azurepipelines/activate_conda "/usr/share/miniconda/bin/python"
       conda info
       ps -ef | grep $$
+      conda list
+      grep '^#' "${CONDA_PREFIX}/conda-meta/history"
       conda install python=$PYTHON_VERSION -y
       mkdir -p /usr/share/miniconda/locks
       mkdir -p /usr/share/miniconda/bin
@@ -156,6 +158,8 @@ jobs:
       set -e -u
       source ci/azurepipelines/activate_conda "$(Build.StagingDirectory)/miniconda/bin/python"
       conda info
+      conda list
+      grep '^#' "${CONDA_PREFIX}/conda-meta/history"
       conda install python=$PYTHON_VERSION -y
       mkdir -p $(Build.StagingDirectory)/miniconda/locks
       mkdir -p $(Build.StagingDirectory)/miniconda/bin

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -108,7 +108,7 @@ def retrieve_python_version(file_path):
                 index = json.load(index_file)
 
         build_version_number = re.search('(.*)?(py)(\d\d)(.*)?', index['build']).group(3)
-        build_version = re.sub('\A.*py\d\d.*\Z', 'python', index['build'])
+        build_version = re.sub(r'\A.*py\d\d.*\Z', 'python', index['build'])
 
         return '{}{}.{}' .format(build_version,
             build_version_number[0], build_version_number[1])

--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -27,7 +27,7 @@ NONE
 gpl2_regex = re.compile('GPL[^3]*2')  # match GPL2
 gpl3_regex = re.compile('GPL[^2]*3')  # match GPL3
 gpl23_regex = re.compile('GPL[^2]*>= *2')  # match GPL >= 2
-cc_regex = re.compile('CC\w+')  # match CC
+cc_regex = re.compile(r'CC\w+')  # match CC
 punk_regex = re.compile('[%s]' % re.escape(string.punctuation))  # removes punks
 
 
@@ -49,7 +49,7 @@ def normalize(s):
 def remove_special_characters(s):
     """Remove punctuation, spaces, tabs, and line feeds"""
     s = punk_regex.sub(' ', s)
-    s = re.sub('\s+', '', s)
+    s = re.sub(r'\s+', '', s)
     return s
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1278,7 +1278,7 @@ class MetaData(object):
                 build_string_excludes.append('numpy')
         # always exclude older stuff that's always in the build string (py, np, pl, r, lua)
         if build_string_excludes:
-            exclude_pattern = re.compile('|'.join('{}[\s$]?.*'.format(exc)
+            exclude_pattern = re.compile('|'.join(r'{}[\s$]?.*'.format(exc)
                                                   for exc in build_string_excludes))
             dependencies = [req for req in dependencies if not exclude_pattern.match(req) or
                                 ' ' in self.config.variant[req]]
@@ -1315,10 +1315,10 @@ class MetaData(object):
         if not manual_build_string and not raw_recipe_text:
             raise RuntimeError("Couldn't extract raw recipe text for {} output".format(self.name()))
         raw_recipe_text = self.extract_package_and_build_text()
-        raw_manual_build_string = re.search("\s*string:", raw_recipe_text)
+        raw_manual_build_string = re.search(r"\s*string:", raw_recipe_text)
         # user setting their own build string.  Don't modify it.
         if manual_build_string and not (raw_manual_build_string and
-                                        re.findall('h\{\{\s*PKG_HASH\s*\}\}', raw_manual_build_string.string)):
+                                        re.findall(r'h\{\{\s*PKG_HASH\s*\}\}', raw_manual_build_string.string)):
             check_bad_chrs(manual_build_string, 'build/string')
             out = manual_build_string
         else:
@@ -1690,7 +1690,7 @@ class MetaData(object):
             #    (?:-\s+name:\s+%s.*?)requirements:.*?
             # terminate match of other sections
             #    (?=^\s*-\sname|^\s*test:|^\s*extra:|^\s*about:|^outputs:|\Z)
-            f = '(^requirements:.*?)(?=^test:|^extra:|^about:|^outputs:|\Z)'
+            f = r'(^requirements:.*?)(?=^test:|^extra:|^about:|^outputs:|\Z)'
         return self.get_recipe_text(f, force_top_level=force_top_level)
 
     def extract_outputs_text(self, apply_selectors=True):
@@ -1766,7 +1766,7 @@ class MetaData(object):
         if not in_reqs and self.meta_path:
             data = self.extract_requirements_text(force_top_level=True)
             if data:
-                subpackage_pin = re.search("{{\s*pin_subpackage\(.*\)\s*}}", data)
+                subpackage_pin = re.search(r"{{\s*pin_subpackage\(.*\)\s*}}", data)
         return in_reqs or bool(subpackage_pin)
 
     @property

--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -745,7 +745,7 @@ def get_static_lib_exports_nm(filename):
 
 
 def get_static_lib_exports_dumpbin(filename):
-    '''
+    r'''
     > dumpbin /SYMBOLS /NOLOGO C:\msys64\mingw64\lib\libasprintf.a
     > C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.20.27508\bin\Hostx64\x64\dumpbin.exe
     > 020 00000000 UNDEF  notype ()    External     | malloc

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -1119,7 +1119,7 @@ def check_overlinking_impl(pkg_name, pkg_version, build_str, build_number, subdi
                     with open(os.path.join(sysroot, f), 'rb') as tbd_fh:
                         lines = [line for line in tbd_fh.read().decode('utf-8').splitlines() if line.startswith('install-name:')]
                     if lines:
-                        install_names = [re.match('^install-name:\s+(.*)$', line) for line in lines]
+                        install_names = [re.match(r'^install-name:\s+(.*)$', line) for line in lines]
                         install_names = [insname.groups(1)[0] for insname in install_names]
                         replaced = install_names[0][1:]
                         if replaced.endswith("'"):

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -177,7 +177,7 @@ else
             install_name_tool -change /usr/lib/libcurl.4.dylib "${{PREFIX}}"/lib/libcurl.4.dylib "${{SHARED_LIB}}" || true
             install_name_tool -change /usr/lib/libc++.1.dylib "${{PREFIX}}"/lib/libc++.1.dylib "${{SHARED_LIB}}" || true
             install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "${{PREFIX}}"/lib/libc++.1.dylib "${{SHARED_LIB}}" || true
-          done <   <(find . \( -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R" \) -print0)
+          done <   <(find . \\( -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R" \\) -print0)
         popd
       done
     popd
@@ -206,8 +206,8 @@ if "%target_platform%" == "win-64" goto skip_source_build
 IF %ERRORLEVEL% NEQ 0 exit /B 1
 exit 0
 :skip_source_build
-mkdir %PREFIX%\lib\R\library
-robocopy /E . "%PREFIX%\lib\R\library\{cran_packagename}"
+mkdir %PREFIX%\\lib\\R\\library
+robocopy /E . "%PREFIX%\\lib\\R\\library\\{cran_packagename}"
 if %ERRORLEVEL% NEQ 1 exit /B 1
 exit 0
 """
@@ -1528,7 +1528,7 @@ def get_license_info(license_text, allowed_license_families):
     license_files = []
 
     # split license_text by "|" and "+" into parts for further matching
-    license_text_parts = [l_opt.strip() for l_opt in re.split('\||\+', license_text)]
+    license_text_parts = [l_opt.strip() for l_opt in re.split(r'\||\+', license_text)]
     for l_opt in license_text_parts:
         # the file case
         if l_opt.startswith("file "):

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -132,7 +132,7 @@ export DISABLE_AUTOBREW=1
 # R refuses to build packages that mark themselves as Priority: Recommended
 mv DESCRIPTION DESCRIPTION.old
 grep -va '^Priority: ' DESCRIPTION.old > DESCRIPTION
-$R CMD INSTALL --build .
+${{R}} CMD INSTALL --build .
 
 # Add more build steps here, if they are necessary.
 

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -209,7 +209,7 @@ def _formating_value(attribute_name, attribute_value):
     :param string attribute_value: Attribute value
     :return string: Value quoted if need
     """
-    pattern_search = re.compile('[@_!#$%^&*()<>?/\|}{~:]')
+    pattern_search = re.compile(r'[@_!#$%^&*()<>?/\|}{~:]')
     if isinstance(attribute_value, string_types) \
             and pattern_search.search(attribute_value) \
             or attribute_name in ["summary", "description", "version", "script"]:

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -287,7 +287,7 @@ def dictify_pickled(xml_file, src_cache, dict_massager=None, cdt=None):
 def get_repo_dict(repomd_url, data_type, dict_massager, cdt, src_cache):
     xmlstring = urlopen(repomd_url).read()
     # Remove the default namespace definition (xmlns="http://some/namespace")
-    xmlstring = re.sub(b'\sxmlns="[^"]+"', b'', xmlstring, count=1)
+    xmlstring = re.sub(br'\sxmlns="[^"]+"', b'', xmlstring, count=1)
     repomd = ET.fromstring(xmlstring)
     for child in repomd.findall("*[@type='{}']".format(data_type)):
         open_csum = child.findall("open-checksum")[0].text

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -94,9 +94,9 @@ CDTs = dict({'centos5': {'dirname': 'centos5',
                          'macros': {}},
              'centos6': {'dirname': 'centos6',
                          'short_name': 'cos6',
-                         'base_url': 'http://mirror.centos.org/centos/6.10/os/{base_architecture}/CentOS/',  # noqa
+                         'base_url': 'http://vault.centos.org/centos/6.10/os/{base_architecture}/CentOS/',  # noqa
                          'sbase_url': 'http://vault.centos.org/6.10/os/Source/SPackages/',
-                         'repomd_url': 'http://mirror.centos.org/centos/6.10/os/{base_architecture}/repodata/repomd.xml',  # noqa
+                         'repomd_url': 'http://vault.centos.org/centos/6.10/os/{base_architecture}/repodata/repomd.xml',  # noqa
                          'host_machine': '{architecture}-conda_cos6-linux-gnu',
                          'host_subdir': 'linux-{bits}',
                          'fname_architecture': '{architecture}',
@@ -110,9 +110,9 @@ CDTs = dict({'centos5': {'dirname': 'centos5',
                                     'gdk_pixbuf_base_version': '2.24.1'}},
              'centos7': {'dirname': 'centos7',
                          'short_name': 'cos7',
-                         'base_url': 'http://mirror.centos.org/altarch/7/os/{base_architecture}/CentOS/',  # noqa
+                         'base_url': 'http://vault.centos.org/altarch/7/os/{base_architecture}/CentOS/',  # noqa
                          'sbase_url': 'http://vault.centos.org/7.7.1908/os/Source/SPackages/',
-                         'repomd_url': 'http://mirror.centos.org/altarch/7/os/{base_architecture}/repodata/repomd.xml',  # noqa
+                         'repomd_url': 'http://vault.centos.org/altarch/7/os/{base_architecture}/repodata/repomd.xml',  # noqa
                          'host_machine': '{gnu_architecture}-conda_cos7-linux-gnu',
                          'host_subdir': 'linux-ppc64le',
                          'fname_architecture': '{architecture}',

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -188,7 +188,7 @@ def directory_size(path):
         if on_win:
             # Windows can give long output, we need only 2nd to last line
             out = out.strip().rsplit('\r\n', 2)[-2]
-            pattern = "\s([\d\W]+).+"  # Language and punctuation neutral
+            pattern = r"\s([\d\W]+).+"  # Language and punctuation neutral
             out = re.search(pattern, out.strip()).group(1).strip()
             out = out.replace(',', '').replace('.', '').replace(' ', '')
         else:
@@ -1053,7 +1053,7 @@ def sys_path_prepended(prefix):
         sys.path.insert(1, os.path.join(prefix, 'lib', 'site-packages'))
     else:
         lib_dir = os.path.join(prefix, 'lib')
-        python_dir = glob(os.path.join(lib_dir, 'python[0-9\.]*'))
+        python_dir = glob(os.path.join(lib_dir, r'python[0-9\.]*'))
         if python_dir:
             python_dir = python_dir[0]
             sys.path.insert(1, os.path.join(python_dir, 'site-packages'))
@@ -1075,7 +1075,7 @@ def path_prepended(prefix):
 
 bin_dirname = 'Scripts' if sys.platform == 'win32' else 'bin'
 
-entry_pat = re.compile('\s*([\w\-\.]+)\s*=\s*([\w.]+):([\w.]+)\s*$')
+entry_pat = re.compile(r'\s*([\w\-\.]+)\s*=\s*([\w.]+):([\w.]+)\s*$')
 
 
 def iter_entry_points(items):
@@ -1520,12 +1520,12 @@ def apply_pin_expressions(version, min_pin='x.x.x.x.x.x.x', max_pin='x'):
     return ','.join([v for v in versions if v])
 
 
-def filter_files(files_list, prefix, filter_patterns=('(.*[\\\\/])?\.git[\\\\/].*',
-                                                      '(.*[\\\\/])?\.git$',
-                                                      '(.*)?\.DS_Store.*',
-                                                      '.*\.la$',
-                                                      'conda-meta.*',
-                                                      '.*\.conda_trash(?:_\d+)*$')):
+def filter_files(files_list, prefix, filter_patterns=(r'(.*[\\/])?\.git[\\/].*',
+                                                      r'(.*[\\/])?\.git$',
+                                                      r'(.*)?\.DS_Store.*',
+                                                      r'.*\.la$',
+                                                      r'conda-meta.*',
+                                                      r'.*\.conda_trash(?:_\d+)*$')):
     """Remove things like the .git directory from the list of files to be copied"""
     for pattern in filter_patterns:
         r = re.compile(pattern)
@@ -1872,7 +1872,7 @@ def insert_variant_versions(requirements_dict, variant, env):
                         val = val[0]
                     reqs.insert(i, ensure_valid_spec(' '.join((x.group(1), val))))
 
-    xx_re = re.compile("([0-9a-zA-Z\.\-\_]+)\s+x\.x")
+    xx_re = re.compile(r"([0-9a-zA-Z\.\-\_]+)\s+x\.x")
 
     matches = [xx_re.match(pkg) for pkg in reqs]
     if any(matches):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -94,7 +94,7 @@ def msvc_env_cmd(bits, config, override=None):
     if override:
         log.warn("msvc_compiler key in meta.yaml is deprecated. Use the new"
         "variant-powered compiler configuration instead. Note that msvc_compiler"
-        "is incompatible with the new \{\{compiler('c')\}\} jinja scheme.")
+        "is incompatible with the new {{{{compiler('c')}}}} jinja scheme.")
     # this has been an int at times.  Make sure it's a string for consistency.
     bits = str(bits)
     arch_selector = 'x86' if bits == '32' else 'amd64'

--- a/news/gh-4154-ci-fixes.rst
+++ b/news/gh-4154-ci-fixes.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Fix skeleton URLs for CentOS 6 (EOL)
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/tests/test_api_consistency.py
+++ b/tests/test_api_consistency.py
@@ -1,10 +1,15 @@
 # This file makes sure that our API has not changed.  Doing so can not be accidental.  Whenever it
 #    happens, we should bump our major build number, because we may have broken someone.
 
-from inspect import getargspec
 import sys
 
 from conda_build import api
+from conda_build.conda_interface import PY3
+
+if PY3:
+    from inspect import getfullargspec as getargspec
+else:
+    from inspect import getargspec
 
 
 def test_api_config():

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -447,7 +447,7 @@ def test_pypi_section_order_preserved(testing_workdir):
 
 # CRAN packages to test license_file entry.
 # (package, license_id, license_family, license_files)
-cran_packages = [('r-usethis', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
+cran_packages = [('r-rmarkdown', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
                  ('r-cortools', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),  # cran: 'Artistic License 2.0'
                  ('r-udpipe', 'MPL-2.0', 'OTHER', ''),  # cran: 'MPL-2.0'
                  ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),  # cran: 'MIT + file LICENSE'
@@ -493,7 +493,7 @@ def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.skipif(not external.find_executable("shellcheck"), reason="requires shellcheck >=0.7.0")
 @pytest.mark.parametrize(
-    "package, repo", [("r-usethis", "cran"), ("Perl::Lint", "cpan"), ("screen", "rpm")]
+    "package, repo", [("r-rmarkdown", "cran"), ("Perl::Lint", "cpan"), ("screen", "rpm")]
 )
 def test_build_sh_shellcheck_clean(package, repo, testing_workdir, testing_config):
     api.skeletonize(packages=package, repo=repo, output_dir=testing_workdir, config=testing_config)


### PR DESCRIPTION
This updates the RPM skeleton URLs for CentOS 6 to use `http://vault.centos.org` (the previous ones aren't valid anymore due to CentOS 6(.10)'s EOL).

Also has some small test/CI fixes.