### PR TITLE
Fix keeping old work when workdir does not match package name

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -590,7 +590,7 @@ class Config:
         else:
             # Maybe call set_invocation_time() here?
             pat_dict['t'] = invocation_time
-            test_old_dir = join(self.croot, package_name, 'work')
+            test_old_dir = self.work_dir
             old_dir = test_old_dir if os.path.exists(test_old_dir) else None
 
         if self.set_build_id and (not self._build_id or reset):

--- a/news/rebuild_id_mismatch.rst
+++ b/news/rebuild_id_mismatch.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Old work directories will be preserved when `croot` and `build_id` are set manually
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>


### PR DESCRIPTION
#4167 changed the way `compute_build_id` was computed to be based on the package name. However, it also made the assumption that the old `work_dir` would be equal to `{croot}/{package name}/work` which is not true if someone manually passes in a `croot` and a `build_id` to the `Config` constructor; either manually or as a pass through on `api.render`.

The result was old work would be lost if the original `work_dir` did not match the specific string, instead of just looking where the original work_dir was. This PR fixes the bug and adds a test to make sure the work is preserved and correctly moved to the new folder.

This is a very niche edge case found when directly using the API at omnia-md/conda-dev-recipes#212

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
