### PR TITLE
Add --append option to conda-index

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -365,7 +365,7 @@ def create_metapackage(name, version, entry_points=(), build_string=None, build_
 
 def update_index(dir_paths, config=None, force=False, check_md5=False, remove=False, channel_name=None,
                  subdir=None, threads=None, patch_generator=None, verbose=False, progress=False,
-                 hotfix_source_repo=None, current_index_versions=None, **kwargs):
+                 hotfix_source_repo=None, current_index_versions=None, append=None, **kwargs):
     import yaml
     from locale import getpreferredencoding
     import os
@@ -386,7 +386,7 @@ def update_index(dir_paths, config=None, force=False, check_md5=False, remove=Fa
                      patch_generator=patch_generator, threads=threads, verbose=verbose,
                      progress=progress, hotfix_source_repo=hotfix_source_repo,
                      subdirs=ensure_list(subdir), current_index_versions=current_index_versions,
-                     index_file=kwargs.get('index_file', None))
+                     index_file=kwargs.get('index_file', None), append=append)
 
 
 def debug(recipe_or_package_path_or_metadata_tuples, path=None, test=False,

--- a/conda_build/cli/main_index.py
+++ b/conda_build/cli/main_index.py
@@ -78,6 +78,11 @@ def parse_args(args):
         help="A file that contains a new line separated list of packages to add to repodata.",
         action="store"
     )
+    p.add_argument(
+        "-a", "--append",
+        help="Existing repodatas to append to.",
+        nargs="*"
+    )
 
     args = p.parse_args(args)
     return p, args
@@ -89,7 +94,7 @@ def execute(args):
     api.update_index(args.dir, check_md5=args.check_md5, channel_name=args.channel_name,
                      threads=args.threads, subdir=args.subdir, patch_generator=args.patch_generator,
                      verbose=args.verbose, progress=args.progress, hotfix_source_repo=args.hotfix_source_repo,
-                     current_index_versions=args.current_index_versions_file, index_file=args.file)
+                     current_index_versions=args.current_index_versions_file, index_file=args.file, append=args.append)
 
 
 def main():

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -787,7 +787,6 @@ class ChannelIndex:
         else:
             level = logging.ERROR
 
-        # dict(subdir: repodata)
         existing_repodatas = {}
         append = append or []
         for repodata in append:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -789,11 +789,12 @@ class ChannelIndex:
 
         # dict(subdir: repodata)
         existing_repodatas = {}
-        append = [] if not append else append
+        append = append or []
         for repodata in append:
-            with open(repodata) as fh:
-                j = json.load(fh)
-            existing_repodatas[j.get("info", {}).get("subdir", None)] = j
+            with open(repodata) as repodata_file:
+                loaded = json.load(repodata_file)
+            subdir = loaded.get("info", {}).get("subdir", None)
+            existing_repodatas[subdir] = loaded
 
         with utils.LoggingContext(level, loggers=[__name__]):
             if not self._subdirs:
