### PR TITLE
Use conda.base.constants.KNOWN_SUBDIRS for setting up selectors

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -133,13 +133,13 @@ def get_selectors(config: Config) -> dict[str, bool]:
     )
 
     subdirs = [subdir for subdir in DEFAULT_SUBDIRS if subdir != "noarch"]
-    subdir_oses = set([subdir.split("-")[0] for subdir in DEFAULT_SUBDIRS])
-    subdir_archs = set([subdir.split("-")[1] for subdir in DEFAULT_SUBDIRS])
+    subdir_oses = set([subdir.split("-")[0] for subdir in subdirs])
+    subdir_archs = set([subdir.split("-")[1] for subdir in subdirs])
 
     for subdir_os in subdir_oses:
         d[subdir_os] = plat.startswith(f"{subdir_os}-")
 
-    for arch in subdir_arches:
+    for arch in subdir_archs:
         arch_full = ARCH_MAP.get(arch, arch)
         d[arch_full] = plat.endswith(f"-{arch}")
         if arch == "32":

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -133,6 +133,10 @@ def get_selectors(config: Config) -> dict[str, bool]:
     )
 
     subdirs = [subdir for subdir in DEFAULT_SUBDIRS if subdir != "noarch"]
+    # Add the current platform to the list as well to enable conda-build
+    # to bootstrap new platforms without a new conda release.
+    subdirs.append(plat)
+
     subdir_oses = {subdir.split("-")[0] for subdir in subdirs}
     subdir_archs = {subdir.split("-")[1] for subdir in subdirs}
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -132,7 +132,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
         nomkl=bool(int(os.environ.get("FEATURE_NOMKL", False))),
     )
 
-    subdirs = [subdir for subdir in DEFAULT_SUBDIRS if subdir != "noarch"]
+    subdirs = [subdir for subdir in DEFAULT_SUBDIRS if "-" not in subdir]
     # Add the current platform to the list as well to enable conda-build
     # to bootstrap new platforms without a new conda release.
     subdirs.append(plat)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -21,13 +21,13 @@ from conda_build.config import Config, get_or_merge_config
 from conda_build.features import feature_list
 from conda_build.license_family import ensure_valid_license_family
 from conda_build.utils import (
+    DEFAULT_SUBDIRS,
     HashableDict,
     ensure_list,
     expand_globs,
     find_recipe,
     get_installed_packages,
     insert_variant_versions,
-    DEFAULT_SUBDIRS,
 )
 
 from .conda_interface import MatchSpec, envs_dirs, md5_file, non_x86_linux_machines
@@ -133,8 +133,8 @@ def get_selectors(config: Config) -> dict[str, bool]:
     )
 
     subdirs = [subdir for subdir in DEFAULT_SUBDIRS if subdir != "noarch"]
-    subdir_oses = set([subdir.split("-")[0] for subdir in subdirs])
-    subdir_archs = set([subdir.split("-")[1] for subdir in subdirs])
+    subdir_oses = {subdir.split("-")[0] for subdir in subdirs}
+    subdir_archs = {subdir.split("-")[1] for subdir in subdirs}
 
     for subdir_os in subdir_oses:
         d[subdir_os] = plat.startswith(f"{subdir_os}-")

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -132,7 +132,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
         nomkl=bool(int(os.environ.get("FEATURE_NOMKL", False))),
     )
 
