### PR TITLE
Run Python in isolated mode unless in dev mode

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1821,7 +1821,7 @@ def _write_sh_activation_text(file_handle, m):
                             cygpath_suffix))
 
     if conda_46:
-        py_flags = '-m' if m.config.debug else '-m -I'
+        py_flags = '-m' if m.config.debug else '-I -m'
         file_handle.write(
             f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
         )

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1821,8 +1821,8 @@ def _write_sh_activation_text(file_handle, m):
                             cygpath_suffix))
 
     if conda_46:
-        file_handle.write("eval \"$('{sys_python}' -m conda shell.bash hook)\"\n".format(
-            sys_python=sys.executable,
+        file_handle.write("eval \"$('{sys_python}'{I_flag} -m conda shell.bash hook)\"\n".format(
+            sys_python=sys.executable, I_flag=('' if m.config.debug else ' -I'),
         ))
 
     if m.is_cross:
@@ -2729,15 +2729,18 @@ def write_test_scripts(metadata, env_vars, py_files, pl_files, lua_files, r_file
                 if utils.on_win:
                     tf.write('set "CONDA_SHLVL=" '
                              '&& @CALL {}\\condabin\\conda_hook.bat {}'
-                             '&& set CONDA_EXE={}'
+                             '&& set CONDA_EXE={python_exe}'
+                             '&& set CONDA_PYTHON_EXE={python_exe}'
+                             '&& set _CE_I={}'
                              '&& set _CE_M=-m'
                              '&& set _CE_CONDA=conda\n'.format(sys.prefix,
                                                                '--dev' if metadata.config.debug else '',
-                                                               sys.executable))
+                                                               '' if metadata.config.debug else '-I',
+                                                               python_exe=sys.executable))
 
                 else:
-                    tf.write("eval \"$('{sys_python}' -m conda shell.bash hook)\"\n".format(
-                        sys_python=sys.executable))
+                    tf.write("eval \"$('{sys_python}'{I_flag} -m conda shell.bash hook)\"\n".format(
+                        sys_python=sys.executable, I_flag=('' if metadata.config.debug else ' -I')))
                 tf.write(f'conda activate "{metadata.config.test_prefix}"\n')
             else:
                 tf.write('{source} "{conda_root}activate{ext}" "{test_env}"\n'.format(

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1821,9 +1821,10 @@ def _write_sh_activation_text(file_handle, m):
                             cygpath_suffix))
 
     if conda_46:
-        file_handle.write("eval \"$('{sys_python}'{I_flag} -m conda shell.bash hook)\"\n".format(
-            sys_python=sys.executable, I_flag=('' if m.config.debug else ' -I'),
-        ))
+        py_flags = '-m' if m.config.debug else '-m -I'
+        file_handle.write(
+            f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
+        )
 
     if m.is_cross:
         # HACK: we need both build and host envs "active" - i.e. on PATH,
@@ -2727,20 +2728,25 @@ def write_test_scripts(metadata, env_vars, py_files, pl_files, lua_files, r_file
             ext = ".bat" if utils.on_win else ""
             if conda_46:
                 if utils.on_win:
-                    tf.write('set "CONDA_SHLVL=" '
-                             '&& @CALL {}\\condabin\\conda_hook.bat {}'
-                             '&& set CONDA_EXE={python_exe}'
-                             '&& set CONDA_PYTHON_EXE={python_exe}'
-                             '&& set _CE_I={}'
-                             '&& set _CE_M=-m'
-                             '&& set _CE_CONDA=conda\n'.format(sys.prefix,
-                                                               '--dev' if metadata.config.debug else '',
-                                                               '' if metadata.config.debug else '-I',
-                                                               python_exe=sys.executable))
-
+                    tf.write(
+                        'set "CONDA_SHLVL=" '
+                        '&& @CALL {}\\condabin\\conda_hook.bat {}'
+                        '&& set CONDA_EXE={python_exe}'
+                        '&& set CONDA_PYTHON_EXE={python_exe}'
+                        '&& set _CE_I={}'
+                        '&& set _CE_M=-m'
+                        '&& set _CE_CONDA=conda\n'.format(
+                            sys.prefix,
+                            '--dev' if metadata.config.debug else '',
+                            '' if metadata.config.debug else '-I',
+                            python_exe=sys.executable
+                        )
+                    )
                 else:
-                    tf.write("eval \"$('{sys_python}'{I_flag} -m conda shell.bash hook)\"\n".format(
-                        sys_python=sys.executable, I_flag=('' if metadata.config.debug else ' -I')))
+                    py_flags = '-m' if metadata.config.debug else '-m -I'
+                    tf.write(
+                        f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
+                    )
                 tf.write(f'conda activate "{metadata.config.test_prefix}"\n')
             else:
                 tf.write('{source} "{conda_root}activate{ext}" "{test_env}"\n'.format(

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2743,7 +2743,7 @@ def write_test_scripts(metadata, env_vars, py_files, pl_files, lua_files, r_file
                         )
                     )
                 else:
-                    py_flags = '-m' if metadata.config.debug else '-m -I'
+                    py_flags = '-m' if metadata.config.debug else '-I -m'
                     tf.write(
                         f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
                     )

--- a/news/4604-run-conda-in-isolated-mode
+++ b/news/4604-run-conda-in-isolated-mode
@@ -1,0 +1,19 @@
+### Enhancements
+
+* When invoking conda ensure it runs in isolated (`python -I -m`) mode unless running with `--dev`. (#4604)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda build` generates some shell scripts wrappers to run `build.sh` and `bld.bat`. This includes setting a number of environment variables and activating the host and build environments in a stacked way. To do this, it employs `python -m conda shell.posix hook`. 

However, the `-m` semantics implies that the current working directories (`SRC_DIR` for conda-build!) and other user installation paths are considered as part of `sys.path`. This is usually ok, but there can be corner cases:

* If we are packaging `conda` and the version being packaged on `SRC_DIR` happens to change how `shell.posix hook` works, it might produce different code than what the released conda-build expects. 
* Not sure, but if we are packaging a dependency needed during the `hook` generation steps, it might also break something?

This discrepancy of which `conda` is used (the one on `SRC_DIR` vs the one installed next to `conda-build`) introduces a fragile behavior, but it can be easily fixed by just adding [`-I` (isolated mode)](https://docs.python.org/3/using/cmdline.html#cmdoption-I) to prevent leakage from non-installed locations:

> `-I`
> Run Python in isolated mode. This also implies -E and -s. In isolated mode [sys.path](https://docs.python.org/3/library/sys.html#sys.path) contains neither the script’s directory nor the user’s site-packages directory. All PYTHON* environment variables are ignored, too. Further restrictions may be imposed to prevent the user from injecting malicious code.

> `-m <module-name>`
> Search [sys.path](https://docs.python.org/3/library/sys.html#sys.path) for the named module and execute its contents as the [__main__](https://docs.python.org/3/library/__main__.html#module-__main__) module.
> ...
> [`-I`](https://docs.python.org/3/using/cmdline.html#cmdoption-I) option can be used to run the script in isolated mode where [sys.path](https://docs.python.org/3/library/sys.html#sys.path) contains neither the current directory nor the user’s site-packages directory. All PYTHON* environment variables are ignored, too.

#### Why?

This bug has been discovered at https://github.com/conda/conda/pull/11995. The sequence goes as:

* Without this PR, `conda-build` uses `python -m conda` for its shell integration. This means that it first finds `conda` the working directory (`SRC_DIR`) executes the hook as produced by the version being packaged.
* If we package https://github.com/conda/conda/pull/11995, the hook will generate shell code with the form of `python -I -m conda ...` instead of `CONDA_PREFIX/bin/conda` (the Python entry point) as the Python command to avoid shebang issues. 
* The `-I` flag will force the next `conda activate` commands to run from the `conda` installation placed next to `conda-build`, not the one from the working directory! 
* In this particular timing, we are mixing two shell code generation strategies. The former one uses `CONDA_PREFIX/bin/conda` and unsets `_CE_M` and `_CE_CONDA` (the shell variables that hold `-m` and `conda` strings, respectively). 
* This causes the hook code to be run like `python shell.posix activate`, where it should have been `python -I -m conda shell.posix activate`. Of course, `shell.posix` is interpreted as a path to a file that doesn't exist and Python errors out.

I know this is a corner case, but in my opinion, conda-build shouldn't rely on software being packaged as part of its implementation :)


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
