### PR TITLE
Update conda-build recipe file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - tomli                        # [py<311]
     - tqdm
   run_constrained:
-    - conda-verify  >=3.0.2
+    - conda-verify  >=3.1.0
 
 test:
   imports:


### PR DESCRIPTION
Updating conda-build's recipe file to have the most up-to-date version requirements, per comparison to [Anaconda's feedstock](https://github.com/AnacondaRecipes/conda-build-feedstock/blob/master/recipe/meta.yaml).

- [`conda-verify`](https://github.com/AnacondaRecipes/conda-build-feedstock/blob/master/recipe/meta.yaml#L67)
