### PR TITLE
Remove unused test fixtures

### DIFF
--- a/tests/test_api_build_conda_v2.py
+++ b/tests/test_api_build_conda_v2.py
@@ -11,7 +11,7 @@ from .utils import metadata_dir
 
 @pytest.mark.parametrize("pkg_format,pkg_ext", [(None, ".tar.bz2"), ("2", ".conda")])
 def test_conda_pkg_format(
-    pkg_format, pkg_ext, testing_config, testing_workdir, monkeypatch, capfd
+    pkg_format, pkg_ext, testing_config, monkeypatch, capfd
 ):
     """Conda package format "2" builds .conda packages."""
 

--- a/tests/test_api_build_dll_package.py
+++ b/tests/test_api_build_dll_package.py
@@ -8,7 +8,7 @@ from .utils import dll_dir
 
 
 @pytest.mark.sanity
-def test_recipe_build(testing_config, testing_workdir, monkeypatch):
+def test_recipe_build(testing_config, monkeypatch):
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts
     testing_config.activate = True

--- a/tests/test_api_build_go_package.py
+++ b/tests/test_api_build_go_package.py
@@ -9,7 +9,7 @@ from .utils import go_dir
 
 @pytest.mark.sanity
 @pytest.mark.serial
-def test_recipe_build(testing_config, testing_workdir, monkeypatch):
+def test_recipe_build(testing_config, monkeypatch):
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts
     testing_config.activate = True

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -43,7 +43,7 @@ def assert_package_paths_matches_files(package_path):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('cryptography-1.8.1', '__about__.py')])
-def test_show_imports(testing_workdir, base_platform, package, capfd):
+def test_show_imports(base_platform, package, capfd):
     package_name, example_file = package
     platforms = ['osx-64', 'win-64', 'win-32', 'linux-64', 'linux-32']
 
@@ -72,7 +72,7 @@ def test_show_imports(testing_workdir, base_platform, package, capfd):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('itsdangerous-0.24', 'itsdangerous.py')])
-def test_no_imports_found(testing_workdir, base_platform, package, capfd):
+def test_no_imports_found(base_platform, package, capfd):
     package_name, example_file = package
 
     f = 'http://repo.anaconda.com/pkgs/free/{}-64/{}-py36_0.tar.bz2'.format(base_platform,
@@ -89,7 +89,7 @@ def test_no_imports_found(testing_workdir, base_platform, package, capfd):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('cryptography-1.8.1', '__about__.py')])
-def test_no_platform(testing_workdir, base_platform, package):
+def test_no_platform(base_platform, package):
     package_name, example_file = package
 
     f = 'http://repo.anaconda.com/pkgs/free/{}-64/{}-py36_0.tar.bz2'.format(base_platform,
@@ -105,7 +105,7 @@ def test_no_platform(testing_workdir, base_platform, package):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('cryptography-1.8.1', '__about__.py')])
-def test_c_extension_error(testing_workdir, base_platform, package):
+def test_c_extension_error(base_platform, package):
     package_name, example_file = package
     platforms = ['osx-64', 'win-64', 'win-32', 'linux-64', 'linux-32']
 
@@ -130,7 +130,7 @@ def test_c_extension_error(testing_workdir, base_platform, package):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('cryptography-1.8.1', '__about__.py')])
-def test_c_extension_conversion(testing_workdir, base_platform, package):
+def test_c_extension_conversion(base_platform, package):
     package_name, example_file = package
     platforms = ['osx-64', 'win-64', 'win-32', 'linux-64', 'linux-32']
 
@@ -154,7 +154,7 @@ def test_c_extension_conversion(testing_workdir, base_platform, package):
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('itsdangerous-0.24', 'itsdangerous.py'),
                                      ('py-1.4.32', 'py/__init__.py')])
-def test_convert_platform_to_others(testing_workdir, base_platform, package):
+def test_convert_platform_to_others(base_platform, package):
     package_name, example_file = package
     subdir = f'{base_platform}-64'
     f = 'http://repo.anaconda.com/pkgs/free/{}/{}-py27_0.tar.bz2'.format(subdir,
@@ -226,7 +226,7 @@ def test_convert_from_unix_to_win_creates_entry_points(testing_config):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('anaconda-4.4.0', 'version.txt')])
-def test_convert_dependencies(testing_workdir, base_platform, package):
+def test_convert_dependencies(base_platform, package):
     package_name, example_file = package
     subdir = f'{base_platform}-64'
     f = 'http://repo.anaconda.com/pkgs/free/{}/{}-np112py36_0.tar.bz2'.format(subdir,
@@ -259,7 +259,7 @@ def test_convert_dependencies(testing_workdir, base_platform, package):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('anaconda-4.4.0', 'version.txt')])
-def test_convert_no_dependencies(testing_workdir, base_platform, package):
+def test_convert_no_dependencies(base_platform, package):
     package_name, example_file = package
     subdir = f'{base_platform}-64'
     f = 'http://repo.anaconda.com/pkgs/free/{}/{}-np112py36_0.tar.bz2'.format(subdir,
@@ -289,7 +289,7 @@ def test_convert_no_dependencies(testing_workdir, base_platform, package):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'win', 'osx'])
 @pytest.mark.parametrize('package', [('anaconda-4.4.0', 'version.txt')])
