### PR TITLE
add type annotations created by monkeytype

### DIFF
--- a/conda_build/_load_setup_py_data.py
+++ b/conda_build/_load_setup_py_data.py
@@ -1,17 +1,19 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 
 def load_setup_py_data(
-    setup_file,
-    from_recipe_dir=False,
-    recipe_dir=None,
-    work_dir=None,
-    permit_undefined_jinja=True,
-):
+    setup_file: str,
+    from_recipe_dir: bool=False,
+    recipe_dir: Optional[str]=None,
+    work_dir: Optional[str]=None,
+    permit_undefined_jinja: bool=True,
+) -> Dict[str, Union[List[str], str, Dict[str, str], Dict[str, List[str]]]]:
     _setuptools_data = {}
     log = logging.getLogger(__name__)
 

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -1,11 +1,17 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import logging
 import sys
 from os.path import abspath, expanduser
 
 from conda_build import api
 from conda_build.conda_interface import ArgumentParser
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 logging.basicConfig(level=logging.INFO)
 
@@ -34,7 +40,7 @@ install on Mac OS X):
 """
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, Namespace]:
     p = ArgumentParser(
         description="""
 Various tools to convert conda packages. Takes a pure Python package build for
@@ -117,7 +123,7 @@ all.""",
     return p, args
 
 
-def execute(args):
+def execute(args: List[str]) -> None:
     _, args = parse_args(args)
     files = args.files
     del args.__dict__["files"]

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import logging
 import sys
 
@@ -7,11 +8,16 @@ from conda.base.context import context, determine_target_prefix
 
 from conda_build import api
 from conda_build.conda_interface import ArgumentParser, add_parser_prefix
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 logging.basicConfig(level=logging.INFO)
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, Namespace]:
     p = ArgumentParser(
         description="""
 
@@ -73,7 +79,7 @@ This works by creating a conda.pth file in site-packages."""
     return p, args
 
 
-def execute(args):
+def execute(args: List[str]) -> None:
     _, args = parse_args(args)
     prefix = determine_target_prefix(context, args)
     api.develop(

--- a/conda_build/cli/main_index.py
+++ b/conda_build/cli/main_index.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import logging
 import os
 import sys
@@ -8,11 +9,16 @@ from conda_build import api
 from conda_build.conda_interface import ArgumentParser
 from conda_build.index import MAX_THREADS_DEFAULT
 from conda_build.utils import DEFAULT_SUBDIRS
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 logging.basicConfig(level=logging.INFO)
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, Namespace]:
     p = ArgumentParser(
         description="Update package index metadata files in given directories."
     )
@@ -93,7 +99,7 @@ def parse_args(args):
     return p, args
 
 
-def execute(args):
+def execute(args: List[str]) -> None:
     _, args = parse_args(args)
 
     api.update_index(

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import logging
 import sys
 from os.path import expanduser
@@ -9,11 +10,16 @@ from conda.base.context import context, determine_target_prefix
 
 from conda_build import api
 from conda_build.conda_interface import ArgumentParser, add_parser_prefix
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 logging.basicConfig(level=logging.INFO)
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, Namespace]:
     p = ArgumentParser(
         description="Tools for inspecting conda packages.",
         epilog="""
@@ -177,7 +183,7 @@ Tools for investigating conda channels.
     return p, args
 
 
