### PR TITLE
Document build/script_env and support setting values containing "="

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -433,8 +433,7 @@ def meta_vars(meta, skip_build_id=False):
     d = {}
     for var_name in ensure_list(meta.get_value('build/script_env', [])):
         if '=' in var_name:
-            value = var_name.split('=')[-1]
-            var_name = var_name.split('=')[0]
+            var_name, value = var_name.split('=', 1)
         else:
             value = os.getenv(var_name)
         if value is None:

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -669,10 +669,19 @@ seen by the conda-build process itself, a UserWarning is
 emitted during the build process and the variable remains
 undefined.
 
+Additionally, values can be set by including ``=`` followed by the desired value:
+
+.. code-block:: yaml
+
+     build:
+       script_env:
+        - MY_VAR=some value
+
 .. note::
    Inheriting environment variables can make it difficult for
    others to reproduce binaries from source with your recipe. Use
-   this feature with caution or avoid it.
+   this feature with caution or explicitly set values using the ``=``
+   syntax.
 
 .. note::
    If you split your build and test phases with ``--no-test`` and ``--test``,

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -280,10 +280,19 @@ If an inherited variable is missing from your shell environment,
 it remains unassigned, but a warning is issued noting that it has
 no value assigned.
 
+Additionally, values can be set by including ``=`` followed by the desired value:
+
+.. code-block:: yaml
+
+     build:
+       script_env:
+        - MY_VAR=some value
+
 .. warning::
    Inheriting environment variables can make it difficult for
    others to reproduce binaries from source with your recipe. Use
-   this feature with caution or avoid it.
+   this feature with caution or explicitly set values using the ``=``
+   syntax.
 
 .. note::
    If you split your build and test phases with ``--no-test`` and ``--test``,


### PR DESCRIPTION
Fixes setting values in `build/script_env` containing `=` and add docs for this feature.