### PR TITLE
Add `win-arm64` as a recognized platform

### DIFF
--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -63,7 +63,7 @@ all.""",
         choices=['osx-64', 'osx-arm64',
                  'linux-32', 'linux-64', 'linux-ppc64', 'linux-ppc64le',
                  'linux-s390x', 'linux-armv6l', 'linux-armv7l', 'linux-aarch64',
-                 'win-32', 'win-64', 'all'],
+                 'win-32', 'win-64', 'win-arm64', 'all'],
         help="Platform to convert the packages to.",
         default=None
     )

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -767,7 +767,8 @@ def conda_convert(file_path, output_dir=".", show_imports=False, platforms=None,
         platforms = ['osx-64', 'osx-arm64',
                      'linux-32', 'linux-64', 'linux-ppc64', 'linux-ppc64le',
                      'linux-s390x', 'linux-armv6l', 'linux-armv7l', 'linux-aarch64',
-                     'win-32', 'win-64']
+                     'win-32', 'win-64', 'win-arm64',
+                     ]
 
     for platform in platforms:
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -104,6 +104,7 @@ DEFAULT_SUBDIRS = {
     "linux-aarch64",
     "win-64",
     "win-32",
+    "win-arm64",
     "osx-64",
     "osx-arm64",
     "zos-z",

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -85,6 +85,9 @@ def build_vcvarsall_vs_path(version):
 
 
 def msvc_env_cmd(bits, config, override=None):
+    # TODO: this function will likely break on `win-arm64`. However, unless
+    # there's clear user demand, it's not clear that we should invest the
+    # effort into updating a known deprecated function for a new platform.
     log = get_logger(__name__)
     log.warn("Using legacy MSVC compiler setup.  This will be removed in conda-build 4.0. "
              "If this recipe does not use a compiler, this message is safe to ignore.  "

--- a/news/4579-add-win-arm64
+++ b/news/4579-add-win-arm64
@@ -1,0 +1,11 @@
+### Enhancements
+
+* Add `win-arm64` as a recognized platform (subdir).
+
+### Bug fixes
+
+### Deprecations
+
+### Docs
+
+### Other


### PR DESCRIPTION
### Description

Add `win-64` to the list of known platforms (subdirs) as a step to addressing conda/conda#11472.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?  - Declined; currently (public) systems for us to perform CI on.
- [x] Add / update outdated documentation? - Declined; this is a spike, and until we can perform an initial buildout (i.e., Python + conda + conda-build), we don't necessarily want to publicly broadcast its availability.

This is the conda-build counterpart to conda/conda#11778.