### PR TITLE
Add `patch`/`m2-patch` as a hard dependency

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - futures       # [py<3]
     - jinja2
     - patchelf      # [linux]
+    - patch     >=2.6   # [not win]
+    - m2-patch  >=2.6   # [win]
     - pkginfo
     - psutil
     - py-lief       # [not win]

--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -46,7 +46,7 @@ class UnableToParseMissingJinja2(UnableToParse):
         ])
 
 
-class UnableToParseMissingSetuptoolsDependencies(CondaBuildException):
+class MissingDependency(CondaBuildException):
     pass
 
 

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -787,6 +787,7 @@ def apply_one_patch(src_dir, recipe_dir, rel_path, config, git=None):
     attributes_output = ""
     # While --binary was first introduced in patch 2.3 it wasn't until patch 2.6 that it produced
     # consistent results across OSes. So patch/m2-patch is a hard dependency of conda-build.
+    # See conda-build#4495
     patch_exe = external.find_executable("patch")
     if not patch_exe:
         raise MissingDependency("Failed to find conda-build dependency: 'patch'")

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -493,9 +493,7 @@ _RE_LF = re.compile(rb"(?<!\r)\n")
 _RE_CRLF = re.compile(rb"\r\n")
 
 
-def _ensure_unix_line_endings(
-    src: os.PathLike, dst: Optional[os.PathLike] = None
-) -> Path:
+def _ensure_LF(src: os.PathLike, dst: Optional[os.PathLike] = None) -> Path:
     """Replace windows line endings with Unix.  Return path to modified file."""
     src = Path(src)
     dst = Path(dst or src)  # overwrite src if dst is undefined
