### PR TITLE
Deprecate `conda.models.dist.IndexRecord`

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -74,9 +74,18 @@ from conda.exports import (  # noqa: F401
     win_path_to_unix,
 )
 from conda.models.channel import get_conda_build_local_url  # noqa: F401
-from conda.models.dist import Dist, IndexRecord  # noqa: F401
+from conda.models.dist import Dist  # noqa: F401
+from conda.models.records import PackageRecord
 
 from .deprecations import deprecated
+
+deprecated.constant(
+    "24.3",
+    "24.9",
+    "IndexRecord",
+    PackageRecord,
+    addendum="Use `conda.models.records.PackageRecord` instead.",
+)
 
 # TODO: Go to references of all properties below and import them from `context` instead
 binstar_upload = context.binstar_upload

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -80,8 +80,8 @@ from conda.models.records import PackageRecord
 from .deprecations import deprecated
 
 deprecated.constant(
-    "24.3",
-    "24.9",
+    "3.28.0",
+    "4.0.0",
     "IndexRecord",
     PackageRecord,
     addendum="Use `conda.models.records.PackageRecord` instead.",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Xref https://github.com/conda/conda/issues/13192

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
