### PR TITLE
Skeleton perl installdirs vendor

### DIFF
--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -100,7 +100,7 @@ elif [ -f Makefile.PL ]; then
     perl Makefile.PL INSTALLDIRS={installdirs} NO_PERLLOCAL=1 NO_PACKLIST=1
     make
     make test
-    make install
+    make install VERBINST=1
 else
     echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
     exit 1
@@ -142,7 +142,7 @@ IF NOT exist Makefile.PL GOTO NOT_exist_Makefile_PL
     IF %ERRORLEVEL% NEQ 0 exit /B 1
     %MAKE% test
     IF %ERRORLEVEL% NEQ 0 exit /B 1
-    %MAKE% install
+    %MAKE% install VERBINST=1
     IF %ERRORLEVEL% NEQ 0 exit /B 1
     GOTO build_done
 :NOT_exist_Makefile_PL

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -90,11 +90,11 @@ if [ -f Build.PL ]; then
     perl Build.PL
     perl ./Build
     perl ./Build test
-    # Make sure this goes in site
-    perl ./Build install --installdirs site
+    # Make sure this goes in the desired location (site or vendor)
+    perl ./Build install --installdirs {installdirs}
 elif [ -f Makefile.PL ]; then
-    # Make sure this goes in site
-    perl Makefile.PL INSTALLDIRS=site
+    # Make sure this goes in the desired location (site or vendor)
+    perl Makefile.PL INSTALLDIRS={installdirs}
     make
     make test
     make install
@@ -118,12 +118,12 @@ IF exist Build.PL (
     Build
     IF %ERRORLEVEL% NEQ 0 exit /B 1
     Build test
-    :: Make sure this goes in site
-    Build install --installdirs site
+    :: Make sure this goes in the desired location (site or vendor)
+    Build install --installdirs {installdirs}
     IF %ERRORLEVEL% NEQ 0 exit /B 1
 ) ELSE IF exist Makefile.PL (
-    :: Make sure this goes in site
-    perl Makefile.PL INSTALLDIRS=site
+    :: Make sure this goes in the desired location (site or vendor)
+    perl Makefile.PL INSTALLDIRS={installdirs}
     IF %ERRORLEVEL% NEQ 0 exit /B 1
     make
     IF %ERRORLEVEL% NEQ 0 exit /B 1
@@ -346,7 +346,8 @@ def get_core_modules_for_this_perl_version(version, cache_dir):
 # meta_cpan_url="http://api.metacpan.org",
 def skeletonize(packages, output_dir=".", version=None,
                 meta_cpan_url="https://fastapi.metacpan.org/v1",
-                recursive=False, force=False, config=None, write_core=False):
+                recursive=False, force=False, config=None, write_core=False,
+                installdirs="site"):
     '''
     Loops over packages, outputting conda recipes converted from CPAN metata.
     '''
@@ -432,6 +433,7 @@ def skeletonize(packages, output_dir=".", version=None,
                                                'source_comment': '',
                                                'summary': "''",
                                                'import_tests': ''})
+        d['installdirs'] = installdirs
 
         # Fetch all metadata from CPAN
         if version is None:
@@ -606,6 +608,11 @@ def add_parser(repos):
         "--write_core",
         action='store_true',
         help='Write recipes for perl core modules (default: %(default)s). ')
+    cpan.add_argument(
+        "--installdirs",
+        help="Installation destination category (default: %(default)s).",
+        choices=("vendor", "site", "core"),
+        default="site")
 
 
 @memoized

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -347,7 +347,7 @@ def get_core_modules_for_this_perl_version(version, cache_dir):
 def skeletonize(packages, output_dir=".", version=None,
                 meta_cpan_url="https://fastapi.metacpan.org/v1",
                 recursive=False, force=False, config=None, write_core=False,
-                installdirs="site"):
+                installdirs="vendor"):
     '''
     Loops over packages, outputting conda recipes converted from CPAN metata.
     '''
@@ -612,7 +612,7 @@ def add_parser(repos):
         "--installdirs",
         help="Installation destination category (default: %(default)s).",
         choices=("vendor", "site", "core"),