-def execute(args):
+def execute(args: List[str]) -> None:
     parser, args = parse_args(args)
 
     if not args.subcommand:

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -1,20 +1,22 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import argparse
+from __future__ import annotations
 import logging
 import sys
 
 from conda_build import api
 from conda_build.conda_interface import (
-    ArgumentParser,
-    add_parser_channels,
-    binstar_upload,
-)
+    ArgumentParser, add_parser_channels, binstar_upload)
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 logging.basicConfig(level=logging.INFO)
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, argparse.Namespace]:
     p = ArgumentParser(
         description="""
 Tool for building conda metapackages.  A metapackage is a package with no
@@ -108,7 +110,7 @@ command line with the conda metapackage command.
     return p, args
 
 
-def execute(args):
+def execute(args: List[str]) -> None:
     _, args = parse_args(args)
     channel_urls = args.__dict__.get("channel") or args.__dict__.get("channels") or ()
     api.create_metapackage(channel_urls=channel_urls, **args.__dict__)

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import argparse
+from __future__ import annotations
 import logging
 import sys
 from pprint import pprint
@@ -10,13 +10,15 @@ from yaml.parser import ParserError
 
 from conda_build import __version__, api
 from conda_build.conda_interface import (
-    ArgumentParser,
-    add_parser_channels,
-    cc_conda_build,
-)
+    ArgumentParser, add_parser_channels, cc_conda_build)
 from conda_build.config import get_channel_urls, get_or_merge_config
 from conda_build.utils import LoggingContext
 from conda_build.variants import get_package_variants, set_language_env_vars
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 on_win = sys.platform == "win32"
 log = logging.getLogger(__name__)
@@ -24,7 +26,7 @@ log = logging.getLogger(__name__)
 
 # see: https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
 class ParseYAMLArgument(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser:     conda.cli.conda_argparse.ArgumentParser, namespace:     argparse.Namespace, values: List[str], option_string: Optional[str]=None) -> None:
         if len(values) != 1:
             raise RuntimeError("This switch requires exactly one argument")
 
@@ -42,7 +44,7 @@ class ParseYAMLArgument(argparse.Action):
             )
 
 
-def get_render_parser():
+def get_render_parser() -> conda.cli.conda_argparse.ArgumentParser:
     p = ArgumentParser(
         description="""
 Tool for expanding the template meta.yml file (containing Jinja syntax and
@@ -166,7 +168,7 @@ source to try fill in related template variables.",
     return p
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, argparse.Namespace]:
     p = get_render_parser()
     p.add_argument(
         "-f",
@@ -190,7 +192,7 @@ def parse_args(args):
     return p, args
 
 
-def execute(args, print_results=True):
+def execute(args: List[str], print_results: bool=True) -> None:
     p, args = parse_args(args)
 
     config = get_or_merge_config(None, **args.__dict__)

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import importlib
 import logging
 import os
@@ -9,12 +10,17 @@ import sys
 import conda_build.api as api
 from conda_build.conda_interface import ArgumentParser
 from conda_build.config import Config
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from conda.cli.conda_argparse import ArgumentParser
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
 logging.basicConfig(level=logging.INFO)
 
 
-def parse_args(args):
+def parse_args(args: List[str]) -> Tuple[conda.cli.conda_argparse.ArgumentParser, Namespace]:
     p = ArgumentParser(
         description="""
 Generates a boilerplate/skeleton recipe, which you can then edit to create a
@@ -42,7 +48,7 @@ options available.
     return p, args
 
 
-def execute(args):
+def execute(args: List[str]):
     parser, args = parse_args(args)
     config = Config(**args.__dict__)
 

--- a/conda_build/cli/validators.py
+++ b/conda_build/cli/validators.py
@@ -7,6 +7,7 @@ from argparse import ArgumentError
 
 from conda_build import utils
 from conda_build.utils import CONDA_PACKAGE_EXTENSIONS
+from typing import TYPE_CHECKING
 
 CONDA_PKG_OR_RECIPE_ERROR_MESSAGE = (
     "\nUnable to parse provided recipe directory or package file.\n\n"

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -3,6 +3,7 @@
 """
 Tools for converting conda packages
 """
+from __future__ import annotations
 import glob
 import hashlib
 import json
@@ -15,9 +16,10 @@ import tempfile
 from pathlib import Path
 
 from conda_build.utils import filter_info_files, walk
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
 
-def retrieve_c_extensions(file_path, show_imports=False):
+def retrieve_c_extensions(file_path: str, show_imports: bool=False) -> List[Union[str, Any]]:
     """Check tarfile for compiled C files with '.pyd' or '.so' suffixes.
 
     If a file ends in either .pyd or .so, it is a compiled C file.
@@ -47,7 +49,7 @@ def retrieve_c_extensions(file_path, show_imports=False):
     return imports
 
 
-def retrieve_package_platform(file_path):
+def retrieve_package_platform(file_path: str) -> Tuple[str, str, str]:
     """Retrieve the platform and architecture of the source package.
 
     Positional arguments:
@@ -73,7 +75,7 @@ def retrieve_package_platform(file_path):
         raise RuntimeError("Package platform not recognized.")
 
 
-def retrieve_python_version(file_path):
+def retrieve_python_version(file_path: str) -> str:
     """Retrieve the python version from a path.
 
     This function is overloaded to handle three separate cases:
@@ -118,7 +120,7 @@ def retrieve_python_version(file_path):
         )
 
 
-def extract_temporary_directory(file_path):
+def extract_temporary_directory(file_path: str) -> str:
     """Extract the source tar archive contents to a temporary directory.
 
     Positional arguments:
@@ -133,7 +135,7 @@ def extract_temporary_directory(file_path):
     return temporary_directory
 
 
-def update_dependencies(new_dependencies, existing_dependencies):
+def update_dependencies(new_dependencies: List[str], existing_dependencies: List[str]) -> List[str]:
     """Update the source package's existing dependencies.
 
     When a user passes additional dependencies from the command line,
@@ -164,7 +166,7 @@ def update_dependencies(new_dependencies, existing_dependencies):
     return existing_dependencies
 
 
-def update_index_file(temp_dir, target_platform, dependencies, verbose):
+def update_index_file(temp_dir: str, target_platform: str, dependencies: Optional[List[str]], verbose: bool) -> str:
     """Update the source package's index file with the target platform's information.
 
     Positional arguments:
@@ -225,7 +227,7 @@ def update_index_file(temp_dir, target_platform, dependencies, verbose):
     return index_file
 
 
-def update_lib_path(path, target_platform, temp_dir=None):
+def update_lib_path(path: str, target_platform: str, temp_dir: Optional[str]=None) -> str:
     """Update the lib path found in the source package's paths.json file.
 
     For conversions from unix to windows, the 'lib/pythonx.y/' paths are
@@ -253,7 +255,7 @@ def update_lib_path(path, target_platform, temp_dir=None):
     return os.path.normpath(renamed_lib_path)
 
 
-def update_lib_contents(lib_directory, temp_dir, target_platform, file_path):
+def update_lib_contents(lib_directory: str, temp_dir: str, target_platform: str, file_path: str) -> None:
     """Update the source package's 'lib' directory.
 
     When converting from unix to windows, the 'lib' directory is renamed to
@@ -312,7 +314,7 @@ def update_lib_contents(lib_directory, temp_dir, target_platform, file_path):
             lib_file.rename(py_folder / lib_file.name)
 
 
-def update_executable_path(temp_dir, file_path, target_platform):
+def update_executable_path(temp_dir: str, file_path: str, target_platform: str) -> str:
     """Update the name of the executable files found in the paths.json file.
 
     When converting from unix to windows, executables are renamed with a '-script.py'
@@ -339,7 +341,7 @@ def update_executable_path(temp_dir, file_path, target_platform):
     return renamed_executable_path
 
 
-def update_executable_sha(package_directory, executable_path):
+def update_executable_sha(package_directory: str, executable_path: str) -> str:
     """Update the sha of executable scripts.
 
     When moving from windows to linux, a shebang line is removed/added from
@@ -351,7 +353,7 @@ def update_executable_sha(package_directory, executable_path):
         return hashlib.sha256(script_file_contents).hexdigest()
 
 
-def update_executable_size(temp_dir, executable):
+def update_executable_size(temp_dir: str, executable: str) -> int:
     """Update the size of the converted executable files.
 
     Positional arguments:
@@ -365,7 +367,7 @@ def update_executable_size(temp_dir, executable):
     return os.path.getsize(os.path.join(temp_dir, executable))
 
 
-def add_new_windows_path(executable_directory, executable):
+def add_new_windows_path(executable_directory: str, executable: str) -> Dict[str, Union[str, int]]:
     """Add a new path to the paths.json file.
 
     When an executable is renamed during a unix to windows conversion, a
@@ -389,7 +391,7 @@ def add_new_windows_path(executable_directory, executable):
     return new_path
 
 
-def update_paths_file(temp_dir, target_platform):
+def update_paths_file(temp_dir: str, target_platform: str) -> None:
     """Update the paths.json file when converting between platforms.
 
     Positional arguments:
@@ -450,7 +452,7 @@ def update_paths_file(temp_dir, target_platform):
             json.dump(paths, file, indent=2)
 
 
-def retrieve_executable_name(executable):
+def retrieve_executable_name(executable: str) -> str:
     """Retrieve the name of the executable to rename.
 
     When converting between unix and windows, we need to be careful
@@ -462,7 +464,7 @@ def retrieve_executable_name(executable):
     return os.path.splitext(os.path.basename(executable))[0]
 
 
-def is_binary_file(directory, executable):
+def is_binary_file(directory: str, executable: str) -> bool:
     """Read a file's contents to check whether it is a binary file.
 
     When converting files, we need to check that binary files are not
@@ -489,7 +491,7 @@ def is_binary_file(directory, executable):
     return False
 
 
-def rename_executable(directory, executable, target_platform):
+def rename_executable(directory: str, executable: str, target_platform: str) -> None:
     """Rename an executable file when converting between platforms.
 
     When converting from unix to windows, each file inside the 'bin' directory
@@ -550,7 +552,7 @@ def remove_executable(directory, executable):
         os.remove(script)
 
 
-def create_exe_file(directory, executable, target_platform):
+def create_exe_file(directory: str, executable: str, target_platform: str) -> None:
     """Create an exe file for each executable during a unix to windows conversion.
 
     Positional arguments:
@@ -571,7 +573,7 @@ def create_exe_file(directory, executable, target_platform):
     shutil.copyfile(executable_file, renamed_executable_file)
 
 
-def update_prefix_file(temp_dir, prefixes):
+def update_prefix_file(temp_dir: str, prefixes: Set[str]) -> None:
     """Update the source package's 'has_prefix' file.
 
     Each file in the 'bin' or 'Scripts' folder will be written
@@ -589,7 +591,7 @@ def update_prefix_file(temp_dir, prefixes):
             prefix_file.write(prefix)
 
 
-def update_files_file(temp_dir, verbose):
+def update_files_file(temp_dir: str, verbose: bool) -> None:
     """Update the source package's 'files' file.
 
     The file path to each file that will be in the target archive is
@@ -616,7 +618,7 @@ def update_files_file(temp_dir, verbose):
             files.write(file_path + "\n")
 
 
-def create_target_archive(file_path, temp_dir, platform, output_dir):
+def create_target_archive(file_path: str, temp_dir: str, platform: str, output_dir: str) -> None:
     """Create the converted package's tar file.
 
     Positional arguments:
@@ -642,8 +644,8 @@ def create_target_archive(file_path, temp_dir, platform, output_dir):
 
 
 def convert_between_unix_platforms(
-    file_path, output_dir, platform, dependencies, verbose
-):
+    file_path: str, output_dir: str, platform: str, dependencies: Optional[List[str]], verbose: bool
+) -> None:
     """Convert package between unix platforms.
 
     Positional arguments:
@@ -664,8 +666,8 @@ def convert_between_unix_platforms(
 
 
 def convert_between_windows_architechtures(
-    file_path, output_dir, platform, dependencies, verbose
-):
+    file_path: str, output_dir: str, platform: str, dependencies: Optional[List[str]], verbose: bool
+) -> None:
     """Convert package between windows architectures.
 
     Positional arguments:
@@ -686,8 +688,8 @@ def convert_between_windows_architechtures(
 
 
 def convert_from_unix_to_windows(
-    file_path, output_dir, platform, dependencies, verbose
-):
+    file_path: str, output_dir: str, platform: str, dependencies: Optional[List[str]], verbose: bool
+) -> None:
     """Convert a package from a unix platform to windows.
 
     Positional arguments:
@@ -738,8 +740,8 @@ def convert_from_unix_to_windows(
 
 
 def convert_from_windows_to_unix(
-    file_path, output_dir, platform, dependencies, verbose
-):
+    file_path: str, output_dir: str, platform: str, dependencies: Optional[List[str]], verbose: bool
+) -> None:
     """Convert a package from windows to a unix platform.
 
     Positional arguments:
@@ -785,16 +787,16 @@ def convert_from_windows_to_unix(
 
 
 def conda_convert(
-    file_path,
-    output_dir=".",
-    show_imports=False,
-    platforms=None,
-    force=False,
-    dependencies=None,
-    verbose=False,
-    quiet=False,
-    dry_run=False,
-):
+    file_path: str,
+    output_dir: str=".",
+    show_imports: bool=False,
+    platforms: Optional[List[Union[str, Any]]]=None,
+    force: bool=False,
+    dependencies: Optional[List[str]]=None,
+    verbose: bool=False,
+    quiet: bool=False,
+    dry_run: bool=False,
+) -> None:
     """Convert a conda package between different platforms and architectures.
 
     Positional arguments:

--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -1,6 +1,11 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import textwrap
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from conda.exceptions import ResolvePackageNotFound
 
 SEPARATOR = "-" * 70
 
@@ -71,8 +76,8 @@ class VerifyError(CondaBuildException):
 
 class DependencyNeedsBuildingError(CondaBuildException):
     def __init__(
-        self, conda_exception=None, packages=None, subdir=None, *args, **kwargs
-    ):
+        self, conda_exception: Optional[ResolvePackageNotFound]=None, packages: None=None, subdir: Optional[str]=None, *args, **kwargs
+    ) -> None:
         self.subdir = subdir
         self.matchspecs = []
         if packages:
@@ -92,11 +97,11 @@ class DependencyNeedsBuildingError(CondaBuildException):
                 " {}".format(str(conda_exception))
             )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
     @property
