### PR TITLE
Print package file name in get_hash_input

### DIFF
--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -372,7 +372,7 @@ def inspect_objects(packages, prefix=sys.prefix, groupby="package"):
 def get_hash_input(packages):
     hash_inputs = {}
     for pkg in ensure_list(packages):
-        pkgname = os.path.basename(pkg)[:-8]
+        pkgname = os.path.basename(pkg)
         hash_inputs[pkgname] = {}
         hash_input = package_has_file(pkg, "info/hash_input.json")
         if hash_input:

--- a/news/5021-get_hash_input
+++ b/news/5021-get_hash_input
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Print package file name in get_hash_input (#5021)
+* Print package file name in `get_hash_input`. (#5021)
 
 ### Deprecations
 

--- a/news/5021-get_hash_input
+++ b/news/5021-get_hash_input
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Print package file name in get_hash_input (#5021)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

This PR fixes #5020 by patching `conda_build.inspect_pkg.get_hash_input` to use the package file basename as the hash key, rather than attempting to strip off the extension (which it currently gets wrong for `.conda` packages).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
