### PR TITLE
Refactor `test_misc.py` and deprecate `CrossPlatformStLink`

### DIFF
--- a/conda_build/_link.py
+++ b/conda_build/_link.py
@@ -54,7 +54,10 @@ def _unlink(path):
         pass
 
 
-def pyc_f(path: Path | str, version_info: tuple[int, ...] = sys.version_info) -> str:
+def pyc_f(
+    path: str | os.PathLike,
+    version_info: tuple[int, ...] = sys.version_info,
+) -> str:
     path = Path(path)
     if version_info[0] == 2:
         return str(path.with_suffix(".pyc"))

--- a/conda_build/_link.py
+++ b/conda_build/_link.py
@@ -3,10 +3,12 @@
 """
 This is code that is added to noarch Python packages. See
 conda_build/noarch_python.py.
-
 """
+from __future__ import annotations
+
 import os
 from os.path import dirname, exists, isdir, join, normpath
+from pathlib import Path
 import re
 import sys
 import shutil
@@ -52,12 +54,15 @@ def _unlink(path):
         pass
 
 
-def pyc_f(f, version_info=sys.version_info):
+def pyc_f(path: Path | str, version_info: tuple[int, ...] = sys.version_info) -> str:
+    path = Path(path)
     if version_info[0] == 2:
-        return f + 'c'
-    dn, fn = f.rsplit('/', 1)
-    return '%s/__pycache__/%s.cpython-%d%d.pyc' % (
-              dn, fn[:-3], version_info[0], version_info[1])
+        return str(path.with_suffix(".pyc"))
+    return str(
+        path.parent
+        / "__pycache__"
+        / f"{path.stem}.cpython-{version_info[0]}{version_info[1]}.pyc"
+    )
 
 
 def link_files(src_root, dst_root, files):

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -36,7 +36,6 @@ from .conda_interface import env_path_backup_var_exists
 from .conda_interface import prefix_placeholder
 from .conda_interface import TemporaryDirectory
 from .conda_interface import VersionOrder
-from .conda_interface import CrossPlatformStLink
 from .conda_interface import PathType, FileMode
 from .conda_interface import EntityEncoder
 from .conda_interface import get_rc_urls
@@ -1412,8 +1411,10 @@ def build_info_files_json_v1(m, prefix, files, files_with_prefix):
         if prefix_placeholder and file_mode:
             file_info["prefix_placeholder"] = prefix_placeholder
             file_info["file_mode"] = file_mode
-        if file_info.get("path_type") == PathType.hardlink and CrossPlatformStLink.st_nlink(
-                path) > 1:
+        if (
+            file_info.get("path_type") == PathType.hardlink
+            and os.stat(path).st_nlink > 1
+        ):
             target_short_path_inode = get_inode(path)
             inode_paths = [files[index] for index, ino in enumerate(files_inodes) if ino == target_short_path_inode]
             file_info["inode_paths"] = inode_paths

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from functools import partial
 import os
-from os import lstat
 from importlib import import_module
+import warnings
 
 from conda import __version__ as CONDA_VERSION
 
@@ -148,96 +148,18 @@ LockError, non_x86_linux_machines, NoPackagesFoundError = LockError, non_x86_lin
 PaddingError, UnsatisfiableError = PaddingError, UnsatisfiableError
 
 
-# work-around for python bug on Windows prior to python 3.2
-# https://bugs.python.org/issue10027
-# Adapted from the ntfsutils package, Copyright (c) 2012, the Mozilla Foundation
 class CrossPlatformStLink:
-    _st_nlink = None
-
     def __call__(self, path):
         return self.st_nlink(path)
 
     @classmethod
     def st_nlink(cls, path):