-    def message(self):
+    def message(self) -> str:
         return "Unsatisfiable dependencies for platform {}: {}".format(
             self.subdir, set(self.matchspecs)
         )
@@ -111,14 +116,14 @@ class BuildLockError(CondaBuildException):
 
 
 class OverLinkingError(RuntimeError):
-    def __init__(self, error, *args):
+    def __init__(self, error: List[str], *args) -> None:
         self.error = error
         self.msg = "overlinking check failed \n%s" % (error)
         super().__init__(self.msg)
 
 
 class OverDependingError(RuntimeError):
-    def __init__(self, error, *args):
+    def __init__(self, error: List[str], *args) -> None:
         self.error = error
         self.msg = "overdepending check failed \n%s" % (error)
         super().__init__(self.msg)

--- a/conda_build/license_family.py
+++ b/conda_build/license_family.py
@@ -1,10 +1,14 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import re
+from __future__ import annotations
 import string
 
 from conda_build import exceptions
 from conda_build.utils import comma_join
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from re import Match
 
 allowed_license_families = """
 AGPL
@@ -32,12 +36,12 @@ cc_regex = re.compile(r"CC\w+")  # match CC
 punk_regex = re.compile("[%s]" % re.escape(string.punctuation))  # removes punks
 
 
-def match_gpl3(family):
+def match_gpl3(family: str) -> Optional[re.Match]:
     """True if family matches GPL3 or GPL >= 2, else False"""
     return gpl23_regex.search(family) or gpl3_regex.search(family)
 
 
-def normalize(s):
+def normalize(s: str) -> str:
     """Set to ALL CAPS, replace common GPL patterns, and strip"""
     s = s.upper()
     s = re.sub("GENERAL PUBLIC LICENSE", "GPL", s)
@@ -46,7 +50,7 @@ def normalize(s):
     return s.strip()
 
 
-def remove_special_characters(s):
+def remove_special_characters(s: str) -> str:
     """Remove punctuation, spaces, tabs, and line feeds"""
     s = punk_regex.sub(" ", s)
     s = re.sub(r"\s+", "", s)
@@ -67,7 +71,7 @@ def guess_license_family_from_index(index=None, recognized=allowed_license_famil
     return guess_license_family(license_name, recognized)
 
 
-def guess_license_family(license_name=None, recognized=allowed_license_families):
+def guess_license_family(license_name: Optional[str]=None, recognized: List[str]=allowed_license_families) -> str:
     """Return best guess of license_family from the conda package index.
 
     Note: Logic here is simple, and focuses on existing set of allowed families
