### PR TITLE
fix: conda-build CLI overrode condarc's zstd_compression_level with the default value

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -160,8 +160,8 @@ def parse_args(args):
         help=("When building v2 packages, set the compression level used by "
               "conda-package-handling. Defaults to the maximum."),
         type=int,
-        choices=range(1, 22),
-        default=zstd_compression_level_default,
+        choices=range(1, 23),
+        default=cc_conda_build.get('zstd_compression_level', zstd_compression_level_default),
     )
     pypi_grp = p.add_argument_group("PyPI upload parameters (twine)")
     pypi_grp.add_argument(

--- a/news/gh-4650-fix-cli-zstd-level-override-gh-4649.md
+++ b/news/gh-4650-fix-cli-zstd-level-override-gh-4649.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* fix: `conda-build` CLI overrode `condarc`'s `zstd_compression_level` with the default value


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

fixes gh-4649:
> The `conda-build` command defines a default value for `--zstd-compression-level` (`conda_build.config.zstd_compression_level_default=22`) without querying the Conda config for the `conda_build.zstd_compression_level` key. Since parameters given by the CLI take precedence over those from `.condarc`, a `zstd_compression_level` set in the latter is always overridden by the default value when `conda-build ...` is invoked.