### PR TITLE
Fix cross compiling noarch packages with arch dependent sub-package as dependency

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2851,8 +2851,8 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True, prov
     #     something like QEMU or Wine will be used on the build machine,
     #     therefore, for now, we use host_subdir.
 
-    subdir = ('noarch' if (metadata.noarch or metadata.noarch_python)
-                else metadata.config.host_subdir)
+    subdir = metadata.config.host_subdir
+
     # ensure that the test prefix isn't kept between variants
     utils.rm_rf(metadata.config.test_prefix)
 


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->

Fixes https://github.com/conda/conda-build/issues/2899