-def test_skip_conversion(testing_workdir, base_platform, package, capfd):
+def test_skip_conversion(base_platform, package, capfd):
     package_name, example_file = package
     source_plat_arch = '{}-64' .format(base_platform)
 
@@ -314,7 +314,7 @@ def test_skip_conversion(testing_workdir, base_platform, package, capfd):
 
 @pytest.mark.parametrize('base_platform', ['linux', 'osx'])
 @pytest.mark.parametrize('package', [('sparkmagic-0.12.1', '')])
-def test_renaming_executables(testing_workdir, base_platform, package):
+def test_renaming_executables(base_platform, package):
     """Test that the files in /bin are properly renamed.
 
     When converting the bin/ directory to Scripts/, only scripts

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -20,7 +20,7 @@ from tests import utils
 from .utils import metadata_dir, thisdir
 
 
-def test_render_need_download(testing_workdir, testing_config):
+def test_render_need_download(testing_config):
     # first, test that the download/render system renders all it can,
     #    and accurately returns its needs
 
@@ -74,7 +74,7 @@ def test_get_output_file_path_metadata_object(testing_metadata):
                 "test_get_output_file_path_metadata_object-1.0-1.tar.bz2")
 
 
-def test_get_output_file_path_jinja2(testing_workdir, testing_config):
+def test_get_output_file_path_jinja2(testing_config):
     # If this test does not raise, it's an indicator that the workdir is not
     #    being cleaned as it should.
     recipe = os.path.join(metadata_dir, "source_git_jinja2")
@@ -98,7 +98,7 @@ def test_get_output_file_path_jinja2(testing_workdir, testing_config):
 
 
 @mock.patch('conda_build.source')
-def test_output_without_jinja_does_not_download(mock_source, testing_workdir, testing_config):
+def test_output_without_jinja_does_not_download(mock_source, testing_config):
     api.get_output_file_path(os.path.join(metadata_dir, "source_git"), config=testing_config)[0]
     mock_source.provide.assert_not_called()
 
@@ -225,18 +225,18 @@ def test_run_exports_with_pin_compatible_in_subpackages(testing_config):
             assert all(len(export.split()) > 1 for export in run_exports), run_exports
 
 
-def test_ignore_build_only_deps(testing_config):
+def test_ignore_build_only_deps():
     ms = api.render(os.path.join(thisdir, 'test-recipes', 'variants', 'python_in_build_only'),
                     bypass_env_check=True, finalize=False)
     assert len(ms) == 1
 
 
-def test_merge_build_host_build_key(testing_workdir, testing_metadata):
+def test_merge_build_host_build_key():
     m = api.render(os.path.join(metadata_dir, '_no_merge_build_host'))[0][0]
     assert not any('bzip2' in dep for dep in m.meta['requirements']['run'])
 
 
-def test_merge_build_host_empty_host_section(testing_config):
+def test_merge_build_host_empty_host_section():
     m = api.render(os.path.join(metadata_dir, '_empty_host_avoids_merge'))[0][0]
     assert not any('bzip2' in dep for dep in m.meta['requirements']['run'])
 

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -456,7 +456,7 @@ def test_build_sh_shellcheck_clean(package, repo, testing_workdir, testing_confi
     api.skeletonize(packages=package, repo=repo, output_dir=testing_workdir, config=testing_config)
 
     matches = []
-    for root, filenames in os.walk(testing_workdir):
+    for root, dirnames, filenames in os.walk(testing_workdir):
         for filename in fnmatch.filter(filenames, "build.sh"):
             matches.append(os.path.join(root, filename))
 

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -59,7 +59,7 @@ def test_repo(prefix, repo, package, version, testing_workdir, testing_config):
 
 
 @pytest.mark.slow
-def test_name_with_version_specified(testing_workdir, testing_config):
+def test_name_with_version_specified(testing_config):
     api.skeletonize(
         packages="sympy",
         repo="pypi",
@@ -70,7 +70,7 @@ def test_name_with_version_specified(testing_workdir, testing_config):
     assert m.version() == "1.10"
 
 
-def test_pypi_url(testing_workdir, testing_config):
+def test_pypi_url(testing_config):
     api.skeletonize(
         packages="https://pypi.python.org/packages/source/s/sympy/sympy-1.10.tar.gz#md5=b3f5189ad782bbcb1bedc1ec2ca12f29",
         repo="pypi",
@@ -110,7 +110,7 @@ def mock_metada_pylint(url_pylint_package):
 
 
 @pytest.fixture
-def pkginfo_pylint(url_pylint_package):
+def pkginfo_pylint():
     # Hardcoding it to avoid to use the get_pkginfo because it takes too much time
     return {
         'classifiers': [
@@ -158,8 +158,7 @@ def pkginfo_pylint(url_pylint_package):
     }
 
 
-def test_get_entry_points(testing_workdir, pkginfo_pylint,
-                          result_metadata_pylint):
+def test_get_entry_points(pkginfo_pylint, result_metadata_pylint):
     pkginfo = pkginfo_pylint
     entry_points = get_entry_points(pkginfo)
 
@@ -284,7 +283,6 @@ def test_get_tests_require(pkginfo_pylint, result_metadata_pylint):
 
 
 def test_get_package_metadata(
-        testing_workdir,
         testing_config,
         url_pylint_package,
         mock_metada_pylint,
@@ -310,7 +308,7 @@ def test_get_package_metadata(
 
 
 @pytest.mark.slow
-def test_pypi_with_setup_options(testing_workdir, testing_config):
+def test_pypi_with_setup_options(testing_config):
     # Use photutils package below because skeleton will fail unless the setup.py is given
     # the flag --offline because of a bootstrapping a helper file that
     # occurs by default.
@@ -325,7 +323,7 @@ def test_pypi_with_setup_options(testing_workdir, testing_config):
     assert '--offline' in m.meta['build']['script']
 
 
-def test_pypi_pin_numpy(testing_workdir, testing_config):
+def test_pypi_pin_numpy(testing_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
     api.skeletonize(packages='msumastro', repo='pypi', version='0.9.0',
@@ -337,7 +335,7 @@ def test_pypi_pin_numpy(testing_workdir, testing_config):
         api.build('msumastro')
 
 
-def test_pypi_version_sorting(testing_workdir, testing_config):
+def test_pypi_version_sorting(testing_config):
     # The package used here must have a numpy dependence for pin-numpy to have
     # any effect.
     api.skeletonize(packages='impyla', repo='pypi', config=testing_config)
@@ -350,12 +348,12 @@ def test_list_skeletons():
     assert set(skeletons) == {'pypi', 'cran', 'cpan', 'luarocks', 'rpm'}
 
 
-def test_pypi_with_entry_points(testing_workdir):
+def test_pypi_with_entry_points():
     api.skeletonize('planemo', repo='pypi', python_version="3.7")
     assert os.path.isdir('planemo')
 
 
-def test_pypi_with_version_arg(testing_workdir):
+def test_pypi_with_version_arg():
     # regression test for https://github.com/conda/conda-build/issues/1442
     api.skeletonize('PrettyTable', 'pypi', version='0.7.2')
     m = api.render('prettytable')[0][0]
@@ -363,7 +361,7 @@ def test_pypi_with_version_arg(testing_workdir):
 
 
 @pytest.mark.slow
-def test_pypi_with_extra_specs(testing_workdir, testing_config):
+def test_pypi_with_extra_specs(testing_config):
     # regression test for https://github.com/conda/conda-build/issues/1697
     # For mpi4py:
     testing_config.channel_urls.append('https://repo.anaconda.com/pkgs/free')
@@ -379,7 +377,7 @@ def test_pypi_with_extra_specs(testing_workdir, testing_config):
 
 
 @pytest.mark.slow
-def test_pypi_with_version_inconsistency(testing_workdir, testing_config):
+def test_pypi_with_version_inconsistency(testing_config):
     # regression test for https://github.com/conda/conda-build/issues/189
     # For mpi4py:
     extra_specs = ['mpi4py']
@@ -392,7 +390,7 @@ def test_pypi_with_version_inconsistency(testing_workdir, testing_config):
     assert parse_version(m.version()) == parse_version("0.0.10")
 
 
-def test_pypi_with_basic_environment_markers(testing_workdir):
+def test_pypi_with_basic_environment_markers():
     # regression test for https://github.com/conda/conda-build/issues/1974
     api.skeletonize('coconut', 'pypi', version='1.2.2')
     m = api.render('coconut')[0][0]
@@ -410,14 +408,14 @@ def test_pypi_with_basic_environment_markers(testing_workdir):
         assert "pygments" not in run_reqs
 
 
-def test_setuptools_test_requirements(testing_workdir):
+def test_setuptools_test_requirements():
     api.skeletonize(packages='hdf5storage', repo='pypi')
     m = api.render('hdf5storage')[0][0]
     assert m.meta['test']['requires'] == ['nose >=1.0']
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="sympy is python 3.8+")
-def test_pypi_section_order_preserved(testing_workdir):
+def test_pypi_section_order_preserved():
     """
     Test whether sections have been written in the correct order.
     """
@@ -458,7 +456,7 @@ def test_build_sh_shellcheck_clean(package, repo, testing_workdir, testing_confi
     api.skeletonize(packages=package, repo=repo, output_dir=testing_workdir, config=testing_config)
 
     matches = []
-    for root, dirnames, filenames in os.walk(testing_workdir):
+    for root, filenames in os.walk(testing_workdir):
         for filename in fnmatch.filter(filenames, "build.sh"):
             matches.append(os.path.join(root, filename))
 

--- a/tests/test_api_test.py
+++ b/tests/test_api_test.py
@@ -13,7 +13,7 @@ from .utils import metadata_dir
 
 
 @pytest.mark.sanity
-def test_recipe_test(testing_workdir, testing_config):
+def test_recipe_test(testing_config):
     """Test calling conda build -t <recipe dir>"""
     recipe = os.path.join(metadata_dir, 'has_prefix_files')
     metadata = api.render(recipe, config=testing_config)[0][0]
@@ -22,7 +22,7 @@ def test_recipe_test(testing_workdir, testing_config):
 
 
 @pytest.mark.sanity
-def test_package_test(testing_workdir, testing_config):
+def test_package_test(testing_config):
     """Test calling conda build -t <package file> - rather than <recipe dir>"""
     recipe = os.path.join(metadata_dir, 'has_prefix_files')
     metadata = api.render(recipe, config=testing_config)[0][0]
@@ -30,14 +30,14 @@ def test_package_test(testing_workdir, testing_config):
     api.test(outputs[0], config=metadata.config)
 
 
-def test_package_test_without_recipe_in_package(testing_workdir, testing_metadata):
+def test_package_test_without_recipe_in_package(testing_metadata):
     """Can't test packages after building if recipe is not included.  Not enough info to go on."""
     testing_metadata.config.include_recipe = False
     output = api.build(testing_metadata, notest=True, copy_test_source_files=True)[0]
     api.test(output, config=testing_metadata.config)
 
 
