### PR TITLE
Remove rpaths that occur multiple times

### DIFF
--- a/ci/github/run_conda_forge_build_setup_osx
+++ b/ci/github/run_conda_forge_build_setup_osx
@@ -5,7 +5,7 @@ export PYTHONUNBUFFERED=1
 # deployment target should be set by conda_build_config.yaml (default in conda-forge-pinning).
 # The default here will only be used when that is undefined,
 # which should only be recipes still using conda-build 2.
-export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-11.0}
+export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-10.15}
 export CPU_COUNT=$(sysctl -n hw.ncpu)
 export INSTALL_XCODE=${INSTALL_XCODE:-0}
 echo "Intial \$(xcode-select -p) is $(xcode-select -p)"

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -415,8 +415,9 @@ def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
                              '').replace('/./', '/')
             macho.add_rpath(path, rpath_new, build_prefix=prefix, verbose=True)
             full_rpath = join(host_prefix, rpath)
-            for _ in range(existing_rpaths.count(full_rpath)):
-                macho.delete_rpath(path, full_rpath, build_prefix=prefix, verbose=True)
+            for existing_rpath in existing_rpaths:
+                if normpath(existing_rpath) == normpath(full_rpath):
+                    macho.delete_rpath(path, existing_rpath, build_prefix=prefix, verbose=True)
 
         base_prefix = dirname(host_prefix)
         for rpath in existing_rpaths:

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -394,6 +394,7 @@ def osx_ch_link(path, link_dict, host_prefix, build_prefix, files):
 
 def mk_relative_osx(path, host_prefix, m, files, rpaths=('lib',)):
     base_prefix = m.config.build_folder
+    assert base_prefix == dirname(host_prefix)
     build_prefix = m.config.build_prefix
     prefix = build_prefix if exists(build_prefix) else host_prefix
     names = macho.otool(path, prefix)

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -414,13 +414,14 @@ def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
                              relpath(join(host_prefix, rpath), dirname(path)),
                              '').replace('/./', '/')
             macho.add_rpath(path, rpath_new, build_prefix=prefix, verbose=True)
-            if join(host_prefix, rpath) in existing_rpaths:
-                macho.delete_rpath(path, join(host_prefix, rpath), build_prefix=prefix, verbose=True)
+            full_rpath = join(host_prefix, rpath)
+            for _ in range(existing_rpaths.count(full_rpath)):
+                macho.delete_rpath(path, full_rpath, build_prefix=prefix, verbose=True)
 
-        if build_prefix != host_prefix:
-            for rpath in existing_rpaths:
-                if rpath.startswith(build_prefix):
-                    macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
+        base_prefix = dirname(host_prefix)
+        for rpath in existing_rpaths:
+            if rpath.startswith(base_prefix) and not rpath.startswith(host_prefix):
+                macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be
         # made relocatable.

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -392,7 +392,9 @@ def osx_ch_link(path, link_dict, host_prefix, build_prefix, files):
     return ret
 
 
