### PR TITLE
[RFC] Add pyupgrade via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v2.31.0
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py37-plus"]
   - repo: https://github.com/akaihola/darker
     rev: github-action-v1.3.2-2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # generally speaking we ignore all vendored code as well as tests data
 # ignore patches/diffs since slight reformatting can break them
-exclude: ^(tests/(archives|index_data|test-cran-skeleton|test-recipes|test-skeleton|variant_recipe)/|.*\.(patch|diff))
+exclude: ^(tests/(archives|index_data|test-cran-skeleton|test-recipes|test-skeleton|variant_recipe)/|.*\.(patch|diff)|versioneer.py)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -15,6 +15,11 @@ repos:
         exclude: ^(conda\.recipe/meta\.yaml|conda_build/templates/.*\.yaml|docs/click/meta\.yaml|docs/source/user-guide/tutorials/meta\.yaml)
       # catch git merge/rebase problems
       - id: check-merge-conflict
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py36-plus"]
   - repo: https://github.com/akaihola/darker
     rev: github-action-v1.3.2-2
     hooks:


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
pyupgrade was applied before, so adding it to pre-commit does nothing, except for newly added code to be upgraded.

Also exclude versioneer.py as it is a vendored file.