### PR TITLE
`test_api_skeleton_cran.py`: Inline parametrize, use pathlib, update CRAN packages

### DIFF
--- a/tests/test_api_skeleton_cran.py
+++ b/tests/test_api_skeleton_cran.py
@@ -56,7 +56,7 @@ def test_cran_license(
     ],
 )
 @pytest.mark.flaky(rerun=5, reruns_delay=2)
-def test_cran_os_type(package, skip_text, tmp_path, testing_config):
+def test_cran_os_type(package: str, skip_text: str, tmp_path: Path, testing_config):
     api.skeletonize(
         packages=package, repo="cran", output_dir=tmp_path, config=testing_config
     )
@@ -65,7 +65,7 @@ def test_cran_os_type(package, skip_text, tmp_path, testing_config):
 
 # Test cran skeleton argument --no-comments
 @pytest.mark.flaky(rerun=5, reruns_delay=2)
-def test_cran_no_comments(tmp_path, testing_config):
+def test_cran_no_comments(tmp_path: Path, testing_config):
     package = "data.table"
     meta_yaml_comment = '  # This is required to make R link correctly on Linux.'
     build_sh_comment = '# Add more build steps here, if they are necessary.'

--- a/tests/test_api_skeleton_cran.py
+++ b/tests/test_api_skeleton_cran.py
@@ -4,80 +4,68 @@
 Integrative tests of the CRAN skeleton that start from
 conda_build.api.skeletonize and check the output files
 '''
+from pathlib import Path
+from typing import Sequence
 
-
-import os
 import pytest
 
 from conda_build import api
 from conda_build.skeletons.cran import CRAN_BUILD_SH_SOURCE, CRAN_META
-from conda_build.utils import ensure_list
-
-
-# CRAN packages to test license_file entry.
-# (package, license_id, license_family, license_files)
-cran_packages = [
-    ("r-rmarkdown", "GPL-3", "GPL3", "GPL-3"),  # cran: 'GPL-3'
-    (
-        # cran: 'Artistic License 2.0'
-        "r-badger",
-        "Artistic-2.0",
-        "OTHER",
-        "Artistic-2.0",
-    ),
-    ("r-udpipe", "MPL-2.0", "OTHER", ""),  # cran: 'MPL-2.0'
-    ("r-broom", "MIT", "MIT", ["MIT", "LICENSE"]),  # cran: 'MIT + file LICENSE'
-    (
-        # cran: 'BSD 2-clause License + file LICENSE'
-        "r-meanr",
-        "BSD_2_clause",
-        "BSD",
-        ["BSD_2_clause", "LICENSE"],
-    ),
-    ("r-zoo", "GPL-2 | GPL-3", "GPL3", ["GPL-2", "GPL-3"]),  # cran: 'GPL-2 | GPL-3'
-    ("r-magree", "GPL-3 | GPL-2", "GPL3", ["GPL-3", "GPL-2"]),  # cran: 'GPL-3 | GPL-2'
-    ("r-mglm", "GPL-2", "GPL2", "GPL-2"),  # cran: 'GPL (>= 2)'
-]
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("package, license_id, license_family, license_files", cran_packages)
+@pytest.mark.parametrize(
+    "package,license_id,license_family,license_files",
+    [
+        ("r-rmarkdown", "GPL-3", "GPL3", {"GPL-3"}),
+        ("r-fastdigest", "Artistic-2.0", "OTHER", {"Artistic-2.0"}),
+        ("r-tokenizers.bpe", "MPL-2.0", "OTHER", set()),
+        ("r-broom", "MIT", "MIT", {"MIT", "LICENSE"}),
+        ("r-meanr", "BSD_2_clause", "BSD", {"BSD_2_clause", "LICENSE"}),
+        ("r-base64enc", "GPL-2 | GPL-3", "GPL3", {"GPL-2", "GPL-3"}),
+        ("r-magree", "GPL-3 | GPL-2", "GPL3", {"GPL-3", "GPL-2"}),
+        ("r-mglm", "GPL-2", "GPL2", {"GPL-2"}),
+    ],
+)
+# @pytest.mark.flaky(rerun=5, reruns_delay=2)
+def test_cran_license(
+    package: str,
+    license_id: str,
+    license_family: str,
+    license_files: Sequence[str],
+    tmp_path: Path,
+    testing_config,
+):
+    api.skeletonize(
+        packages=package, repo="cran", output_dir=tmp_path, config=testing_config
+    )
+    m = api.render(str(tmp_path / package / "meta.yaml"))[0][0]
+
+    assert m.get_value("about/license") == license_id
+    assert m.get_value("about/license_family") == license_family
+    assert {
+        Path(license).name for license in m.get_value("about/license_file", "")
+    } == set(license_files)
+
+
+@pytest.mark.parametrize(
+    "package,skip_text",
+    [
+        ("bigReg", "skip: True  # [not unix]"),
+        ("blatr", "skip: True  # [not win]"),
+    ],
+)
 @pytest.mark.flaky(rerun=5, reruns_delay=2)
-def test_cran_license(package, license_id, license_family, license_files, testing_workdir, testing_config):
-    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
-                    config=testing_config)
-    m = api.render(os.path.join(package, 'meta.yaml'))[0][0]
-    m_license_id = m.get_value('about/license')
-    assert m_license_id == license_id
-    m_license_family = m.get_value('about/license_family')
-    assert m_license_family == license_family
-    m_license_files = ensure_list(m.get_value('about/license_file', ''))
-    license_files = ensure_list(license_files)
-    for m_license_file in m_license_files:
-        assert os.path.basename(m_license_file) in license_files
-
-
-# CRAN packages to test skip entry.
-# (package, skip_text)
-cran_os_type_pkgs = [
-                     ('bigReg', 'skip: True  # [not unix]'),
-                     ('blatr', 'skip: True  # [not win]')
-                    ]
-
-
-@pytest.mark.parametrize("package, skip_text", cran_os_type_pkgs)
-@pytest.mark.flaky(rerun=5, reruns_delay=2)
-def test_cran_os_type(package, skip_text, testing_workdir, testing_config):
-    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
-                    config=testing_config)
-    fpath = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml')
-    with open(fpath) as f:
-        assert skip_text in f.read()
+def test_cran_os_type(package, skip_text, tmp_path, testing_config):
+    api.skeletonize(
+        packages=package, repo="cran", output_dir=tmp_path, config=testing_config
+    )
+    assert skip_text in (tmp_path / f"r-{package.lower()}" / "meta.yaml").read_text()
 
 
 # Test cran skeleton argument --no-comments
 @pytest.mark.flaky(rerun=5, reruns_delay=2)
-def test_cran_no_comments(testing_workdir, testing_config):
+def test_cran_no_comments(tmp_path, testing_config):
     package = "data.table"
     meta_yaml_comment = '  # This is required to make R link correctly on Linux.'
     build_sh_comment = '# Add more build steps here, if they are necessary.'
@@ -88,16 +76,18 @@ def test_cran_no_comments(testing_workdir, testing_config):
     assert build_sh_comment in CRAN_BUILD_SH_SOURCE
     assert build_sh_shebang in CRAN_BUILD_SH_SOURCE
 
-    api.skeletonize(packages=package, repo='cran', output_dir=testing_workdir,
-                    config=testing_config, no_comments=True)
+    api.skeletonize(
+        packages=package,
+        repo="cran",
+        output_dir=tmp_path,
+        config=testing_config,
+        no_comments=True,
+    )
 
     # Check that comments got removed
-    meta_yaml = os.path.join(testing_workdir, 'r-' + package.lower(), 'meta.yaml')
-    with open(meta_yaml) as f:
-        assert meta_yaml_comment not in f.read()
+    meta_yaml_text = (tmp_path / f"r-{package.lower()}" / "meta.yaml").read_text()
+    assert meta_yaml_comment not in meta_yaml_text
 
-    build_sh = os.path.join(testing_workdir, 'r-' + package.lower(), 'build.sh')
-    with open(build_sh) as f:
-        build_sh_text = f.read()
-        assert build_sh_comment not in build_sh_text
-        assert build_sh_shebang in build_sh_text
+    build_sh_text = (tmp_path / f"r-{package.lower()}" / "build.sh").read_text()
+    assert build_sh_comment not in build_sh_text
+    assert build_sh_shebang in build_sh_text


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Inline parameterized logic. Switches from `os.path` to `pathlib`. Replace select CRAN packages in favor of smaller packages (with identical licenses) for faster testing:

| Old CRAN | Old Runs | New CRAN | New Runs |
|---|---|---|---|
| `r-badger` | 190.31s | `r-fastdigest` | 24.27s |
| `r-udpipe` | 28.82s | `r-tokenizers.bpe` | 23.67s |
| `r-zoo` | 24.65s | `r-base64enc` | 7.71s |

Xref https://github.com/conda/conda-build/issues/4549 https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
