### PR TITLE
Document build.force_use_keys and build.force_ignore_keys

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -312,6 +312,22 @@ OR
 
   * package uses {{ compiler() }} jinja2 function
 
+You can also influence which variables are considered for the hash with:
+
+.. code-block:: yaml
+
+   build:
+     force_use_keys:
+       - package_1
+     force_ignore_keys:
+       - package_2
+
+This will ensure that the value of ``package_2`` will *not* be considered for the hash,
+and ``package_1`` *will* be, regardless of what conda-build discovers is used by its inspection.
+
+This may be useful to further split complex multi-output builds, to ensure each package is built,
+or to ensure the right package hash when using more complex templating or scripting.
+
 
 Python entry points
 -------------------


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Added documentation for `build.force_[use|ignore]_keys`, which are useful for influencing the build string.

I've found these useful for multi-output repos that include e.g. a library and its Python bindings. Often conda-build's default hashes do not produce the correct output without  including `python` in the hash inputs of `libfoo`. Adding `python` to `build.force_use_keys` is an easy fix for that.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
