### PR TITLE
Ensure `build` and `host` install the same OpenSSL

### DIFF
--- a/news/4912-fix-resolved_packages-test-failure
+++ b/news/4912-fix-resolved_packages-test-failure
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Fix failing `resolved_packages` test due to recent OpenSSL 3.0.8 release to defaults. (#4912)

--- a/tests/test-recipes/metadata/_resolved_packages_host_build/meta.yaml
+++ b/tests/test-recipes/metadata/_resolved_packages_host_build/meta.yaml
@@ -6,8 +6,10 @@ requirements:
   build:
     - numpy
     - nomkl    # [unix]
+    - openssl
   host:
     - curl
+    - {{ pin_compatible('openssl', exact=True) }}
   run:
   {% for package in resolved_packages('build') %}
     - {{ package }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The recent release of OpenSSL 3.0.8 caused the `resolve_packages` test to start failing with incompatible OpenSSLs being installed in the `build` and `host` environments.

Resolves https://github.com/conda/conda-build/issues/4911

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