-    subdirs = [subdir for subdir in DEFAULT_SUBDIRS if "-" not in subdir]
+    subdirs = [subdir for subdir in DEFAULT_SUBDIRS if "-" in subdir]
     # Add the current platform to the list as well to enable conda-build
     # to bootstrap new platforms without a new conda release.
     subdirs.append(plat)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -124,7 +124,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
     d = dict(
         linux32=bool(plat == "linux-32"),
         linux64=bool(plat == "linux-64"),
-        arm=plat.startswith(("linux-arm", "osx-arm", "win-arm")),
+        arm=plat.startswith("linux-arm"),
         unix=plat.startswith(("linux-", "osx-", "emscripten-")),
         win32=bool(plat == "win-32"),
         win64=bool(plat == "win-64"),

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -124,6 +124,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
     d = dict(
         linux32=bool(plat == "linux-32"),
         linux64=bool(plat == "linux-64"),
+        arm=plat.startswith(("linux-arm", "osx-arm", "win-arm")),
         unix=plat.startswith(("linux-", "osx-", "emscripten-")),
         win32=bool(plat == "win-32"),
         win64=bool(plat == "win-64"),

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -132,10 +132,12 @@ def get_selectors(config: Config) -> dict[str, bool]:
         nomkl=bool(int(os.environ.get("FEATURE_NOMKL", False))),
     )
 
-    subdirs = [subdir for subdir in DEFAULT_SUBDIRS if "-" in subdir]
-    # Add the current platform to the list as well to enable conda-build
+    # Add the current platform to the list of subdirs to enable conda-build
     # to bootstrap new platforms without a new conda release.
-    subdirs.append(plat)
+    subdirs = list(DEFAULT_SUBDIRS) + [plat]
+
+    # filter out noarch and other weird subdirs
+    subdirs = [subdir for subdir in subdirs if "-" in subdir]
 
     subdir_oses = {subdir.split("-")[0] for subdir in subdirs}
     subdir_archs = {subdir.split("-")[1] for subdir in subdirs}

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -30,7 +30,7 @@ from conda_build.utils import (
     insert_variant_versions,
 )
 
-from .conda_interface import MatchSpec, envs_dirs, md5_file, non_x86_linux_machines
+from .conda_interface import MatchSpec, envs_dirs, md5_file
 
 try:
     import yaml
@@ -186,9 +186,6 @@ def get_selectors(config: Config) -> dict[str, bool]:
     lua = config.variant.get("lua", defaults["lua"])
     d["lua"] = lua
     d["luajit"] = bool(lua[0] == "2")
-
-    for machine in non_x86_linux_machines:
-        d[machine] = bool(plat.endswith("-%s" % machine))
 
     for feature, value in feature_list:
         d[feature] = value

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -136,8 +136,8 @@ def get_selectors(config: Config) -> dict[str, bool]:
     subdir_oses = set([subdir.split("-")[0] for subdir in DEFAULT_SUBDIRS])
     subdir_archs = set([subdir.split("-")[1] for subdir in DEFAULT_SUBDIRS])
 
-    for os in subdir_oses:
-        d[os] = plat.startswith(f"{os}-")
+    for subdir_os in subdir_oses:
+        d[subdir_os] = plat.startswith(f"{subdir_os}-")
 
     for arch in subdir_arches:
         arch_full = ARCH_MAP.get(arch, arch)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -61,14 +61,13 @@ except Exception:
     CONDA_PACKAGE_EXTENSION_V2 = ".conda"
     CONDA_PACKAGE_EXTENSIONS = (CONDA_PACKAGE_EXTENSION_V2, CONDA_PACKAGE_EXTENSION_V1)
 
-from conda.base.constants import KNOWN_SUBDIRS
-
 import urllib.parse as urlparse
 import urllib.request as urllib
 from contextlib import ExitStack  # noqa: F401
 from glob import glob
 
 from conda.api import PackageCacheData  # noqa
+from conda.base.constants import KNOWN_SUBDIRS
 
 # NOQA because it is not used in this file.
 from conda_build.conda_interface import rm_rf as _rm_rf  # noqa

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -61,6 +61,8 @@ except Exception:
     CONDA_PACKAGE_EXTENSION_V2 = ".conda"
     CONDA_PACKAGE_EXTENSIONS = (CONDA_PACKAGE_EXTENSION_V2, CONDA_PACKAGE_EXTENSION_V1)
 
+from conda.base.constants import KNOWN_SUBDIRS
+
 import urllib.parse as urlparse
 import urllib.request as urllib
 from contextlib import ExitStack  # noqa: F401
@@ -104,25 +106,7 @@ mmap_MAP_PRIVATE = 0 if on_win else mmap.MAP_PRIVATE
 mmap_PROT_READ = 0 if on_win else mmap.PROT_READ
 mmap_PROT_WRITE = 0 if on_win else mmap.PROT_WRITE
 
-DEFAULT_SUBDIRS = {
-    "emscripten-wasm32",
-    "wasi-wasm32",
-    "linux-64",
-    "linux-32",
-    "linux-s390x",
-    "linux-ppc64",
-    "linux-ppc64le",
-    "linux-armv6l",
-    "linux-armv7l",
-    "linux-aarch64",
-    "win-64",
-    "win-32",
-    "win-arm64",
-    "osx-64",
-    "osx-arm64",
-    "zos-z",
-    "noarch",
-}
+DEFAULT_SUBDIRS = set(KNOWN_SUBDIRS)
 
 RUN_EXPORTS_TYPES = {
     "weak",

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -1928,10 +1928,10 @@ variables are booleans.
    * - osx
      - True if the platform is macOS.
    * - arm64
-     - True if the platform is macOS and the Python architecture
-       is arm64.
+     - True if the platform is either macOS or Windows and the
+       Python architecture is arm64.
    * - unix
-     - True if the platform is either macOS or Linux.
+     - True if the platform is either macOS or Linux or emscripten.
    * - win
      - True if the platform is Windows.
    * - win32
@@ -1964,6 +1964,11 @@ variables are booleans.
 The use of the Python version selectors, `py27`, `py34`, etc. is discouraged in
 favor of the more general comparison operators.  Additional selectors in this
 series will not be added to conda-build.
+
+Note that for each subdir with OS and architecture that `conda` supports,
+two preprocessing selectors are created for the OS and the architecture separately
+except when the architecture is not a valid python expression (`*-32` and `*-64`
+in particular).
 
 Because the selector is any valid Python expression, complicated
 logic is possible:

--- a/news/5009-use-conda-known-subdirs
+++ b/news/5009-use-conda-known-subdirs
@@ -1,0 +1,24 @@
+### Enhancements
+
+* Use subdirs known to conda for selector definitions. (#5009)
+  This allows conda_build to support new architectures with just
+  a new version of conda. For new OSes, there are more information
+  needed for conda_build to work properly, including whether the
+  new OS is a UNIX-like platform, the shared library prefix, and
+  the binary archive format for the platform.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -383,10 +383,10 @@ OS_ARCH = (
         ("linux-riscv64", {"unix", "linux", "riscv64"}),
         ("linux-s390x", {"unix", "linux", "s390x"}),
         ("osx-64", {"unix", "osx", "x86", "x86_64"}),
-        ("osx-arm64", {"unix", "osx", "arm", "arm64"}),
+        ("osx-arm64", {"unix", "osx", "arm64"}),
         ("win-32", {"win", "win32", "x86"}),
         ("win-64", {"win", "win64", "x86", "x86_64"}),
-        ("win-arm64", {"win", "arm", "arm64"}),
+        ("win-arm64", {"win", "arm64"}),
         ("zos-z", {"zos", "z"}),
     ],
 )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -383,10 +383,10 @@ OS_ARCH = (
         ("linux-riscv64", {"unix", "linux", "riscv64"}),
         ("linux-s390x", {"unix", "linux", "s390x"}),
         ("osx-64", {"unix", "osx", "x86", "x86_64"}),
-        ("osx-arm64", {"unix", "osx", "arm64"}),
+        ("osx-arm64", {"unix", "osx", "arm", "arm64"}),
         ("win-32", {"win", "win32", "x86"}),
         ("win-64", {"win", "win64", "x86", "x86_64"}),
-        ("win-arm64", {"win", "arm64"}),
+        ("win-arm64", {"win", "arm", "arm64"}),
         ("zos-z", {"zos", "z"}),
     ],
 )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -342,6 +342,7 @@ OS_ARCH = (
     "armv6l",
     "armv7l",
     "emscripten",
+    "freebsd",
     "linux",
     "linux32",
     "linux64",
@@ -358,6 +359,8 @@ OS_ARCH = (
     "win64",
     "x86",
     "x86_64",
+    "z",
+    "zos",
 )
 
 
@@ -369,7 +372,7 @@ OS_ARCH = (
     [
         ("emscripten-wasm32", {"unix", "emscripten", "wasm32"}),
         ("wasi-wasm32", {"wasi", "wasm32"}),
-        ("freebsd-64", {"x86", "x86_64"}),
+        ("freebsd-64", {"freebsd", "x86", "x86_64"}),
         ("linux-32", {"unix", "linux", "linux32", "x86"}),
         ("linux-64", {"unix", "linux", "linux64", "x86", "x86_64"}),
         ("linux-aarch64", {"unix", "linux", "aarch64"}),
@@ -384,7 +387,7 @@ OS_ARCH = (
         ("win-32", {"win", "win32", "x86"}),
         ("win-64", {"win", "win64", "x86", "x86_64"}),
         ("win-arm64", {"win", "arm64"}),
-        ("zos-z", {}),
+        ("zos-z", {"zos", "z"}),
     ],
 )
 @pytest.mark.parametrize("nomkl", [0, 1])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Refactor `conda_build.metadata.get_selectors` to use `conda.base.constants.KNOWN_SUBDIRS` instead of duplicating this list in `conda_build`. Furthermore, abstract the selector generation so theres less effort to add new OS/Archs in the future.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
