### PR TITLE
Investigate breakage with `setuptools=66` (DNM)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ deps = [
     "psutil",
     "six",
     "libarchive-c",
-    "setuptools",
+    "setuptools>=66",
     # "conda-package-handling",  # remove comment once released on PyPI
     "glob2",
 ]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -33,3 +33,5 @@ requests
 ripgrep
 toml
 tqdm
+# temporary
+setuptools=66

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -34,4 +34,4 @@ ripgrep
 toml
 tqdm
 # temporary
-setuptools=66
+setuptools>=66

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -34,4 +34,4 @@ ripgrep
 toml
 tqdm
 # temporary
-setuptools>=66
+conda-forge::setuptools>=66


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Checking whether this is breaking for conda-build too, or just conda-smithy. See https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
