### PR TITLE
More unit tests for CRAN skeleton

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -802,7 +802,7 @@ def get_available_binaries(cran_url, details):
 
 
 def remove_comments(template):
-    re_comment = re.compile('^\s*#\s')
+    re_comment = re.compile(r'^\s*#\s')
     lines = template.split('\n')
     lines_no_comments = [line for line in lines if not re_comment.match(line)]
     return '\n'.join(lines_no_comments)

--- a/news/cran-skeleton-tests.rst
+++ b/news/cran-skeleton-tests.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* cran-skeleton: more unit tests

--- a/tests/test-cran-skeleton/rpart/DESCRIPTION
+++ b/tests/test-cran-skeleton/rpart/DESCRIPTION
@@ -1,0 +1,32 @@
+Package: rpart
+Priority: recommended
+Version: 4.1-15
+Date: 2019-04-10
+Authors@R: c(person("Terry", "Therneau", role = "aut",
+	            email = "therneau@mayo.edu"),
+             person("Beth", "Atkinson", role = c("aut", "cre"),
+	            email = "atkinson@mayo.edu"),
+             person("Brian", "Ripley", role = "trl",
+                    email = "ripley@stats.ox.ac.uk",
+		    comment = "producer of the initial R port, maintainer 1999-2017"))
+Description: Recursive partitioning for classification, 
+  regression and survival trees.  An implementation of most of the 
+  functionality of the 1984 book by Breiman, Friedman, Olshen and Stone.
+Title: Recursive Partitioning and Regression Trees
+Depends: R (>= 2.15.0), graphics, stats, grDevices
+Suggests: survival
+License: GPL-2 | GPL-3
+LazyData: yes
+ByteCompile: yes
+NeedsCompilation: yes
+Author: Terry Therneau [aut],
+  Beth Atkinson [aut, cre],
+  Brian Ripley [trl] (producer of the initial R port, maintainer
+    1999-2017)
+Maintainer: Beth Atkinson <atkinson@mayo.edu>
+Repository: CRAN
+URL: https://github.com/bethatkinson/rpart,
+        https://cran.r-project.org/package=rpart
+BugReports: https://github.com/bethatkinson/rpart/issues
+Packaged: 2019-04-11 15:59:38 UTC; atkinson
+Date/Publication: 2019-04-12 14:32:39 UTC

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -6,7 +6,6 @@ import sys
 from pkg_resources import parse_version
 import pytest
 
-from conda_build.skeletons.cran import CRAN_BUILD_SH_SOURCE, CRAN_META
 from conda_build.skeletons.pypi import get_package_metadata, \
     get_entry_points, is_setuptools_enabled, convert_to_flat_list, \
     get_dependencies, get_import_tests, get_tests_require, get_home, \
@@ -24,7 +23,7 @@ except ImportError:
 from conda_build import api
 from conda_build.exceptions import DependencyNeedsBuildingError
 import conda_build.os_utils.external as external
-from conda_build.utils import on_win, ensure_list
+from conda_build.utils import on_win
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 
@@ -442,50 +441,6 @@ def test_pypi_section_order_preserved(testing_workdir):
         assert list(v.keys()) == list(recipe[k])
 
 
-# CRAN packages to test license_file entry.
-# (package, license_id, license_family, license_files)
-cran_packages = [('r-rmarkdown', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
-                 ('r-cortools', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),  # cran: 'Artistic License 2.0'
-                 ('r-udpipe', 'MPL-2.0', 'OTHER', ''),  # cran: 'MPL-2.0'
-                 ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),  # cran: 'MIT + file LICENSE'
-                 ('r-meanr', 'BSD_2_clause', 'BSD', ['BSD_2_clause', 'LICENSE']),  # cran: 'BSD 2-clause License + file LICENSE'
-                 ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),  # cran: 'GPL-2 | GPL-3'
-                 ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),  # cran: 'GPL-3 | GPL-2'
-                 ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),  # cran: 'GPL (>= 2)'
-                 ]
-
-@pytest.mark.slow
-@pytest.mark.parametrize("package, license_id, license_family, license_files", cran_packages)
-@pytest.mark.flaky(max_runs=5)
-def test_cran_license(package, license_id, license_family, license_files, testing_workdir, testing_config):
-    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
-                    config=testing_config)
-    m = api.render(os.path.join(package, 'meta.yaml'))[0][0]
-    m_license_id = m.get_value('about/license')
-    assert m_license_id == license_id
-    m_license_family = m.get_value('about/license_family')
-    assert m_license_family == license_family
-    m_license_files = ensure_list(m.get_value('about/license_file', ''))
-    license_files = ensure_list(license_files)
-    for m_license_file in m_license_files:
-        assert os.path.basename(m_license_file) in license_files
-
-
-# CRAN packages to test skip entry.
-# (package, skip_text)
-cran_os_type_pkgs = [('bigReg', 'skip: True  # [not unix]'),
-                     ('blatr',  'skip: True  # [not win]')
-                    ]
-
-@pytest.mark.parametrize("package, skip_text", cran_os_type_pkgs)
-def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
-    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
-                    config=testing_config)
-    fpath = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml')
-    with open(fpath) as f:
-        assert skip_text in f.read()
-
-
 @pytest.mark.slow
 @pytest.mark.flaky(max_runs=5)
 @pytest.mark.skipif(not external.find_executable("shellcheck"), reason="requires shellcheck >=0.7.0")
