### PR TITLE
Use `pip`'s in-tree build feature

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2610,6 +2610,9 @@ def write_build_scripts(m, script, build_file):
     # locally, and if we don't, it's a problem.
     env["PIP_NO_INDEX"] = True
 
+    # Opt into building in-tree without copying to a temp dir
+    env["PIP_USE_FEATURE"] = "in-tree-build"
+
     if m.noarch == "python":
         env["PYTHONDONTWRITEBYTECODE"] = True
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -275,6 +275,9 @@ def build(m, bld_bat, stats, provision_only=False):
     # locally, and if we don't, it's a problem.
     env["PIP_NO_INDEX"] = True
 
+    # Opt into building in-tree without copying to a temp dir
+    env["PIP_USE_FEATURE"] = "in-tree-build"
+
     # set variables like CONDA_PY in the test environment
     env.update(set_language_env_vars(m.config.variant))
 

--- a/tests/test-recipes/test-package-pyproject/conda_build_test2/__init__.py
+++ b/tests/test-recipes/test-package-pyproject/conda_build_test2/__init__.py
@@ -1,0 +1,4 @@
+"""
+conda build test package
+"""
+print("conda_build_test2 has been imported")

--- a/tests/test-recipes/test-package-pyproject/conda_build_test2/manual_entry.py
+++ b/tests/test-recipes/test-package-pyproject/conda_build_test2/manual_entry.py
@@ -1,0 +1,10 @@
+def main():
+    import argparse
+
+    # Just picks them up from `sys.argv`.
+    parser = argparse.ArgumentParser(
+        description="Basic parser."
+    )
+    parser.parse_args()
+
+    print("Manual entry point")

--- a/tests/test-recipes/test-package-pyproject/pyproject.toml
+++ b/tests/test-recipes/test-package-pyproject/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "conda-build-test-pyproject"
+version = "1.0"
+author = "Continuum Analytics Inc."
+url = "https://github.com/conda/conda-build"
+license = "BSD-3-Clause"
+description = "test package for testing conda-build"
+    
+packages = [
+    { include = "conda_build_test2" }
+]
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]

--- a/tests/test-recipes/test-package-pyproject/setup.py
+++ b/tests/test-recipes/test-package-pyproject/setup.py
@@ -1,0 +1,10 @@
+import sys
+from setuptools import setup
+# from distutils.core import setup
+
+# test with an old version of Python that we'll never normally use
+if sys.version_info[:2] == (3, 5):
+    # die intentionally to signal that we're using the old python version
+    sys.exit(1)
+
+setup()


### PR DESCRIPTION
This is future behavior of `pip` to not copy to a temporary directory first. As this will soon become default. Opt-in on older `pip` versions for consistency. Uses `pip`'s doc's guidance for setting environment variables (linked below).

ref: https://pip.pypa.io/en/stable/topics/configuration/#environment-variables
xref: https://github.com/pypa/pip/issues/7555

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
