### PR TITLE
Correct typo in Sphinx docs tutorials/build-pkgs.rst

### DIFF
--- a/docs/source/user-guide/tutorials/build-pkgs.rst
+++ b/docs/source/user-guide/tutorials/build-pkgs.rst
@@ -172,7 +172,7 @@ on your local computer.
 
       conda-build click
 
-   If you are already in the click folder, you can type ``conda build .``.
+   If you are already in the click folder, you can type ``conda-build .``.
 
 
 


### PR DESCRIPTION
Correct typo from `conda build .` to `conda-build .`

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