-        if cls._st_nlink is None:
-            cls._initialize()
-        return cls._st_nlink(path)
-
-    @classmethod
-    def _standard_st_nlink(cls, path):
-        return lstat(path).st_nlink
-
-    @classmethod
-    def _windows_st_nlink(cls, path):
-        st_nlink = cls._standard_st_nlink(path)
-        if st_nlink != 0:
-            return st_nlink
-        else:
-            # cannot trust python on Windows when st_nlink == 0
-            # get value using windows libraries to be sure of its true value
-            # Adapted from the ntfsutils package, Copyright (c) 2012, the Mozilla Foundation
-            GENERIC_READ = 0x80000000
-            FILE_SHARE_READ = 0x00000001
-            OPEN_EXISTING = 3
-            hfile = cls.CreateFile(path, GENERIC_READ, FILE_SHARE_READ, None,
-                                   OPEN_EXISTING, 0, None)
-            if hfile is None:
-                from ctypes import WinError
-                raise WinError(
-                    "Could not determine determine number of hardlinks for %s" % path)
-            info = cls.BY_HANDLE_FILE_INFORMATION()
-            rv = cls.GetFileInformationByHandle(hfile, info)
-            cls.CloseHandle(hfile)
-            if rv == 0:
-                from ctypes import WinError
-                raise WinError("Could not determine file information for %s" % path)
-            return info.nNumberOfLinks
-
-    @classmethod
-    def _initialize(cls):
-        if os.name != 'nt':
-            cls._st_nlink = cls._standard_st_nlink
-        else:
-            # http://msdn.microsoft.com/en-us/library/windows/desktop/aa363858
-            import ctypes
-            from ctypes import POINTER
-            from ctypes.wintypes import DWORD, HANDLE, BOOL
-
-            cls.CreateFile = ctypes.windll.kernel32.CreateFileW
-            cls.CreateFile.argtypes = [ctypes.c_wchar_p, DWORD, DWORD, ctypes.c_void_p,
-                                       DWORD, DWORD, HANDLE]
-            cls.CreateFile.restype = HANDLE
-
-            # http://msdn.microsoft.com/en-us/library/windows/desktop/ms724211
-            cls.CloseHandle = ctypes.windll.kernel32.CloseHandle
-            cls.CloseHandle.argtypes = [HANDLE]
-            cls.CloseHandle.restype = BOOL
-
-            class FILETIME(ctypes.Structure):
-                _fields_ = [("dwLowDateTime", DWORD),
-                            ("dwHighDateTime", DWORD)]
-
-            class BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
-                _fields_ = [("dwFileAttributes", DWORD),
-                            ("ftCreationTime", FILETIME),
-                            ("ftLastAccessTime", FILETIME),
-                            ("ftLastWriteTime", FILETIME),
-                            ("dwVolumeSerialNumber", DWORD),
-                            ("nFileSizeHigh", DWORD),
-                            ("nFileSizeLow", DWORD),
-                            ("nNumberOfLinks", DWORD),
-                            ("nFileIndexHigh", DWORD),
-                            ("nFileIndexLow", DWORD)]
-
-            cls.BY_HANDLE_FILE_INFORMATION = BY_HANDLE_FILE_INFORMATION
-
-            # http://msdn.microsoft.com/en-us/library/windows/desktop/aa364952
-            cls.GetFileInformationByHandle = ctypes.windll.kernel32.GetFileInformationByHandle
-            cls.GetFileInformationByHandle.argtypes = [HANDLE,
-                                                       POINTER(BY_HANDLE_FILE_INFORMATION)]
-            cls.GetFileInformationByHandle.restype = BOOL
-
-            cls._st_nlink = cls._windows_st_nlink
+        warnings.warn(
+            "`conda_build.conda_interface.CrossPlatformStLink` is pending deprecation and will be removed in a "
+            "future release. Please use `os.stat().st_nlink` instead.",
+            PendingDeprecationWarning,
+        )
+        return os.stat(path).st_nlink
 
 
 class SignatureError(Exception):

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from functools import partial
 import os
 from importlib import import_module
@@ -149,11 +151,11 @@ PaddingError, UnsatisfiableError = PaddingError, UnsatisfiableError
 
 
 class CrossPlatformStLink:
-    def __call__(self, path):
+    def __call__(self, path: str | os.PathLike) -> int:
         return self.st_nlink(path)
 
     @classmethod
-    def st_nlink(cls, path):
+    def st_nlink(cls, path: str | os.PathLike) -> int:
         warnings.warn(
             "`conda_build.conda_interface.CrossPlatformStLink` is pending deprecation and will be removed in a "
             "future release. Please use `os.stat().st_nlink` instead.",

--- a/news/4728-deprecate-CrossPlatformStLink
+++ b/news/4728-deprecate-CrossPlatformStLink
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* `conda_build.conda_interface.CrossPlatformStLink` is pending deprecation in favor of using `os.stat().st_nlink`. (#4728)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,25 +2,25 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 from os.path import join
+from pathlib import Path
 
 import pytest
 from conda_build.utils import on_win
-import conda_build._link as _link
+from conda_build._link import pyc_f
 from conda_build.conda_interface import PathType, EntityEncoder, CrossPlatformStLink
 
 
-def test_pyc_f_2():
-    assert _link.pyc_f('sp/utils.py', (2, 7, 9)) == 'sp/utils.pyc'
-
-
-def test_pyc_f_3():
-    for f, r in [
-            ('sp/utils.py',
-             'sp/__pycache__/utils.cpython-34.pyc'),
-            ('sp/foo/utils.py',
-             'sp/foo/__pycache__/utils.cpython-34.pyc'),
-    ]:
-        assert _link.pyc_f(f, (3, 4, 2)) == r
+@pytest.mark.parametrize(
+    "source,python,compiled",
+    [
+        ("path/utils.py", (2, 7), "path/utils.pyc"),
+        ("pa/th/utils.py", (2, 7), "pa/th/utils.pyc"),
+        ("path/utils.py", (3, 10), "path/__pycache__/utils.cpython-310.pyc"),
+        ("pa/th/utils.py", (3, 10), "pa/th/__pycache__/utils.cpython-310.pyc"),
+    ],
+)
+def test_pyc_f(source, python, compiled):
+    assert Path(pyc_f(source, python)) == Path(compiled)
 
 
 def test_pathtype():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -47,7 +48,7 @@ def test_crossplatform_st_link(tmp_path):
 
     test_file.touch()
     test_file_link.touch()
-    test_file_linked.hardlink_to(test_file_link)
+    os.link(test_file_link, test_file_linked)
 
     assert 1 == CrossPlatformStLink.st_nlink(test_file)
     assert 2 == CrossPlatformStLink.st_nlink(test_file_link)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Combined `pyc_f` tests into a parameterized test and deprecated `CrossPlatformStLink` in favor of `os.stat().st_nlink`.

Xref https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
