### PR TITLE
Also rewrite long prefix paths in `output` scripts $PREFIX, etc.

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2397,6 +2397,7 @@ def build(m, stats, post=None, need_source_download=True, need_reparse_in_env=Fa
 
 def initialize_rewrite_env(
     env: "typing.Mapping[str, str]",
+    *,
     is_windows: bool,
     metadata: MetaData,
     verbose_output: bool = True,
@@ -2942,6 +2943,7 @@ def test(recipedir_or_package_or_metadata, config, stats, move_broken=True, prov
                 metadata=metadata,
                 verbose_output=metadata.config.verbose,
                 include_build_prefix=False,
+                is_windows=utils.on_win,
             )
             utils.check_call_env(
                 cmd,


### PR DESCRIPTION
Whilst the intention initially was for ouput scripts to mostly do bundling it has emerged as a rather common pattern for recipes to not have a base recipe at all and the main build work is done in an output script.

As a result of this use case, output scripts should have the same filtering applied to them as build scripts

Example: https://github.com/conda-forge/arrow-cpp-feedstock/blob/main/recipe/meta.yaml
