### PR TITLE
`test_jinja_context.py`: remove unnecessary `skipif` clause and convert `tmpdir` to `tmp_path`

### DIFF
--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any
 

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -115,22 +115,6 @@ def test_resolved_packages(testing_metadata):
     assert any('python' == pkg.split()[0] for pkg in packages)
 
 
-try:
-    try:
-        # Recommended for setuptools 61.0.0+
-        # (though may disappear in the future)
-        from setuptools.config.setupcfg import read_configuration
-    except ImportError:
-        from setuptools.config import read_configuration
-    del read_configuration
-except ImportError:
-    _has_read_configuration = False
-else:
-    _has_read_configuration = True
-
-
-@pytest.mark.skipif(not _has_read_configuration,
-                    reason="setuptools <30.3.0 cannot read metadata / options from 'setup.cfg'")
 def test_load_setup_py_data_from_setup_cfg(testing_metadata, tmpdir):
     setup_py = tmpdir.join('setup.py')
     setup_cfg = tmpdir.join('setup.cfg')


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since conda-build depends on `conda>=4.13`, which in turn depends on `setuptools>=31.0.1`, we can drop the `pytest.mark.skipif` fence checking for `setuptools<30.3.0`.

Also converted pytest `tmpdir` to `tmp_path`.

Xref https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