@@ -515,30 +470,3 @@ def test_build_sh_shellcheck_clean(package, repo, testing_workdir, testing_confi
     findings = sc_stdout.decode(sys.stdout.encoding).replace("\r\n", "\n").splitlines()
     assert findings == []
     assert p.returncode == 0
-
-
-# Test cran skeleton argument --no-comments
-def test_cran_no_comments(testing_workdir, testing_config):
-    package = "data.table"
-    meta_yaml_comment = '  # This is required to make R link correctly on Linux.'
-    build_sh_comment = '# Add more build steps here, if they are necessary.'
-    build_sh_shebang = '#!/bin/bash'
-
-    # Check that comments are part of the templates
-    assert meta_yaml_comment in CRAN_META
-    assert build_sh_comment in CRAN_BUILD_SH_SOURCE
-    assert build_sh_shebang in CRAN_BUILD_SH_SOURCE
-
-    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
-                    config=testing_config, no_comments=True)
-
-    # Check that comments got removed
-    meta_yaml = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml')
-    with open(meta_yaml) as f:
-        assert meta_yaml_comment not in f.read()
-
-    build_sh = os.path.join(testing_workdir, 'r-' + package.lower(), 'build.sh')
-    with open(build_sh) as f:
-        build_sh_text = f.read()
-        assert build_sh_comment not in build_sh_text
-        assert build_sh_shebang in build_sh_text

--- a/tests/test_api_skeleton_cran.py
+++ b/tests/test_api_skeleton_cran.py
@@ -1,0 +1,86 @@
+'''
+Integrative tests of the CRAN skeleton that start from
+conda_build.api.skeletonize and check the output files
+'''
+
+
+import os
+import pytest
+
+from conda_build import api
+from conda_build.skeletons.cran import CRAN_BUILD_SH_SOURCE, CRAN_META
+from conda_build.utils import ensure_list
+
+
+# CRAN packages to test license_file entry.
+# (package, license_id, license_family, license_files)
+cran_packages = [('r-rmarkdown', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
+                 ('r-cortools', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),  # cran: 'Artistic License 2.0'
+                 ('r-udpipe', 'MPL-2.0', 'OTHER', ''),  # cran: 'MPL-2.0'
+                 ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),  # cran: 'MIT + file LICENSE'
+                 ('r-meanr', 'BSD_2_clause', 'BSD', ['BSD_2_clause', 'LICENSE']),  # cran: 'BSD 2-clause License + file LICENSE'
+                 ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),  # cran: 'GPL-2 | GPL-3'
+                 ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),  # cran: 'GPL-3 | GPL-2'
+                 ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),  # cran: 'GPL (>= 2)'
+                 ]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("package, license_id, license_family, license_files", cran_packages)
+@pytest.mark.flaky(max_runs=5)
+def test_cran_license(package, license_id, license_family, license_files, testing_workdir, testing_config):
+    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
+                    config=testing_config)
+    m = api.render(os.path.join(package, 'meta.yaml'))[0][0]
+    m_license_id = m.get_value('about/license')
+    assert m_license_id == license_id
+    m_license_family = m.get_value('about/license_family')
+    assert m_license_family == license_family
+    m_license_files = ensure_list(m.get_value('about/license_file', ''))
+    license_files = ensure_list(license_files)
+    for m_license_file in m_license_files:
+        assert os.path.basename(m_license_file) in license_files
+
+
+# CRAN packages to test skip entry.
+# (package, skip_text)
+cran_os_type_pkgs = [
+                     ('bigReg', 'skip: True  # [not unix]'),
+                     ('blatr', 'skip: True  # [not win]')
+                    ]
+
+
+@pytest.mark.parametrize("package, skip_text", cran_os_type_pkgs)
+def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
+    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
+                    config=testing_config)
+    fpath = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml')
+    with open(fpath) as f:
+        assert skip_text in f.read()
+
+
+# Test cran skeleton argument --no-comments
+def test_cran_no_comments(testing_workdir, testing_config):
+    package = "data.table"
+    meta_yaml_comment = '  # This is required to make R link correctly on Linux.'
+    build_sh_comment = '# Add more build steps here, if they are necessary.'
+    build_sh_shebang = '#!/bin/bash'
+
+    # Check that comments are part of the templates
+    assert meta_yaml_comment in CRAN_META
+    assert build_sh_comment in CRAN_BUILD_SH_SOURCE
+    assert build_sh_shebang in CRAN_BUILD_SH_SOURCE
+
+    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
+                    config=testing_config, no_comments=True)
+
+    # Check that comments got removed
+    meta_yaml = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml')
+    with open(meta_yaml) as f:
+        assert meta_yaml_comment not in f.read()
+
+    build_sh = os.path.join(testing_workdir, 'r-' + package.lower(), 'build.sh')
+    with open(build_sh) as f:
+        build_sh_text = f.read()
+        assert build_sh_comment not in build_sh_text
+        assert build_sh_shebang in build_sh_text

