### PR TITLE
use scandir() to avoid separate is_dir() syscall

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -789,8 +789,8 @@ class ChannelIndex:
 
         with utils.LoggingContext(level, loggers=[__name__]):
             if not self._subdirs:
-                detected_subdirs = {subdir for subdir in os.listdir(self.channel_root)
-                                    if subdir in utils.DEFAULT_SUBDIRS and isdir(join(self.channel_root, subdir))}
+                detected_subdirs = set(subdir.name for subdir in os.scandir(self.channel_root)
+                                    if subdir.name in utils.DEFAULT_SUBDIRS and subdir.is_dir())
                 log.debug("found subdirs %s" % detected_subdirs)
                 self.subdirs = subdirs = sorted(detected_subdirs | {'noarch'})
             else:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -789,8 +789,11 @@ class ChannelIndex:
 
         with utils.LoggingContext(level, loggers=[__name__]):
             if not self._subdirs:
-                detected_subdirs = set(subdir.name for subdir in os.scandir(self.channel_root)
-                                    if subdir.name in utils.DEFAULT_SUBDIRS and subdir.is_dir())
+                detected_subdirs = {
+                    subdir.name
+                    for subdir in os.scandir(self.channel_root)
+                    if subdir.name in utils.DEFAULT_SUBDIRS and subdir.is_dir()
+                }
                 log.debug("found subdirs %s" % detected_subdirs)
                 self.subdirs = subdirs = sorted(detected_subdirs | {'noarch'})
             else:


### PR DESCRIPTION
This should avoid one syscall per directory entry for the (modest) `channel_root` listing.