@@ -503,9 +501,7 @@ def _ensure_unix_line_endings(
     return dst
 
 
-def _ensure_win_line_endings(
-    src: os.PathLike, dst: Optional[os.PathLike] = None
-) -> Path:
+def _ensure_CRLF(src: os.PathLike, dst: Optional[os.PathLike] = None) -> Path:
     """Replace unix line endings with win.  Return path to modified file."""
     src = Path(src)
     dst = Path(dst or src)  # overwrite src if dst is undefined
@@ -661,9 +657,9 @@ def _get_patch_attributes(path, patch_exe, git, src_dir, stdout, stderr, retaine
                     except:
                         shutil.copy(path, new_patch)
                 elif fmt == 'lf':
-                    _ensure_unix_line_endings(path, new_patch)
+                    _ensure_LF(path, new_patch)
                 elif fmt == 'crlf':
-                    _ensure_win_line_endings(path, new_patch)
+                    _ensure_CRLF(path, new_patch)
                 result['patches'][fmt] = new_patch
 
             tmp_src_dir = os.path.join(tmpdir, 'src_dir')

--- a/news/4495-patch-hard-dependency
+++ b/news/4495-patch-hard-dependency
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Fix patch tests. (#4495)
+* Added patch/m2-patch as a hard dependency. (#4495)

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -70,9 +70,6 @@ def patch_paths(tmp_path):
     return paths
 
 
-# TODO :: These should require a build env with patch (or m2-patch) in it.
-#         at present, only ci/github/install_conda_build_test_deps installs
-#         this.
 def test_patch_paths(tmp_path, patch_paths, testing_config):
     assert patch_paths.deletion.exists()
     assert not patch_paths.creation.exists()

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -5,8 +5,12 @@ from subprocess import CalledProcessError
 
 import pytest
 
-from conda_build.source import (_ensure_unix_line_endings, _ensure_win_line_endings,
-                                _guess_patch_strip_level, apply_patch)
+from conda_build.source import (
+    _ensure_LF,
+    _ensure_CRLF,
+    _guess_patch_strip_level,
+    apply_patch,
+)
 
 
 def test_patch_strip_level(testing_workdir, monkeypatch):
@@ -88,14 +92,14 @@ def test_ensure_unix_line_endings_with_nonutf8_characters(tmp_path):
     win_path.write_bytes(b"\xf1\r\n")  # tilde-n encoded in latin1
 
     unix_path = tmp_path / "unix_le"
-    _ensure_unix_line_endings(win_path, unix_path)
+    _ensure_LF(win_path, unix_path)
     unix_path.read_bytes() == b"\xf1\n"
 
 
 def test_lf_source_lf_patch(tmp_path, patch_paths, testing_config):
-    _ensure_unix_line_endings(patch_paths.modification)
-    _ensure_unix_line_endings(patch_paths.deletion)
-    _ensure_unix_line_endings(patch_paths.diff)
+    _ensure_LF(patch_paths.modification)
+    _ensure_LF(patch_paths.deletion)
+    _ensure_LF(patch_paths.diff)
 
     apply_patch(str(tmp_path), patch_paths.diff, testing_config)
 
@@ -103,27 +107,27 @@ def test_lf_source_lf_patch(tmp_path, patch_paths, testing_config):
 
 
 def test_lf_source_crlf_patch(tmp_path, patch_paths, testing_config):
-    _ensure_unix_line_endings(patch_paths.modification)
-    _ensure_unix_line_endings(patch_paths.deletion)
-    _ensure_win_line_endings(patch_paths.diff)
+    _ensure_LF(patch_paths.modification)
+    _ensure_LF(patch_paths.deletion)
+    _ensure_CRLF(patch_paths.diff)
 
     with pytest.raises(CalledProcessError):
         apply_patch(str(tmp_path), patch_paths.diff, testing_config)
 
 
 def test_crlf_source_lf_patch(tmp_path, patch_paths, testing_config):
-    _ensure_win_line_endings(patch_paths.modification)
-    _ensure_win_line_endings(patch_paths.deletion)
-    _ensure_unix_line_endings(patch_paths.diff)
+    _ensure_CRLF(patch_paths.modification)
+    _ensure_CRLF(patch_paths.deletion)
+    _ensure_LF(patch_paths.diff)
 
     with pytest.raises(CalledProcessError):
         apply_patch(str(tmp_path), patch_paths.diff, testing_config)
 
 
 def test_crlf_source_crlf_patch(tmp_path, patch_paths, testing_config):
-    _ensure_win_line_endings(patch_paths.modification)
-    _ensure_win_line_endings(patch_paths.deletion)
-    _ensure_win_line_endings(patch_paths.diff)
+    _ensure_CRLF(patch_paths.modification)
+    _ensure_CRLF(patch_paths.deletion)
+    _ensure_CRLF(patch_paths.diff)
 
     apply_patch(str(tmp_path), patch_paths.diff, testing_config)
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While doing the recent conda-build 3.21.9 release (#4483) we noticed that the [`test_ensure_unix_line_endings_with_nonutf8_characters` test would fail](https://github.com/conda/conda-build/runs/6667921343?check_suite_focus=true#step:11:1160) during cleanup of it's temporary files. No good reason for why this occurred as the test would usually pass. 🤷🏻‍♂️ 

#### Rabbit hole
In trying to rework the test to be more robust we learned a couple of things:
1. The tests defined in `tests/test_patch.py` weren't actually testing what they claimed to test. They claimed to be able to successfully apply a mismatched line endings patch (e.g. an LF patch could be applied to a CRLF source and vice-versa). The tests were instead consistently testing matching line endings.
3. In trying to correct the test to actually test the expected behavior we found that the claim was in fact false. `patch` will not apply a patch with a mismatched line endings source.
4. We also discovered that the necessary `--binary` flag for `patch` while originally introduced in `patch` 2.3 does not work as we expect/need it to until it was amended in `patch` 2.6. MacOS however still ships `patch` 2.5.

#### Solution
With all of this in mind, we propose adding `patch`/`m2-patch`>=2.6 as a hard dependency of conda-build in addition to the other improvements to `conda_build.source._ensure_LF` and `conda_build.source._ensure_CRLF` and their tests.

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda/blob/master/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).
     Finally, once again thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!
     Helpful links:
       - Conda Org COC:
       - Contributing docs: https://github.com/conda/conda/blob/master/CONTRIBUTING.md -->