### PR TITLE
Deprecate Python 2 silliness and use `os.makedirs(exists_ok=True)`

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import sys
 import time
+import warnings
 from collections import namedtuple
 from os.path import abspath, expanduser, expandvars, join
 
@@ -57,20 +58,20 @@ conda_pkg_format_default = None
 zstd_compression_level_default = 19
 
 
-# Python2 silliness:
 def python2_fs_encode(strin):
-    return (
-        strin.decode(sys.getfilesystemencoding()) if hasattr(strin, "decode") else strin
+    warnings.warn(
+        "`conda_build.config.python2_fs_encode` is pending deprecation and will be removed in a future release.",
+        PendingDeprecationWarning,
     )
+    return strin
 
 
 def _ensure_dir(path):
     # this can fail in parallel operation, depending on timing.  Just try to make the dir,
     #    but don't bail if fail.
-    encpath = python2_fs_encode(path)
-    if not os.path.isdir(encpath):
+    if not os.path.isdir(path):
         try:
-            os.makedirs(encpath)
+            os.makedirs(path)
         except OSError:
             pass
 
@@ -485,7 +486,7 @@ class Config:
                 self._croot = join(root_dir, "conda-bld")
             else:
                 self._croot = abspath(expanduser("~/conda-bld"))
-        return python2_fs_encode(self._croot)
+        return self._croot
 
     @croot.setter
     def croot(self, croot):
@@ -672,7 +673,7 @@ class Config:
             "build_id should not be an absolute path, "
             "to preserve croot during path joins"
         )
-        self._build_id = python2_fs_encode(_build_id)
+        self._build_id = _build_id
 
     @property
     def prefix_length(self):

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -75,7 +75,9 @@ def _ensure_dir(path: os.PathLike):
     # this can fail in parallel operation, depending on timing.  Just try to make the dir,
     #    but don't bail if fail.
     warnings.warn(
-        "`conda_build.config._ensure_dir` is pending deprecation and will be removed in a future release. Please use `os.makedirs(path, exist_ok=True)` instead",
+        "`conda_build.config._ensure_dir` is pending deprecation and will be removed "
+        "in a future release. Please use `pathlib.Path.mkdir(exist_ok=True)` or "
+        "`os.makedirs(exist_ok=True)` instead",
         PendingDeprecationWarning,
     )
     os.makedirs(path, exist_ok=True)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -66,14 +66,19 @@ def python2_fs_encode(strin):
     return strin
 
 
-def _ensure_dir(path):
+def _ensure_dir(path: os.PathLike):
+    """Try to ensure a directory exists
+
+    Args:
+        path (os.PathLike): Path to directory
+    """
     # this can fail in parallel operation, depending on timing.  Just try to make the dir,
     #    but don't bail if fail.
-    if not os.path.isdir(path):
-        try:
-            os.makedirs(path)
-        except OSError:
-            pass
+    warnings.warn(
+        "`conda_build.config._ensure_dir` is pending deprecation and will be removed in a future release. Please use `os.makedirs(path, exist_ok=True)` instead",
+        PendingDeprecationWarning,
+    )
+    os.makedirs(path, exist_ok=True)
 
 
 # we need this to be accessible to the CLI, so it needs to be more static.
@@ -767,7 +772,7 @@ class Config:
     def info_dir(self):
         """Path to the info dir in the build prefix, where recipe metadata is stored"""
         path = join(self.host_prefix, "info")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
@@ -775,21 +780,21 @@ class Config:
         """Path to the conda-meta dir in the build prefix, where package index json files are
         stored"""
         path = join(self.host_prefix, "conda-meta")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def broken_dir(self):
         """Where packages that fail the test phase are placed"""
         path = join(self.croot, "broken")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def bldpkgs_dir(self):
         """Dir where the package is saved."""
         path = join(self.croot, self.host_subdir)
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
@@ -807,41 +812,41 @@ class Config:
     def src_cache(self):
         """Where tarballs and zip files are downloaded and stored"""
         path = join(self.src_cache_root, "src_cache")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def git_cache(self):
         """Where local clones of git sources are stored"""
         path = join(self.src_cache_root, "git_cache")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def hg_cache(self):
         """Where local clones of hg sources are stored"""
         path = join(self.src_cache_root, "hg_cache")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def svn_cache(self):
         """Where local checkouts of svn sources are stored"""
         path = join(self.src_cache_root, "svn_cache")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def work_dir(self):
         """Where the source for the build is extracted/copied to."""
         path = join(self.build_folder, "work")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property
     def pip_cache_dir(self):
         path = self._pip_cache_dir or join(self.build_folder, "pip_cache")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @pip_cache_dir.setter
