### PR TITLE
add overlinking_ignore_patterns build parameter

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -153,6 +153,7 @@ def _get_default_settings():
             Setting('no_rewrite_stdout_env', cc_conda_build.get('no_rewrite_stdout_env',
                                                               no_rewrite_stdout_env_default).lower() == 'true'),
 
+
             Setting('index', None),
             # support legacy recipes where only build is specified and expected to be the
             #    folder that packaging is done on

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -443,6 +443,7 @@ FIELDS = {
         'missing_dso_whitelist': None,
         'error_overdepending': None,
         'error_overlinking': None,
+        'overlinking_ignore_patterns': [],
     },
     'outputs': {
         'name': None,

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -1221,6 +1221,10 @@ def check_overlinking_impl(pkg_name, pkg_version, build_str, build_number, subdi
 def check_overlinking(m, files, host_prefix=None):
     if not host_prefix:
         host_prefix = m.config.host_prefix
+
+    overlinking_ignore_patterns = m.meta.get("build", {}).get("overlinking_ignore_patterns")
+    if overlinking_ignore_patterns:
+        files = [f for f in files if not any([fnmatch(f, p) for p in overlinking_ignore_patterns])]
     return check_overlinking_impl(m.get_value('package/name'),
                                   m.get_value('package/version'),
                                   m.get_value('build/string'),

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -849,6 +849,25 @@ pinned down to the build string level. This will
 supersede any dynamic or compatible pinning that
 conda-build may otherwise be doing.
 
+Ignoring files in overlinking/overdepending checks
+--------------------------------------------------
+
+The ``overlinking_ignore_patterns`` key in the build section can be used to
+ignore patterns of files for the overlinking and overdepending checks. This
+is sometimes useful to speed up builds that have many files (large repackage jobs)
+or builds where you know only a small fraction of the files should be checked.
+
+Glob patterns are allowed here, but mind your quoting, especially with leading wildcards.
+
+Use this sparingly, as the overlinking checks generally do prevent you from making mistakes.
+
+.. code-block:: yaml
+
+ build:
+   overlinking_ignore_patterns:
+     - "bin/*"
+
+
 Whitelisting shared libraries
 -----------------------------
 

--- a/news/add-overlinking-ignore-patterns
+++ b/news/add-overlinking-ignore-patterns
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Add overlinking_ignore_patterns build parameter to speed up recipes where it is not
+  helpful
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/add-overlinking-ignore-patterns
+++ b/news/add-overlinking-ignore-patterns
@@ -1,7 +1,6 @@
 ### Enhancements
 
-* Add overlinking_ignore_patterns build parameter to speed up recipes where it is not
-  helpful
+* Add overlinking_ignore_patterns build parameter to speed up recipes where it is not helpful. (#4576)
 
 ### Bug fixes
 

--- a/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/default.bat
+++ b/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/default.bat
@@ -1,0 +1,4 @@
+@echo on
+echo int main() { return 0; }>main.c
+cl -c -EHsc -GR -Zc:forScope -Zc:wchar_t -Fomain.obj main.c
+link -out:%PREFIX%\Library\bin\main.exe main.obj

--- a/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/default.sh
+++ b/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/default.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "int main() { return 0; }" | ${CC} ${CFLAGS} ${LDFLAGS} -o ${PREFIX}/bin/overlinking -lbz2 -x c -

--- a/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/no_as_needed.sh
+++ b/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/no_as_needed.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# this recipe will overlink libraries without the --as-needed/-dead_strip_dylibs linker arg
+re='^(.*)-Wl,--as-needed(.*)$'
+if [[ ${LDFLAGS} =~ $re ]]; then
+  export LDFLAGS="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+fi
+re='^(.*)-Wl,-dead_strip_dylibs(.*)$'
+if [[ ${LDFLAGS} =~ $re ]]; then
+  export LDFLAGS="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+fi
+
+echo "int main() { return 0; }" | ${CC} ${CFLAGS} ${LDFLAGS} -o ${PREFIX}/bin/overlinking -lbz2 -x c -

--- a/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/with_bzip2.bat
+++ b/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/build_scripts/with_bzip2.bat
@@ -1,0 +1,5 @@
+@echo on
+echo #include ^<bzlib.h^>>main.c
+echo int main() { BZ2_bzlibVersion(); return 0; }>>main.c
+cl -c -EHsc -GR -Zc:forScope -Zc:wchar_t -Fomain.obj main.c -INCLUDE:%PREFIX%\Library\include
+link -out:%PREFIX%\Library\bin\main.exe main.obj -LIBPATH:%PREFIX%\Library\lib bzip2.lib

--- a/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/conda_build_config.yaml
+++ b/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/conda_build_config.yaml
@@ -1,0 +1,2 @@
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.10.sdk        # [osx]

--- a/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/meta.yaml
+++ b/tests/test-recipes/metadata/_overlinking_detection_ignore_patterns/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: overlinking_ignore_patterns
+  version: 0
+
+build:
+  number: 0
+  ignore_run_exports:
+    -  bzip2
+  overlinking_ignore_patterns:
+    - "bin/*"           # [unix]
+    - "Library/bin/*"   # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - bzip2

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1524,6 +1524,25 @@ def test_overlinking_detection(testing_config):
     rm_rf(dest_bat)
 
 
+@pytest.mark.skipif(on_win and sys.version[:3] == "2.7",
+                    reason="py-lief not available on win for Python 2.7")
+def test_overlinking_detection_ignore_patterns(testing_config):
+    testing_config.activate = True
+    testing_config.error_overlinking = True
+    testing_config.verify = False
+    recipe = os.path.join(metadata_dir, '_overlinking_detection_ignore_patterns')
+    dest_sh = os.path.join(recipe, 'build.sh')
+    dest_bat = os.path.join(recipe, 'bld.bat')
+    copy_into(os.path.join(recipe, 'build_scripts', 'default.sh'), dest_sh, clobber=True)
+    copy_into(os.path.join(recipe, 'build_scripts', 'default.bat'), dest_bat, clobber=True)
+    api.build(recipe, config=testing_config)
+    copy_into(os.path.join(recipe, 'build_scripts', 'no_as_needed.sh'), dest_sh, clobber=True)
+    copy_into(os.path.join(recipe, 'build_scripts', 'with_bzip2.bat'), dest_bat, clobber=True)
+    api.build(recipe, config=testing_config)
+    rm_rf(dest_sh)
+    rm_rf(dest_bat)
+
+
 def test_overdepending_detection(testing_config):
     testing_config.activate = True
     testing_config.error_overlinking = True


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adds a new `build.overlinking_ignore_patterns` key to ignore file patterns for the overlinking and overdepending checks. This is sometimes useful to speed up builds that have many files (large repackage jobs) or builds where you know only a small fraction of the files should be checked.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
