### PR TITLE
Metadata Schema

### DIFF
--- a/tests/test-recipes/metadata/always_include_files_glob/meta.yaml
+++ b/tests/test-recipes/metadata/always_include_files_glob/meta.yaml
@@ -41,8 +41,6 @@ outputs:
         - jpeg
     script: echo_file.sh            # [not win]
     script: echo_file.bat           # [win]
-    missing_dso_whitelist:
-      - '*'
     test:
       commands:
         - test -e $PREFIX/test.txt                              # [unix]

--- a/tests/test-recipes/metadata/r_test_import/meta.yaml
+++ b/tests/test-recipes/metadata/r_test_import/meta.yaml
@@ -6,6 +6,6 @@ requirements:
   run:
     - r-base
 
-tests:
+test:
   imports:
-    - r-boot
+    - base


### PR DESCRIPTION
Instead of having a highly decentralized process of validating the contents and format of the metadata this introduces a schema that is used to validate/standardize the metadata prior to storage/usage.

Using this schema obsoletes the need to check whether a section is an `OPTIONALLY_ITERABLE_FIELDS` and other optional styles of defining the metadata (e.g. "build/run_exports" which can be a simple `list` which implicitly means those values are "weak", or a `dict` explicitly specifying "weak", "strong", etc. values).

This further helps to centralize the checking of the metadata to where it happens all at once upon parsing the metafile and not randomly throughout the build process and at least theoretically should help users to more easily catch metadata issues.

I'm leaving the cleanup process of removing obsolete code to future PRs.