### PR TITLE
Update documentation on load_file_regex

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -1778,7 +1778,7 @@ to load data from other files. These are ``load_setup_py_data``, ``load_file_reg
 * ``load_file_regex``: Searches a file for a regular expression and returns the
   first match as a Python ``re.Match object``. For example::
 
-    {% set readme_heading = load_file_regex(load_file='README.rst', regex_pattern=r'^# (\S+)') %}
+    {% set readme_heading = load_file_regex(load_file='README.rst', regex_pattern='^# (\S+)') %}
     package:
       name: {{ readme_heading.string }}
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The documentation on `load_file_regex` says to use a regex string starting with an `r`:

```
{% set readme_heading = load_file_regex(load_file='README.rst', regex_pattern=r'^# (\S+)') %}
```

Doing this causes an error:

```
Error: Failed to render jinja template in .../meta.yaml:
expected token ',', got 'string'
```

The tests for `load_file_regex` provide the pattern as a normal string without an `r`:

- https://github.com/conda/conda-build/blob/33d3d7f90869529913cca6de923cd2b27298b122/tests/test-recipes/metadata/source_regex/meta.yaml#L6
- https://github.com/conda/conda-build/blob/33d3d7f90869529913cca6de923cd2b27298b122/tests/test-recipes/metadata/source_regex_from_recipe_dir/meta.yaml#L6

Since the tests do not use a regex string I assume that's the intended behaviour and that the documentation is out of date, so I updated the documentation to remove the leading `r`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
