### PR TITLE
Add support for FreeBSD

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -94,7 +94,7 @@ if sys.platform == "win32":
     import conda_build.windows as windows
 
 if "bsd" in sys.platform:
-    shell_path = "/bin/sh"
+    shell_path = "/usr/local/bin/bash"
 elif utils.on_win:
     shell_path = "bash"
 else:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -3205,7 +3205,7 @@ def write_build_scripts(m, script, build_file):
     with open(work_file, "w") as bf:
         # bf.write('set -ex\n')
         bf.write("if [ -z ${CONDA_BUILD+x} ]; then\n")
-        bf.write(f"    source {env_file}\n")
+        bf.write(f"    . {env_file}\n")
         bf.write("fi\n")
         if script:
             bf.write(script)
@@ -3231,7 +3231,7 @@ def _write_test_run_script(
     with open(test_run_script, "w") as tf:
         tf.write(
             '{source} "{test_env_script}"\n'.format(
-                source="call" if utils.on_win else "source",
+                source="call" if utils.on_win else ".",
                 test_env_script=test_env_script,
             )
         )

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -581,9 +581,7 @@ def get_shlib_ext(host_platform):
         return ".dll"
     elif host_platform in ["osx", "darwin"]:
         return ".dylib"
-    elif host_platform.startswith("linux") or host_platform.endswith("-wasm32"):
-        return ".so"
-    elif host_platform.startswith("freebsd"):
+    elif host_platform.startswith(("linux", "freebsd")) or host_platform.endswith("-wasm32"):
         return ".so"
     elif host_platform == "noarch":
         # noarch packages should not contain shared libraries, use the system

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -583,6 +583,8 @@ def get_shlib_ext(host_platform):
         return ".dylib"
     elif host_platform.startswith("linux") or host_platform.endswith("-wasm32"):
         return ".so"
+    elif host_platform.startswith("freebsd"):
+        return ".so"
     elif host_platform == "noarch":
         # noarch packages should not contain shared libraries, use the system
         # platform if this is requested

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -125,7 +125,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
         linux32=bool(plat == "linux-32"),
         linux64=bool(plat == "linux-64"),
         arm=plat.startswith("linux-arm"),
-        unix=plat.startswith(("linux-", "osx-", "emscripten-")),
+        unix=plat.startswith(("linux-", "osx-", "emscripten-", "freebsd-")),
         win32=bool(plat == "win-32"),
         win64=bool(plat == "win-64"),
         os=os,

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -59,6 +59,7 @@ filetypes_for_platform = {
     "win": ("DLLfile", "EXEfile"),
     "osx": ["machofile"],
     "linux": ["elffile"],
+    "freebsd": ["elffile"],
 }
 
 

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -934,7 +934,7 @@ def apply_one_patch(src_dir, recipe_dir, rel_path, config, git=None):
         temp_name = os.path.join(
             tempfile.gettempdir(), next(tempfile._get_candidate_names())
         )
-        base_patch_args = ["--no-backup-if-mismatch", "--batch"] + patch_args
+        base_patch_args = ["--posix", "--batch"] + patch_args
         try:
             try_patch_args = base_patch_args[:]
             try_patch_args.append("--dry-run")

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -78,6 +78,11 @@ DEFAULT_COMPILERS = {
         "cxx": "clangxx",
         "fortran": "gfortran",
     },
+    "freebsd": {
+        "c": "clang",
+        "cxx": "clangxx",
+        "fortran": "gfortran",
+    },
 }
 
 arch_name = subdir.rsplit("-", 1)[-1]

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -1931,7 +1931,10 @@ variables are booleans.
      - True if the platform is either macOS or Windows and the
        Python architecture is arm64.
    * - unix
-     - True if the platform is either macOS or Linux or emscripten.
+     - True if the platform is either macOS or Linux or emscripten
+       or FreeBSD.
+   * - freebsd
+     - True if the platform is FreeBSD.
    * - win
      - True if the platform is Windows.
    * - win32

--- a/news/4872-add-freebsd-support
+++ b/news/4872-add-freebsd-support
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add support for FreeBSD. (#4872)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

* Add support for FreeBSD platform and the freebsd-64 subdir.
* Update some non-POSIX uses of `source` and a patch argument which are not supported on FreeBSD.
* Document the new `freebsd` selector and clarify that `unix` includes the FreeBSD platform.
* Use bash on FreeBSD rather than the default shell given the numerous uses of bashisms in recipes.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [x] Add / update outdated documentation?
