### PR TITLE
Fix macOS test failure by updating test recipe

### DIFF
--- a/tests/test-recipes/metadata/source_setup_py_data/meta.yaml
+++ b/tests/test-recipes/metadata/source_setup_py_data/meta.yaml
@@ -24,3 +24,7 @@ requirements:
     # cython inclusion here is to test https://github.com/conda/conda-build/issues/149
     # cython chosen because it is implicated somehow in setup.py complications.  Numpy would also work.
     - cython
+    # Ensure pip & setuptools are installed to ensure this test does not fail
+    # when the conda `add_pip_as_python_dependency` configuration option is set
+    # to False (as is done on some of this repository's CI systems).
+    - pip


### PR DESCRIPTION
Include `pip` as a build requirement in the `source_setup_py_data` test recipe to ensure the test does not fail when conda's `add_pip_as_python_dependency` configuration option is set.