### PR TITLE
Replace `r-cortools` with `r-badger` for "Artistic-2.0" license testing

### DIFF
--- a/news/4516-replace-cortools-badger
+++ b/news/4516-replace-cortools-badger
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Update "Artistic-2.0" license test to use a valid package. (#4516)

--- a/tests/test_api_skeleton_cran.py
+++ b/tests/test_api_skeleton_cran.py
@@ -14,15 +14,28 @@ from conda_build.utils import ensure_list
 
 # CRAN packages to test license_file entry.
 # (package, license_id, license_family, license_files)
-cran_packages = [('r-rmarkdown', 'GPL-3', 'GPL3', 'GPL-3'),  # cran: 'GPL-3'
-                 ('r-cortools', 'Artistic-2.0', 'OTHER', 'Artistic-2.0'),  # cran: 'Artistic License 2.0'
-                 ('r-udpipe', 'MPL-2.0', 'OTHER', ''),  # cran: 'MPL-2.0'
-                 ('r-broom', 'MIT', 'MIT', ['MIT', 'LICENSE']),  # cran: 'MIT + file LICENSE'
-                 ('r-meanr', 'BSD_2_clause', 'BSD', ['BSD_2_clause', 'LICENSE']),  # cran: 'BSD 2-clause License + file LICENSE'
-                 ('r-zoo', 'GPL-2 | GPL-3', 'GPL3', ['GPL-2', 'GPL-3']),  # cran: 'GPL-2 | GPL-3'
-                 ('r-magree', 'GPL-3 | GPL-2', 'GPL3', ['GPL-3', 'GPL-2']),  # cran: 'GPL-3 | GPL-2'
-                 ('r-mglm', 'GPL-2', 'GPL2', 'GPL-2'),  # cran: 'GPL (>= 2)'
-                 ]
+cran_packages = [
+    ("r-rmarkdown", "GPL-3", "GPL3", "GPL-3"),  # cran: 'GPL-3'
+    (
+        # cran: 'Artistic License 2.0'
+        "r-badger",
+        "Artistic-2.0",
+        "OTHER",
+        "Artistic-2.0",
+    ),
+    ("r-udpipe", "MPL-2.0", "OTHER", ""),  # cran: 'MPL-2.0'
+    ("r-broom", "MIT", "MIT", ["MIT", "LICENSE"]),  # cran: 'MIT + file LICENSE'
+    (
+        # cran: 'BSD 2-clause License + file LICENSE'
+        "r-meanr",
+        "BSD_2_clause",
+        "BSD",
+        ["BSD_2_clause", "LICENSE"],
+    ),
+    ("r-zoo", "GPL-2 | GPL-3", "GPL3", ["GPL-2", "GPL-3"]),  # cran: 'GPL-2 | GPL-3'
+    ("r-magree", "GPL-3 | GPL-2", "GPL3", ["GPL-3", "GPL-2"]),  # cran: 'GPL-3 | GPL-2'
+    ("r-mglm", "GPL-2", "GPL2", "GPL-2"),  # cran: 'GPL (>= 2)'
+]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
CRAN R archived `cortools` on 2022-06-20 so this test fails.

Found a different "Artistic-2.0" licensed package (`badger`) to use instead.