-def test_package_with_jinja2_does_not_redownload_source(testing_workdir, testing_config, mocker):
+def test_package_with_jinja2_does_not_redownload_source(testing_config, mocker):
     recipe = os.path.join(metadata_dir, 'jinja2_build_str')
     metadata = api.render(recipe, config=testing_config, dirty=True)[0][0]
     outputs = api.build(metadata, notest=True, anaconda_upload=False)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -43,7 +43,7 @@ def test_find_prefix_files(testing_workdir):
     assert len(list(build.have_prefix_files(files, testing_workdir))) == len(files)
 
 
-def test_build_preserves_PATH(testing_workdir, testing_config):
+def test_build_preserves_PATH(testing_config):
     m = api.render(os.path.join(metadata_dir, 'source_git'), config=testing_config)[0][0]
     ref_path = os.environ['PATH']
     build.build(m, stats=None)
@@ -233,7 +233,7 @@ def test_create_info_files_json_no_inodes(testing_workdir, testing_metadata):
         assert output == expected_output
 
 
-def test_rewrite_output(testing_workdir, testing_config, capsys):
+def test_rewrite_output(testing_config, capsys):
     api.build(os.path.join(metadata_dir, "_rewrite_env"), config=testing_config)
     captured = capsys.readouterr()
     stdout = captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,7 @@ def test_build_add_channel():
     main_build.execute(args)
 
 
