### PR TITLE
Revert "Consider any file containing .yaml in its name as maybe a recipe file"

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -812,7 +812,7 @@ def render_recipe(recipe_path, config, no_download_source=False, variants=None,
             t.extractall(path=recipe_dir)
             t.close()
             need_cleanup = True
-        elif '.yaml' in arg:
+        elif arg.endswith('.yaml'):
             recipe_dir = os.path.dirname(arg)
             need_cleanup = False
         else:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -450,7 +450,7 @@ def get_recipe_abspath(recipe):
     # Don't use byte literals for paths in Python 2
     if not PY3:
         recipe = recipe.decode(getpreferredencoding() or 'utf-8')
-    if isfile(recipe) and '.yaml' not in recipe:
+    if isfile(recipe):
         if recipe.lower().endswith(decompressible_exts) or recipe.lower().endswith(CONDA_PACKAGE_EXTENSIONS):
             recipe_dir = tempfile.mkdtemp()
             if recipe.lower().endswith(CONDA_PACKAGE_EXTENSIONS):
@@ -464,11 +464,8 @@ def get_recipe_abspath(recipe):
                 tar_xf(recipe_tarfile, os.path.join(recipe_dir, 'info'))
             need_cleanup = True
         else:
-            print("Ignoring non-recipe file: %s" % recipe)
+            print("Ignoring non-recipe: %s" % recipe)
             return (None, None)
-    elif '.yaml' in recipe:
-        recipe_dir = os.path.dirname(recipe)
-        need_cleanup = False
     else:
         recipe_dir = abspath(os.path.join(os.getcwd(), recipe))
         need_cleanup = False


### PR DESCRIPTION
This reverts commit 264663da57afe2c7960376032460966e4d5be1f1.

Fixes #4219 as we don't know what the initial reasoning for this change was but it is breaking one of the dependencies of conda-build itself. 
