### PR TITLE
Make default logger list more complete

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1332,7 +1332,8 @@ class LoggingContext:
     default_loggers = ['conda', 'binstar', 'install', 'conda.install', 'fetch', 'conda.instructions',
                        'fetch.progress', 'print', 'progress', 'dotupdate', 'stdoutlog', 'requests',
                        'conda.core.package_cache', 'conda.plan', 'conda.gateways.disk.delete',
-                       'conda_build', 'conda_build.index']
+                       'conda_build', 'conda_build.index', 'conda_build.noarch_python',
+                       'urllib3.connectionpool']
 
     def __init__(self, level=logging.WARN, handler=None, close=True, loggers=None):
         self.level = level

--- a/news/reduce-urllib3-verbosity
+++ b/news/reduce-urllib3-verbosity
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Reduce verbosity of urllib3 on the default log level


### PR DESCRIPTION
Notably, `urllib3.connectionpool` was missing from the list. This caused debug messages like the following to be added to the output, even though `--verbose` was not given and the log level of the other loggers was set to `INFO`:

```
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): conda.anaconda.org:443
DEBUG:urllib3.connectionpool:https://conda.anaconda.org:443 "GET /conda-forge/linux-64/repodata.json HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://conda.anaconda.org:443 "GET /conda-forge/noarch/repodata.json HTTP/1.1" 200 None
```

Also, `conda_build.noarch_python` was missing.