@@ -830,7 +831,7 @@ class ChannelIndex:
 
                             if existing_repodata:
                                 existing_repodata.get("packages").update(
-                                        repodata_from_packages.get("packages")
+                                    repodata_from_packages.get("packages")
                                 )
 
                             t2.set_description("Writing pre-patch repodata")

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -258,7 +258,7 @@ def update_index(dir_path, check_md5=False, channel_name=None, patch_generator=N
         return update_index(base_path, check_md5=check_md5, channel_name=channel_name,
                             threads=threads, verbose=verbose, progress=progress,
                             hotfix_source_repo=hotfix_source_repo,
-                            current_index_versions=current_index_versions, append=appen)
+                            current_index_versions=current_index_versions, append=append)
     return ChannelIndex(dir_path, channel_name, subdirs=subdirs, threads=threads,
                         deep_integrity_check=check_md5, debug=debug).index(
                             patch_generator=patch_generator, verbose=verbose,

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -791,7 +791,7 @@ class ChannelIndex:
         existing_repodatas = {}
         append = [] if not append else append
         for repodata in append:
-            with open(repodata, "r") as fh:
+            with open(repodata) as fh:
                 j = json.load(fh)
             existing_repodatas[j.get("info", {}).get("subdir", None)] = j
 

--- a/news/add_append_option_to_conda_index.rst
+++ b/news/add_append_option_to_conda_index.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* Adds `--append` to `conda-index` which allows a user to append to a `repodata.json`. This is useful because sometimes a user may not have the entire channel locally to run `conda-index` against. As an example, if a user wanted to upload a single package to a channel, this would allow them to simply download the `repodata.json` run `conda-index --append $PATH_TO_REPODATA $PATH_TO_PKGS` and have an up-to-date `repodata.json`.
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -135,6 +135,95 @@ def test_index_on_single_subdir_1(testing_workdir):
     assert actual_channeldata_json == expected_channeldata_json
 
 
+def test_index_on_single_subdir_1_append(testing_workdir):
+    test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
+    test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
+    download(test_package_url, test_package_path)
+    test_repodata_path = join(testing_workdir, "osx-64", "repodata.json")
+    test_repodata_data = {
+        "info": {
+            'subdir': 'osx-64',
+        },
+        "packages": {
+            "test-pkg-a-1.0-py37h5e241af_0.tar.bz2": {
+                "build": "py37h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "osx-64",
+                "timestamp": 1508520039632,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    with open(test_repodata_path, "w") as fh:
+        json.dump(test_repodata_data, fh)
+    conda_build.index.update_index(testing_workdir, channel_name='test-channel', append=[test_repodata_path])
+
+    # #######################################
+    # tests for osx-64 subdir
+    # #######################################
+    assert isfile(join(testing_workdir, 'osx-64', 'index.html'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json.bz2'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json.bz2'))
+
+    with open(join(testing_workdir, 'osx-64', 'repodata.json')) as fh:
+        actual_repodata_json = json.loads(fh.read())
+    with open(join(testing_workdir, 'osx-64', 'repodata_from_packages.json')) as fh:
+        actual_pkg_repodata_json = json.loads(fh.read())
+    expected_repodata_json = {
+        "info": {
+            'subdir': 'osx-64',
+        },
+        "packages": {
+            "conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2": {
+                "build": "py27h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "osx-64",
+                "timestamp": 1508520039632,
+                "version": "1.0",
+            },
+            "test-pkg-a-1.0-py37h5e241af_0.tar.bz2": {
+                "build": "py37h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "osx-64",
+                "timestamp": 1508520039632,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    assert actual_repodata_json == expected_repodata_json
+    assert actual_pkg_repodata_json == expected_repodata_json
+
+
 def test_file_index_on_single_subdir_1(testing_workdir):
     test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
     test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
@@ -359,6 +448,192 @@ def test_index_noarch_osx64_1(testing_workdir):
                 "size": 7882,
                 "subdir": "noarch",
                 "timestamp": 1508520204768,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    assert actual_repodata_json == expected_repodata_json
+    assert actual_pkg_repodata_json == expected_repodata_json
+
+    # #######################################
+    # tests for full channel
+    # #######################################
+
+    with open(join(testing_workdir, 'channeldata.json')) as fh:
+        actual_channeldata_json = json.loads(fh.read())
+    expected_channeldata_json = {
+        "channeldata_version": 1,
+        "packages": {
+            "conda-index-pkg-a": {
+                "description": "Description field for conda-index-pkg-a. Actually, this is just the python description. "
+                               "Python is a widely used high-level, general-purpose, interpreted, dynamic "
+                               "programming language. Its design philosophy emphasizes code "
+                               "readability, and its syntax allows programmers to express concepts in "
+                               "fewer lines of code than would be possible in languages such as C++ or "
+                               "Java. The language provides constructs intended to enable clear programs "
+                               "on both a small and large scale.",
+                "dev_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/meta.yaml",
+                "doc_source_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a/README.md",
+                "doc_url": "https://github.com/kalefranz/conda-test-packages/blob/master/conda-index-pkg-a",
+                "home": "https://anaconda.org/conda-test/conda-index-pkg-a",
+                "license": "BSD",
+                "source_git_url": "https://github.com/kalefranz/conda-test-packages.git",
+                'source_url': None,
+                "subdirs": [
+                    "noarch",
+                    "osx-64",
+                ],
+                "summary": "Summary field for conda-index-pkg-a. This is the python noarch version.",  # <- tests that the higher noarch build number is the data collected
+                "version": "1.0",
+                "activate.d": False,
+                "deactivate.d": False,
+                "post_link": True,
+                "pre_link": False,
+                "pre_unlink": False,
+                "binary_prefix": False,
+                "text_prefix": True,
+                "run_exports": {},
+                'icon_hash': None,
+                'icon_url': None,
+                'identifiers': None,
+                'tags': None,
+                'timestamp': 1508520039,
+                'keywords': None,
+                'recipe_origin': None,
+            }
+        },
+        "subdirs": [
+            "noarch",
+            "osx-64",
+        ]
+    }
+    assert actual_channeldata_json == expected_channeldata_json
+
+
+def test_index_noarch_osx64_1_append(testing_workdir):
+    test_package_path = join(testing_workdir, 'osx-64', 'conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2')
+    test_package_url = 'https://conda.anaconda.org/conda-test/osx-64/conda-index-pkg-a-1.0-py27h5e241af_0.tar.bz2'
+    download(test_package_url, test_package_path)
+    test_repodata_path_osx = join(testing_workdir, "osx-64", "repodata.json")
+    test_repodata_data_osx = {
+        "info": {
+            'subdir': 'osx-64',
+        },
+        "packages": {
+            "some-fake-pkg-a-1.0-py37h5e241af_0.tar.bz2": {
+                "build": "py37h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "osx-64",
+                "timestamp": 1508520039632,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    with open(test_repodata_path_osx, "w") as fh:
+        json.dump(test_repodata_data_osx, fh)
+
+    test_package_path = join(testing_workdir, 'noarch', 'conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2')
+    test_package_url = 'https://conda.anaconda.org/conda-test/noarch/conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2'
+    download(test_package_url, test_package_path)
+    test_repodata_path_noarch = join(testing_workdir, "noarch", "repodata.json")
+    test_repodata_data_noarch = {
+        "info": {
+            'subdir': 'noarch',
+        },
+        "packages": {
+            "some-fake-pkg-but-noarch-a-1.0-py37h5e241af_0.tar.bz2": {
+                "build": "py37h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "noarch",
+                "timestamp": 1508520039632,
+                "version": "1.0",
+            },
+        },
+        "packages.conda": {},
+        "removed": [],
+        "repodata_version": 1,
+    }
+    with open(test_repodata_path_noarch, "w") as fh:
+        json.dump(test_repodata_data_noarch, fh)
+
+    conda_build.index.update_index(testing_workdir, channel_name='test-channel', append=[test_repodata_path_osx, test_repodata_path_noarch])
+
+    # #######################################
+    # tests for osx-64 subdir
+    # #######################################
+    assert isfile(join(testing_workdir, 'osx-64', 'index.html'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json'))  # repodata is tested in test_index_on_single_subdir_1
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata.json.bz2'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json'))
+    assert isfile(join(testing_workdir, 'osx-64', 'repodata_from_packages.json.bz2'))
+
+    # #######################################
+    # tests for noarch subdir
+    # #######################################
+    assert isfile(join(testing_workdir, 'noarch', 'index.html'))
+    assert isfile(join(testing_workdir, 'noarch', 'repodata.json.bz2'))
+    assert isfile(join(testing_workdir, 'noarch', 'repodata_from_packages.json.bz2'))
+
+    with open(join(testing_workdir, 'noarch', 'repodata.json')) as fh:
+        actual_repodata_json = json.loads(fh.read())
+    with open(join(testing_workdir, 'noarch', 'repodata_from_packages.json')) as fh:
+        actual_pkg_repodata_json = json.loads(fh.read())
+    expected_repodata_json = {
+        "info": {
+            'subdir': 'noarch',
+        },
+        "packages": {
+            "conda-index-pkg-a-1.0-pyhed9eced_1.tar.bz2": {
+                "build": "pyhed9eced_1",
+                "build_number": 1,
+                "depends": [
+                    "python"
+                ],
+                "license": "BSD",
+                "md5": "56b5f6b7fb5583bccfc4489e7c657484",
+                "name": "conda-index-pkg-a",
+                "noarch": "python",
+                "sha256": "7430743bffd4ac63aa063ae8518e668eac269c783374b589d8078bee5ed4cbc6",
+                "size": 7882,
+                "subdir": "noarch",
+                "timestamp": 1508520204768,
+                "version": "1.0",
+            },
+            "some-fake-pkg-but-noarch-a-1.0-py37h5e241af_0.tar.bz2": {
+                "build": "py37h5e241af_0",
+                "build_number": 0,
+                "depends": [
+                    "python >=2.7,<2.8.0a0"
+                ],
+                "license": "BSD",
+                "md5": "37861df8111170f5eed4bff27868df59",
+                "name": "conda-index-pkg-a",
+                "sha256": "459f3e9b2178fa33bdc4e6267326405329d1c1ab982273d9a1c0a5084a1ddc30",
+                "size": 8733,
+                "subdir": "noarch",
+                "timestamp": 1508520039632,
                 "version": "1.0",
             },
         },


### PR DESCRIPTION
Adds `--append` option to `conda-index` in order to simply add newly built packages to `repodata.json`. The motivation is to be able add to an existing repodata without needing every file locally and regenerating it. 