### PR TITLE
`test_build.py`: removed unnecessary `skipif` markers and converted `os.path` to `pathlib`

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,15 +4,11 @@
 This file tests the build.py module.  It sits lower in the stack than the API tests,
 and is more unit-test oriented.
 """
-
 import json
 import os
 import sys
 
-import pytest
-
 from conda_build import build, api
-from conda_build.utils import on_win
 
 from .utils import metadata_dir, get_noarch_python_meta
 
@@ -81,8 +77,6 @@ def test_is_no_link():
     assert build.is_no_link(no_link, "path/nope") is None
 
 
-@pytest.mark.skipif(on_win and sys.version[:3] == "2.7",
-                    reason="os.link is not available so can't setup test")
 def test_sorted_inode_first_path(testing_workdir):
     path_one = os.path.join(testing_workdir, "one")
     path_two = os.path.join(testing_workdir, "two")
@@ -130,8 +124,6 @@ def test_create_info_files_json(testing_workdir, testing_metadata):
         assert output == expected_output
 
 
-@pytest.mark.skipif(on_win and sys.version[:3] == "2.7",
-                    reason="os.symlink is not available so can't setup test")
 def test_create_info_files_json_symlinks(testing_workdir, testing_metadata):
     info_dir = os.path.join(testing_workdir, "info")
     os.mkdir(info_dir)
@@ -194,8 +186,6 @@ def test_create_info_files_json_symlinks(testing_workdir, testing_metadata):
         assert output == expected_output
 
 
-@pytest.mark.skipif(on_win and sys.version[:3] == "2.7",
-                    reason="os.link is not available so can't setup test")
 def test_create_info_files_json_no_inodes(testing_workdir, testing_metadata):
     info_dir = os.path.join(testing_workdir, "info")
     os.mkdir(info_dir)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -6,22 +6,18 @@ and is more unit-test oriented.
 """
 import json
 import os
+from pathlib import Path
 import sys
+
+from conda.common.compat import on_win
 
 from conda_build import build, api
 
 from .utils import metadata_dir, get_noarch_python_meta
 
-prefix_tests = {"normal": os.path.sep}
-if sys.platform == "win32":
-    prefix_tests.update({"double_backslash": "\\\\",
-                         "forward_slash": "/"})
-
-
-def _write_prefix(filename, prefix, replacement):
-    with open(filename, "w") as f:
-        f.write(prefix.replace(os.path.sep, replacement))
-        f.write("\n")
+PREFIX_TESTS = {"normal": os.path.sep}
+if on_win:
+    PREFIX_TESTS.update({"double_backslash": "\\\\", "forward_slash": "/"})
 
 
 def test_find_prefix_files(testing_workdir):
