### PR TITLE
Add noarch as valid field for outputs

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -451,6 +451,7 @@ FIELDS = {
         'version': None,
         'number': None,
         'script': None,
+        'noarch': None,
         'script_interpreter': None,
         'build': None,
         'requirements': None,


### PR DESCRIPTION
I feel like you need this to make a subpackage noarch when the parent package is noarch.

Correct me if I'm wrong. Example package found:

https://github.com/conda-forge/staged-recipes/pull/16559