### PR TITLE
Remove false-positives in the list of Perl core modules

### DIFF
--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -326,7 +326,9 @@ def install_perl_get_core_modules(version):
         with TemporaryDirectory() as tmpdir:
             environ.create_env(tmpdir, [f'perl={version}'], env='host', config=config, subdir=subdirs[0])
             args = [f'{join(tmpdir, *subdirs[1:])}', '-e',
-                    'use Module::CoreList; print join "\n", Module::CoreList->find_modules(qr/.*/);']
+                    'use Module::CoreList; '
+                    'my @modules = grep {Module::CoreList::is_core($_)} Module::CoreList->find_modules(qr/.*/); '
+                    'print join "\n", @modules;']
             from subprocess import check_output
             all_core_modules = check_output(args, shell=False).decode('utf-8').replace('\r\n', '\n').split('\n')
             return all_core_modules


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
The detection of Perl core modules reports many false-positives, i.e. modules are reported as core even though they are not (anymore). This commit fixes this by only reporting modules as core modules if they are core modules in the current Perl version. This fixes issue #4591. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests? -> I haven't added any new tests, do you think there should be tests to capture such issues in the future? 
- [x] Add / update outdated documentation? -> I don't think this is documented somewhere, but correct me if I'm wrong

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
