### PR TITLE
`test_api_render.py`: remove unused `skipif` and converted `unittest.mock` to pytest-mocker

### DIFF
--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -4,12 +4,10 @@
 This module tests the test API.  These are high-level integration tests.  Lower level unit tests
 should go in test_render.py
 """
-
 import os
 import re
 import sys
 
-from unittest import mock
 import pytest
 import yaml
 
@@ -97,10 +95,12 @@ def test_get_output_file_path_jinja2(testing_workdir, testing_config):
                                       "py{}{}_0_g262d444.tar.bz2".format(python, _hash))
 
 
-@mock.patch('conda_build.source')
-def test_output_without_jinja_does_not_download(mock_source, testing_workdir, testing_config):
-    api.get_output_file_path(os.path.join(metadata_dir, "source_git"), config=testing_config)[0]
-    mock_source.provide.assert_not_called()
+def test_output_without_jinja_does_not_download(mocker, testing_config):
+    mock = mocker.patch("conda_build.source")
+    api.get_output_file_path(
+        os.path.join(metadata_dir, "source_git"), config=testing_config
+    )
+    mock.assert_not_called()
 
 
 def test_pin_compatible_semver(testing_config):


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Removed `pytest.mark.skipif` conditions for Python 3+ codes.

Removed test (`test_run_exports_from_repo_without_channeldata`) marked as `pytest.mark.xfail` and never had its recipe files (`tests/test-recipes/metadata/_run_export_no_channeldata`) committed when originally added in 2019 (see https://github.com/conda/conda-build/pull/3596). Furthermore, the test was designed to only run on Linux + Python 2 (`pytest.mark.skipif(sys.platform != "linux2")`), which is no longer supported.

Xref https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
