### PR TITLE
Fix: Build environments not activated

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2584,6 +2584,9 @@ def construct_metadata_for_test(recipedir_or_package, config):
 
 
 def write_build_scripts(m, script, build_file):
+    # TODO: Prepending the prefixes here should probably be guarded by
+    #         if not m.activate_build_script:
+    #       Leaving it as is, for now, since we need a quick, non-disruptive patch release.
     with utils.path_prepended(m.config.host_prefix):
         with utils.path_prepended(m.config.build_prefix):
             env = environ.get_dict(m=m)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2587,8 +2587,8 @@ def write_build_scripts(m, script, build_file):
     # TODO: Prepending the prefixes here should probably be guarded by
     #         if not m.activate_build_script:
     #       Leaving it as is, for now, since we need a quick, non-disruptive patch release.
-    with utils.path_prepended(m.config.host_prefix):
-        with utils.path_prepended(m.config.build_prefix):
+    with utils.path_prepended(m.config.host_prefix, False):
+        with utils.path_prepended(m.config.build_prefix, False):
             env = environ.get_dict(m=m)
     env["CONDA_BUILD_STATE"] = "BUILD"
 

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -663,7 +663,6 @@ def system_vars(env_dict, m, prefix):
     return os_vars(m, prefix)
 
 
-@lru_cache(maxsize=None)
 def os_vars(m, prefix):
     d = dict()
     # note the dictionary is passed in here - variables are set in that dict if they are non-null

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1047,6 +1047,7 @@ def stringify_numbers():
 
 class MetaData:
     __hash__ = None  # declare as non-hashable to avoid its use with memoization
+
     def __init__(self, path, config=None, variant=None):
 
         self.undefined_jinja_vars = []

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1046,6 +1046,7 @@ def stringify_numbers():
 
 
 class MetaData:
+    __hash__ = None  # declare as non-hashable to avoid its use with memoization
     def __init__(self, path, config=None, variant=None):
 
         self.undefined_jinja_vars = []

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -950,11 +950,10 @@ def get_build_folders(croot):
 
 
 def prepend_bin_path(env, prefix, prepend_prefix=False):
-    # bin_dirname takes care of bin on *nix, Scripts on win
-    env['PATH'] = join(prefix, bin_dirname) + os.pathsep + env['PATH']
+    env['PATH'] = join(prefix, "bin") + os.pathsep + env['PATH']
     if sys.platform == "win32":
         env['PATH'] = join(prefix, "Library", "mingw-w64", "bin") + os.pathsep + \
-                      join(prefix, "Library", "usr", "bin") + os.pathsep + os.pathsep + \
+                      join(prefix, "Library", "usr", "bin") + os.pathsep + \
                       join(prefix, "Library", "bin") + os.pathsep + \
                       join(prefix, "Scripts") + os.pathsep + \
                       env['PATH']
@@ -985,9 +984,10 @@ def sys_path_prepended(prefix):
 
 
 @contextlib.contextmanager
-def path_prepended(prefix):
+def path_prepended(prefix, prepend_prefix=True):
+    # FIXME: Unclear why prepend_prefix=True for all platforms.
     old_path = os.environ['PATH']
-    os.environ['PATH'] = prepend_bin_path(os.environ.copy(), prefix, True)['PATH']
+    os.environ['PATH'] = prepend_bin_path(os.environ.copy(), prefix, prepend_prefix)['PATH']
     try:
         yield
     finally:

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -250,6 +250,9 @@ def write_build_scripts(m, env, bld_bat):
 
 
 def build(m, bld_bat, stats, provision_only=False):
+    # TODO: Prepending the prefixes here should probably be guarded by
+    #         if not m.activate_build_script:
+    #       Leaving it as is, for now, since we need a quick, non-disruptive patch release.
     with path_prepended(m.config.host_prefix):
         with path_prepended(m.config.build_prefix):
             env = environ.get_dict(m=m)

--- a/news/4665-fix-activation-path
+++ b/news/4665-fix-activation-path
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix: Remove invalid memoization for MetaData
+  This fixes build environment activation in version `3.23.*`.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/4665-fix-activation-path
+++ b/news/4665-fix-activation-path
@@ -4,8 +4,8 @@
 
 ### Bug fixes
 
