### PR TITLE
Include conda, chardet, psutil in tests/requirements.txt

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,8 @@
 # run as 'conda install --file tests/requirements.txt -c defaults'
 anaconda-client
 bs4
+chardet
+conda
 conda-package-handling
 filelock
 flaky
@@ -9,6 +11,7 @@ glob2
 jinja2
 mock
 pkginfo
+psutil
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
Suggested in #4300 to ease the process of installing dependencies into a standalone environment for development/testing.

An obvious downside of this change is that `conda` would be updated if `requirements.txt` are installed into the base env. I am unsure if we consider that a downside given that this would only be occurring for users who have clearly chosen to open pandoras box and we expect any development to be occurring on the most recent `conda`/`conda-build`.

An alternative would be to create a secondary requirements file (e.g. `requirements-standalone.txt`) that contains the contents of `requirements.txt` along with the `conda` dependency for install into a standalone env.