### PR TITLE
Fix broken 3.21.1

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1345,7 +1345,7 @@ def build_info_files_json_v1(m, prefix, files, files_with_prefix):
     files_json = []
     files_inodes = get_inodes(files, prefix)
     for fi in sorted(files):
-        _prefix_placeholder, file_mode = has_prefix(fi, files_with_prefix)
+        prefix_placeholder, file_mode = has_prefix(fi, files_with_prefix)
         path = os.path.join(prefix, fi)
         short_path = get_short_path(m, fi)
         if short_path:


### PR DESCRIPTION
[Release 3.21.1](https://github.com/conda/conda-build/releases/tag/3.21.1) breaks my builds (`prefix_placeholder` not replaced).

Fixes typo in  https://github.com/conda/conda-build/pull/4174.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
