### PR TITLE
Add `protocol.file.allow=always` to `git submodule update`

### DIFF
--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -400,7 +400,15 @@ def git_mirror_checkout_recursive(
         # Now that all relative-URL-specified submodules are locally mirrored to
         # relatively the same place we can go ahead and checkout the submodules.
         check_call_env(
-            [git, "submodule", "update", "--init", "--recursive"],
+            [
+                git,
+                # CVE-2022-39253
+                *("-c", "protocol.file.allow=always"),
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+            ],
             cwd=checkout_dir,
             stdout=stdout,
             stderr=stderr,

--- a/news/4914-fix-test_relative_git_url_submodule_clone
+++ b/news/4914-fix-test_relative_git_url_submodule_clone
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix git cloning for repositories with submodules containing local relative paths. (#4914)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -684,6 +684,8 @@ def test_relative_git_url_submodule_clone(testing_workdir, testing_config, monke
             check_call_env(
                 [
                     git,
+                    # CVE-2022-39253
+                    *("-c", "protocol.file.allow=always"),
                     "submodule",
                     "add",
                     convert_path_for_cygwin_or_msys2(git, absolute_sub),
@@ -692,14 +694,33 @@ def test_relative_git_url_submodule_clone(testing_workdir, testing_config, monke
                 env=sys_git_env,
             )
             check_call_env(
-                [git, "submodule", "add", "../relative_sub", "relative"],
+                [
+                    git,
+                    # CVE-2022-39253
+                    *("-c", "protocol.file.allow=always"),
+                    "submodule",
+                    "add",
+                    "../relative_sub",
+                    "relative",
+                ],
                 env=sys_git_env,
             )
         else:
             # Once we use a more recent Git for Windows than 2.6.4 on Windows or m2-git we
             # can change this to `git submodule update --recursive`.
             gits = git.replace("\\", "/")
-            check_call_env([git, "submodule", "foreach", gits, "pull"], env=sys_git_env)
+            check_call_env(
+                [
+                    git,
+                    # CVE-2022-39253
+                    *("-c", "protocol.file.allow=always"),
+                    "submodule",
+                    "foreach",
+                    gits,
+                    "pull",
+                ],
+                env=sys_git_env,
+            )
         check_call_env(
             [git, "commit", "-am", f"added submodules@{tag}"], env=sys_git_env
         )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Includes `-c protocol.file.allow=always` when calling `git submodule update --init --recursive` to allow cloning of local paths.

Resolves #4895 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