-* Fix: Remove invalid memoization for MetaData
-  This fixes build environment activation in version `3.23.*`.
+* Fix build/host environment activation broken in >=3.23.0,<=3.23.2
+* Add PREFIX/bin to PATH on Windows and remove PREFIX root from PATH on Unix
 
 ### Deprecations
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -36,7 +36,7 @@ from conda_build.build import VersionOrder
 from conda_build.render import finalize_metadata
 from conda_build.utils import (copy_into, on_win, check_call_env, convert_path_for_cygwin_or_msys2,
                                package_has_file, check_output_env, get_conda_operation_locks, rm_rf,
-                               walk, env_var, FileNotFoundError)
+                               prepend_bin_path, walk, env_var, FileNotFoundError)
 from conda_build.os_utils.external import find_executable
 from conda_build.exceptions import (DependencyNeedsBuildingError, CondaBuildException,
                                     OverLinkingError, OverDependingError)
@@ -1652,3 +1652,24 @@ def test_script_env_warnings(testing_config, recwarn):
         assert_keyword('<hidden>')
     finally:
         os.environ.pop(token)
+
+
+@pytest.mark.slow
+def test_activated_prefixes_in_actual_path(testing_config, testing_metadata):
+    file = "env-path-dump"
+    meta = testing_metadata.meta
+    meta["requirements"]["host"] = []
+    meta["build"]["script"] = [
+        f"echo %PATH%>%PREFIX%/{file}" if on_win else f"echo $PATH>$PREFIX/{file}"
+    ]
+    outputs = api.build(testing_metadata, activate=True)
+    env = {"PATH": ""}
+    prepend_bin_path(env, testing_metadata.config.host_prefix)
+    prepend_bin_path(env, testing_metadata.config.build_prefix)
+    expected_paths = [path for path in env["PATH"].split(os.pathsep) if path]
+    actual_paths = [
+        path
+        for path in package_has_file(outputs[0], file).strip().split(os.pathsep)
+        if path in expected_paths
+    ]
+    assert actual_paths == expected_paths

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1656,6 +1656,12 @@ def test_script_env_warnings(testing_config, recwarn):
 
 @pytest.mark.slow
 def test_activated_prefixes_in_actual_path(testing_config, testing_metadata):
+    """
+    Check if build and host env are properly added to PATH in the correct order.
+    Do this in an actual build and not just in a unit test to avoid regression.
+    Currently only tests for single non-"outputs" recipe with build/host split
+    and proper env activation (Metadata.is_cross and Config.activate both True).
+    """
     file = "env-path-dump"
     testing_metadata.config.activate = True
     meta = testing_metadata.meta


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In https://github.com/conda-forge/conda-feedstock/pull/181#issuecomment-1334110585 we encountered unexpected failures for PyPy variants of the builds with
```cmd
D:/bld/conda_1669913819035/_h_env/python.exe: error while loading shared libraries: libpypy3.9-c.dll: cannot open shared object file: No such file or directory
```
It turned out, this happened because the build environments were not activated at all.
The correct Python interpreter was launched because the build script used `$PYTHON`.
The CPython variants built fine "by chance" only since our CPython builds carry library lookup patches to also function without an activated environment and other programs needed for the build were already on `PATH` from outside the build environment.

This happened due to a regression caused by https://github.com/conda/conda-build/pull/4615/commits/cecb031f8e4a37adaffbd9a84bf3195fd51e6d7a .
Previously, `conda`'s `memoized` bailed out from caching anything because of the additionally passed non-hashable `dict`.
Memoizing with a `MetaData` instance as a key is problematic since that object/its members are highly mutable during `conda-build`'s work.

The actual fix in commit 7f047c7 just removes the memoization.
I also added two guards to avoid regressions:
1. Make `MetaData` non-hashable in 9fd7165.
2. Add a test in 9fde4c1 + 060f10f to check if the prefixes are added to `PATH` as expected.

Note that the added test did not replicate the behavior from the conda-forge build entirely.
During the test runs, the prefixes were only added in a wrong order (possibly due to merged `build`/`host` at the time of memoization) but they were not completely omitted like in the `conda-feedstock` build.
These subtleties can be expected due to different setups and different times of memoization.
It is also likely that the early memoization changed other parts of the builds; changes to `PATH` were just most visible.

----
This PR also adds PREFIX/bin to PATH on Windows and removes PREFIX root from PATH on Unix.
Those were two bugs I noticed broke the added test case.
Fixing that should be non-controversial without any downsides, really (those are plain bugs anyway).
<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
