### PR TITLE
Support Setuptools 61.0.0+

### DIFF
--- a/conda_build/_load_setup_py_data.py
+++ b/conda_build/_load_setup_py_data.py
@@ -47,7 +47,12 @@ def load_setup_py_data(setup_file, from_recipe_dir=False, recipe_dir=None, work_
 
     setup_cfg_data = {}
     try:
-        from setuptools.config import read_configuration
+        try:
+            # Recommended for setuptools 61.0.0+
+            # (though may disappear in the future)
+            from setuptools.config.setupcfg import read_configuration
+        except ImportError:
+            from setuptools.config import read_configuration
     except ImportError:
         pass  # setuptools <30.3.0 cannot read metadata / options from 'setup.cfg'
     else:

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -114,7 +114,12 @@ def test_resolved_packages(testing_metadata):
 
 
 try:
-    from setuptools.config import read_configuration
+    try:
+        # Recommended for setuptools 61.0.0+
+        # (though may disappear in the future)
+        from setuptools.config.setupcfg import read_configuration
+    except ImportError:
+        from setuptools.config import read_configuration
     del read_configuration
 except ImportError:
     _has_read_configuration = False


### PR DESCRIPTION
Fixes https://github.com/conda/conda-build/issues/4428

This fixes the deprecation warning raised by Setuptools when using `load_setup_py_data` in recipes. Also fixes a similar issue in the tests.

It is worth noting that Setuptools status this provisional module `setupcfg` may go away in the future. So we may need another solution for when that happens. Though it is unclear atm what that would be.

<!---
Thanks for opening a PR on conda-build!

Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html

If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.

Thanks again!
-->
