### PR TITLE
Only continue tests.yml workflow if not canceled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,18 +145,18 @@ jobs:
           flags: ${{ matrix.test-type }},${{ matrix.python-version }},linux-64
 
       - name: Tar Allure Results
-        if: always()
+        if: '!canceled()'
         run: tar -zcf "${{ env.ALLURE_DIR }}.tar.gz" "${{ env.ALLURE_DIR }}"
 
       - name: Upload Allure Results
-        if: always()
+        if: '!canceled()'
         uses: actions/upload-artifact@v3
         with:
           name: allure-Linux-${{ matrix.conda-version }}-Py${{ matrix.python-version }}-${{ matrix.test-type }}
           path: allure-results.tar.gz
 
       - name: Upload Pytest Replay
-        if: always()
+        if: '!canceled()'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.REPLAY_NAME }}-${{ matrix.test-type }}
@@ -250,21 +250,21 @@ jobs:
           flags: ${{ matrix.test-type }},${{ matrix.python-version }},win-64
 
       - name: Tar Allure Results
-        if: always()
+        if: '!canceled()'
         run: tar -zcf "${{ env.ALLURE_DIR }}.tar.gz" "${{ env.ALLURE_DIR }}"
         # windows-2019/powershell ships with GNU tar 1.28 which struggles with Windows paths
         # window-2019/cmd ships with bsdtar 3.5.2 which doesn't have this problem
         shell: cmd
 
       - name: Upload Allure Results
-        if: always()
+        if: '!canceled()'
         uses: actions/upload-artifact@v3
         with:
           name: allure-Win-${{ matrix.conda-version }}-Py${{ matrix.python-version }}-${{ matrix.test-type  }}
           path: allure-results.tar.gz
 
       - name: Upload Pytest Replay
-        if: always()
+        if: '!canceled()'
         uses: actions/upload-artifact@v3
         with:
           path: ${{ env.REPLAY_DIR }}
@@ -361,18 +361,18 @@ jobs:
           flags: ${{ matrix.test-type }},${{ matrix.python-version }},osx-64
 
       - name: Tar Allure Results
-        if: always()
+        if: '!canceled()'
         run: tar -zcf "${{ env.ALLURE_DIR }}.tar.gz" "${{ env.ALLURE_DIR }}"
 
       - name: Upload Allure Results
-        if: always()
+        if: '!canceled()'
         uses: actions/upload-artifact@v3
         with:
           name: allure-macOS-${{ matrix.conda-version }}-Py${{ matrix.python-version }}-${{ matrix.test-type }}
           path: allure-results.tar.gz
 
       - name: Upload Pytest Replay
-        if: always()
+        if: '!canceled()'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.REPLAY_NAME }}-${{ matrix.test-type  }}
@@ -382,7 +382,12 @@ jobs:
   aggregate:
     # only aggregate test suite if there are code changes
     needs: [changes, linux, windows, macos]
-    if: always() && (github.event_name == 'schedule' || needs.changes.outputs.code == 'true')
+    if: >-
+      !canceled()
+      && (
+        github.event_name == 'schedule'
+        || needs.changes.outputs.code == 'true'
+      )
 
     runs-on: ubuntu-latest
     steps:
@@ -407,7 +412,7 @@ jobs:
   analyze:
     name: Analyze results
     needs: [linux, windows, macos, aggregate]
-    if: always()
+    if: '!canceled()'
 
     runs-on: ubuntu-latest
     steps:
@@ -426,7 +431,7 @@ jobs:
     # - this is the main repo, and
     # - we are on the main, feature, or release branch
     if: >-
-      always()
+      !canceled()
       && !github.event.repository.fork
       && (
         github.ref_name == 'main'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,18 +145,18 @@ jobs:
           flags: ${{ matrix.test-type }},${{ matrix.python-version }},linux-64
 
       - name: Tar Allure Results
-        if: '!canceled()'
+        if: '!cancelled()'
         run: tar -zcf "${{ env.ALLURE_DIR }}.tar.gz" "${{ env.ALLURE_DIR }}"
 
       - name: Upload Allure Results
-        if: '!canceled()'
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: allure-Linux-${{ matrix.conda-version }}-Py${{ matrix.python-version }}-${{ matrix.test-type }}
           path: allure-results.tar.gz
 
       - name: Upload Pytest Replay
-        if: '!canceled()'
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.REPLAY_NAME }}-${{ matrix.test-type }}
@@ -250,21 +250,21 @@ jobs:
           flags: ${{ matrix.test-type }},${{ matrix.python-version }},win-64
 
       - name: Tar Allure Results
-        if: '!canceled()'
+        if: '!cancelled()'
         run: tar -zcf "${{ env.ALLURE_DIR }}.tar.gz" "${{ env.ALLURE_DIR }}"
         # windows-2019/powershell ships with GNU tar 1.28 which struggles with Windows paths
         # window-2019/cmd ships with bsdtar 3.5.2 which doesn't have this problem
         shell: cmd
 
       - name: Upload Allure Results
-        if: '!canceled()'
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: allure-Win-${{ matrix.conda-version }}-Py${{ matrix.python-version }}-${{ matrix.test-type  }}
           path: allure-results.tar.gz
 
       - name: Upload Pytest Replay
-        if: '!canceled()'
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           path: ${{ env.REPLAY_DIR }}
@@ -361,18 +361,18 @@ jobs:
           flags: ${{ matrix.test-type }},${{ matrix.python-version }},osx-64
 
       - name: Tar Allure Results
-        if: '!canceled()'
+        if: '!cancelled()'
         run: tar -zcf "${{ env.ALLURE_DIR }}.tar.gz" "${{ env.ALLURE_DIR }}"
 
       - name: Upload Allure Results
-        if: '!canceled()'
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: allure-macOS-${{ matrix.conda-version }}-Py${{ matrix.python-version }}-${{ matrix.test-type }}
           path: allure-results.tar.gz
 
       - name: Upload Pytest Replay
-        if: '!canceled()'
+        if: '!cancelled()'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.REPLAY_NAME }}-${{ matrix.test-type  }}
@@ -383,7 +383,7 @@ jobs:
     # only aggregate test suite if there are code changes
     needs: [changes, linux, windows, macos]
     if: >-
-      !canceled()
+      !cancelled()
       && (
         github.event_name == 'schedule'
         || needs.changes.outputs.code == 'true'
@@ -412,7 +412,7 @@ jobs:
   analyze:
     name: Analyze results
     needs: [linux, windows, macos, aggregate]
-    if: '!canceled()'
+    if: '!cancelled()'
 
     runs-on: ubuntu-latest
     steps:
@@ -431,7 +431,7 @@ jobs:
     # - this is the main repo, and
     # - we are on the main, feature, or release branch
     if: >-
-      !canceled()
+      !cancelled()
       && !github.event.repository.fork
       && (
         github.ref_name == 'main'


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Sometimes we need to cancel workflows and we expect them to quickly finish so we can restart them. Currently this is not possible as several jobs will `always()` run even when prior jobs have been canceled.

Xref https://github.com/conda/conda/pull/13157

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
