### PR TITLE
Changed token name to be specific to canary channel.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -416,4 +416,4 @@ jobs:
           subdir: ${{ matrix.subdir }}
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ github.ref_name == 'main' && 'dev' || github.ref_name }}
-          anaconda-org-token: ${{ secrets.ANACONDA_ORG_TOKEN }}
+          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

We're moving the token from being per-project to org-wide and it'd be best to be overly specific about the name to prevent overlap. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->
