### PR TITLE
Enable `xattr` test for macOS

### DIFF
--- a/news/4845-enable-xattr-test-macos
+++ b/news/4845-enable-xattr-test-macos
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Enable `xattr` test on macOS. (#4845)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 import tempfile
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Generator
 
 import pytest
 from conda.common.compat import on_mac, on_win
@@ -60,7 +60,7 @@ def testing_workdir(tmpdir, request):
 
 
 @pytest.fixture(scope="function")
-def testing_homedir() -> Generator[Path, None, None]:
+def testing_homedir() -> Iterator[Path]:
     """Create a temporary testing directory in the users home directory; cd into dir before test, cd out after."""
     saved = Path.cwd()
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 import tempfile
 from collections import defaultdict
-from collections.abc import Iterator
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 from conda.common.compat import on_mac, on_win


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Xattr test previously only ran on Linux (if `setfattr` is present), made necessary changes to allow the test to also run on macOS.

Updated `testing_homedir` fixture to use a simpler `tempfile.TemporaryDirectory` implementation.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
