### PR TITLE
get_stdlib_dir(): Don't select python3.1 symlink; select python3.10

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -2,6 +2,7 @@ from collections import OrderedDict, defaultdict
 import contextlib
 import fnmatch
 import hashlib
+from itertools import filterfalse
 import json
 from locale import getpreferredencoding
 import libarchive
@@ -1008,6 +1009,7 @@ def get_stdlib_dir(prefix, py_ver):
     else:
         lib_dir = os.path.join(prefix, 'lib')
         python_folder = glob(os.path.join(lib_dir, 'python?.*'))
+        python_folder = sorted(filterfalse(islink, python_folder))
         if python_folder:
             lib_dir = os.path.join(lib_dir, python_folder[0])
         else:

--- a/news/fix-sp_dir.rst
+++ b/news/fix-sp_dir.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* When building with Python 3.10, ``STDLIB_DIR`` and ``SP_DIR`` now refer to ``python3.10``, not the symlink ``python3.1``. (#4479)
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/tests/test-recipes/metadata/python_build/build.sh
+++ b/tests/test-recipes/metadata/python_build/build.sh
@@ -1,6 +1,9 @@
 if [ -z "${STDLIB_DIR:-}" ]; then
     echo "STDLIB_DIR is unset";
     exit 1
+elif [[ ${STDLIB_DIR} =~ '.*python3\.(1|2)$' ]]; then
+    echo "STDLIB_DIR is set to wrong path: $STDLIB_DIR"
+    exit 1
 else
     echo "STDLIB_DIR is set to $STDLIB_DIR";
     echo "STDLIB_DIR has $(ls -l $STDLIB_DIR | wc -l) lines"


### PR DESCRIPTION
This way, variables like `STDLIB_DIR` and `SP_DIR` will point to the `python3.10` directory, not the symlink `python3.1`.

Fixes #4477

Related threads:

- https://github.com/conda/conda/issues/10969
- https://github.com/conda/conda/issues/11423
- https://github.com/conda/conda/pull/10478
- https://github.com/conda/conda/pull/10970
- https://github.com/conda-forge/python-feedstock/pull/511
- https://github.com/AnacondaRecipes/python-feedstock/pull/47