@@ -98,7 +102,7 @@ def guess_license_family(license_name=None, recognized=allowed_license_families)
     return "OTHER"
 
 
-def ensure_valid_license_family(meta):
+def ensure_valid_license_family(meta: Any) -> None:
     try:
         license_family = meta["about"]["license_family"]
     except KeyError:

--- a/conda_build/metapackage.py
+++ b/conda_build/metapackage.py
@@ -1,23 +1,25 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 from collections import defaultdict
 
 from conda_build.config import Config
 from conda_build.metadata import MetaData
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 
 def create_metapackage(
-    name,
-    version,
-    entry_points=(),
-    build_string=None,
-    build_number=0,
-    dependencies=(),
-    home=None,
-    license_name=None,
-    summary=None,
-    config=None,
-):
+    name: str,
+    version: str,
+    entry_points: Tuple[()]=(),
+    build_string: Optional[str]=None,
+    build_number: int=0,
+    dependencies: List[str]=(),
+    home: Optional[str]=None,
+    license_name: Optional[str]=None,
+    summary: Optional[str]=None,
+    config: Optional[Config]=None,
+) -> List[str]:
     # local import to avoid circular import, we provide create_metapackage in api
     from conda_build.api import build
 

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import json
 import locale
 import logging
@@ -7,11 +8,15 @@ import os
 import shutil
 import sys
 from os.path import basename, dirname, isdir, isfile, join
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from conda_build.metadata import MetaData
 
 ISWIN = sys.platform.startswith("win")
 
 
