### PR TITLE
Move tar-ing into separate step to avoid shadowing test results

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,6 @@ jobs:
               -m "serial" tests \
               ${{ env.pytest-replay }} \
               --alluredir=allure-results
-          tar -zcf allure-results.tar.gz allure-results
 
       - name: Run Parallel tests
         if: matrix.test-type == 'parallel'
@@ -133,7 +132,9 @@ jobs:
               -m "not serial" tests \
               ${{ env.pytest-replay }} \
               --alluredir=allure-results
-          tar -zcf allure-results.tar.gz allure-results
+
+      - name: Tar Allure Results
+        run: tar -zcf allure-results.tar.gz allure-results
 
       - name: Upload Pytest Replay
         uses: actions/upload-artifact@v2
@@ -279,8 +280,6 @@ jobs:
           set LUA=
           set R=
           pytest --color=yes -vv -n 0 --basetemp %UserProfile%\cbtmp_serial --cov conda_build --cov-report xml -m "serial" ${{ env.pytest-replay }} --alluredir=allure-results
-          tar -zcf allure-results.tar.gz allure-results
-
         shell: cmd
 
       - name: Run Parallel Tests
@@ -295,11 +294,13 @@ jobs:
           set LUA=
           set R=
           pytest --color=yes -vv -n auto --basetemp %UserProfile%\cbtmp --cov conda_build --cov-append --cov-report xml -m "not serial" ${{ env.pytest-replay }} --alluredir=allure-results
-          tar -zcf allure-results.tar.gz allure-results
         shell: cmd
         env:
           VS90COMNTOOLS: C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC\bin
           LIB:
+
+      - name: Tar Allure Results
+        run: tar -zcf allure-results.tar.gz allure-results
 
       - name: Upload Pytest Replay
         uses: actions/upload-artifact@v2
@@ -379,7 +380,6 @@ jobs:
           source ci/github/activate_conda "${{ github.workspace }}/miniconda/bin/python"
           conda install conda-verify -y
           pytest --color=yes -v -n 0 --basetemp /tmp/cb_serial --cov conda_build --cov-report xml -m "serial" tests "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}" --alluredir=allure-results
-          tar -zcf allure-results.tar.gz allure-results
 
       - name: Run Parallel Tests
         if: matrix.test-type == 'parallel'
@@ -394,7 +394,9 @@ jobs:
           conda create -n blarg3 -yq python=3.7
           conda create -n blarg4 -yq python nomkl numpy pandas svn
           pytest --color=yes -v -n auto --basetemp /tmp/cb --cov conda_build --cov-append --cov-report xml -m "not serial" tests "${PYTEST_REPLAY_OPTIONS[@]+"${PYTEST_REPLAY_OPTIONS[@]}"}" --alluredir=allure-results
-          tar -zcf allure-results.tar.gz allure-results
+
+      - name: Tar Allure Results
+        run: tar -zcf allure-results.tar.gz allure-results
 
       - name: Upload Pytest Replay
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

https://github.com/conda/conda-build/pull/4621 added allure reports and adds a `tar` command:

https://github.com/conda/conda-build/blob/9951c3ee0e208cf9c7e3c42a0b88b44560f04989/.github/workflows/tests.yml#L281-L282

Unfortunately, this `tar` command occurs within the same step as `pytest` resulting in the `pytest` exitcode being shadowed by the `tar` exitcode. The fix is to move the `tar` process into a separate step.

See this test that reports the test step as having passed despite there being failures: https://github.com/conda/conda-build/actions/runs/3709733101/jobs/6288635122#step:11:3184

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
