### PR TITLE
check return code when selecting patch type

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -879,6 +879,9 @@ def _get_patch_attributes(
                         result[check_name] = False
                         pass
                     else:
+                        if process.returncode:
+                            result[check_name] = False
+                            continue
                         result[check_name] = fmt
                         # Save the first one found.
                         if check_name == "applicable" and not result["args"]:

--- a/news/4873-check-patch-return-code
+++ b/news/4873-check-patch-return-code
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Check the return code when selecting how to apply patchs. (#4873)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

When selecting between the .native, .lf, and .crlf patches, do not mark the result as successful if a non-zero (failure) return value was returned.

This also allows platforms whose patch commands do not support the `--binary` argument, such as FreeBSD, to use patches in recipes.  

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?