-def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
+def mk_relative_osx(path, host_prefix, m, files, rpaths=('lib',)):
+    base_prefix = m.config.build_folder
+    build_prefix = m.config.build_prefix
     prefix = build_prefix if exists(build_prefix) else host_prefix
     names = macho.otool(path, prefix)
     s = macho.install_name_change(path, prefix,
@@ -419,7 +421,6 @@ def mk_relative_osx(path, host_prefix, build_prefix, files, rpaths=('lib',)):
                 if normpath(existing_rpath) == normpath(full_rpath):
                     macho.delete_rpath(path, existing_rpath, build_prefix=prefix, verbose=True)
 
-        base_prefix = dirname(host_prefix)
         for rpath in existing_rpaths:
             if rpath.startswith(base_prefix) and not rpath.startswith(host_prefix):
                 macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
@@ -1260,7 +1261,7 @@ def post_process_shared_lib(m, f, files, host_prefix=None):
             log = utils.get_logger(__name__)
             log.warn("Found Mach-O file but patching is only supported on macOS, skipping: %s", path)
             return
-        mk_relative_osx(path, host_prefix, m.config.build_prefix, files=files, rpaths=rpaths)
+        mk_relative_osx(path, host_prefix, m, files=files, rpaths=rpaths)
 
 
 def fix_permissions(files, prefix):

--- a/news/rpaths.rst
+++ b/news/rpaths.rst
@@ -1,0 +1,26 @@
+Enhancements:
+-------------
+
+* Remove rpaths in PREFIX/../ that doesn't start with PREFIX
+  This includes BUILD_PREFIX, SRC_DIR. Previously it was only BUILD_PREFIX
+
+Bug fixes:
+----------
+
+* Remove rpaths that occur multiple times
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/news/rpaths.rst
+++ b/news/rpaths.rst
@@ -23,4 +23,3 @@ Other:
 ------
 
 * <news item>
-

--- a/tests/test-recipes/metadata/_clean_rpaths/meta.yaml
+++ b/tests/test-recipes/metadata/_clean_rpaths/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: clean_rpaths
+  version: 0.0.1
+
+build:
+  number: 0
+  skip: True  # [not osx]
+  script:
+    - echo "int main(){}" > hello.c
+    - ${CC} hello.c -Wl,-rpath,${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath,${SRC_DIR} -o hello
+    - mkdir -p ${PREFIX}/bin
+    - cp hello ${PREFIX}/bin
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+  run:
+
+test:
+  requires:
+    - {{ compiler('c') }} 
+  commands:
+    - export CHECK_PREFIX=$(dirname {{ SRC_DIR }})
+    - ${OTOOL} -l ${PREFIX}/bin/hello | grep LC_RPATH -A 3 | grep -v ${CHECK_PREFIX}

--- a/tests/test-recipes/metadata/_clean_rpaths/meta.yaml
+++ b/tests/test-recipes/metadata/_clean_rpaths/meta.yaml
@@ -5,6 +5,13 @@ package:
 build:
   number: 0
   skip: True  # [not osx]
+  # Inheriting environment variables like this is a bit of an anti-pattern,
+  # but it's the best mechanism we currently have for allowing flexibility
+  # in where the macOS SDK needed for this test is installed.  Assuming or
+  # forcing developers and/or CI systems to put the needed SDK in the same
+  # place just to run this test seems like an even bigger anti-pattern.
+  script_env:
+    - CONDA_BUILD_SYSROOT
   script:
     - echo "int main(){}" > hello.c
     - ${CC} hello.c -Wl,-rpath,${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib -Wl,-rpath,${BUILD_PREFIX}/lib -Wl,-rpath,${SRC_DIR} -o hello

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1638,6 +1638,11 @@ def test_symlink_dirs_in_always_include_files(testing_config):
     api.build(recipe, config=testing_config)
 
 
+def test_clean_rpaths(testing_config):
+    recipe = os.path.join(metadata_dir, '_clean_rpaths')
+    api.build(recipe, config=testing_config)
+
+
 def test_script_env_warnings(testing_config, recwarn):
     recipe_dir = os.path.join(metadata_dir, '_script_env_warnings')
     token = 'CONDA_BUILD_PYTEST_SCRIPT_ENV_TEST_TOKEN'

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1640,7 +1640,7 @@ def test_symlink_dirs_in_always_include_files(testing_config):
 
 def test_clean_rpaths(testing_config):
     recipe = os.path.join(metadata_dir, '_clean_rpaths')
-    api.build(recipe, config=testing_config)
+    api.build(recipe, config=testing_config, activate=True)
 
 
 def test_script_env_warnings(testing_config, recwarn):


### PR DESCRIPTION
And also remove any rpaths in PREFIX/../ that doesn't start with PREFIX.
This remove rpaths in BUILD_PREFIX, SRC_DIR, etc

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
