### PR TITLE
`test_api_skeleton.py`: Reorg fixtures, remove pre-Python 2.7 condition, require `ruamel.yaml`

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -31,5 +31,6 @@ python-libarchive-c
 pytz
 requests
 ripgrep
+ruamel.yaml
 toml
 tqdm

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import fnmatch
 import os
 import subprocess

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -16,24 +16,22 @@ from conda_build.skeletons.pypi import get_package_metadata, \
 
 from conda_build import api
 from conda_build.exceptions import DependencyNeedsBuildingError
-import conda_build.os_utils.external as external
 from conda_build.utils import on_win
 
 thisdir = os.path.dirname(os.path.realpath(__file__))
 
-repo_packages = [('', 'pypi', 'pip', '8.1.2'),
-                 ('r', 'cran', 'acs', ''),
-                 (
-                     'r', 'cran',
-                     'https://github.com/twitter/AnomalyDetection.git',
-                     ''),
-                 ('perl', 'cpan', 'Moo', ''),
-                 ('', 'rpm', 'libX11-devel', ''),
-                 # ('lua', luarocks', 'LuaSocket', ''),
-                 ]
 
-
-@pytest.mark.parametrize("prefix, repo, package, version", repo_packages)
+@pytest.mark.parametrize(
+    "prefix, repo, package, version",
+    [
+        ("", "pypi", "pip", "8.1.2"),
+        ("r", "cran", "acs", ""),
+        ("r", "cran", "https://github.com/twitter/AnomalyDetection.git", ""),
+        ("perl", "cpan", "Moo", ""),
+        ("", "rpm", "libX11-devel", ""),
+        # ('lua', luarocks', 'LuaSocket', ''),
+    ],
+)
 def test_repo(prefix, repo, package, version, testing_workdir, testing_config):
     api.skeletonize(package, repo, version=version, output_dir=testing_workdir,
                     config=testing_config)
@@ -441,7 +439,7 @@ def test_pypi_section_order_preserved(testing_workdir):
 
 @pytest.mark.slow
 @pytest.mark.flaky(rerun=5, reruns_delay=2)
-@pytest.mark.skipif(not external.find_executable("shellcheck"), reason="requires shellcheck >=0.7.0")
+@pytest.mark.skipif(on_win, reason="shellcheck is only available on Windows")
 @pytest.mark.parametrize(
     "package, repo", [("r-rmarkdown", "cran"), ("Perl::Lint", "cpan"), ("screen", "rpm")]
 )

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -377,12 +377,8 @@ def test_pypi_with_basic_environment_markers(testing_workdir):
     # should include the right dependencies for the right version
     assert "futures" not in build_reqs
     assert "futures" not in run_reqs
-    if sys.version_info >= (2, 7):
-        assert "pygments" in build_reqs
-        assert "pygments" in run_reqs
-    else:
-        assert "pygments" not in build_reqs
-        assert "pygments" not in run_reqs
+    assert "pygments" in build_reqs
+    assert "pygments" in run_reqs
 
 
 def test_setuptools_test_requirements(testing_workdir):

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -7,20 +7,12 @@ import sys
 
 from pkg_resources import parse_version
 import pytest
+import ruamel.yaml
 
 from conda_build.skeletons.pypi import get_package_metadata, \
     get_entry_points, is_setuptools_enabled, convert_to_flat_list, \
     get_dependencies, get_import_tests, get_tests_require, get_home, \
     get_summary, get_license_name, clean_license_name
-
-try:
-    import ruamel_yaml
-except ImportError:
-    try:
-        import ruamel.yaml as ruamel_yaml
-    except ImportError:
-        raise ImportError("No ruamel_yaml library available.\n"
-                          "To proceed, conda install ruamel_yaml")
 
 from conda_build import api
 from conda_build.exceptions import DependencyNeedsBuildingError
@@ -434,8 +426,7 @@ def test_pypi_section_order_preserved(testing_workdir):
         lines = [ln for ln in file.readlines() if not ln.startswith("{%")]
 
     # The loader below preserves the order of entries...
-    recipe = ruamel_yaml.load('\n'.join(lines),
-                              Loader=ruamel_yaml.RoundTripLoader)
+    recipe = ruamel.yaml.load("\n".join(lines), Loader=ruamel.yaml.RoundTripLoader)
 
     major_sections = list(recipe.keys())
     # Blank fields are omitted when skeletonizing, so prune any missing ones

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -144,10 +144,12 @@ def pylint_metadata():
     [
         ("", "pypi", "pip", "8.1.2"),
         ("r-", "cran", "acs", None),
-        ("r-", "cran", "https://github.com/twitter/AnomalyDetection.git", ""),
+        ("r-", "cran", "https://github.com/twitter/AnomalyDetection.git", None),
         ("perl-", "cpan", "Moo", None),
         ("", "rpm", "libX11-devel", None),
-        # ('lua', luarocks', 'LuaSocket', ''),
+        # skeleton("luarocks") appears broken and needs work
+        # https://github.com/conda/conda-build/issues/4756
+        # ("lua-", "luarocks", "LuaSocket", None),
     ],
 )
 def test_repo(
@@ -453,7 +455,7 @@ def test_pypi_section_order_preserved(tmp_path: Path):
 
 @pytest.mark.slow
 @pytest.mark.flaky(rerun=5, reruns_delay=2)
-@pytest.mark.skipif(on_win, reason="shellcheck is only available on Windows")
+@pytest.mark.skipif(on_win, reason="shellcheck is not available on Windows")
 @pytest.mark.parametrize(
     "package, repo",
     [


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Grouped fixtures at the top of the file. Remove pre-Python 2.7 condition. Require `ruamel.yaml` to avoid try-except.

Xref https://github.com/conda/conda-build/issues/4590

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
