### PR TITLE
avoid duplicate logging by preventing propagation from the conda_build logger to the root logger

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1749,7 +1749,9 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
     # these are defaults.  They can be overridden by configuring a log config yaml file.
     top_pkg = name.split(".")[0]
     if top_pkg == "conda_build":
-        logging.getLogger(top_pkg).propagate = False
+        # we don't want propagation in CLI, but we do want it in tests
+        # this is a pytest limitation: https://github.com/pytest-dev/pytest/issues/3697
+        logging.getLogger(top_pkg).propagate = "PYTEST_CURRENT_TEST" in os.environ
     if add_stdout_stderr_handlers and not log.handlers:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stderr_handler = logging.StreamHandler(sys.stderr)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1706,10 +1706,10 @@ class DuplicateFilter(logging.Filter):
         self.msgs.add(record.msg)
         return int(log)
 
-
 dedupe_filter = DuplicateFilter()
 info_debug_stdout_filter = LessThanFilter(logging.WARNING)
 warning_error_stderr_filter = GreaterThanFilter(logging.INFO)
+level_formatter = logging.Formatter("%(levelname)s: %(message)s")
 
 # set filelock's logger to only show warnings by default
 logging.getLogger("filelock").setLevel(logging.WARN)
@@ -1747,14 +1747,14 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
 
     # these are defaults.  They can be overridden by configuring a log config yaml file.
     top_pkg = name.split(".")[0]
-    top_pkg_logger = logging.getLogger(top_pkg)
     if top_pkg == "conda_build":
-        top_pkg_logger.propagate = False
-    if add_stdout_stderr_handlers and not log.handlers:
+        logging.getLogger(top_pkg).propagate = False
+    if add_stdout_stderr_handlers and not log.hasHandlers():
         stdout_handler = logging.StreamHandler(sys.stdout)
         stderr_handler = logging.StreamHandler(sys.stderr)
         stdout_handler.addFilter(info_debug_stdout_filter)
         stderr_handler.addFilter(warning_error_stderr_filter)
+        stderr_handler.setFormatter(level_formatter)
         stdout_handler.setLevel(level)
         stderr_handler.setLevel(level)
         log.addHandler(stdout_handler)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1750,7 +1750,7 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
     top_pkg = name.split(".")[0]
     if top_pkg == "conda_build":
         logging.getLogger(top_pkg).propagate = False
-    if add_stdout_stderr_handlers and not log.hasHandlers():
+    if add_stdout_stderr_handlers and not log.handlers:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stderr_handler = logging.StreamHandler(sys.stderr)
         stdout_handler.addFilter(info_debug_stdout_filter)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1746,7 +1746,11 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
         log.addFilter(dedupe_filter)
 
     # these are defaults.  They can be overridden by configuring a log config yaml file.
-    if not log.handlers and add_stdout_stderr_handlers:
+    top_pkg = name.split(".")[0]
+    top_pkg_logger = logging.getLogger(top_pkg)
+    if top_pkg == "conda_build":
+        top_pkg_logger.propagate = False
+    if add_stdout_stderr_handlers and not log.handlers:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stderr_handler = logging.StreamHandler(sys.stderr)
         stdout_handler.addFilter(info_debug_stdout_filter)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1706,6 +1706,7 @@ class DuplicateFilter(logging.Filter):
         self.msgs.add(record.msg)
         return int(log)
 
+
 dedupe_filter = DuplicateFilter()
 info_debug_stdout_filter = LessThanFilter(logging.WARNING)
 warning_error_stderr_filter = GreaterThanFilter(logging.INFO)

--- a/news/4903-duplicate-logging
+++ b/news/4903-duplicate-logging
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Avoid duplicate logging by not propagating the top-level conda-build logger. (#4903)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

conda-build produces duplicated logging for a while now. This makes logs unnecessarily long and confusing.

The reason is that another application in the import tree must be calling `logging.basicConfig()` blindly, so the root logger gets the default stderr handler. 

We can prevent this by adding `propagate = False` to the `conda_build` top-level logger. 

I don't understand why the `get_logger` function checks every time for handlers (should be enough with the one at the top-level?) but well, I won't go down that rabbit hole now. This fixes it :)

Before:

```
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Attempting to finalize metadata for conda-build-test-python-run
INFO:conda_build.metadata:Attempting to finalize metadata for conda-build-test-python-run
BUILD START: ['conda-build-test-python-run-1.0-0.tar.bz2']
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
source tree in: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/conda-build-test-python-run_1685112046950/work
Packaging conda-build-test-python-run
INFO:conda_build.build:Packaging conda-build-test-python-run
Packaging conda-build-test-python-run-1.0-0
INFO:conda_build.build:Packaging conda-build-test-python-run-1.0-0
No files or script found for output conda-build-test-python-run
WARNING:conda_build.build:No files or script found for output conda-build-test-python-run
Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
WARNING:conda_build.build:Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
```

After:

```
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Adding in variants from internal_defaults
Attempting to finalize metadata for conda-build-test-python-run
BUILD START: ['conda-build-test-python-run-1.0-0.tar.bz2']
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
source tree in: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/conda-build-test-python-run_1685115478751/work
Packaging conda-build-test-python-run
Packaging conda-build-test-python-run-1.0-0
WARNING: No files or script found for output conda-build-test-python-run
number of files: 0
Fixing permissions
INFO :: Time taken to mark (prefix)
        0 replacements in 0 files was 0.00 seconds
WARNING: Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