--- a/tests/test_cran_skeleton.py
+++ b/tests/test_cran_skeleton.py
@@ -1,0 +1,71 @@
+'''
+Unit tests of the CRAN skeleton utility functions
+'''
+
+
+import os
+import pytest
+
+from conda_build.license_family import allowed_license_families
+from conda_build.skeletons.cran import (get_license_info,
+                                        read_description_contents,
+                                        remove_comments)
+
+
+thisdir = os.path.dirname(os.path.realpath(__file__))
+
+
+# (license_string, license_id, license_family, license_files)
+cran_licenses = [('GPL-3', 'GPL-3', 'GPL3',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\''),
+                 ('Artistic License 2.0', 'Artistic-2.0', 'OTHER',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/Artistic-2.0\''),
+                 ('MPL-2.0', 'MPL-2.0', 'OTHER', ''),
+                 ('MIT + file LICENSE', 'MIT', 'MIT',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT\'\n    - LICENSE'),
+                 ('BSD 2-clause License + file LICENSE', 'BSD_2_clause', 'BSD',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_2_clause\'\n    - LICENSE'),
+                 ('GPL-2 | GPL-3', 'GPL-2 | GPL-3', 'GPL3',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\'\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\''),
+                 ('GPL-3 | GPL-2', 'GPL-3 | GPL-2', 'GPL3',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3\'\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\''),
+                 ('GPL (>= 2)', 'GPL-2', 'GPL2',
+                  'license_file:\n    - \'{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2\''),
+                 ]
+
+
+@pytest.mark.parametrize("license_string, license_id, license_family, license_files", cran_licenses)
+def test_get_license_info(license_string, license_id, license_family, license_files):
+    observed = get_license_info(license_string, allowed_license_families)
+    assert observed[0] == license_id
+    assert observed[2] == license_family
+    assert observed[1] == license_files
+
+
+def test_read_description_contents():
+    description = os.path.join(thisdir, 'test-cran-skeleton', 'rpart', 'DESCRIPTION')
+    with open(description, 'rb') as fp:
+        contents = read_description_contents(fp)
+    assert contents['Package'] == 'rpart'
+    assert contents['Priority'] == 'recommended'
+    assert contents['Title'] == 'Recursive Partitioning and Regression Trees'
+    assert contents['Depends'] == 'R (>= 2.15.0), graphics, stats, grDevices'
+    assert contents['License'] == 'GPL-2 | GPL-3'
+    assert contents['URL'] == 'https://github.com/bethatkinson/rpart, https://cran.r-project.org/package=rpart'
+
+
+def test_remove_comments():
+    example = '''
+#!keep
+# remove
+  # remove
+keep
+keep # keep
+'''
+    expected = '''
+#!keep
+keep
+keep # keep
+'''
+    observed = remove_comments(example)
+    assert observed == expected


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

I've found it difficult to work on the CRAN skeleton because its unit tests are in `tests/test_api_skeleton.py`, which for me takes about 45 minutes to run the entire file. It also has lots of errors and warnings, which make it difficult to quickly see if I've broken anything new.

This PR does 2 things:

1. It moves the existing CRAN skeleton tests in `test_api_skeleton.py` to `test_api_skeleton_cran.py`. Now `test_api_skeleton_cran.py` completes in ~90 seconds without errors
2. I created a new file `test_cran_skeleton.py` for quick unit tests. It was inspired by `test_pypi_skeleton.py`. It purposefully avoids downloading any internet resources so that it can run as quickly as possible. It completes in under a second without errors

I also confirmed that both test files pass flake8.

@dbast Please review