-def test_build_without_channel_fails(testing_workdir):
+def test_build_without_channel_fails():
     # remove the conda forge channel from the arguments and make sure that we fail.  If we don't,
     #    we probably have channels in condarc, and this is not a good test.
     args = ['--no-anaconda-upload', '--no-activate',
@@ -117,7 +117,7 @@ def test_no_filename_hash(testing_workdir, testing_metadata, capfd):
     assert not re.search('test_no_filename_hash.*h[0-9a-f]{%d}' % testing_metadata.config.hash_length, error)
 
 
-def test_render_output_build_path(testing_workdir, testing_metadata, capfd, caplog):
+def test_render_output_build_path(testing_workdir, testing_metadata, capfd):
     api.output_yaml(testing_metadata, 'meta.yaml')
     args = ['--output', testing_workdir]
     main_render.execute(args)
@@ -128,7 +128,7 @@ def test_render_output_build_path(testing_workdir, testing_metadata, capfd, capl
     assert error == ""
 
 
-def test_render_output_build_path_and_file(testing_workdir, testing_metadata, capfd, caplog):
+def test_render_output_build_path_and_file(testing_workdir, testing_metadata, capfd):
     api.output_yaml(testing_metadata, 'meta.yaml')
     rendered_filename = 'out.yaml'
     args = ['--output', '--file', rendered_filename, testing_workdir]
@@ -173,7 +173,7 @@ def test_build_output_build_path_multiple_recipes(testing_workdir, testing_metad
     assert output.rstrip().splitlines() == test_paths, error
 
 
-def test_slash_in_recipe_arg_keeps_build_id(testing_workdir, testing_config):
+def test_slash_in_recipe_arg_keeps_build_id(testing_config):
     args = [os.path.join(metadata_dir, "has_prefix_files"), '--croot', testing_config.croot,
             '--no-anaconda-upload']
     outputs = main_build.execute(args)
@@ -186,7 +186,7 @@ def test_slash_in_recipe_arg_keeps_build_id(testing_workdir, testing_config):
 
 @pytest.mark.sanity
 @pytest.mark.skipif(on_win, reason="prefix is always short on win.")
-def test_build_long_test_prefix_default_enabled(mocker, testing_workdir):
+def test_build_long_test_prefix_default_enabled():
     recipe_path = os.path.join(metadata_dir, '_test_long_test_prefix')
     args = [recipe_path, '--no-anaconda-upload']
     main_build.execute(args)
@@ -196,7 +196,7 @@ def test_build_long_test_prefix_default_enabled(mocker, testing_workdir):
         main_build.execute(args)
 
 
-def test_build_no_build_id(testing_workdir, testing_config):
+def test_build_no_build_id(testing_config):
     args = [os.path.join(metadata_dir, "has_prefix_files"), '--no-build-id',
             '--croot', testing_config.croot, '--no-activate', '--no-anaconda-upload']
     outputs = main_build.execute(args)
@@ -207,7 +207,7 @@ def test_build_no_build_id(testing_workdir, testing_config):
     assert 'has_prefix_files_1' not in data
 
 
-def test_build_multiple_recipes(testing_metadata, testing_workdir, testing_config):
+def test_build_multiple_recipes(testing_metadata):
     """Test that building two recipes in one CLI call separates the build environment for each"""
     os.makedirs('recipe1')
     os.makedirs('recipe2')
@@ -222,7 +222,7 @@ def test_build_multiple_recipes(testing_metadata, testing_workdir, testing_confi
     main_build.execute(args)
 
 
-def test_build_output_folder(testing_workdir, testing_metadata, capfd):
+def test_build_output_folder(testing_workdir, testing_metadata):
     api.output_yaml(testing_metadata, 'meta.yaml')
     with TemporaryDirectory() as tmp:
         out = os.path.join(tmp, 'out')
@@ -234,7 +234,7 @@ def test_build_output_folder(testing_workdir, testing_metadata, capfd):
                                            os.path.basename(output)))
 
 
-def test_build_source(testing_workdir):
+def test_build_source():
     with TemporaryDirectory() as tmp:
         args = [os.path.join(metadata_dir, '_pyyaml_find_header'), '--source', '--no-build-id',
                 '--croot', tmp, '--no-activate', '--no-anaconda-upload', ]
@@ -266,7 +266,7 @@ def test_render_output_build_path_set_python(testing_workdir, testing_metadata, 
 
 
 @pytest.mark.sanity
-def test_skeleton_pypi(testing_workdir, testing_config):
+def test_skeleton_pypi():
     args = ['pypi', 'peppercorn']
     main_skeleton.execute(args)
     assert os.path.isdir('peppercorn')
@@ -276,14 +276,14 @@ def test_skeleton_pypi(testing_workdir, testing_config):
 
 
 @pytest.mark.sanity
-def test_skeleton_pypi_compatible_versions(testing_workdir, testing_config):
+def test_skeleton_pypi_compatible_versions():
     args = ['pypi', 'openshift']
     main_skeleton.execute(args)
     assert os.path.isdir('openshift')
 
 
 @pytest.mark.slow
-def test_skeleton_pypi_arguments_work(testing_workdir):
+def test_skeleton_pypi_arguments_work():
     """
     These checks whether skeleton executes without error when these
     options are specified on the command line AND whether the underlying
@@ -310,7 +310,7 @@ def test_skeleton_pypi_arguments_work(testing_workdir):
     assert m.version() == '0.2.2'
 
 
-def test_metapackage(testing_config, testing_workdir):
+def test_metapackage(testing_config):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test', '1.0', '-d', 'bzip2', '--no-anaconda-upload']
     main_metapackage.execute(args)
@@ -319,7 +319,7 @@ def test_metapackage(testing_config, testing_workdir):
     assert os.path.isfile(test_path)
 
 
-def test_metapackage_build_number(testing_config, testing_workdir):
+def test_metapackage_build_number(testing_config):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test_build_number', '1.0', '-d', 'bzip2', '--build-number', '1',
             '--no-anaconda-upload']
@@ -329,7 +329,7 @@ def test_metapackage_build_number(testing_config, testing_workdir):
     assert os.path.isfile(test_path)
 
 
-def test_metapackage_build_string(testing_config, testing_workdir):
+def test_metapackage_build_string(testing_config):
     """the metapackage command creates a package with runtime dependencies specified on the CLI"""
     args = ['metapackage_test_build_string', '1.0', '-d', 'bzip2', '--build-string', 'frank',
             '--no-anaconda-upload']
@@ -339,7 +339,7 @@ def test_metapackage_build_string(testing_config, testing_workdir):
     assert os.path.isfile(test_path)
 
 
-def test_metapackage_metadata(testing_config, testing_workdir):
+def test_metapackage_metadata(testing_config):
     args = ['metapackage_testing_metadata', '1.0', '-d', 'bzip2', "--home", "http://abc.com",
             "--summary", "wee", "--license", "BSD", '--no-anaconda-upload']
     main_metapackage.execute(args)
@@ -354,18 +354,18 @@ def test_metapackage_metadata(testing_config, testing_workdir):
     assert info['summary'] == 'wee'
 
 
-def testing_index(testing_workdir):
+def testing_index():
     args = ['.']
     main_index.execute(args)
     assert os.path.isfile('noarch/repodata.json')
 
 
-def test_inspect_installable(testing_workdir):
+def test_inspect_installable():
     args = ['channels', '--test-installable', 'conda-team']
     main_inspect.execute(args)
 
 
-def test_inspect_linkages(testing_workdir, capfd):
+def test_inspect_linkages(capfd):
     # get a package that has known object output
     args = ['linkages', 'python']
     if sys.platform == 'win32':
@@ -378,7 +378,7 @@ def test_inspect_linkages(testing_workdir, capfd):
         assert 'libncursesw' in output
 
 
-def test_inspect_objects(testing_workdir, capfd):
+def test_inspect_objects(capfd):
     # get a package that has known object output
     args = ['objects', 'python']
     if sys.platform != 'darwin':
@@ -392,7 +392,7 @@ def test_inspect_objects(testing_workdir, capfd):
 
 
 @pytest.mark.skipif(on_win, reason="Windows prefix length doesn't matter (yet?)")
-def test_inspect_prefix_length(testing_workdir, capfd):
+def test_inspect_prefix_length(capfd):
     from conda_build import api
     # build our own known-length package here
     test_base = os.path.expanduser("~/cbtmp")
@@ -447,7 +447,7 @@ def test_develop(testing_env):
 
 
 @pytest.mark.xfail(on_win, reason="This is a flaky test that doesn't seem to be working well on Windows.")
-def test_convert(testing_workdir, testing_config):
+def test_convert(testing_config):
     # download a sample py2.7 package
     f = 'https://repo.anaconda.com/pkgs/free/win-64/affine-2.0.0-py27_0.tar.bz2'
     pkg_name = "affine-2.0.0-py27_0.tar.bz2"
@@ -532,7 +532,7 @@ def test_conda_py_no_period(testing_workdir, testing_metadata, monkeypatch):
     assert any('py36' in output for output in outputs)
 
 
-def test_build_skip_existing(testing_workdir, capfd, mocker):
+def test_build_skip_existing(capfd, mocker):
     # build the recipe first
     empty_sections = os.path.join(metadata_dir, "empty_sections")
     args = ['--no-anaconda-upload', empty_sections]

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -86,7 +86,7 @@ def test_write_to_conda_pth(sp_dir, conda_pth):
             assert len(lines) == exp_num_pths
 
 
-def test_uninstall(sp_dir, conda_pth, request):
+def test_uninstall(sp_dir, conda_pth):
     '''
     `conda develop --uninstall pkg_path` invokes uninstall() to remove path
     from conda.pth - this is a unit test for uninstall

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -31,13 +31,3 @@ def test_inspect_objects():
 def test_channel_installable():
     # make sure the default channel is installable as a reference
     assert api.test_installable('conda-team')
-
-#     # create a channel that is not installable to validate function
-
-#     platform = os.path.join(testing_workdir, subdir)
-#     output_file = os.path.join(platform, "empty_sections-0.0-0.tar.bz2")
-
-#     # create the index so conda can find the file
-#     api.update_index(platform)
-
-#     assert not api.test_installable(channel=to_url(testing_workdir))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -158,7 +158,7 @@ def test_native_compiler_metadata_win(testing_config, py_ver, mocker):
     assert any(dep.startswith(py_ver[1]) for dep in metadata.meta['requirements']['build'])
 
 
-def test_native_compiler_metadata_linux(testing_config, mocker):
+def test_native_compiler_metadata_linux(testing_config):
     testing_config.platform = 'linux'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config, permit_unsatisfiable_variants=True,
@@ -169,7 +169,7 @@ def test_native_compiler_metadata_linux(testing_config, mocker):
     assert any(dep.startswith('gfortran_linux-' + _64) for dep in metadata.meta['requirements']['build'])
 
 
-def test_native_compiler_metadata_osx(testing_config, mocker):
+def test_native_compiler_metadata_osx(testing_config):
     testing_config.platform = 'osx'
     metadata = api.render(os.path.join(metadata_dir, '_compiler_jinja2'),
                           config=testing_config, permit_unsatisfiable_variants=True,

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -29,7 +29,7 @@ def test_compile_missing_pyc(testing_workdir):
     assert not os.path.isfile(os.path.join(tmp, add_mangling(bad_file)))
 
 
-def test_hardlinks_to_copies(testing_workdir):
+def test_hardlinks_to_copies():
     with open('test1', 'w') as f:
         f.write("\n")
 
@@ -44,7 +44,7 @@ def test_hardlinks_to_copies(testing_workdir):
     assert os.lstat('test2').st_nlink == 1
 
 
-def test_postbuild_files_raise(testing_metadata, testing_workdir):
+def test_postbuild_files_raise(testing_metadata):
     fn = 'buildstr', 'buildnum', 'version'
     for f in fn:
         with open(os.path.join(testing_metadata.config.work_dir,
@@ -55,7 +55,7 @@ def test_postbuild_files_raise(testing_metadata, testing_workdir):
 
 
 @pytest.mark.skipif(on_win, reason="fix_shebang is not executed on win32")
-def test_fix_shebang(testing_config):
+def test_fix_shebang():
     fname = 'test1'
     with open(fname, 'w') as f:
         f.write("\n")

--- a/tests/test_published_examples.py
+++ b/tests/test_published_examples.py
@@ -12,7 +12,7 @@ from .utils import published_path, get_valid_recipes
 
 
 @pytest.mark.sanity
-def test_skeleton_pypi(testing_workdir):
+def test_skeleton_pypi():
     """published in docs at https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html"""
     conda_path = os.path.join(sys.prefix, BIN_DIRECTORY, "conda")
 
@@ -22,7 +22,7 @@ def test_skeleton_pypi(testing_workdir):
 
 @pytest.mark.sanity
 @pytest.mark.parametrize("recipe", get_valid_recipes(published_path))
-def test_recipe_builds(recipe, testing_config, testing_workdir):
+def test_recipe_builds(recipe, testing_config):
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts
     build(str(recipe), config=testing_config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,7 +57,7 @@ def test_merge_namespace_trees(namespace_setup):
 
 
 @pytest.fixture(scope='function')
-def namespace_setup(testing_workdir, request):
+def namespace_setup(testing_workdir):
     namespace = os.path.join(testing_workdir, 'namespace')
     package = os.path.join(namespace, 'package')
     makefile(os.path.join(package, "module.py"))
@@ -65,7 +65,7 @@ def namespace_setup(testing_workdir, request):
 
 
 @pytest.mark.sanity
-def test_disallow_merge_conflicts(namespace_setup, testing_config):
+def test_disallow_merge_conflicts(namespace_setup):
     duplicate = os.path.join(namespace_setup, 'dupe', 'namespace', 'package', 'module.py')
     makefile(duplicate)
     with pytest.raises(IOError):
@@ -250,7 +250,7 @@ def test_logger_filtering(caplog, capfd):
     log.removeHandler(logging.StreamHandler(sys.stderr))
 
 
-def test_logger_config_from_file(testing_workdir, caplog, capfd, mocker):
+def test_logger_config_from_file(testing_workdir, capfd, mocker):
     test_file = os.path.join(testing_workdir, 'build_log_config.yaml')
     with open(test_file, 'w') as f:
         f.write("""

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -226,7 +226,7 @@ def test_variants_in_output_names():
     assert len(outputs) == 4
 
 
-def test_variants_in_versions_with_setup_py_data(testing_workdir):
+def test_variants_in_versions_with_setup_py_data():
     recipe = os.path.join(variants_dir, "12_variant_versions")
     outputs = api.get_output_file_paths(recipe)
     assert len(outputs) == 2
@@ -234,7 +234,7 @@ def test_variants_in_versions_with_setup_py_data(testing_workdir):
     assert any(os.path.basename(pkg).startswith('my_package-480.480') for pkg in outputs)
 
 
-def test_git_variables_with_variants(testing_workdir, testing_config):
+def test_git_variables_with_variants(testing_config):
     recipe = os.path.join(variants_dir, "13_git_vars")
     m = api.render(
         recipe, config=testing_config, finalize=False, bypass_env_check=True
@@ -259,7 +259,7 @@ def test_variant_input_with_zip_keys_keeps_zip_keys_list():
 
 @pytest.mark.serial
 @pytest.mark.xfail(sys.platform == "win32", reason="console readout issues on appveyor")
-def test_ensure_valid_spec_on_run_and_test(testing_workdir, testing_config, caplog):
+def test_ensure_valid_spec_on_run_and_test(testing_config, caplog):
     testing_config.debug = True
     testing_config.verbose = True
     recipe = os.path.join(variants_dir, "14_variant_in_run_and_test")
@@ -329,7 +329,7 @@ def test_subspace_selection(testing_config):
     assert ms[0][0].config.variant['c'] == 'animal'
 
 
-def test_get_used_loop_vars(testing_config):
+def test_get_used_loop_vars():
     m = api.render(
         os.path.join(variants_dir, "19_used_variables"),
         finalize=False,
@@ -343,7 +343,7 @@ def test_get_used_loop_vars(testing_config):
     assert m.get_used_vars() == {'python', 'some_package', 'zlib', 'pthread_stubs', 'target_platform'}
 
 
-def test_reprovisioning_source(testing_config):
+def test_reprovisioning_source():
     api.render(os.path.join(variants_dir, "20_reprovision_source"))
 
 
@@ -383,7 +383,7 @@ def test_reduced_hashing_behavior(testing_config):
     assert not re.search('h[0-9a-f]{%d}' % testing_config.hash_length, m.build_id())
 
 
-def test_variants_used_in_jinja2_conditionals(testing_config):
+def test_variants_used_in_jinja2_conditionals():
     ms = api.render(
         os.path.join(variants_dir, "21_conditional_sections"),
         finalize=False,
@@ -394,7 +394,7 @@ def test_variants_used_in_jinja2_conditionals(testing_config):
     assert sum(m.config.variant['blas_impl'] == 'openblas' for m, _, _ in ms) == 1
 
 
-def test_build_run_exports_act_on_host(testing_config, caplog):
+def test_build_run_exports_act_on_host(caplog):
     """Regression test for https://github.com/conda/conda-build/issues/2559"""
     api.render(
         os.path.join(variants_dir, "22_run_exports_rerendered_for_other_variants"),
@@ -404,7 +404,7 @@ def test_build_run_exports_act_on_host(testing_config, caplog):
     assert "failed to get install actions, retrying" not in caplog.text
 
 
-def test_detect_variables_in_build_and_output_scripts(testing_config):
+def test_detect_variables_in_build_and_output_scripts():
     ms = api.render(
         os.path.join(variants_dir, "24_test_used_vars_in_scripts"),
         platform="linux",
@@ -457,7 +457,7 @@ def test_detect_variables_in_build_and_output_scripts(testing_config):
             assert 'OUTPUT_VAR' in used_vars
 
 
-def test_target_platform_looping(testing_config):
+def test_target_platform_looping():
     outputs = api.get_output_file_paths(
         os.path.join(variants_dir, "25_target_platform_looping"),
         platform="win",
@@ -468,12 +468,12 @@ def test_target_platform_looping(testing_config):
 
 @pytest.mark.skipif(on_mac and platform.machine() == "arm64", reason="Unsatisfiable dependencies for M1 MacOS systems: {'numpy=1.16'}")
 # TODO Remove the above skip decorator once https://github.com/conda/conda-build/issues/4717 is resolved
-def test_numpy_used_variable_looping(testing_config):
+def test_numpy_used_variable_looping():
     outputs = api.get_output_file_paths(os.path.join(variants_dir, "numpy_used"))
     assert len(outputs) == 4
 
 
-def test_exclusive_config_files(testing_workdir):
+def test_exclusive_config_files():
     with open('conda_build_config.yaml', 'w') as f:
         yaml.dump({'abc': ['someval'], 'cwd': ['someval']}, f, default_flow_style=False)
     os.makedirs('config_dir')
@@ -504,7 +504,7 @@ def test_exclusive_config_files(testing_workdir):
     assert variant['abc'] == '123'
 
 
-def test_exclusive_config_file(testing_workdir):
+def test_exclusive_config_file():
     with open("conda_build_config.yaml", "w") as f:
         yaml.dump({"abc": ["someval"], "cwd": ["someval"]}, f, default_flow_style=False)
     os.makedirs("config_dir")
@@ -606,7 +606,7 @@ def test_top_level_finalized(testing_config):
     assert '5.2.3' in xzcat_output
 
 
-def test_variant_subkeys_retained(testing_config):
+def test_variant_subkeys_retained():
     m = api.render(
         os.path.join(variants_dir, "31_variant_subkeys"),
         finalize=False,


### PR DESCRIPTION
Related to current test pruning/update efforts per the following epic:
https://github.com/conda/conda-build/issues/4590

There are many instances of unused fixtures in several test files (e.g., some instances of `testing_workdir`); removing them in order to simplify/streamline the test code.

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~