### PR TITLE
Update setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Continuum Analytics, Inc.",
     author_email="conda@continuum.io",
     url="https://github.com/conda/conda-build",
-    license="BSD 3-clause",
+    license="BSD-3-clause",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Continuum Analytics, Inc.",
     author_email="conda@continuum.io",
     url="https://github.com/conda/conda-build",
-    license="BSD-3-clause",
+    license="BSD-3-Clause",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
As conda-build dropped support for Python 2.7, this PR is just to remove the classifiers from the ``setup.py``