### PR TITLE
Add test for `conda_build.metadata.get_selectors`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -147,15 +147,16 @@ def get_selectors(config: Config) -> dict[str, bool]:
         py = py[0]
     # go from "3.6 *_cython" -> "36"
     # or from "3.6.9" -> "36"
-    py = int("".join(py.split(" ")[0].split(".")[:2]))
+    py_major, py_minor, *_ = py.split(" ")[0].split(".")
+    py = int(f"{py_major}{py_minor}")
 
     d["build_platform"] = config.build_subdir
 
     d.update(
         dict(
             py=py,
-            py3k=bool(30 <= py < 40),
-            py2k=bool(20 <= py < 30),
+            py3k=bool(py_major == "3"),
+            py2k=bool(py_major == "2"),
             py26=bool(py == 26),
             py27=bool(py == 27),
             py33=bool(py == 33),

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 
 import pytest
+from conda.base.context import context
+from pytest import MonkeyPatch
 
 from conda_build import api
-from conda_build.metadata import MetaData, _hash_dependencies, select_lines, yamlize
+from conda_build.config import Config
+from conda_build.metadata import (
+    MetaData,
+    _hash_dependencies,
+    get_selectors,
+    select_lines,
+    yamlize,
+)
 from conda_build.utils import DEFAULT_SUBDIRS
 
 from .utils import metadata_dir, thisdir
@@ -323,3 +333,93 @@ def test_yamlize_versions():
     )
 
     assert yml == ["1.2.3", "1.2.3.4"]
+
+
+OS_ARCH = (
+    "aarch64",
+    "arm",
+    "arm64",
+    "armv6l",
+    "armv7l",
+    "emscripten",
+    "linux",
+    "linux32",
+    "linux64",
+    "osx",
+    "ppc64",
+    "ppc64le",
+    "riscv64",
+    "s390x",
+    "unix",
+    "wasi",
+    "wasm32",
+    "win",
+    "win32",
+    "win64",
+    "x86",
+    "x86_64",
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "subdir",  # defined in conda.base.constants.KNOWN_SUBDIRS
+        "expected",  # OS_ARCH keys expected to be True
+    ),
+    [
+        ("emscripten-wasm32", {"unix", "emscripten", "wasm32"}),
+        ("wasi-wasm32", {"wasi", "wasm32"}),
+        ("freebsd-64", {"x86", "x86_64"}),
+        ("linux-32", {"unix", "linux", "linux32", "x86"}),
+        ("linux-64", {"unix", "linux", "linux64", "x86", "x86_64"}),
+        ("linux-aarch64", {"unix", "linux", "aarch64"}),
+        ("linux-armv6l", {"unix", "linux", "arm", "armv6l"}),
+        ("linux-armv7l", {"unix", "linux", "arm", "armv7l"}),
+        ("linux-ppc64", {"unix", "linux", "ppc64"}),
+        ("linux-ppc64le", {"unix", "linux", "ppc64le"}),
+        ("linux-riscv64", {"unix", "linux", "riscv64"}),
+        ("linux-s390x", {"unix", "linux", "s390x"}),
+        ("osx-64", {"unix", "osx", "x86", "x86_64"}),
+        ("osx-arm64", {"unix", "osx", "arm64"}),
+        ("win-32", {"win", "win32", "x86"}),
+        ("win-64", {"win", "win64", "x86", "x86_64"}),
+        ("win-arm64", {"win", "arm64"}),
+        ("zos-z", {}),
+    ],
+)
+@pytest.mark.parametrize("nomkl", [0, 1])
+def test_get_selectors(
+    monkeypatch: MonkeyPatch,
+    subdir: str,
+    expected: set[str],
+    nomkl: int,
+):
+    monkeypatch.setenv("FEATURE_NOMKL", str(nomkl))
+
+    config = Config(host_subdir=subdir)
+    assert get_selectors(config) == {
+        # defaults
+        "build_platform": context.subdir,
+        "lua": "5",  # see conda_build.variants.DEFAULT_VARIANTS["lua"]
+        "luajit": False,  # lua[0] == 2
+        "np": 122,  # see conda_build.variants.DEFAULT_VARIANTS["numpy"]
+        "os": os,
+        "pl": "5.26.2",  # see conda_build.variants.DEFAULT_VARIANTS["perl"]
+        "py": int(f"{sys.version_info.major}{sys.version_info.minor}"),
+        "py26": sys.version_info.major == 2 and sys.version_info.minor == 6,
+        "py27": sys.version_info.major == 2 and sys.version_info.minor == 7,
+        "py2k": sys.version_info.major == 2,
+        "py33": sys.version_info.major == 3 and sys.version_info.minor == 3,
+        "py34": sys.version_info.major == 3 and sys.version_info.minor == 4,
+        "py35": sys.version_info.major == 3 and sys.version_info.minor == 5,
+        "py36": sys.version_info.major == 3 and sys.version_info.minor == 6,
+        "py3k": sys.version_info.major == 3,
+        "nomkl": bool(nomkl),
+        # default OS/arch values
+        **{key: False for key in OS_ARCH},
+        # environment variables
+        "environ": os.environ,
+        **os.environ,
+        # override with True values
+        **{key: True for key in expected},
+    }


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Adding test to confirm we aren't loosing any selectors with the proposed change in #5009.

Corrects `py3k` selector to correctly evaluated to True for all Python 3 versions. While the `py*` selectors are deprecated (see https://github.com/conda/conda-build/issues/4032, https://github.com/conda/conda-build/issues/4297, and https://github.com/conda/conda-build/issues/4324) in favor of the `py` selector there's no reason for the deprecated selectors to be incorrect.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
