### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ on:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/docs.yml'
       - 'docs/**'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ conda-build
 .. image:: https://github.com/conda/conda-build/actions/workflows/tests.yml/badge.svg
   :target: https://github.com/conda/conda-build/actions/workflows/tests.yml
 
-.. image:: https://codecov.io/gh/conda/conda-build/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/conda/conda-build/branch/main/graph/badge.svg
   :target: https://codecov.io/gh/conda/conda-build
 
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -3,7 +3,7 @@
     "project": "conda-build",
     "project_url": "http://github.com/conda/conda-build",
     "repo": ".",
-    "branches": ["master"],
+    "branches": ["main"],
     "dvcs": "git",
     "environment_type": "conda",
     "show_commit_url": "http://github.com/conda/conda-build/commit/",

--- a/tests/test-recipes/variants/conda-build-demo.ipynb
+++ b/tests/test-recipes/variants/conda-build-demo.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "This document is intended as a quick overview of new features in conda-build 3.  For more information, see the docs PR at https://conda.io/docs/building/variants.html\n",
     "\n",
-    "These demos use conda-build's python API to render and build recipes.  That API currently does not have a docs page, but is pretty self explanatory.  See the source at https://github.com/conda/conda-build/blob/master/conda_build/api.py\n",
+    "These demos use conda-build's python API to render and build recipes.  That API currently does not have a docs page, but is pretty self explanatory.  See the source at https://github.com/conda/conda-build/blob/main/conda_build/api.py\n",
     "\n",
     "This jupyter notebook itself is included in conda-build's tests folder.  If you're interested in running this notebook yourself, see the tests/test-recipes/variants folder in a git checkout of the conda-build source.  Tests are not included with conda packages of conda-build."
    ]


### PR DESCRIPTION
### Description
Performing necessary changes to rename master branch to main.

Ref: https://github.com/conda/conda-build/issues/4494