### PR TITLE
Fix the broken link to the jinja2 template page

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -1749,7 +1749,7 @@ practice means changing the conda-build source code. See the
 <https://github.com/conda/conda-build/issues>`_.
 
 For more information, see the `Jinja2 template
-documentation <http://jinja.pocoo.org/docs/dev/templates/>`_
+documentation <https://jinja.palletsprojects.com/en/latest/templates/>`_
 and :ref:`the list of available environment
 variables <env-vars>`.
 


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
The current link is dead, fixed to the correct source. Looked at the original link in the wayback machine and this matches the same content previously provided. 



### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?