-        default="site")
+        default="vendor")
 
 
 @memoized

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -108,8 +108,8 @@ else
 fi
 
 perl -e 'foreach(@INC) {{ $_ ne "." && -d $_ && print "$_\\n" }}' | \\
-    while IFS= read -r i; do \\
-        find "$i" -type f '(' -name .packlist -o -name perllocal.pod ')' -delete
+    while IFS= read -r d; do \\
+        find "${{d}}" -type f '(' -name .packlist -o -name perllocal.pod ')' -delete
     done
 
 # Add more build steps here, if they are necessary.
@@ -150,10 +150,10 @@ IF NOT exist Makefile.PL GOTO NOT_exist_Makefile_PL
 
 build_done:
 
-for /F "usebackq delims=" %%i in (
+for /F "usebackq delims=" %%d in (
     `perl -e "foreach(@INC) {{ $_ ne \\".\\" && -d $_ && print \\"$_\\n\\" }}"`
 ) do (
-    find "%%i" -type f "(" -iname .packlist -o -name perllocal.pod ")" -delete
+    find "%%d" -type f "(" -iname .packlist -o -name perllocal.pod ")" -delete
 )
 
 :: Add more build steps here, if they are necessary.

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -57,8 +57,7 @@ requirements:
   build:
     # - findutils   # [not win]
     - make          # [not win]
-    - m2-findutils  # [win]
-    - m2-make       # [win]{build_depends}
+    - m2-findutils  # [win]{build_depends}
 
   # Run exports are used now
   host:
@@ -135,20 +134,21 @@ IF NOT exist Build.PL GOTO NOT_exist_Build_PL
 
 IF NOT exist Makefile.PL GOTO NOT_exist_Makefile_PL
     :: Make sure this goes in the desired location (site or vendor)
+    set MAKE=nmake
     perl Makefile.PL INSTALLDIRS={installdirs} NO_PERLLOCAL=1 NO_PACKLIST=1
     IF %ERRORLEVEL% NEQ 0 exit /B 1
-    make
+    %MAKE%
     IF %ERRORLEVEL% NEQ 0 exit /B 1
-    make test
+    %MAKE% test
     IF %ERRORLEVEL% NEQ 0 exit /B 1
-    make install
+    %MAKE% install
     GOTO build_done
 :NOT_exist_Makefile_PL
 
     ECHO 'Unable to find Build.PL or Makefile.PL. You need to modify bld.bat.'
     exit 1
 
-build_done:
+:build_done
 
 for /F "usebackq delims=" %%d in (
     `perl -e "foreach(@INC) {{ $_ ne \\".\\" && -d $_ && print \\"$_\\n\\" }}"`

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -55,9 +55,9 @@ build:
 
 requirements:
   build:
-    - findutils     # [not win]
+    # - findutils   # [not win]
     - m2-findutils  # [win]
-    - make{build_depends}
+    - make          # [not win]{build_depends}
 
   # Run exports are used now
   host:

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -363,7 +363,7 @@ def get_core_modules_for_this_perl_version(version, cache_dir):
 def skeletonize(packages, output_dir=".", version=None,
                 meta_cpan_url="https://fastapi.metacpan.org/v1",
                 recursive=False, force=False, config=None, write_core=False,
-                installdirs="vendor"):
+                installdirs="site"):
     '''
     Loops over packages, outputting conda recipes converted from CPAN metata.
     '''
@@ -631,7 +631,7 @@ def add_parser(repos):
         "--installdirs",
         help="Installation destination category (default: %(default)s).",
         choices=("vendor", "site", "core"),
-        default="vendor")
+        default="site")
 
 
 @memoized

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -56,8 +56,9 @@ build:
 requirements:
   build:
     # - findutils   # [not win]
+    - make          # [not win]
     - m2-findutils  # [win]
