### PR TITLE
Respect scripts path inside bin/Scripts dir

### DIFF
--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -4,6 +4,7 @@ import json
 import locale
 import logging
 import os
+import re
 import shutil
 import sys
 from os.path import basename, dirname, isdir, isfile, join
@@ -44,9 +45,8 @@ def rewrite_script(fn, prefix):
         fn = fn[:-10]
 
     # Rewrite the file to the python-scripts directory
-    dst_dir = join(prefix, "python-scripts")
-    _force_dir(dst_dir)
-    dst = join(dst_dir, fn)
+    dst = join(prefix, "python-scripts", fn)
+    _force_dir(dirname(dst))
     with open(dst, "w") as fo:
         fo.write(data)
     os.chmod(dst, src_mode)
@@ -80,7 +80,8 @@ def handle_file(f, d, prefix):
 
     # Treat scripts specially with the logic from above
     elif f.startswith(("bin/", "Scripts")):
-        fn = basename(path)
+        *_, fn = re.split("(bin|Scripts)", path)
+        fn = fn.split(os.sep, 1)[1]
         fn = rewrite_script(fn, prefix)
         d["python-scripts"].append(fn)
 


### PR DESCRIPTION
### Description

Our `Scripts` directory contains directories with more scripts. Building a `win-64` package puts these scripts into the package as expected. When trying to build `noarch` there is an error that looks like

```
FileNotFoundError: [Errno 2] No such file or directory: 'E:\\conda3\\conda-bld\\my_lib_1685951238714\\_h_env\\Scripts\\my_important_script.py'
```

This is because `my_important_script.py` exists in `Scripts/a_dir/my_important_script.py`.


### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?