### PR TITLE
Fix spelling of pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,7 +242,7 @@ jobs:
           set PERL=
           set LUA=
           set R=
-          py.test --color=yes -vv -n 0 --basetemp %UserProfile%\cbtmp_serial --cov conda_build --cov-report xml -m "serial" ${{ env.pytest-replay }}
+          pytest --color=yes -vv -n 0 --basetemp %UserProfile%\cbtmp_serial --cov conda_build --cov-report xml -m "serial" ${{ env.pytest-replay }}
         shell: cmd
 
       - name: Run Parallel Tests
@@ -256,7 +256,7 @@ jobs:
           set PERL=
           set LUA=
           set R=
-          py.test --color=yes -vv -n auto --basetemp %UserProfile%\cbtmp --cov conda_build --cov-append --cov-report xml -m "not serial" ${{ env.pytest-replay }}
+          pytest --color=yes -vv -n auto --basetemp %UserProfile%\cbtmp --cov conda_build --cov-append --cov-report xml -m "not serial" ${{ env.pytest-replay }}
         shell: cmd
         env:
           VS90COMNTOOLS: C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC\bin
@@ -332,7 +332,7 @@ jobs:
           set -e -u
           source ci/github/activate_conda "${{ github.workspace }}/miniconda/bin/python"
           conda install conda-verify -y
-          py.test --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
+          pytest --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
 
       - name: Run Parallel Tests
         if: matrix.test-type == 'parallel'
@@ -346,7 +346,7 @@ jobs:
           conda create -n blarg1 -yq python=2.7
           conda create -n blarg3 -yq python=3.7
           conda create -n blarg4 -yq python nomkl numpy pandas svn
-          py.test --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
+          pytest --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}"
 
       - name: Upload Pytest Replay
         uses: actions/upload-artifact@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ outside of `conda-build`'s build tree.
 
 Follow the installation instructions above to properly set up your environment for testing.
 
-The test suite runs with `py.test`. The following are some useful commands for running specific
+The test suite runs with `pytest`. The following are some useful commands for running specific
 tests, assuming you are in the `conda-build` root folder:
 
 ### Run all tests:
@@ -81,12 +81,12 @@ tests, assuming you are in the `conda-build` root folder:
 
 ### Run one test file:
 ```bash
-    py.test tests/test_api_build.py
+    pytest tests/test_api_build.py
 ```
 
 ### Run one test function:
 ```bash
-    py.test tests/test_api_build.py::test_early_abort
+    pytest tests/test_api_build.py::test_early_abort
 ```
 
 ### Run one parameter of one parametrized test function:
@@ -94,9 +94,9 @@ tests, assuming you are in the `conda-build` root folder:
 Several tests are parametrized, to run some small change, or build several
 recipe folders. To choose only one of them::
 ```bash
-    py.test tests/test_api_build.py::test_recipe_builds.py[entry_points]
+    pytest tests/test_api_build.py::test_recipe_builds.py[entry_points]
 ```
-Note that our tests use `py.test` fixtures extensively. These sometimes trip up IDE
+Note that our tests use `pytest` fixtures extensively. These sometimes trip up IDE
 style checkers about unused or redefined variables. These warnings are safe to
 ignore.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,8 @@ from conda_build.utils import check_call_env, prepend_bin_path, copy_into
 def testing_workdir(tmpdir, request):
     """ Create a workdir in a safe temporary folder; cd into dir above before test, cd out after
 
-    :param tmpdir: py.test fixture, will be injected
-    :param request: py.test fixture-related, will be injected (see pytest docs)
+    :param tmpdir: pytest fixture, will be injected
+    :param request: pytest fixture-related, will be injected (see pytest docs)
     """
 
     saved_path = os.getcwd()
@@ -47,8 +47,8 @@ def testing_workdir(tmpdir, request):
 def testing_homedir(tmpdir, request):
     """ Create a homedir in the users home directory; cd into dir above before test, cd out after
 
-    :param tmpdir: py.test fixture, will be injected
-    :param request: py.test fixture-related, will be injected (see pytest docs)
+    :param tmpdir: pytest fixture, will be injected
+    :param request: pytest fixture-related, will be injected (see pytest docs)
     """
 
     saved_path = os.getcwd()


### PR DESCRIPTION
pytest dropped the dot as in `py.test` already a couple of years ago.