@@ -31,10 +27,10 @@ def test_find_prefix_files(testing_workdir):
     """
     # create text files to be replaced
     files = []
-    for slash_style in prefix_tests:
-        filename = os.path.join(testing_workdir, "%s.txt" % slash_style)
-        _write_prefix(filename, testing_workdir, prefix_tests[slash_style])
-        files.append(filename)
+    for style, replacement in PREFIX_TESTS.items():
+        filename = Path(testing_workdir, f"{style}.txt")
+        filename.write_text(testing_workdir.replace(os.path.sep, replacement))
+        files.append(str(filename))
 
     assert len(list(build.have_prefix_files(files, testing_workdir))) == len(files)
 
@@ -78,13 +74,13 @@ def test_is_no_link():
 
 
 def test_sorted_inode_first_path(testing_workdir):
-    path_one = os.path.join(testing_workdir, "one")
-    path_two = os.path.join(testing_workdir, "two")
-    path_one_hardlink = os.path.join(testing_workdir, "one_hl")
-    open(path_one, "a").close()
-    open(path_two, "a").close()
+    path_one = Path(testing_workdir, "one")
+    path_two = Path(testing_workdir, "two")
+    path_hardlink = Path(testing_workdir, "one_hl")
 
-    os.link(path_one, path_one_hardlink)
+    path_one.touch()
+    path_two.touch()
+    os.link(path_one, path_hardlink)
 
     files = ["one", "two", "one_hl"]
     assert build.get_inode_paths(files, "one", testing_workdir) == ["one", "one_hl"]
@@ -93,21 +89,18 @@ def test_sorted_inode_first_path(testing_workdir):
 
 
 def test_create_info_files_json(testing_workdir, testing_metadata):
-    info_dir = os.path.join(testing_workdir, "info")
-    os.mkdir(info_dir)
-    path_one = os.path.join(testing_workdir, "one")
-    path_two = os.path.join(testing_workdir, "two")
-    path_foo = os.path.join(testing_workdir, "foo")
-    open(path_one, "a").close()
-    open(path_two, "a").close()
-    open(path_foo, "a").close()
+    info_dir = Path(testing_workdir, "info")
+    info_dir.mkdir()
+    Path(testing_workdir, "one").touch()
+    Path(testing_workdir, "two").touch()
+    Path(testing_workdir, "foo").touch()
+
     files_with_prefix = [("prefix/path", "text", "foo")]
     files = ["one", "two", "foo"]
-
     build.create_info_files_json_v1(testing_metadata, info_dir, testing_workdir, files,
                                     files_with_prefix)
-    files_json_path = os.path.join(info_dir, "paths.json")
-    expected_output = {
+
+    assert json.loads((info_dir / "paths.json").read_text()) == {
         "paths": [{"file_mode": "text", "path_type": "hardlink", "_path": "foo",
                    "prefix_placeholder": "prefix/path",
                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -119,26 +112,24 @@ def test_create_info_files_json(testing_workdir, testing_metadata):
                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                    "size_in_bytes": 0}],
         "paths_version": 1}
-    with open(files_json_path) as files_json:
-        output = json.load(files_json)
-        assert output == expected_output
 
 
 def test_create_info_files_json_symlinks(testing_workdir, testing_metadata):
-    info_dir = os.path.join(testing_workdir, "info")
-    os.mkdir(info_dir)
-    path_one = os.path.join(testing_workdir, "one")
-    path_two = os.path.join(testing_workdir, "two")
-    path_three = os.path.join(testing_workdir, "three")  # do not make this one
-    path_foo = os.path.join(testing_workdir, "foo")
-    path_two_symlink = os.path.join(testing_workdir, "two_sl")
-    symlink_to_nowhere = os.path.join(testing_workdir, "nowhere_sl")
-    recursive_symlink = os.path.join(testing_workdir, "recursive_sl")
-    cycle1_symlink = os.path.join(testing_workdir, "cycle1_sl")
-    cycle2_symlink = os.path.join(testing_workdir, "cycle2_sl")
-    open(path_one, "a").close()
-    open(path_two, "a").close()
-    open(path_foo, "a").close()
+    info_dir = Path(testing_workdir, "info")
+    info_dir.mkdir()
+    path_one = Path(testing_workdir, "one")
+    path_two = Path(testing_workdir, "two")
+    path_three = Path(testing_workdir, "three")  # do not make this one
+    path_foo = Path(testing_workdir, "foo")
+    path_two_symlink = Path(testing_workdir, "two_sl")
+    symlink_to_nowhere = Path(testing_workdir, "nowhere_sl")
+    recursive_symlink = Path(testing_workdir, "recursive_sl")
+    cycle1_symlink = Path(testing_workdir, "cycle1_sl")
+    cycle2_symlink = Path(testing_workdir, "cycle2_sl")
+
+    path_one.touch()
+    path_two.touch()
+    path_foo.touch()
     os.symlink(path_two, path_two_symlink)
     os.symlink(path_three, symlink_to_nowhere)
 
@@ -152,8 +143,7 @@ def test_create_info_files_json_symlinks(testing_workdir, testing_metadata):
 
     build.create_info_files_json_v1(testing_metadata, info_dir, testing_workdir, files,
                                     files_with_prefix)
-    files_json_path = os.path.join(info_dir, "paths.json")
-    expected_output = {
+    assert json.loads((info_dir / "paths.json").read_text()) == {
         "paths": [
                   {"path_type": "softlink", "_path": "cycle1_sl",
                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -181,29 +171,26 @@ def test_create_info_files_json_symlinks(testing_workdir, testing_metadata):
                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                    "size_in_bytes": 0}],
         "paths_version": 1}
-    with open(files_json_path) as files_json:
-        output = json.load(files_json)
-        assert output == expected_output
 
 
 def test_create_info_files_json_no_inodes(testing_workdir, testing_metadata):
-    info_dir = os.path.join(testing_workdir, "info")
-    os.mkdir(info_dir)
-    path_one = os.path.join(testing_workdir, "one")
-    path_two = os.path.join(testing_workdir, "two")
-    path_foo = os.path.join(testing_workdir, "foo")
-    path_one_hardlink = os.path.join(testing_workdir, "one_hl")
-    open(path_one, "a").close()
-    open(path_two, "a").close()
-    open(path_foo, "a").close()
+    info_dir = Path(testing_workdir, "info")
+    info_dir.mkdir()
+    path_one = Path(testing_workdir, "one")
+    path_two = Path(testing_workdir, "two")
+    path_foo = Path(testing_workdir, "foo")
+    path_one_hardlink = Path(testing_workdir, "one_hl")
+
+    path_one.touch()
+    path_two.touch()
+    path_foo.touch()
     os.link(path_one, path_one_hardlink)
+
     files_with_prefix = [("prefix/path", "text", "foo")]
     files = ["one", "two", "one_hl", "foo"]
-
     build.create_info_files_json_v1(testing_metadata, info_dir, testing_workdir, files,
                                     files_with_prefix)
-    files_json_path = os.path.join(info_dir, "paths.json")
-    expected_output = {
+    assert json.loads((info_dir / "paths.json").read_text()) == {
         "paths": [{"file_mode": "text", "path_type": "hardlink", "_path": "foo",
                    "prefix_placeholder": "prefix/path",
                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -218,9 +205,6 @@ def test_create_info_files_json_no_inodes(testing_workdir, testing_metadata):
                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                    "size_in_bytes": 0}],
         "paths_version": 1}
-    with open(files_json_path) as files_json:
-        output = json.load(files_json)
-        assert output == expected_output
 
 
 def test_rewrite_output(testing_workdir, testing_config, capsys):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Removed `skipif` markers checking for Python 2.7. Converted `os.path` to `pathlib`.

Xref https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
