### PR TITLE
Don't check build for circular dependencies when cross compiling

### DIFF
--- a/news/circular-deps-cross-compile.rst
+++ b/news/circular-deps-cross-compile.rst
@@ -1,0 +1,6 @@
+
+Bug fixes:
+----------
+
+* When checking for circular dependencies in cross-compiling mode, ``build``
+  requirements are ignored now.

--- a/tests/test-recipes/split-packages/_circular_deps_cross/conda_build_config.yaml
+++ b/tests/test-recipes/split-packages/_circular_deps_cross/conda_build_config.yaml
@@ -1,0 +1,4 @@
+target_platform:
+  - linux-32
+cross_target_platform:
+  - linux-32

--- a/tests/test-recipes/split-packages/_circular_deps_cross/meta.yaml
+++ b/tests/test-recipes/split-packages/_circular_deps_cross/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "gcc_impl" %}
+{% set version = "7.5.0" %}
+
+package:
+  name: gcc_compilers
+  version: {{ version }}
+
+build:
+  number: 0
+
+outputs:
+  - name: gcc_impl_{{ cross_target_platform }}
+    requirements:
+      build:
+        - gcc_impl_{{ target_platform }}   # [build_platform != target_platform]
+        - gxx_impl_{{ target_platform }}   # [build_platform != target_platform]
+        - gcc_impl_{{ cross_target_platform }}   # [build_platform != target_platform]
+        - gxx_impl_{{ cross_target_platform }}   # [build_platform != target_platform]
+        - sysroot_{{ cross_target_platform }}
+      host:
+        - sysroot_{{ cross_target_platform }}
+      run:
+        - sysroot_{{ cross_target_platform }}
+
+  - name: gxx_impl_{{ cross_target_platform }}
+    requirements:
+      build:
+        - gcc_impl_{{ target_platform }}   # [build_platform != target_platform]
+        - gxx_impl_{{ target_platform }}   # [build_platform != target_platform]
+        - gcc_impl_{{ cross_target_platform }}   # [build_platform != target_platform]
+        - gxx_impl_{{ cross_target_platform }}   # [build_platform != target_platform]
+        - sysroot_{{ cross_target_platform }}
+      host:
+        - sysroot_{{ cross_target_platform }}
+      run:
+        - sysroot_{{ cross_target_platform }}

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -336,6 +336,12 @@ def test_inherit_build_number(testing_config):
         assert int(m.meta['build']['number']) == 1, "build number should have been inherited as '1'"
 
 
+def test_circular_deps_cross(testing_config):
+    recipe = os.path.join(subpackage_dir, '_circular_deps_cross')
+    # check that this does not raise an exception
+    ms = api.render(recipe, config=testing_config)
+
+
 @pytest.mark.slow
 def test_loops_do_not_remove_earlier_packages(testing_config):
     recipe = os.path.join(subpackage_dir, '_xgboost_example')


### PR DESCRIPTION
When cross compiling, build dependencies are coming from already
built packages and cannot be subpackages from the same recipe.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

This is similar to https://github.com/conda/conda-build/pull/4011