### PR TITLE
Fallback to solved record filename to find the downloaded tarball in `get_upstream_pins`

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -384,7 +384,7 @@ def execute_download_actions(m, actions, env, package_subset=None, require_files
             with utils.LoggingContext():
                 pfe.execute()
             for pkg_dir in pkgs_dirs:
-                _loc = os.path.join(pkg_dir, index[pkg].fn)
+                _loc = os.path.join(pkg_dir, index.get(pkg, pkg).fn)
                 if os.path.isfile(_loc):
                     pkg_loc = _loc
                     break

--- a/news/5037-conda-libmamba-solver-pins
+++ b/news/5037-conda-libmamba-solver-pins
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fallback to solved record filename to find the downloaded tarball in `get_upstream_pins`. (#4991 via #5037)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #4991 

After quite some effort debugging this issue, this is what we've found:

* The channel configuration must either redefine `default_channels` or `channel_alias`, or both.
* The package cache must be clean (e.g. after `conda clean -pt`)

In this situation, the `get_upstream_pins` calculation is forced to download the package on the spot to extract it and retrieve its `run_exports` metadata. 

The problem is caused by a small divergence in the indices (parsed repodatas) as loaded by libmamba and conda, respectively. With customized `default_channels` and `channel_alias` values, the `channel` attribute of each `PackageRecord` in the `conda-build` index is set differently than in `libmamba`.

For example, with this configuration:

```yaml
channels:
  - defaults
default_channels:
  - conda-forge
solver: libmamba
```

, the offending block tries to match these two records:

* `conda-forge::python-3.11.6-h43d1f9e_0_cpython` (provided by libmamba, the solver)
* `defaults::python-3.11.6-h43d1f9e_0_cpython` (calculated by conda-build's index, which is built separately but not used in practice)

They are the same package with different channel. Since `conda-build` loads the repodata on its own, it interprets that the `conda-forge` channel should be called `defaults` given the config in `default_channels`. However that's a multichannel and libmamba doesn't handle those well and it prefers to use the actual channel behind the multichannel abstraction (e.g. `pkgs/main` for the default `defaults`). Hence the divergence.

I was going to try fix this in conda-libmamba-solver so the indices match, but:

* That's going to be a bigger fix touching an already fragile interface
* The fix in conda-build is insultingly simple. I can't imagine a scenario where the filenames may not match, and I would say the must by design. That means we can reuse the one in the solver-provided `PackageRecord`. I am only adding it as a fallback if not found in the `conda-build` index as an abundance of caution.
* This code path will be obsolete soon when we add `run_exports.json` support (via CEP-11).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
