### PR TITLE
[WIP] Handle case where `files` is set to `None`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2853,16 +2853,17 @@ def build(
                             is_conda=m.name() == "conda",
                         )
 
+                    files = output_d.get("files") or []
                     to_remove = set()
-                    for f in output_d.get("files", []):
+                    for f in files:
                         if f.startswith("conda-meta"):
                             to_remove.add(f)
 
                     # This is wrong, files has not been expanded at this time and could contain
                     # wildcards.  Also well, I just do not understand this, because when this
                     # does contain wildcards, the files in to_remove will slip back in.
-                    if "files" in output_d:
-                        output_d["files"] = set(output_d["files"]) - to_remove
+                    if files:
+                        output_d["files"] = set(files) - to_remove
 
                     # copies the backed-up new prefix files into the newly created host env
                     for f in new_prefix_files:


### PR DESCRIPTION
### Description

If the `files` key is specified, but lacks any entries (say for a platform where the list would wind up empty), the YAML parser reads it as `null` instead of an empty array `[]`. As a result, when conda-build tries to iterate over `None` it runs into issues. To fix this, we treat the absence of `files`.

Please see issue ( https://github.com/conda/conda-build/issues/4972 ) for more details.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
