### PR TITLE
Stop using pending deprecation `get_prefix`

### DIFF
--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -3,7 +3,8 @@
 import logging
 import sys
 
-from conda_build.conda_interface import ArgumentParser, add_parser_prefix, get_prefix
+from conda.base.context import context, determine_target_prefix
+from conda_build.conda_interface import ArgumentParser, add_parser_prefix
 from conda_build import api
 
 
@@ -57,7 +58,7 @@ This works by creating a conda.pth file in site-packages."""
 
 def execute(args):
     _, args = parse_args(args)
-    prefix = get_prefix(args)
+    prefix = determine_target_prefix(context, args)
     api.develop(args.source, prefix=prefix, no_pth_file=args.no_pth_file,
                 build_ext=args.build_ext, clean=args.clean, uninstall=args.uninstall)
 

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -5,7 +5,8 @@ from os.path import expanduser
 from pprint import pprint
 import sys
 
-from conda_build.conda_interface import ArgumentParser, add_parser_prefix, get_prefix
+from conda.base.context import context, determine_target_prefix
+from conda_build.conda_interface import ArgumentParser, add_parser_prefix
 
 from conda_build import api
 
@@ -187,15 +188,30 @@ def execute(args):
             parser.error("At least one option (--test-installable) is required.")
         else:
             print(api.test_installable(args.channel))
-    elif args.subcommand == 'linkages':
-        print(api.inspect_linkages(args.packages, prefix=get_prefix(args),
-                                   untracked=args.untracked, all_packages=args.all,
-                                   show_files=args.show_files, groupby=args.groupby,
-                                   sysroot=expanduser(args.sysroot)))
-    elif args.subcommand == 'objects':
-        print(api.inspect_objects(args.packages, prefix=get_prefix(args), groupby=args.groupby))
-    elif args.subcommand == 'prefix-lengths':
-        if not api.inspect_prefix_length(args.packages, min_prefix_length=args.min_prefix_length):
+    elif args.subcommand == "linkages":
+        print(
+            api.inspect_linkages(
+                args.packages,
+                prefix=determine_target_prefix(context, args),
+                untracked=args.untracked,
+                all_packages=args.all,
+                show_files=args.show_files,
+                groupby=args.groupby,
+                sysroot=expanduser(args.sysroot),
+            )
+        )
+    elif args.subcommand == "objects":
+        print(
+            api.inspect_objects(
+                args.packages,
+                prefix=determine_target_prefix(context, args),
+                groupby=args.groupby,
+            )
+        )
+    elif args.subcommand == "prefix-lengths":
+        if not api.inspect_prefix_length(
+            args.packages, min_prefix_length=args.min_prefix_length
+        ):
             sys.exit(1)
     elif args.subcommand == 'hash-inputs':
         pprint(api.inspect_hash_inputs(args.packages))

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -84,7 +84,7 @@ from conda.exceptions import (  # noqa: F401
 from conda.base.context import (  # noqa: F401
     non_x86_machines as non_x86_linux_machines,
     context,
-    get_prefix as context_get_prefix,
+    determine_target_prefix,
     reset_context,
 )
 from conda.models.channel import get_conda_build_local_url  # noqa: F401
@@ -101,7 +101,7 @@ subdir = context.subdir
 create_default_packages = context.create_default_packages
 
 get_rc_urls = lambda: list(context.channels)
-get_prefix = partial(context_get_prefix, context)
+get_prefix = partial(determine_target_prefix, context)
 cc_conda_build = context.conda_build if hasattr(context, 'conda_build') else {}
 
 get_conda_channel = Channel.from_value


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`conda.base.context.get_prefix` has been marked for deprecation so we should stop using it.

Xref https://github.com/conda/conda/issues/12385
Resolves https://github.com/conda/conda/issues/12515

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
