### PR TITLE
Remove unused `test_api_inspect.py` tests & global variable

### DIFF
--- a/tests/test_api_inspect.py
+++ b/tests/test_api_inspect.py
@@ -7,23 +7,8 @@ import pytest
 from conda_build import api
 from .utils import metadata_dir
 
-thisdir = os.path.dirname(os.path.abspath(__file__))
-
 
 @pytest.mark.sanity
 def test_check_recipe():
     """Technically not inspect, but close enough to belong here"""
     assert api.check(os.path.join(metadata_dir, "source_git_jinja2"))
-
-
-# These tests are already being done in test_cli.py.  If we have a better way to test, move here.
-def test_inpect_linkages():
-    pass
-
-
-def test_inspect_objects():
-    pass
-
-
-def test_installable():
-    pass


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Removes a duplicate `thisdir` variable (also defined in `utils.py`) and removed no-op/unused tests.

Xref: https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
