### PR TITLE
Change Zstd compression default to 19

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -158,7 +158,7 @@ def parse_args(args):
     p.add_argument(
         "--zstd-compression-level",
         help=("When building v2 packages, set the compression level used by "
-              "conda-package-handling. Defaults to the maximum."),
+              "conda-package-handling. Defaults to 19."),
         type=int,
         choices=range(1, 23),
         default=cc_conda_build.get('zstd_compression_level', zstd_compression_level_default),

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -158,7 +158,8 @@ def parse_args(args):
     p.add_argument(
         "--zstd-compression-level",
         help=("When building v2 packages, set the compression level used by "
-              "conda-package-handling. Defaults to 19."),
+              "conda-package-handling. "
+              f"Defaults to {zstd_compression_level_default}."),
         type=int,
         choices=range(1, 23),
         default=cc_conda_build.get('zstd_compression_level', zstd_compression_level_default),

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -50,7 +50,7 @@ no_rewrite_stdout_env_default = 'false'
 ignore_verify_codes_default = []
 exit_on_verify_error_default = False
 conda_pkg_format_default = None
-zstd_compression_level_default = 22
+zstd_compression_level_default = 19
 
 
 # Python2 silliness:

--- a/news/zstd_def_19
+++ b/news/zstd_def_19
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Change Zstd default compression to 19
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

This uses less memory and takes less time while still providing a good level compression. Also lines up with how this was changed in conda-package-handling and conda-forge.

xref: https://github.com/conda/conda-package-handling/pull/169
xref: https://github.com/conda/conda-package-handling/issues/168
xref: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/217

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
