### PR TITLE
Require the source when rendering if load_file_data is used

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1930,11 +1930,20 @@ class MetaData:
         return "load_file_regex" in meta_text
 
     @property
+    def uses_load_file_data_in_meta(self):
+        meta_text = ""
+        if self.meta_path:
+            with open(self.meta_path, "rb") as f:
+                meta_text = UnicodeDammit(f.read()).unicode_markup
+        return "load_file_data" in meta_text
+
+    @property
     def needs_source_for_render(self):
         return (
             self.uses_vcs_in_meta
             or self.uses_setup_py_in_meta
             or self.uses_regex_in_meta
+            or self.uses_load_file_data_in_meta
         )
 
     @property

--- a/news/4817-require-source-when-load-file-data-used
+++ b/news/4817-require-source-when-load-file-data-used
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Require the source when rendering a recipe that uses the load_file_data function (#4817, fixes #4807)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/metadata/jinja_load_toml_from_source/meta.yaml
+++ b/tests/test-recipes/metadata/jinja_load_toml_from_source/meta.yaml
@@ -1,0 +1,8 @@
+{% set pyproject = load_file_data("pyproject.toml") %}
+
+package:
+  name: example
+  version: {{ pyproject['project']['version'] }}
+
+source:
+  path: ./src

--- a/tests/test-recipes/metadata/jinja_load_toml_from_source/src/pyproject.toml
+++ b/tests/test-recipes/metadata/jinja_load_toml_from_source/src/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+version = "1.test"


### PR DESCRIPTION
### Description

Require the source to be downloaded and available if the `load_file_data` Jinja2 function is used in the recipe's meta.yaml.

closes #4807 

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?