### PR TITLE
Add tests for #4763

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 from collections import OrderedDict, defaultdict
 from functools import lru_cache
 import json
@@ -8,7 +10,6 @@ from os.path import isdir, isfile, abspath
 from pathlib import Path
 import random
 import re
-import shutil
 import string
 import subprocess
 import sys
@@ -200,37 +201,36 @@ def _filter_run_exports(specs, ignore_list):
     return filtered_specs
 
 
-def find_pkg_dir_or_file_in_pkgs_dirs(pkg_dist, m, files_only=False):
-    _pkgs_dirs = pkgs_dirs + list(m.config.bldpkgs_dirs)
-    pkg_loc = None
-    for pkgs_dir in _pkgs_dirs:
-        pkg_dir = os.path.join(pkgs_dir, pkg_dist)
-        pkg_file = os.path.join(pkgs_dir, pkg_dist + CONDA_PACKAGE_EXTENSION_V1)
-        if not files_only and os.path.isdir(pkg_dir):
-            pkg_loc = pkg_dir
-            break
-        elif os.path.isfile(pkg_file):
-            pkg_loc = pkg_file
-            break
-        elif files_only and os.path.isdir(pkg_dir):
-            pkg_loc = pkg_file
-            # create the tarball on demand.  This is so that testing on archives works.
-            with tarfile.open(pkg_file, 'w:bz2') as archive:
-                for entry in os.listdir(pkg_dir):
-                    archive.add(os.path.join(pkg_dir, entry), arcname=entry)
+def find_pkg_dir_or_file_in_pkgs_dirs(
+    distribution: str, m: MetaData, files_only: bool = False
+) -> str | None:
+    for cache in map(Path, (*pkgs_dirs, *m.config.bldpkgs_dirs)):
+        package = cache / (distribution + CONDA_PACKAGE_EXTENSION_V1)
+        if package.is_file():
+            return str(package)
 
-            # use the package's subdir
+        directory = cache / distribution
+        if directory.is_dir():
+            if not files_only:
+                return str(directory)
+
+            # get the package's subdir
             try:
-                info = json.loads(Path(pkg_dir, "info", "index.json").read_text())
-                subdir = info["subdir"]
+                subdir = json.loads((directory / "info" / "index.json").read_text())[
+                    "subdir"
+                ]
             except (FileNotFoundError, KeyError):
                 subdir = m.config.host_subdir
 
-            pkg_subdir = os.path.join(m.config.croot, subdir)
-            pkg_loc = os.path.join(pkg_subdir, os.path.basename(pkg_file))
-            shutil.move(pkg_file, pkg_loc)
-            break
-    return pkg_loc
+            # create the tarball on demand so testing on archives works
+            package = Path(
+                m.config.croot, subdir, distribution + CONDA_PACKAGE_EXTENSION_V1
+            )
+            with tarfile.open(package, "w:bz2") as archive:
+                for entry in directory.iterdir():
+                    archive.add(entry, arcname=entry.name)
+
+            return str(package)
 
 
 @lru_cache(maxsize=None)

--- a/news/4763-subdir
+++ b/news/4763-subdir
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Install downstream packages in correct subdir. (#4763, #4803)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,11 +1,16 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+import json
 import os
+from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
 from conda_build import api
 from conda_build import render
+from conda_build.metadata import MetaData
+from conda_build.utils import CONDA_PACKAGE_EXTENSION_V1
 
 
 @pytest.mark.parametrize(
@@ -45,3 +50,63 @@ def test_pin_run_as_build_preserve_string(testing_metadata):
         {'pkg': '1.2.3 somestring_h1234'}
     )
     assert dep == 'pkg >=1.2.3,<1.3.0a0 somestring*'
+
+
+@pytest.mark.parametrize(
+    "create_package,subdir,is_file,files_only",
+    [
+        pytest.param(False, None, None, None, id="not found"),
+        pytest.param(True, None, False, False, id="directory"),
+        pytest.param(True, None, False, True, id="on demand"),
+        pytest.param(True, "magic", False, True, id="on demand, different subdir"),
+        pytest.param(True, None, True, None, id="file"),
+    ],
+)
+def test_find_package(
+    testing_metadata: MetaData,
+    tmp_path: Path,
+    create_package: bool,
+    subdir: str | None,
+    is_file: bool,
+    files_only: bool,
+):
+    """
+    Testing our ability to find the package directory or archive.
+
+    The render.find_pkg_dir_or_file_in_pkgs_dirs function will scan the various
+    locations where packages may exist locally and returns the full package path
+    if found.
+    """
+    # setup
+    distribution = uuid4().hex[:20]
+    testing_metadata.config.croot = tmp_path
+    host_cache = tmp_path / testing_metadata.config.host_subdir
+    host_cache.mkdir()
+    subdir = subdir or testing_metadata.config.host_subdir
+    other_cache = tmp_path / subdir
+    other_cache.mkdir(exist_ok=True)
+
+    # generate a dummy package as needed
+    package = None
+    if create_package:
+        # generate dummy package
+        if is_file:
+            (host_cache / (distribution + CONDA_PACKAGE_EXTENSION_V1)).touch()
+        else:
+            info = host_cache / distribution / "info"
+            info.mkdir(parents=True)
+            (info / "index.json").write_text(json.dumps({"subdir": subdir}))
+
+        # expected package path
+        if is_file or files_only:
+            package = other_cache / (distribution + CONDA_PACKAGE_EXTENSION_V1)
+        else:
+            package = other_cache / distribution
+
+    # attempt to find the package and check we found the expected path
+    found = render.find_pkg_dir_or_file_in_pkgs_dirs(
+        distribution,
+        testing_metadata,
+        files_only=files_only,
+    )
+    assert package is found is None or package.samefile(found)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adds missing tests for #4750, #4763.

This adds tests for the 5 different use cases for `conda_build.render.find_pkg_dir_or_file_in_pkgs_dirs`:
1. package not found
1. package tarball found
1. pacakge directory found
1. package directory found, generate on demand tarball
1. package directory found, generate on demand tarball, place in different subdir from host

Took the opportunity to also refactor `conda_build.render.find_pkg_dir_or_file_in_pkgs_dirs` to use `pathlib`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