-def _force_dir(dirname):
+def _force_dir(dirname: str) -> None:
     if not isdir(dirname):
         os.makedirs(dirname)
 
@@ -20,7 +25,7 @@ def _error_exit(exit_message):
     sys.exit("[noarch_python] %s" % exit_message)
 
 
-def rewrite_script(fn, prefix):
+def rewrite_script(fn: str, prefix: str) -> str:
     """Take a file from the bin directory and rewrite it into the python-scripts
     directory with the same permissions after it passes some sanity checks for
     noarch pacakges"""
@@ -53,7 +58,7 @@ def rewrite_script(fn, prefix):
     return fn
 
 
-def handle_file(f, d, prefix):
+def handle_file(f: str, d: Dict[str, Union[str, List[str]]], prefix: str) -> None:
     """Process a file for inclusion in a noarch python package."""
     path = join(prefix, f)
 
@@ -95,7 +100,7 @@ def handle_file(f, d, prefix):
         log.debug("Don't know how to handle file: %s.  Including it as-is." % f)
 
 
-def populate_files(m, files, prefix, entry_point_scripts=None):
+def populate_files(m: MetaData, files: List[Union[str, Any]], prefix: str, entry_point_scripts: Optional[List[Union[str, Any]]]=None) -> Dict[str, Union[str, List[str]]]:
     d = {"dist": m.dist(), "site-packages": [], "python-scripts": [], "Examples": []}
 
     # Populate site-package, python-scripts, and Examples into above

