### PR TITLE
Remove deprecated `context.conda_private`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -42,7 +42,6 @@ from .conda_interface import EntityEncoder
 from .conda_interface import get_rc_urls
 from .conda_interface import url_path
 from .conda_interface import root_dir
-from .conda_interface import conda_private
 from .conda_interface import MatchSpec
 from .conda_interface import reset_context
 from .conda_interface import context
@@ -1172,11 +1171,6 @@ def write_about_json(m):
         evars = ['CIO_TEST']
 
         d['env_vars'] = {ev: os.getenv(ev, '<not set>') for ev in evars}
-        # this information will only be present in conda 4.2.10+
-        try:
-            d['conda_private'] = conda_private
-        except (KeyError, AttributeError):
-            pass
         # Adding this to extra since its arbitrary info
         extra = m.get_section('extra')
         # Add burn-in information to extra

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -121,7 +121,6 @@ get_conda_build_local_url = try_exports("conda.models.channel", "get_conda_build
 
 binstar_upload = context.binstar_upload
 bits = context.bits
-conda_private = context.conda_private
 default_python = context.default_python
 envs_dirs = context.envs_dirs
 pkgs_dirs = list(context.pkgs_dirs)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Deprecating per https://github.com/conda/conda/pull/12101.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
