### PR TITLE
Add `entry_points` to `outputs` in `FIELDS`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -448,6 +448,7 @@ FIELDS = {
         'name': None,
         'version': None,
         'number': None,
+        'entry_points': None,
         'script': None,
         'script_interpreter': None,
         'build': None,


### PR DESCRIPTION
This appears to be usable in recipes and [covered in the tests]( https://github.com/conda/conda-build/blob/3b99b2222a067e113a2282926871cd1e5406ee2b/tests/test-recipes/split-packages/_entry_points/meta.yaml#L19-L22 ). So add it to `FIELDS`.