--- a/conda_build/os_utils/external.py
+++ b/conda_build/os_utils/external.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import os
 import stat
 import sys
@@ -8,9 +9,10 @@ from os.path import expanduser, isfile, join
 from glob2 import glob
 
 from conda_build.conda_interface import root_dir
+from typing import TYPE_CHECKING, List, Optional, Union
 
 
-def find_executable(executable, prefix=None, all_matches=False):
+def find_executable(executable: str, prefix: Optional[str]=None, all_matches: bool=False) -> Union[List[str], str]:
     # dir_paths is referenced as a module-level variable
     #  in other code
     global dir_paths
@@ -68,8 +70,8 @@ def find_executable(executable, prefix=None, all_matches=False):
 
 
 def find_preferably_prefixed_executable(
-    executable, build_prefix=None, all_matches=False
-):
+    executable: str, build_prefix: Optional[str]=None, all_matches: bool=False
+) -> List[str]:
     found = find_executable("*" + executable, build_prefix, all_matches)
     if not found:
         # It is possible to force non-prefixed exes by passing os.sep as the

--- a/conda_build/skeletons/luarocks.py
+++ b/conda_build/skeletons/luarocks.py
@@ -3,6 +3,7 @@
 """
 Tools for converting luarocks packages to conda recipes.
 """
+from __future__ import annotations
 
 # TODO:
 # - mingw32 support (really any windows support, completely untested)
@@ -14,6 +15,10 @@ import subprocess
 import tempfile
 from glob import glob
 from sys import platform as _platform
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from argparse import _SubParsersAction
 
 INDENT = "\n    - "
 
@@ -136,7 +141,7 @@ $PREFIX/bin/luarocks remove {rockname}
 """
 
 
-def add_parser(repos):
+def add_parser(repos: _SubParsersAction) -> None:
     luarocks = repos.add_parser(
         "luarocks",
         help="""

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import argparse
+from typing import TYPE_CHECKING
+
+from __future__ import annotations
 from copy import copy
 
 from conda_build.license_family import guess_license_family
@@ -20,6 +22,9 @@ from textwrap import wrap
 from xml.etree import ElementTree as ET
 
 from .cran import yaml_quote_string
