### PR TITLE
Check that pyc & pyo files exist before removing

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -203,14 +203,18 @@ def rm_pyo(files, prefix):
     re_pyo = re.compile(r'.*(?:\.pyo$|\.opt-[0-9]\.pyc)')
     for fn in files:
         if re_pyo.match(fn):
-            os.unlink(join(prefix, fn))
+            path = join(prefix, fn)
+            if isfile(path):
+                os.unlink(path)
 
 
 def rm_pyc(files, prefix):
     re_pyc = re.compile(r'.*(?:\.pyc$)')
     for fn in files:
         if re_pyc.match(fn):
-            os.unlink(join(prefix, fn))
+            path = join(prefix, fn)
+            if isfile(path):
+                os.unlink(path)
 
 
 def rm_share_info_dir(files, prefix):


### PR DESCRIPTION
It seems like `rm_pyc` and `rm_pyo` can potentially attempt to remove the same file. 

```python-traceback
Traceback (most recent call last):
  File "/home/ci/miniconda3/bin/conda-build", line 11, in <module>
    sys.exit(main())
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/cli/main_build.py", line 488, in main
    execute(sys.argv[1:])
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/cli/main_build.py", line 479, in execute
    verify=args.verify, variants=args.variants, cache_dir=args.cache_dir)
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/api.py", line 195, in build
    variants=variants
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/build.py", line 3093, in build_tree
    notest=notest,
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/build.py", line 2371, in build
    newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/build.py", line 1664, in bundle_conda
    files = post_process_files(metadata, initial_files)
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/build.py", line 1483, in post_process_files
    skip_compile_pyc=m.get_value('build/skip_compile_pyc'))
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/post.py", line 296, in post_process
    rm_pyc(files, prefix)
  File "/home/ci/miniconda3/lib/python3.7/site-packages/conda_build/post.py", line 217, in rm_pyc
    os.unlink(path)
FileNotFoundError: [Errno 2] No such file or directory: ... __future__.cpython-310.opt-1.pyc
```