### PR TITLE
Refactor `test_pypi_skeleton.py` to use parametrize and convert `OrderedDict` to `dict`

### DIFF
--- a/tests/test_pypi_skeleton.py
+++ b/tests/test_pypi_skeleton.py
@@ -1,39 +1,42 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 from collections import OrderedDict
+import pytest
 
 from conda_build.skeletons import pypi
 from conda_build.skeletons.pypi import _print_dict, _formating_value
 
 
-def test_version_compare():
-    short_version = '2.2'
-    long_version = '1.4.5'
-    post_version = '2.2.post3'
-    pre_version = '2.2.pre3'
-    alpha_version = '1.4.5a4'
-    beta_version = '1.4.5b4'
-    rc_version = '1.4.5rc4'
-    padding_version_short = '2.2.0'
-    padding_version_long = '1.4.5.0'
-
-    assert pypi.convert_version(short_version) == ' >=2.2,<3'
-    assert pypi.convert_version(long_version) == ' >=1.4.5,<1.5'
-    assert pypi.convert_version(post_version) == ' >=2.2.post3,<3'
-    assert pypi.convert_version(pre_version) == ' >=2.2.pre3,<3'
-    assert pypi.convert_version(alpha_version) == ' >=1.4.5a4,<1.5'
-    assert pypi.convert_version(beta_version) == ' >=1.4.5b4,<1.5'
-    assert pypi.convert_version(rc_version) == ' >=1.4.5rc4,<1.5'
-    assert pypi.convert_version(padding_version_short) == ' >=2.2.0,<2.3'
-    assert pypi.convert_version(padding_version_long) == ' >=1.4.5.0,<1.4.6'
+@pytest.mark.parametrize(
+    "version,version_range",
+    [
+        ("2.2", " >=2.2,<3"),
+        ("1.4.5", " >=1.4.5,<1.5"),
+        ("2.2.post3", " >=2.2.post3,<3"),
+        ("2.2.pre3", " >=2.2.pre3,<3"),
+        ("1.4.5a4", " >=1.4.5a4,<1.5"),
+        ("1.4.5b4", " >=1.4.5b4,<1.5"),
+        ("1.4.5rc4", " >=1.4.5rc4,<1.5"),
+        ("2.2.0", " >=2.2.0,<2.3"),
+        ("1.4.5.0", " >=1.4.5.0,<1.4.6"),
+    ],
+)
+def test_version_compare(version, version_range):
+    assert pypi.convert_version(version) == version_range
 
 
-def test_formating_value():
-    assert _formating_value("summary", "SUMMARY SUMMARY") == " \"SUMMARY SUMMARY\"\n"
-    assert _formating_value("description", "DESCRIPTION DESCRIPTION") == " \"DESCRIPTION DESCRIPTION\"\n"
-    assert _formating_value("script", "SCRIPT VALUE") == " \"SCRIPT VALUE\"\n"
-    assert _formating_value("name", "{{name|lower}}") == " \"{{name|lower}}\"\n"
-    assert _formating_value("name", "NORMAL NAME") == " NORMAL NAME\n"
+@pytest.mark.parametrize(
+    "name,value,result",
+    [
+        ("summary", "SUMMARY SUMMARY", ' "SUMMARY SUMMARY"\n'),
+        ("description", "DESCRIPTION DESCRIPTION", ' "DESCRIPTION DESCRIPTION"\n'),
+        ("script", "SCRIPT VALUE", ' "SCRIPT VALUE"\n'),
+        ("name", "{{name|lower}}", ' "{{name|lower}}"\n'),
+        ("name", "NORMAL NAME", " NORMAL NAME\n"),
+    ],
+)
+def test_formating_value(name, value, result):
+    assert _formating_value(name, value) == result
 
 
 def test_print_dict():


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Tests were previously written without using parameterize. Was also still using `OrderedDict` when `dict` is sufficient.

Xref: https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
