### PR TITLE
Run `conda` in isolated mode only if opted in

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1815,7 +1815,7 @@ def _write_sh_activation_text(file_handle, m):
                             cygpath_suffix))
 
     if conda_46:
-        py_flags = '-I -m' if os.environ.get("CONDA_BUILD_ISOLATED_ACTIVATION") else '-m'
+        py_flags = '-I -m' if os.environ.get("_CONDA_BUILD_ISOLATED_ACTIVATION") else '-m'
         file_handle.write(
             f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
         )
@@ -2732,12 +2732,12 @@ def write_test_scripts(metadata, env_vars, py_files, pl_files, lua_files, r_file
                         '&& set _CE_CONDA=conda\n'.format(
                             sys.prefix,
                             '--dev' if metadata.config.debug else '',
-                            "-i" if os.environ.get("CONDA_BUILD_ISOLATED_ACTIVATION") else "",
+                            "-i" if os.environ.get("_CONDA_BUILD_ISOLATED_ACTIVATION") else "",
                             python_exe=sys.executable
                         )
                     )
                 else:
-                    py_flags = '-I -m' if os.environ.get("CONDA_BUILD_ISOLATED_ACTIVATION") else '-m'
+                    py_flags = '-I -m' if os.environ.get("_CONDA_BUILD_ISOLATED_ACTIVATION") else '-m'
                     tf.write(
                         f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
                     )

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1815,7 +1815,7 @@ def _write_sh_activation_text(file_handle, m):
                             cygpath_suffix))
 
     if conda_46:
-        py_flags = '-m' if m.config.debug else '-I -m'
+        py_flags = '-I -m' if os.environ.get("CONDA_BUILD_ISOLATED_ACTIVATION") else '-m'
         file_handle.write(
             f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
         )
@@ -2732,12 +2732,12 @@ def write_test_scripts(metadata, env_vars, py_files, pl_files, lua_files, r_file
                         '&& set _CE_CONDA=conda\n'.format(
                             sys.prefix,
                             '--dev' if metadata.config.debug else '',
-                            '' if metadata.config.debug else '-I',
+                            "-i" if os.environ.get("CONDA_BUILD_ISOLATED_ACTIVATION") else "",
                             python_exe=sys.executable
                         )
                     )
                 else:
-                    py_flags = '-m' if metadata.config.debug else '-I -m'
+                    py_flags = '-I -m' if os.environ.get("CONDA_BUILD_ISOLATED_ACTIVATION") else '-m'
                     tf.write(
                         f"""eval "$('{sys.executable}' {py_flags} conda shell.bash hook)"\n"""
                     )

--- a/news/4604-run-conda-in-isolated-mode
+++ b/news/4604-run-conda-in-isolated-mode
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* When invoking conda ensure it runs in isolated (`python -I -m`) mode unless running with `--dev`. (#4604)
+* Provide `CONDA_BUILD_ISOLATED_ACTIVATION` environment variable to run `conda` in isolated mode (`python -I -m`). (#4604, #XXXX)
 
 ### Bug fixes
 

--- a/news/4604-run-conda-in-isolated-mode
+++ b/news/4604-run-conda-in-isolated-mode
@@ -1,6 +1,9 @@
 ### Enhancements
 
-* Provide `CONDA_BUILD_ISOLATED_ACTIVATION` environment variable to run `conda` in isolated mode (`python -I -m`). (#4604, #XXXX)
+* Provide `CONDA_BUILD_ISOLATED_ACTIVATION` environment variable flag to control how `conda` is invoked from `conda-build`. 
+  If this variable is set to a non-empty value, it will run `conda` in isolated mode `python -I -m conda`.
+  Otherwise, the default behavior (`python -m conda`) will be respected. 
+  (#4604, #4625)
 
 ### Bug fixes
 

--- a/news/4604-run-conda-in-isolated-mode
+++ b/news/4604-run-conda-in-isolated-mode
@@ -1,8 +1,8 @@
 ### Enhancements
 
-* Provide `CONDA_BUILD_ISOLATED_ACTIVATION` environment variable flag to control how `conda` is invoked from `conda-build`. 
+* Provide `CONDA_BUILD_ISOLATED_ACTIVATION` environment variable flag to control how `conda` is invoked from `conda-build`.
   If this variable is set to a non-empty value, it will run `conda` in isolated mode `python -I -m conda`.
-  Otherwise, the default behavior (`python -m conda`) will be respected. 
+  Otherwise, the default behavior (`python -m conda`) will be respected.
   (#4604, #4625)
 
 ### Bug fixes

--- a/news/4604-run-conda-in-isolated-mode
+++ b/news/4604-run-conda-in-isolated-mode
@@ -1,9 +1,6 @@
 ### Enhancements
 
-* Provide `CONDA_BUILD_ISOLATED_ACTIVATION` environment variable flag to control how `conda` is invoked from `conda-build`.
-  If this variable is set to a non-empty value, it will run `conda` in isolated mode `python -I -m conda`.
-  Otherwise, the default behavior (`python -m conda`) will be respected.
-  (#4604, #4625)
+* Add opt-in environment variable to run `conda` in isolated mode (`python -I -m conda`) when invoked from `conda-build`. This is necessary to fix an issue when packaging conda itself. Alternative solutions (see #4628) are under investigation, so the current implementation will likely change. (#4604, #4625)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

After discussing #4604 in the community calls, we have come to the conclusion that the changes there contained might disrupt packaging workflows in conda-forge and other communities. Some reasons:

* Isolated mode prevents `PYTHON*` variables from being used and we are unsure this behavior is propagated to subprocesses (like the ones running `build.sh` and `bld.bat`).
* `conda-forge-ci-setup` sets `PYTHONUNBUFFERED`
* Python-based activation scripts might rely on PYTHON* variables as well.
* Since we are not sure and cannot test all the edge cases in time for the release, we are proposing a safer solution that better respects the default behavior in previous releases.
* Since the affected recipes are only `conda` and its dependencies (a very small % of the whole packaging ecosystem), it makes more sense to _not_ enable isolated unless requested explicitly via an environment variable.
* This variable is `CONDA_BUILD_ISOLATED_ACTIVATION`. If set to a non-empty value, it will enable isolated mode for `conda` invocations. 


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