-    - make          # [not win]{build_depends}
+    - m2-make       # [win]{build_depends}
 
   # Run exports are used now
   host:

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -142,6 +142,8 @@ IF exist Build.PL (
 :: for a list of environment variables that are set during the build process.
 """
 
+PERL_5_LICENSE = 'GPL-1.0-or-later OR Artistic-1.0-Perl'
+
 perl_core = []
 
 
@@ -521,11 +523,14 @@ def skeletonize(packages, output_dir=".", version=None,
             d['summary'] = summary
             # d['summary'] = repr(release_data['abstract']).lstrip('u')
         try:
-            d['license'] = (release_data['license'][0] if
-                            isinstance(release_data['license'], list) else
-                            release_data['license'])
+            license = (release_data['license'][0] if
+                       isinstance(release_data['license'], list) else
+                       release_data['license'])
+            if license == 'perl_5':
+                license = PERL_5_LICENSE
         except KeyError:
-            d['license'] = 'perl_5'
+            license = PERL_5_LICENSE
+        d['license'] = license
         d['version'] = release_data['version']
 
         processed_packages.add(packagename + '-' + d['version'])
@@ -990,7 +995,7 @@ def get_release_info(cpan_url, cache_dir, core_modules, package, version):
                    "and are omitting the URL and MD5 from the recipe " +
                    "entirely.").format(orig_package))
             rel_dict = {'version': str(core_version), 'download_url': '',
-                        'license': ['perl_5'], 'dependency': {}}
+                        'license': [PERL_5_LICENSE], 'dependency': {}}
         else:
             sys.exit(("Error: Could not find any versions of package %s on " +
                       "MetaCPAN.") % (orig_package))

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -126,6 +126,7 @@ IF NOT exist Build.PL GOTO NOT_exist_Build_PL
     Build
     IF %ERRORLEVEL% NEQ 0 exit /B 1
     Build test
+    IF %ERRORLEVEL% NEQ 0 exit /B 1
     :: Make sure this goes in the desired location (site or vendor)
     Build install --installdirs {installdirs}
     IF %ERRORLEVEL% NEQ 0 exit /B 1
@@ -142,6 +143,7 @@ IF NOT exist Makefile.PL GOTO NOT_exist_Makefile_PL
     %MAKE% test
     IF %ERRORLEVEL% NEQ 0 exit /B 1
     %MAKE% install
+    IF %ERRORLEVEL% NEQ 0 exit /B 1
     GOTO build_done
 :NOT_exist_Makefile_PL
 

--- a/news/gh-4233-Add---installdirs-option-for-CPAN-skeleton.rst
+++ b/news/gh-4233-Add---installdirs-option-for-CPAN-skeleton.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* Add --installdirs option for CPAN skeleton
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* Change CPAN skeleton default installdirs to vendor
+

--- a/news/gh-4233-Add---installdirs-option-for-CPAN-skeleton.rst
+++ b/news/gh-4233-Add---installdirs-option-for-CPAN-skeleton.rst
@@ -21,5 +21,5 @@ Docs:
 Other:
 ------
 
-* Change CPAN skeleton default installdirs to vendor
+* <news item>
 

--- a/news/gh-4233-Add---installdirs-option-for-CPAN-skeleton.rst
+++ b/news/gh-4233-Add---installdirs-option-for-CPAN-skeleton.rst
@@ -3,6 +3,10 @@ Enhancements:
 
 * Add --installdirs option for CPAN skeleton
 
+* Use SPDX license expression instead of "perl_5" for CPAN skeleton
+
+* Avoid packaging perllocal.pod and .packlist files for CPAN skeleton
+
 Bug fixes:
 ----------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,16 @@ def test_skeleton_pypi_arguments_work(testing_workdir):
     assert m.version() == '0.2.2'
 
 
+@pytest.mark.sanity
+def test_skeleton_cpan(testing_workdir, testing_config):
+    args = ['cpan', 'App-cpanminus']
+    main_skeleton.execute(args)
+    assert os.path.isdir('perl-app-cpanminus')
+
+    # ensure that recipe generated is buildable
+    main_build.execute(('perl-app-cpanminus',))
+
+
 def test_metapackage(testing_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test', '1.0', '-d', 'bzip2', '--no-anaconda-upload']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,6 +311,21 @@ def test_skeleton_cpan(testing_workdir, testing_config):
     main_build.execute(('perl-app-cpanminus',))
 
 
+@pytest.mark.sanity
+def test_skeleton_cpan_vendor(testing_workdir, testing_config):
+    args = ['cpan', '--installdirs=vendor', 'App-cpanminus']
+    main_skeleton.execute(args)
+    assert os.path.isdir('perl-app-cpanminus')
+
+    # ensure that recipe generated is buildable
+    outputs = main_build.execute(
+        ('--channel', 'conda-forge', '--variants', '{perl: [5.32.1]}', 'perl-app-cpanminus',)
+    )
+    data = package_has_file(outputs[0], 'info/paths.json')
+    paths = json.loads(data)["paths"]
+    assert any(re.match(".*vendor.*/App/cpanminus.pm$", path["_path"]) for path in paths)
+
+
 def test_metapackage(testing_config, testing_workdir):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test', '1.0', '-d', 'bzip2', '--no-anaconda-upload']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -303,27 +303,27 @@ def test_skeleton_pypi_arguments_work(testing_workdir):
 
 @pytest.mark.sanity
 def test_skeleton_cpan(testing_workdir, testing_config):
-    args = ['cpan', 'App-cpanminus']
+    args = ['cpan', 'PBKDF2::Tiny']
     main_skeleton.execute(args)
-    assert os.path.isdir('perl-app-cpanminus')
+    assert os.path.isdir('perl-pbkdf2-tiny')
 
     # ensure that recipe generated is buildable
-    main_build.execute(('perl-app-cpanminus',))
+    main_build.execute(('perl-pbkdf2-tiny',))
 
 
 @pytest.mark.sanity
 def test_skeleton_cpan_vendor(testing_workdir, testing_config):
-    args = ['cpan', '--installdirs=vendor', 'App-cpanminus']
+    args = ['cpan', '--installdirs=vendor', 'PBKDF2::Tiny']
     main_skeleton.execute(args)
-    assert os.path.isdir('perl-app-cpanminus')
+    assert os.path.isdir('perl-pbkdf2-tiny')
 
     # ensure that recipe generated is buildable
     outputs = main_build.execute(
-        ('--channel', 'conda-forge', '--variants', '{perl: [5.32.1]}', 'perl-app-cpanminus',)
+        ('--channel', 'conda-forge', '--variants', '{perl: [5.32.1]}', 'perl-pbkdf2-tiny',)
     )
     data = package_has_file(outputs[0], 'info/paths.json')
     paths = json.loads(data)["paths"]
-    assert any(re.match(".*vendor.*/App/cpanminus.pm$", path["_path"]) for path in paths)
+    assert any(re.match(".*vendor.*/PBKDF2/Tiny.pm$", path["_path"]) for path in paths)
 
 
 def test_metapackage(testing_config, testing_workdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,7 +308,11 @@ def test_skeleton_cpan(testing_workdir, testing_config):
     assert os.path.isdir('perl-pbkdf2-tiny')
 
     # ensure that recipe generated is buildable
-    main_build.execute(('perl-pbkdf2-tiny',))
+    # Test with conda-forge::perl since defaults has sitelib at
+    # C:\strawberry\perl\site\lib on Windows.
+    main_build.execute(
+        ('--channel', 'conda-forge', '--variants', '{perl: [5.32.1]}', 'perl-pbkdf2-tiny',)
+    )
 
 
 @pytest.mark.sanity
@@ -318,6 +322,8 @@ def test_skeleton_cpan_vendor(testing_workdir, testing_config):
     assert os.path.isdir('perl-pbkdf2-tiny')
 
     # ensure that recipe generated is buildable
+    # Test with conda-forge::perl since defaults has vendorlib undefined (Linux)
+    # or at C:\strawberry\perl\vendor\lib on Windows.
     outputs = main_build.execute(
         ('--channel', 'conda-forge', '--variants', '{perl: [5.32.1]}', 'perl-pbkdf2-tiny',)
     )


### PR DESCRIPTION
In https://github.com/conda-forge/perl-feedstock/pull/49 I'm changing the directory layout for conda-forge's Perl packages to have the `vendor` dirs split off so that we (as in Conda channel maintainers) can act as the "vendor" and have the Perl packages we build in the "vendor" location and leave the "site" location to the user's (non-Conda) packages.