### PR TITLE
Add CLI option for changing the compression settings

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1689,8 +1689,13 @@ def bundle_conda(output, metadata, env, stats, **kw):
         else CONDA_PACKAGE_EXTENSION_V1
     )
     with TemporaryDirectory() as tmp:
-        conda_package_handling.api.create(metadata.config.host_prefix, files,
-                                          basename + ext, out_folder=tmp)
+        conda_package_handling.api.create(
+            metadata.config.host_prefix,
+            files,
+            basename + ext,
+            out_folder=tmp,
+            compression_tuple=metadata.config.compression_tuple,
+        )
         tmp_archives = [os.path.join(tmp, basename + ext)]
 
         # we're done building, perform some checks

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1683,18 +1683,16 @@ def bundle_conda(output, metadata, env, stats, **kw):
     basename = '-'.join([output['name'], metadata.version(), metadata.build_id()])
     tmp_archives = []
     final_outputs = []
-    ext = (
-        CONDA_PACKAGE_EXTENSION_V2
-        if (output.get('type') == 'conda_v2' or metadata.config.conda_pkg_format == "2")
-        else CONDA_PACKAGE_EXTENSION_V1
-    )
+    cph_kwargs = {}
+    ext = CONDA_PACKAGE_EXTENSION_V1
+    if (output.get('type') == 'conda_v2' or metadata.config.conda_pkg_format == "2"):
+        ext = CONDA_PACKAGE_EXTENSION_V2
+        cph_kwargs["compression_tuple"] = (
+            '.tar.zst', 'zstd', f'zstd:compression-level={metadata.config.zstd_compression_level}'
+        )
     with TemporaryDirectory() as tmp:
         conda_package_handling.api.create(
-            metadata.config.host_prefix,
-            files,
-            basename + ext,
-            out_folder=tmp,
-            compression_tuple=metadata.config.compression_tuple,
+            metadata.config.host_prefix, files, basename + ext, out_folder=tmp, **cph_kwargs
         )
         tmp_archives = [os.path.join(tmp, basename + ext)]
 

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -24,7 +24,7 @@ from conda_build.cli.main_render import get_render_parser
 from conda_build.cli.actions import KeyValueAction
 import conda_build.source as source
 from conda_build.utils import LoggingContext
-from conda_build.config import Config, get_channel_urls
+from conda_build.config import Config, zstd_compression_level_default, get_channel_urls
 from os.path import abspath, expanduser, expandvars
 
 on_win = (sys.platform == 'win32')
@@ -158,6 +158,14 @@ different sets of packages."""
         dest='force_upload',
         default=True,
         action='store_false',
+    )
+    p.add_argument(
+        "--zstd-compression-level",
+        help=("When building v2 packages, set the compression level used by "
+              "conda-package-handling. Defaults to the maximum."),
+        type=int,
+        choices=range(1, 22),
+        default=zstd_compression_level_default,
     )
     pypi_grp = p.add_argument_group("PyPI upload parameters (twine)")
     pypi_grp.add_argument(

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -48,6 +48,7 @@ no_rewrite_stdout_env_default = 'false'
 ignore_verify_codes_default = []
 exit_on_verify_error_default = False
 conda_pkg_format_default = None
+zstd_compression_level_default = 22
 
 
 # Python2 silliness:
@@ -213,8 +214,8 @@ def _get_default_settings():
             # customize this so pip doesn't look in places we don't want.  Per-build path by default.
             Setting('_pip_cache_dir', None),
 
-            # set up compression algorithm used in new-style packages
-            Setting('compression_tuple', ('.tar.zst', 'zstd', 'zstd:compression-level=22')),
+            Setting('zstd_compression_level',
+                    cc_conda_build.get('zstd_compression_level', zstd_compression_level_default)),
 
             # this can be set to different values (currently only 2 means anything) to use package formats
             Setting('conda_pkg_format', cc_conda_build.get('pkg_format', conda_pkg_format_default)),

--- a/news/compression_tuple.rst
+++ b/news/compression_tuple.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* Support using ``--zstd-compression-level`` to control the compression of v2 style conda packages.
+
+Bug fixes:
+----------
+
+* <news item>
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>


### PR DESCRIPTION
I keep finding myself needing to build an extremely large package (many gigabytes) which causes zstandard to use an excessive amount of memory when used in combination with `level=22`. Even when it works I've seen `level=22` an hour when `level=1` takes ~10 seconds which is worthwhile when debugging and not deploying the packages. (I actually wonder if a lower level by default would be more appropriate to make installations faster but that's a separate question.)

As this is configurable behind the scenes I think it would be good to expose the option to the CLI.

Any thoughts?