### PR TITLE
Implement negative matching for `files` in outputs

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1617,12 +1617,20 @@ def bundle_conda(output, metadata, env, stats, **kw):
     elif files:
         # Files is specified by the output
         # we exclude the list of files that we want to keep, so post-process picks them up as "new"
-        include = [f for f in files if not f.startswith('!')]
-        exclude = [f[1:] for f in files if f.startswith('!')]
-        keep_files = {os.path.normpath(pth)
-                         for pth in utils.expand_globs(include, metadata.config.host_prefix)}
-        exclude_files = {os.path.normpath(pth)
-                            for pth in utils.expand_globs(exclude, metadata.config.host_prefix)}
+        if isinstance(files, dict):
+            include = files.get("include", [])
+            exclude = files.get("exclude", [])
+        else:
+            include = list(files)
+            exclude = []
+        keep_files = {
+            os.path.normpath(pth)
+            for pth in utils.expand_globs(include, metadata.config.host_prefix)
+        }
+        exclude_files = {
+            os.path.normpath(pth)
+            for pth in utils.expand_globs(exclude, metadata.config.host_prefix)
+        }
         keep_files -= exclude_files
         pfx_files = set(utils.prefix_files(metadata.config.host_prefix))
         initial_files = {item for item in (pfx_files - keep_files)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1617,8 +1617,13 @@ def bundle_conda(output, metadata, env, stats, **kw):
     elif files:
         # Files is specified by the output
         # we exclude the list of files that we want to keep, so post-process picks them up as "new"
+        include = [f for f in files if not f.startswith('!')]
+        exclude = [f[1:] for f in files if f.startswith('!')]
         keep_files = {os.path.normpath(pth)
-                         for pth in utils.expand_globs(files, metadata.config.host_prefix)}
+                         for pth in utils.expand_globs(include, metadata.config.host_prefix)}
+        exclude_files = {os.path.normpath(pth)
+                            for pth in utils.expand_globs(exclude, metadata.config.host_prefix)}
+        keep_files -= exclude_files
         pfx_files = set(utils.prefix_files(metadata.config.host_prefix))
         initial_files = {item for item in (pfx_files - keep_files)
                             if not any(keep_file.startswith(item + os.path.sep)

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -1247,10 +1247,9 @@ You can specify files to be included in the package in 1 of
 Explicit file lists are relative paths from the root of the
 build prefix. Explicit file lists support glob expressions.
 Directory names are also supported, and they recursively include
-contents. Files can be excluded by preceding the entry with a
-single exclamation mark (``!``).
+contents.
 
-.. code-block:: none
+.. code-block:: yaml
 
    outputs:
      - name: subpackage-name
@@ -1259,12 +1258,22 @@ single exclamation mark (``!``).
          - a-folder
          - *.some-extension
          - somefolder/*.some-extension
-         - "!*.exclude-extension"
 
-.. note::
-   Negative matches must be enclosed in quotations to prevent
-   the YAML parser from interpreting the exclamation mark
-   as a tag.
+Files can be excluded by specifying `files` as a dictionary separating
+files to `include` from those to `exclude`:
+
+.. code-block:: yaml
+
+   outputs:
+     - name: subpackage-name
+       files:
+         include:
+           - a-file
+           - a-folder
+           - *.some-extension
+           - somefolder/*.some-extension
+         exclude:
+           - *.exclude-extension
 
 Scripts that create or move files into the build prefix can be
 any kind of script. Known script types need only specify the

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -1247,7 +1247,8 @@ You can specify files to be included in the package in 1 of
 Explicit file lists are relative paths from the root of the
 build prefix. Explicit file lists support glob expressions.
 Directory names are also supported, and they recursively include
-contents.
+contents. Files can be excluded by preceding the entry with a
+single exclamation mark (``!``).
 
 .. code-block:: none
 
@@ -1258,6 +1259,12 @@ contents.
          - a-folder
          - *.some-extension
          - somefolder/*.some-extension
+         - "!*.exclude-extension"
+
+.. note::
+   Negative matches must be enclosed in quotations to prevent
+   the YAML parser from interpreting the exclamation mark
+   as a tag.
 
 Scripts that create or move files into the build prefix can be
 any kind of script. Known script types need only specify the

--- a/news/files-exclude.rst
+++ b/news/files-exclude.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* implemented negative matching for `files` for `outputs`
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/tests/test-recipes/split-packages/copying_files/build.sh
+++ b/tests/test-recipes/split-packages/copying_files/build.sh
@@ -6,3 +6,4 @@ echo "weee" > $PREFIX/somedir/subpackage_file1
 # test glob patterns
 echo "weee" > $PREFIX/subpackage_file1.ext
 echo "weee" > $PREFIX/subpackage_file2.ext
+echo "weee" > $PREFIX/subpackage_file3.ext

--- a/tests/test-recipes/split-packages/copying_files/meta.yaml
+++ b/tests/test-recipes/split-packages/copying_files/meta.yaml
@@ -12,6 +12,7 @@ outputs:
       - subpackage_file1
       - somedir
       - "*.ext"
+      - "!*3.ext"
     test:
       script: subpackage_test.py
       script_interpreter: python

--- a/tests/test-recipes/split-packages/copying_files/meta.yaml
+++ b/tests/test-recipes/split-packages/copying_files/meta.yaml
@@ -9,10 +9,12 @@ requirements:
 outputs:
   - name: my_script_subpackage
     files:
-      - subpackage_file1
-      - somedir
-      - "*.ext"
-      - "!*3.ext"
+      include:
+        - subpackage_file1
+        - somedir
+        - "*.ext"
+      exclude:
+        - "*3.ext"
     test:
       script: subpackage_test.py
       script_interpreter: python

--- a/tests/test-recipes/split-packages/copying_files/subpackage_test.py
+++ b/tests/test-recipes/split-packages/copying_files/subpackage_test.py
@@ -31,3 +31,7 @@ if hasattr(contents, 'decode'):
     contents = contents.decode()
 assert "weee" in contents, 'incorrect file contents: %s' % contents
 print("glob OK")
+
+filename = os.path.join(os.environ['PREFIX'], 'subpackage_file3.ext')
+assert not os.path.isfile(filename)
+print("glob exclude OK")


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
This PR implements #4196 by adding supporting for a negative match expression for the `files` list in `outputs`.

Closes #4196.