+
+if TYPE_CHECKING:
+    from argparse import _SubParsersAction
 
 try:
     from urllib.request import urlopen
@@ -742,7 +747,9 @@ def skeletonize(
     )
 
 
-def add_parser(repos):
+def add_parser(repos: from typing import TYPE_CHECKING
+
+argparse._SubParsersAction) -> None:
     rpm = repos.add_parser(
         "rpm",
         help="""

--- a/conda_build/tarcheck.py
+++ b/conda_build/tarcheck.py
@@ -1,13 +1,18 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
 import json
 import tarfile
 from os.path import basename, normpath
 
 from conda_build.utils import codec, filter_info_files
+from typing import TYPE_CHECKING, Dict, List
+
+if TYPE_CHECKING:
+    from conda_build.config import Config
 
 
-def dist_fn(fn):
+def dist_fn(fn: str) -> str:
     if fn.endswith(".tar"):
         return fn[:-4]
     elif fn.endswith(".tar.bz2"):
@@ -17,7 +22,7 @@ def dist_fn(fn):
 
 
 class TarCheck:
-    def __init__(self, path, config):
+    def __init__(self, path: str, config: Config) -> None:
         self.t = tarfile.open(path)
         self.paths = {m.path for m in self.t.getmembers()}
         self.dist = dist_fn(basename(path))
@@ -26,13 +31,13 @@ class TarCheck:
         )
         self.config = config
 
-    def __enter__(self):
+    def __enter__(self) -> "TarCheck":
         return self
 
-    def __exit__(self, e_type, e_value, traceback):
+    def __exit__(self, e_type: None, e_value: None, traceback: None) -> None:
         self.t.close()
 
-    def info_files(self):
+    def info_files(self) -> None:
         lista = [
             normpath(p.strip().decode("utf-8"))
             for p in self.t.extractfile("info/files").readlines()
@@ -56,7 +61,7 @@ class TarCheck:
                 print("%r not in tarball" % p)
         raise Exception("info/files")
 
-    def index_json(self):
+    def index_json(self) -> None:
         info = json.loads(self.t.extractfile("info/index.json").read().decode("utf-8"))
         for varname in "name", "version":
             if info[varname] != getattr(self, varname):
@@ -67,7 +72,7 @@ class TarCheck:
                 )
         assert isinstance(info["build_number"], int)
 
-    def prefix_length(self):
+    def prefix_length(self) -> int:
         prefix_length = None
         if "info/has_prefix" in self.t.getnames():
             prefix_files = self.t.extractfile("info/has_prefix").readlines()
@@ -84,7 +89,7 @@ class TarCheck:
                     break
         return prefix_length
 
-    def correct_subdir(self):
+    def correct_subdir(self) -> None:
         info = json.loads(self.t.extractfile("info/index.json").read().decode("utf-8"))
         assert info["subdir"] in [
             self.config.host_subdir,
@@ -96,7 +101,7 @@ class TarCheck:
         )
 
 
-def check_all(path, config):
+def check_all(path: str, config: Config) -> None:
     x = TarCheck(path, config)
     x.info_files()
     x.index_json()
@@ -104,7 +109,7 @@ def check_all(path, config):
     x.t.close()
 
 
-def check_prefix_lengths(files, config):
+def check_prefix_lengths(files: List[str], config: Config) -> Dict[str, int]:
     lengths = {}
     for f in files:
         length = TarCheck(f, config).prefix_length()

--- a/conda_build/version.py
+++ b/conda_build/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 import re
-from typing import Iterator, List, Tuple, Union
+from typing import TYPE_CHECKING, Iterator, List, Tuple, Union
 
 from packaging.version import InvalidVersion, Version, _BaseVersion
 


### PR DESCRIPTION
### Description

This PR is for demonstration and discussion, it is unlikely that these changes should be merged as is.

Add type annotations to the conda_build library created by running the test suite with [MonkeyType](https://monkeytype.readthedocs.io/en/stable/index.html).

This steps used to accomplished this were:
```
make setup
conda activate conda-build
python -m pip install monkeytype
monkeytype run -m pytest
monkeytype list-modules | grep conda_build > modules
cat modules | while read mod
do
    echo "Adding types to $mod"
    monkeytype apply --pep_563 $mod
done
```  

### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?