### PR TITLE
cache test packages in memory

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -3,7 +3,6 @@ from logging import getLogger
 import os
 from os.path import dirname, isdir, join, isfile
 import requests
-import shutil
 import tarfile
 import functools
 
@@ -20,6 +19,7 @@ from conda_build.conda_interface import conda_47
 from .utils import metadata_dir, archive_dir
 
 log = getLogger(__name__)
+
 
 # NOTE: The recipes for test packages used in this module are at https://github.com/kalefranz/conda-test-packages
 @functools.lru_cache(maxsize=None)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -22,7 +22,7 @@ from .utils import metadata_dir, archive_dir
 log = getLogger(__name__)
 
 # NOTE: The recipes for test packages used in this module are at https://github.com/kalefranz/conda-test-packages
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def download_cached(url):
     """
     Store packages in memory during the test run, to avoid each individual test re-downloading.


### PR DESCRIPTION
Each individual test downloads test packages, and this is slow. Cache in memory instead.