### PR TITLE
Don't run lief on UNIX static libraries

### DIFF
--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -1024,6 +1024,11 @@ def codefile_class(filename, skip_symlinks=False):
     # Java .class files share 0xCAFEBABE with Mach-O FAT_MAGIC.
     if filename.endswith('.class'):
         return None
+    # lief does not (yet) support querying for static libraries;
+    # this used to silently work but surfaced by lief 0.12, see
+    # https://github.com/lief-project/LIEF/issues/873
+    if filename.endswith('.a'):
+        return None
     if not os.path.exists(filename) or os.path.getsize(filename) < 4:
         return None
     with open(filename, 'rb') as file:


### PR DESCRIPTION
An updated version of PR #4808 from @h-vetinari

Fixes #4787 

Tested on macOS Big Sur, compiling a custom conda build of LLVM with compiler-rt which was previously failing due to the aforementioned bug.