### PR TITLE
Ensure clean 'hg log' for conda build environment information #4904

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -276,6 +276,8 @@ def get_hg_build_info(repo):
     d = {}
     cmd = [
         "hg",
+        "--config",
+        "defaults.log=",
         "log",
         "--template",
         "{rev}|{node|short}|{latesttag}|{latesttagdistance}|{branch}",


### PR DESCRIPTION
### Description

- conda build can break when defaults.log="something unexpected"

### Checklist 

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?
