### PR TITLE
Use a unique subdir variable name when rebuilding the index for multi-output builds

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2895,14 +2895,14 @@ def build(
                     # must rebuild index because conda has no way to incrementally add our last
                     #    package to the index.
 
-                    subdir = (
+                    index_subdir = (
                         "noarch"
                         if (m.noarch or m.noarch_python)
                         else m.config.host_subdir
                     )
                     if m.is_cross:
                         get_build_index(
-                            subdir=subdir,
+                            subdir=index_subdir,
                             bldpkgs_dir=m.config.bldpkgs_dir,
                             output_folder=m.config.output_folder,
                             channel_urls=m.config.channel_urls,
@@ -2913,7 +2913,7 @@ def build(
                             clear_cache=True,
                         )
                     get_build_index(
-                        subdir=subdir,
+                        subdir=index_subdir,
                         bldpkgs_dir=m.config.bldpkgs_dir,
                         output_folder=m.config.output_folder,
                         channel_urls=m.config.channel_urls,

--- a/news/4862-multi-output-subdir-variable
+++ b/news/4862-multi-output-subdir-variable
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Use a unique subdir variable name when rebuilding the index for multi-output builds (#4862, fixes #4855)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This PR fixes #4855 by renaming the usage of `subdir` as a loop variable when rebuilding the index after building an output in a multi-output build.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
