### PR TITLE
Revert `py` dependency

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -18,7 +18,6 @@ perl
 pip
 pkginfo
 psutil
-py  # https://github.com/ContinuumIO/anaconda-issues/issues/13198
 py-lief
 pyflakes
 pytest


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We can remove `pytest-xdist`'s `py` dependency since `pytest-*` packages have been hotfixed to explicitly depend on `py` (instead of indirectly via `pytest`).

Xref https://github.com/ContinuumIO/anaconda-issues/issues/13198

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
