### PR TITLE
Label `variants_conda_build_sysroot` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,17 @@ def no_numpy_version():
 
 @pytest.fixture(
     scope="function",
-    params=[{}, {"MACOSX_DEPLOYMENT_TARGET": ["10.9"]}] if on_mac else [{}],
+    params=[
+        pytest.param({}, id="default MACOSX_DEPLOYMENT_TARGET"),
+        pytest.param(
+            {"MACOSX_DEPLOYMENT_TARGET": ["10.9"]},
+            id="override MACOSX_DEPLOYMENT_TARGET",
+        ),
+    ]
+    if on_mac
+    else [
+        pytest.param({}, id="no MACOSX_DEPLOYMENT_TARGET"),
+    ],
 )
 def variants_conda_build_sysroot(monkeypatch, request):
     if not on_mac:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Provide meaningful labels for the `variants_conda_build_sysroot` parameters. So instead of:

```
tests/test_api_build.py::test_overlinking_detection[variants_conda_build_sysroot0]
tests/test_api_build.py::test_overlinking_detection[variants_conda_build_sysroot1]
```

We instead get:

```
tests/test_api_build.py::test_overlinking_detection[default MACOSX_DEPLOYMENT_TARGET]
tests/test_api_build.py::test_overlinking_detection[override MACOSX_DEPLOYMENT_TARGET]
tests/test_api_build.py::test_overlinking_detection[no MACOSX_DEPLOYMENT_TARGET]
```

Xref: https://github.com/conda/conda-build/pull/4648

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