@@ -852,7 +857,7 @@ class Config:
     def test_dir(self):
         """The temporary folder where test files are copied to, and where tests start execution"""
         path = join(self.build_folder, "test_tmp")
-        _ensure_dir(path)
+        os.makedirs(path, exist_ok=True)
         return path
 
     @property

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1180,7 +1180,7 @@ class ChannelIndex:
         return new_repodata
 
     def _ensure_dirs(self, subdir: str):
-        """Ensure paths for different parts of the cache directories exist within a specific sub directory.
+        """Create cache directories within a subdir.
 
         Args:
             subdir (str): name of the subdirectory

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1187,7 +1187,7 @@ class ChannelIndex:
         """
         # Create all cache directories in the subdir.
         cache_path = Path(self.channel_root, subdir, ".cache")
-        cache_path.mkdir(exist_ok=True)
+        cache_path.mkdir(parents=True, exist_ok=True)
         (cache_path / "index").mkdir(exist_ok=True)
         (cache_path / "about").mkdir(exist_ok=True)
         (cache_path / "paths").mkdir(exist_ok=True)

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -23,11 +23,11 @@ from os.path import (
     dirname,
     getmtime,
     getsize,
-    isdir,
     isfile,
     join,
     splitext,
 )
+from pathlib import Path
 from uuid import uuid4
 
 import conda_package_handling.api
@@ -1179,20 +1179,24 @@ class ChannelIndex:
                     json.dump(stat_cache, fh)
         return new_repodata
 
-    def _ensure_dirs(self, subdir):
+    def _ensure_dirs(self, subdir: str):
+        """Ensure paths for different parts of the cache directories exist within a specific sub directory.
+
+        Args:
+            subdir (str): name of the subdirectory
+        """
         # Create all cache directories in the subdir.
-        ensure = lambda path: isdir(path) or os.makedirs(path)
-        cache_path = join(self.channel_root, subdir, ".cache")
-        ensure(cache_path)
-        ensure(join(cache_path, "index"))
-        ensure(join(cache_path, "about"))
-        ensure(join(cache_path, "paths"))
-        ensure(join(cache_path, "recipe"))
-        ensure(join(cache_path, "run_exports"))
-        ensure(join(cache_path, "post_install"))
-        ensure(join(cache_path, "icon"))
-        ensure(join(self.channel_root, "icons"))
-        ensure(join(cache_path, "recipe_log"))
+        cache_path = Path(self.channel_root, subdir, ".cache")
+        cache_path.mkdir(exist_ok=True)
+        (cache_path / "index").mkdir(exist_ok=True)
+        (cache_path / "about").mkdir(exist_ok=True)
+        (cache_path / "paths").mkdir(exist_ok=True)
+        (cache_path / "recipe").mkdir(exist_ok=True)
+        (cache_path / "run_exports").mkdir(exist_ok=True)
+        (cache_path / "post_install").mkdir(exist_ok=True)
+        (cache_path / "icon").mkdir(exist_ok=True)
+        (cache_path / "recipe_log").mkdir(exist_ok=True)
+        Path(self.channel_root, "icons").mkdir(exist_ok=True)
 
     def _calculate_update_set(
         self,

--- a/news/4843-config-cleanup
+++ b/news/4843-config-cleanup
@@ -8,9 +8,8 @@
 
 ### Deprecations
 
-* Began deprecation notice for:
-  * `conda_build.config.python2_fs_encode`
-  * `conda_build.config._ensure_dir`
+* Mark `conda_build.config.python2_fs_encode` as pending deprecation. (#4843)
+* Mark `conda_build.config._ensure_dir` as pending deprecation. Use stdlib's `pathlib.Path.mkdir(exist_ok=True)` or `os.makedirs(exist_ok=True)` instead. (#4843)
 
 ### Docs
 

--- a/news/4843-config-cleanup
+++ b/news/4843-config-cleanup
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Began deprecation notice for:
+  * `conda_build.config.python2_fs_encode`
+  * `conda_build.config._ensure_dir`
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Minor code simplification for `conda_build.index.ChannelIndex._ensuredirs`

--- a/news/4843-config-cleanup
+++ b/news/4843-config-cleanup
@@ -17,4 +17,4 @@
 
 ### Other
 
-* Minor code simplification for `conda_build.index.ChannelIndex._ensuredirs`
+* Minor code simplification for `conda_build.index.ChannelIndex._ensuredirs`. (#4843)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
