### PR TITLE
Use `subprocess.DEVNULL` instead of `os.devnull`

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -76,11 +76,7 @@ def verify_git_repo(git_exe, git_dir, git_url, git_commits_since_tag, debug=Fals
     env = os.environ.copy()
     log = utils.get_logger(__name__)
 
-    if debug:
-        stderr = None
-    else:
-        FNULL = open(os.devnull, 'w')
-        stderr = FNULL
+    stderr = None if debug else subprocess.DEVNULL
 
     if not expected_rev:
         return False
@@ -149,9 +145,6 @@ def verify_git_repo(git_exe, git_dir, git_url, git_commits_since_tag, debug=Fals
         log.debug("Error obtaining git information in verify_git_repo.  Error was: ")
         log.debug(str(error))
         OK = False
-    finally:
-        if not debug:
-            FNULL.close()
     return OK
 
 
@@ -170,11 +163,7 @@ def get_git_info(git_exe, repo, debug):
     d = {}
     log = utils.get_logger(__name__)
 
-    if debug:
-        stderr = None
-    else:
-        FNULL = open(os.devnull, 'w')
-        stderr = FNULL
+    stderr = None if debug else subprocess.DEVNULL
 
     # grab information from describe
     env = os.environ.copy()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Instead of using a custom `os.devnull` file handler use the stdlib `subprocess.DEVNULL` constant.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
