### PR TITLE
Add activate_in_script to metadata

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -439,6 +439,7 @@ FIELDS = {
         'missing_dso_whitelist': None,
         'error_overdepending': None,
         'error_overlinking': None,
+        'activate_in_script': bool,
     },
     'outputs': {
         'name': None,

--- a/news/fix_metadata.rst
+++ b/news/fix_metadata.rst
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* The `build/activate_in_script` field will no longer cause `conda_build.api.check` to fail.
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
The activate_in_script field was causing conda_build.api.check to fail.

This PR adds it to the list of valid metadata fields.