### PR TITLE
Rename 'sysroot' variable to avoid overwriting inside nested loop

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -733,9 +733,9 @@ DEFAULT_WIN_WHITELIST = ['**/ADVAPI32.dll',
 def _collect_needed_dsos(sysroots_files, files, run_prefix, sysroot_substitution, build_prefix, build_prefix_substitution):
     all_needed_dsos = set()
     needed_dsos_for_file = dict()
-    sysroot = ''
+    sysroots = ''
     if sysroots_files:
-        sysroot = list(sysroots_files.keys())[0]
+        sysroots = list(sysroots_files.keys())[0]
     for f in files:
         path = join(run_prefix, f)
         if not codefile_type(path):
@@ -743,7 +743,7 @@ def _collect_needed_dsos(sysroots_files, files, run_prefix, sysroot_substitution
         build_prefix = build_prefix.replace(os.sep, '/')
         run_prefix = run_prefix.replace(os.sep, '/')
         needed = get_linkages_memoized(path, resolve_filenames=True, recurse=False,
-                                       sysroot=sysroot, envroot=run_prefix)
+                                       sysroot=sysroots, envroot=run_prefix)
         for lib, res in needed.items():
             resolved = res['resolved'].replace(os.sep, '/')
             for sysroot, sysroot_files in sysroots_files.items():

--- a/news/4529-fix-sysroot-dso-identify
+++ b/news/4529-fix-sysroot-dso-identify
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed issue identifying DSOs from sysroots when cross-compiling (#4529)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
This PR addresses a corner-case bug in identifying needed DSOs when cross-compiling packages that have multiple compiled objects.

The issue was caused by this code:

https://github.com/conda/conda-build/blob/7be9ba75b6bf0cda07ba2ab48e92b454ad398179/conda_build/post.py#L736-L749

where the `sysroot` variable is first declared as the list of `SYSROOT` base paths:

https://github.com/conda/conda-build/blob/7be9ba75b6bf0cda07ba2ab48e92b454ad398179/conda_build/post.py#L738

but then redeclared inside a nested loop while iterating over multiple SYSROOTs:

https://github.com/conda/conda-build/blob/7be9ba75b6bf0cda07ba2ab48e92b454ad398179/conda_build/post.py#L749

This resulted in all but the first file in `files` only seeing the _last_ sysroot in the original `sysroot_files.keys()` list. In turn this meant that builds with multiple sysroots (cross-compiled builds) _and_ multiple dynamically-linked objects failed to identify DSOs as belonging to the target sysroot, [e.g:](https://github.com/conda-forge/lalsimulation-feedstock/pull/49)

```console
...
   INFO (lalsimulation,bin/lalsim-bh-qnmode): Needed DSO aarch64-conda-linux-gnu/sysroot/lib64/ld-linux-aarch64.so.1 found in CDT/compiler package conda-forge::sysroot_linux-aarch64-2.17-h43d7e78_13
...
  ERROR (lalsimulation,bin/lalsim-ns-mass-radius): $RPATH/ld-linux-aarch64.so.1 not found in packages, sysroot(s) nor the missing_dso_whitelist.
.. is this binary repackaging?
...
```

The fix is just to rename the outermost variable `sysroot` -> `sysroots` to avoid the naming collision.

This is seen to resolve the failure currently impacting https://github.com/conda-forge/htcondor-feedstock/pull/82 and https://github.com/conda-forge/lalsimulation-feedstock/pull/49.