### PR TITLE
Replace `black` with `ruff-format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,28 +48,19 @@ repos:
         files: \.py$
         args: [--license-filepath, .github/disclaimer.txt, --no-extra-eol]
         exclude: ^conda_build/version.py
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.13.0
-    hooks:
-      # upgrade standard Python codes
-      - id: pyupgrade
-        args: [--py38-plus]
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      # auto format Python codes
-      - id: black
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0
     hooks:
       # auto format Python codes within docstrings
       - id: blacken-docs
-        additional_dependencies: [black]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.1.3
     hooks:
+      # lint & attempt to correct failures (e.g. pyupgrade)
       - id: ruff
         args: [--fix]
+      # compatible replacement for black
+      - id: ruff-format
   - repo: meta
     # see https://pre-commit.com/#meta-hooks
     hooks:

--- a/conda_build/_load_setup_py_data.py
+++ b/conda_build/_load_setup_py_data.py
@@ -140,18 +140,18 @@ if __name__ == "__main__":
     parser.add_argument("setup_file", help="path or filename of setup.py file")
     parser.add_argument(
         "--from-recipe-dir",
-        help=("look for setup.py file in recipe " "dir (as opposed to work dir)"),
+        help="look for setup.py file in recipe dir (as opposed to work dir)",
         default=False,
         action="store_true",
     )
     parser.add_argument(
         "--recipe-dir",
-        help=("(optional) path to recipe dir, where " "setup.py should be found"),
+        help="(optional) path to recipe dir, where setup.py should be found",
     )
 
     parser.add_argument(
         "--permit-undefined-jinja",
-        help=("look for setup.py file in recipe " "dir (as opposed to work dir)"),
+        help="look for setup.py file in recipe dir (as opposed to work dir)",
         default=False,
         action="store_true",
     )

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -655,17 +655,18 @@ def debug(
             ]
             if len(matched_outputs) > 1:
                 raise ValueError(
-                    "Specified --output-id matches more than one output ({}).  Please refine your output id so that only "
-                    "a single output is found.".format(matched_outputs)
+                    f"Specified --output-id matches more than one output ({matched_outputs}). "
+                    "Please refine your output id so that only a single output is found."
                 )
             elif not matched_outputs:
                 raise ValueError(
-                    f"Specified --output-id did not match any outputs.  Available outputs are: {outputs} Please check it and try again"
+                    f"Specified --output-id did not match any outputs. Available outputs are: {outputs} "
+                    "Please check it and try again"
                 )
         if len(matched_outputs) > 1 and not path_is_build_dir:
             raise ValueError(
-                "More than one output found for this recipe ({}).  Please use the --output-id argument to filter down "
-                "to a single output.".format(outputs)
+                f"More than one output found for this recipe ({outputs}). "
+                "Please use the --output-id argument to filter down to a single output."
             )
         else:
             matched_outputs = outputs

--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -414,7 +414,7 @@ def convert(
         )
     elif package_file.endswith(".whl"):
         raise RuntimeError(
-            "Conversion from wheel packages is not " "implemented yet, stay tuned."
+            "Conversion from wheel packages is not implemented yet, stay tuned."
         )
     else:
         raise RuntimeError("cannot convert: %s" % package_file)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -4090,7 +4090,7 @@ def handle_anaconda_upload(paths, config):
         prompter = "$ "
     if not upload or anaconda is None:
         no_upload_message = (
-            "# If you want to upload package(s) to anaconda.org later, type:\n" "\n"
+            "# If you want to upload package(s) to anaconda.org later, type:\n\n"
         )
         no_upload_message += (
             "\n"

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -501,7 +501,12 @@ def regex_files_py(
                         match_records[file] = {"type": type, "submatches": []}
                     # else:
                     #     if match_records[file]['absolute_offset'] != absolute_offset:
-                    #         print("Dropping match.pos() of {}, neq {}".format(absolute_offset, match_records[file]['absolute_offset']))
+                    #         print(
+                    #             "Dropping match.pos() of {}, neq {}".format(
+                    #                 absolute_offset,
+                    #                 match_records[file]['absolute_offset'],
+                    #             )
+                    #         )
                     g_index = len(match.groups())
                     if g_index == 0:
                         # Complete match.
@@ -639,8 +644,9 @@ def have_regex_files(
         return match_records
     import copy
 
-    match_records_rg, match_records_re = copy.deepcopy(match_records), copy.deepcopy(
-        match_records
+    match_records_rg, match_records_re = (
+        copy.deepcopy(match_records),
+        copy.deepcopy(match_records),
     )
     if not isinstance(regex_re, (bytes, bytearray)):
         regex_re = regex_re.encode("utf-8")
@@ -2257,7 +2263,9 @@ def _write_sh_activation_text(file_handle, m):
             if value:
                 if not done_necessary_env:
                     # file_handle.write(
-                    #     'export CCACHE_SLOPPINESS="pch_defines,time_macros${CCACHE_SLOPPINESS+,$CCACHE_SLOPPINESS}"\n')
+                    #     'export CCACHE_SLOPPINESS="pch_defines,time_macros'
+                    #     '${CCACHE_SLOPPINESS+,$CCACHE_SLOPPINESS}"\n'
+                    # )
                     # file_handle.write('export CCACHE_CPP2=true\n')
                     done_necessary_env = True
                 if method == "symlinks":
@@ -2266,16 +2274,12 @@ def _write_sh_activation_text(file_handle, m):
                     file_handle.write(f"pushd {dirname_ccache_ln_bin}\n")
                     file_handle.write('if [ -n "$CC" ]; then\n')
                     file_handle.write(
-                        "  [ -f {ccache} ] && [ ! -f $(basename $CC) ] && ln -s {ccache} $(basename $CC) || true\n".format(
-                            ccache=ccache
-                        )
+                        f"  [ -f {ccache} ] && [ ! -f $(basename $CC) ] && ln -s {ccache} $(basename $CC) || true\n"
                     )
                     file_handle.write("fi\n")
                     file_handle.write('if [ -n "$CXX" ]; then\n')
                     file_handle.write(
-                        "  [ -f {ccache} ] && [ ! -f $(basename $CXX) ] && ln -s {ccache} $(basename $CXX) || true\n".format(
-                            ccache=ccache
-                        )
+                        f"  [ -f {ccache} ] && [ ! -f $(basename $CXX) ] && ln -s {ccache} $(basename $CXX) || true\n"
                     )
                     file_handle.write("fi\n")
                     file_handle.write("popd\n")

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -437,7 +437,7 @@ def parse_args(args):
     )
     p.add_argument(
         "--stats-file",
-        help=("File path to save build statistics to.  Stats are " "in JSON format"),
+        help="File path to save build statistics to.  Stats are in JSON format",
     )
     p.add_argument(
         "--extra-deps",

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -19,7 +19,7 @@ def parse_args(args):
 
 Install a Python package in 'development mode'.
 
-This works by creating a conda.pth file in site-packages."""
+This works by creating a conda.pth file in site-packages.""",
         # TODO: Use setup.py to determine any entry-points to install.
     )
 

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -66,7 +66,7 @@ source to try fill in related template variables.",
     p.add_argument(
         "--output",
         action="store_true",
-        help="Output the conda package filename which would have been " "created",
+        help="Output the conda package filename which would have been created",
     )
     p.add_argument(
         "--python",

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -868,11 +868,11 @@ class Config:
                 rm_rf(os.path.join(self.build_folder, "prefix_files"))
         else:
             print(
-                "\nLeaving build/test directories:" "\n  Work:\n",
+                "\nLeaving build/test directories:\n  Work:\n",
                 self.work_dir,
                 "\n  Test:\n",
                 self.test_dir,
-                "\nLeaving build/test environments:" "\n  Test:\nsource activate ",
+                "\nLeaving build/test environments:\n  Test:\nsource activate ",
                 self.test_prefix,
                 "\n  Build:\nsource activate ",
                 self.build_prefix,

--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -88,8 +88,7 @@ class DependencyNeedsBuildingError(CondaBuildException):
                 self.packages.append(pkg)
         if not self.packages:
             raise RuntimeError(
-                "failed to parse packages from exception:"
-                " {}".format(str(conda_exception))
+                f"failed to parse packages from exception: {conda_exception}"
             )
 
     def __str__(self):

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -360,7 +360,8 @@ def update_index(
     if dirname in utils.DEFAULT_SUBDIRS:
         if warn:
             log.warn(
-                "The update_index function has changed to index all subdirs at once.  You're pointing it at a single subdir.  "
+                "The update_index function has changed to index all subdirs at once. "
+                "You're pointing it at a single subdir. "
                 "Please update your code to point it at the channel root, rather than a subdir."
             )
         return update_index(

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -283,7 +283,7 @@ def inspect_linkages(
                     if len(deps) > 1:
                         deps_str = [str(dep) for dep in deps]
                         get_logger(__name__).warn(
-                            "Warning: %s comes from multiple " "packages: %s",
+                            "Warning: %s comes from multiple packages: %s",
                             path,
                             comma_join(deps_str),
                         )

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -97,18 +97,8 @@ class UndefinedNeverFail(jinja2.Undefined):
         __call__
     ) = (
         __getitem__
-    ) = (
-        __lt__
-    ) = (
-        __le__
-    ) = (
-        __gt__
-    ) = (
-        __ge__
-    ) = (
-        __complex__
-    ) = __pow__ = __rpow__ = lambda self, *args, **kwargs: self._return_undefined(
-        self._undefined_name
+    ) = __lt__ = __le__ = __gt__ = __ge__ = __complex__ = __pow__ = __rpow__ = (
+        lambda self, *args, **kwargs: self._return_undefined(self._undefined_name)
     )
 
     # Accessing an attribute of an Undefined variable

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -319,7 +319,7 @@ def ensure_valid_fields(meta):
     pin_depends = meta.get("build", {}).get("pin_depends", "")
     if pin_depends and pin_depends not in ("", "record", "strict"):
         raise RuntimeError(
-            "build/pin_depends must be 'record' or 'strict' - " "not '%s'" % pin_depends
+            f"build/pin_depends must be 'record' or 'strict' - not '{pin_depends}'"
         )
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1475,7 +1475,8 @@ class MetaData:
         meta_requirements = ensure_list(self.get_value("requirements/" + typ, []))[:]
         req_names = {req.split()[0] for req in meta_requirements if req}
         extra_reqs = []
-        # this is for the edge case of requirements for top-level being also partially defined in a similarly named output
+        # this is for the edge case of requirements for top-level being
+        # partially defined in a similarly named output
         if not self.is_output:
             matching_output = [
                 out

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -142,11 +142,7 @@ def transform(m, files, prefix):
             """\
     @echo off
     "%PREFIX%\\python.exe" "%SOURCE_DIR%\\link.py"
-    """.replace(
-                "\n", "\r\n"
-            ).encode(
-                "utf-8"
-            )
+    """.replace("\n", "\r\n").encode("utf-8")
         )
 
     d = populate_files(m, files, prefix)

--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -588,8 +588,14 @@ def inspect_linkages_lief(
                     """
                     if binary.format == lief.EXE_FORMATS.PE:
                         import random
-                        path_fixed = os.path.dirname(path_fixed) + os.sep +  \
-                                     ''.join(random.choice((str.upper, str.lower))(c) for c in os.path.basename(path_fixed))
+                        path_fixed = (
+                            os.path.dirname(path_fixed)
+                            + os.sep
+                            +  ''.join(
+                                random.choice((str.upper, str.lower))(c)
+                                for c in os.path.basename(path_fixed)
+                            )
+                        )
                         if random.getrandbits(1):
                             path_fixed = path_fixed.replace(os.sep + 'lib' + os.sep, os.sep + 'Lib' + os.sep)
                         else:
@@ -650,16 +656,11 @@ def get_linkages(
     )
     if debug and result_pyldd and set(result_lief) != set(result_pyldd):
         print(
-            "WARNING: Disagreement in get_linkages(filename={}, resolve_filenames={}, recurse={}, sysroot={}, envroot={}, arch={}):\n lief: {}\npyldd: {}\n  (using lief)".format(
-                filename,
-                resolve_filenames,
-                recurse,
-                sysroot,
-                envroot,
-                arch,
-                result_lief,
-                result_pyldd,
-            )
+            f"WARNING: Disagreement in get_linkages({filename=}, "
+            f"{resolve_filenames=}, {recurse=}, {sysroot=}, {envroot=}, {arch=}):\n"
+            f" lief: {result_lief}\n"
+            f"pyldd: {result_pyldd}\n"
+            "  (using lief)"
         )
     return result_lief
 
@@ -689,7 +690,7 @@ def is_archive(file):
 
 
 def get_static_lib_exports(file):
-    # file = '/Users/rdonnelly/conda/main-augmented-tmp/osx-64_14354bd0cd1882bc620336d9a69ae5b9/lib/python2.7/config/libpython2.7.a'
+    # file = '/Users/rdonnelly/conda/main-augmented-tmp/osx-64_14354bd0cd1882bc620336d9a69ae5b9/lib/python2.7/config/libpython2.7.a'  # noqa: E501
     # References:
     # https://github.com/bminor/binutils-gdb/tree/master/bfd/archive.c
     # https://en.wikipedia.org/wiki/Ar_(Unix)
@@ -737,7 +738,8 @@ def get_static_lib_exports(file):
             typ = "NORMAL"
         if b"/" in name:
             name = name[: name.find(b"/")]
-        # if debug_static_archives: print("index={}, name={}, ending={}, size={}, type={}".format(index, name, ending, size, typ))
+        # if debug_static_archives:
+        #     print(f"index={index}, name={name}, ending={ending}, size={size}, type={typ}")
         index += header_sz + name_len
         return index, name, name_len, size, typ
 
@@ -813,9 +815,7 @@ def get_static_lib_exports(file):
             (size_string_table,) = struct.unpack(
                 "<" + toc_integers_fmt,
                 content[
-                    index
-                    + toc_integers_sz
-                    + (nsymbols * ranlib_struct_sz) : index
+                    index + toc_integers_sz + (nsymbols * ranlib_struct_sz) : index
                     + 4
                     + 4
                     + (nsymbols * ranlib_struct_sz)
@@ -827,8 +827,7 @@ def get_static_lib_exports(file):
                 ran_off, ran_strx = struct.unpack(
                     "<" + ranlib_struct_field_fmt + ranlib_struct_field_fmt,
                     content[
-                        ranlib_index
-                        + (i * ranlib_struct_sz) : ranlib_index
+                        ranlib_index + (i * ranlib_struct_sz) : ranlib_index
                         + ((i + 1) * ranlib_struct_sz)
                     ],
                 )
@@ -845,8 +844,7 @@ def get_static_lib_exports(file):
                     )
                 )
             string_table = content[
-                ranlib_index
-                + (nsymbols * ranlib_struct_sz) : ranlib_index
+                ranlib_index + (nsymbols * ranlib_struct_sz) : ranlib_index
                 + (nsymbols * ranlib_struct_sz)
                 + size_string_table
             ]
@@ -958,7 +956,7 @@ def get_static_lib_exports_dumpbin(filename):
     > 020 00000000 UNDEF  notype ()    External     | malloc
     > vs
     > 004 00000010 SECT1  notype ()    External     | _ZN3gnu11autosprintfC1EPKcz
-    """
+    """  # noqa: E501
     dumpbin_exe = find_executable("dumpbin")
     if not dumpbin_exe:
         """
@@ -1077,19 +1075,15 @@ def get_exports(filename, arch="native", enable_static=False):
                         print(f"errors: {error_count} (-{len(diff1)}, +{len(diff2)})")
                     if debug_static_archives:
                         print(
-                            "WARNING :: Disagreement regarding static lib exports in {} between nm (nsyms={}) and lielfldd (nsyms={}):".format(
-                                filename, len(exports), len(exports2)
-                            )
+                            "WARNING :: Disagreement regarding static lib exports in "
+                            f"{filename} between nm (nsyms={len(exports)}) and "
+                            "lielfldd (nsyms={len(exports2)}):"
                         )
                     print(
-                        "** nm.diff(liefldd) [MISSING SYMBOLS] **\n{}".format(
-                            "\n".join(diff1)
-                        )
+                        "\n".join(("** nm.diff(liefldd) [MISSING SYMBOLS] **", *diff1))
                     )
                     print(
-                        "** liefldd.diff(nm) [  EXTRA SYMBOLS] **\n{}".format(
-                            "\n".join(diff2)
-                        )
+                        "\n".join(("** liefldd.diff(nm) [  EXTRA SYMBOLS] **", *diff2))
                     )
 
     if not result:

--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -708,13 +708,9 @@ class elfheader:
             get_logger(__name__).warning(f"file.tell()={loc} != ehsize={self.ehsize}")
 
     def __str__(self):
-        return "bitness {}, endian {}, version {}, type {}, machine {}, entry {}".format(  # noqa
-            self.bitness,
-            self.endian,
-            self.version,
-            self.type,
-            hex(self.machine),
-            hex(self.entry),
+        return (
+            f"bitness {self.bitness}, endian {self.endian}, version {self.version}, "
+            f"type {self.type}, machine {hex(self.machine)}, entry {hex(self.entry)}"
         )
 
 

--- a/conda_build/plugin.py
+++ b/conda_build/plugin.py
@@ -78,12 +78,18 @@ def conda_subcommands():
     )
     yield conda.plugins.CondaSubcommand(
         name="develop",
-        summary="Install a Python package in 'development mode'. Similar to `pip install --editable`.",
+        summary=(
+            "Install a Python package in 'development mode'. "
+            "Similar to `pip install --editable`."
+        ),
         action=develop,
     )
     yield conda.plugins.CondaSubcommand(
         name="index",
-        summary="Update package index metadata files. Pending deprecation, use https://github.com/conda/conda-index instead.",
+        summary=(
+            "Update package index metadata files. Pending deprecation, "
+            "use https://github.com/conda/conda-index instead."
+        ),
         action=index,
     )
     yield conda.plugins.CondaSubcommand(

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -517,7 +517,14 @@ def check_binary(binary, expected=None):
     print("trying {}".format(binary))
     # import pdb; pdb.set_trace()
     try:
-        txt = check_output([sys.executable, '-c', 'from ctypes import cdll; cdll.LoadLibrary("' + binary + '")'], timeout=2)
+        txt = check_output(
+            [
+                sys.executable,
+                '-c',
+                'from ctypes import cdll; cdll.LoadLibrary("' + binary + '")'
+            ],
+            timeout=2,
+        )
         # mydll = cdll.LoadLibrary(binary)
     except Exception as e:
         print(e)

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -3,8 +3,6 @@
 """
 Tools for converting Cran packages to conda recipes.
 """
-
-
 import argparse
 import copy
 import hashlib
@@ -198,7 +196,7 @@ else
     popd
   fi
 fi
-"""
+"""  # noqa: E501
 
 CRAN_BUILD_SH_BINARY = """\
 #!/bin/bash
@@ -1299,10 +1297,8 @@ def skeletonize(
                     )
             if not is_github_url:
                 available_details["archive_keys"] = (
-                    "{url_key}{sel}"
-                    "    {cranurl}\n"
-                    "  {hash_entry}{sel}".format(**available_details)
-                )
+                    "{url_key}{sel}    {cranurl}\n  {hash_entry}{sel}"
+                ).format(**available_details)
 
         # Extract the DESCRIPTION data from the source
         if cran_package is None:

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -387,7 +387,7 @@ def add_parser(repos):
         "--use-noarch-generic",
         action="store_true",
         dest="use_noarch_generic",
-        help=("Mark packages that do not need compilation as `noarch: generic`"),
+        help="Mark packages that do not need compilation as `noarch: generic`",
     )
     cran.add_argument(
         "--use-rtools-win",

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -473,8 +473,9 @@ def remap_license(rpm_license):
     }
     l_rpm_license = rpm_license.lower()
     if l_rpm_license in mapping:
-        license, family = mapping[l_rpm_license], guess_license_family(
-            mapping[l_rpm_license]
+        license, family = (
+            mapping[l_rpm_license],
+            guess_license_family(mapping[l_rpm_license]),
         )
     else:
         license, family = rpm_license, guess_license_family(rpm_license)

--- a/conda_build/tarcheck.py
+++ b/conda_build/tarcheck.py
@@ -90,9 +90,8 @@ class TarCheck:
             self.config.host_subdir,
             "noarch",
             self.config.target_subdir,
-        ], (
-            "Inconsistent subdir in package - index.json expecting {},"
-            " got {}".format(self.config.host_subdir, info["subdir"])
+        ], "Inconsistent subdir in package - index.json expecting {}, got {}".format(
+            self.config.host_subdir, info["subdir"]
         )
 
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -163,7 +163,6 @@ def directory_size_slow(path):
 
 
 def directory_size(path):
-    """ """
     try:
         if on_win:
             command = 'dir /s "{}"'  # Windows path can have spaces
@@ -716,9 +715,7 @@ def merge_tree(
     existing = [f for f in new_files if isfile(f)]
 
     if existing and not clobber:
-        raise OSError(
-            "Can't merge {} into {}: file exists: " "{}".format(src, dst, existing[0])
-        )
+        raise OSError(f"Can't merge {src} into {dst}: file exists: {existing[0]}")
 
     locks = []
     if locking:

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -164,7 +164,8 @@ def validate_spec(src, spec):
             "  zip_key entry {} in group {} is a duplicate, keys can only occur "
             "in one group".format(k, zg)
             # include error if key has already been seen, otherwise add to unique keys
-            if k in unique else unique.add(k)
+            if k in unique
+            else unique.add(k)
             for zg in zip_keys
             for k in zg
         )

--- a/news/5052-ruff-format
+++ b/news/5052-ruff-format
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Replace `black` with `ruff format` in pre-commit. (#5052)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,9 +81,6 @@ include = ["conda_build", "conda_build/templates/*", "conda_build/cli-*.exe"]
 [tool.hatch.build.hooks.vcs]
 version-file = "conda_build/__version__.py"
 
-[tool.black]
-target-version = ['py38', 'py39', 'py310', 'py311']
-
 [tool.coverage.run]
 # store relative paths in coverage information
 relative_files = true
@@ -95,7 +92,7 @@ skip_covered = true
 omit = ["conda_build/skeletons/_example_skeleton.py"]
 
 [tool.ruff]
-line-length = 180
+pycodestyle = {max-line-length = 120}
 # E, W = pycodestyle errors and warnings
 # F = pyflakes
 # I = isort
@@ -104,7 +101,7 @@ select = ["E", "W", "F", "I"]
 # E722 do not use bare 'except'
 # E731 do not assign a lambda expression, use a def
 ignore = ["E402", "E722", "E731"]
-# Use PEP 257-style docstrings.
+target-version = "py38"
 pydocstyle = {convention = "pep257"}
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,8 @@ def testing_homedir() -> Iterator[Path]:
             os.chdir(saved)
     except OSError:
         pytest.xfail(
-            f"failed to create temporary directory () in {'%HOME%' if on_win else '${HOME}'} (tmpfs inappropriate for xattrs)"
+            f"failed to create temporary directory () in {'%HOME%' if on_win else '${HOME}'} "
+            "(tmpfs inappropriate for xattrs)"
         )
 
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -398,9 +398,7 @@ def dummy_executable(folder, exename):
     echo ******* conda that makes it not add the _build/bin directory onto the
     echo ******* PATH before running the source checkout tool
     exit -1
-    """.format(
-                exename
-            )
+    """.format(exename)
         )
     if sys.platform != "win32":
         import stat
@@ -754,57 +752,30 @@ def test_relative_git_url_submodule_clone(testing_workdir, testing_config, monke
         if not os.path.exists(recipe_dir):
             os.makedirs(recipe_dir)
         filename = os.path.join(testing_workdir, "recipe", "meta.yaml")
-        data = OrderedDict(
-            [
-                (
-                    "package",
-                    OrderedDict(
-                        [
-                            ("name", "relative_submodules"),
-                            ("version", "{{ GIT_DESCRIBE_TAG }}"),
-                        ]
-                    ),
-                ),
-                ("source", OrderedDict([("git_url", toplevel), ("git_tag", str(tag))])),
-                requirements,
-                (
-                    "build",
-                    OrderedDict(
-                        [
-                            (
-                                "script",
-                                [
-                                    "git --no-pager submodule --quiet foreach git log -n 1 --pretty=format:%%s > "
-                                    "%PREFIX%\\summaries.txt  # [win]",
-                                    "git --no-pager submodule --quiet foreach git log -n 1 --pretty=format:%s > "
-                                    "$PREFIX/summaries.txt   # [not win]",
-                                ],
-                            )
-                        ]
-                    ),
-                ),
-                (
-                    "test",
-                    OrderedDict(
-                        [
-                            (
-                                "commands",
-                                [
-                                    "echo absolute{}relative{} > %PREFIX%\\expected_summaries.txt       # [win]".format(
-                                        tag, tag
-                                    ),
-                                    "fc.exe /W %PREFIX%\\expected_summaries.txt %PREFIX%\\summaries.txt # [win]",
-                                    "echo absolute{}relative{} > $PREFIX/expected_summaries.txt         # [not win]".format(
-                                        tag, tag
-                                    ),
-                                    "diff -wuN ${PREFIX}/expected_summaries.txt ${PREFIX}/summaries.txt # [not win]",
-                                ],
-                            )
-                        ]
-                    ),
-                ),
-            ]
-        )
+        data = {
+            "package": {
+                "name": "relative_submodules",
+                "version": "{{ GIT_DESCRIBE_TAG }}",
+            },
+            "source": {"git_url": toplevel, "git_tag": str(tag)},
+            **requirements,
+            "build": {
+                "script": [
+                    "git --no-pager submodule --quiet foreach git log -n 1 --pretty=format:%%s > "
+                    "%PREFIX%\\summaries.txt  # [win]",
+                    "git --no-pager submodule --quiet foreach git log -n 1 --pretty=format:%s > "
+                    "$PREFIX/summaries.txt   # [not win]",
+                ],
+            },
+            "test": {
+                "commands": [
+                    f"echo absolute{tag}relative{tag} > %PREFIX%\\expected_summaries.txt # [win]",
+                    "fc.exe /W %PREFIX%\\expected_summaries.txt %PREFIX%\\summaries.txt # [win]",
+                    f"echo absolute{tag}relative{tag} > $PREFIX/expected_summaries.txt # [not win]",
+                    "diff -wuN ${PREFIX}/expected_summaries.txt ${PREFIX}/summaries.txt # [not win]",
+                ],
+            },
+        }
 
         with open(filename, "w") as outfile:
             outfile.write(yaml.dump(data, default_flow_style=False, width=999999999))
@@ -1614,9 +1585,10 @@ def test_copy_test_source_files(testing_config):
                 found = True
                 break
         if found:
-            assert (
-                copy
-            ), "'info/test/test_files_folder/text.txt' found in tar.bz2 but not copying test source files"
+            assert copy, (
+                "'info/test/test_files_folder/text.txt' found in tar.bz2 "
+                "but not copying test source files"
+            )
             if copy:
                 api.test(outputs[0])
             else:
@@ -1624,8 +1596,8 @@ def test_copy_test_source_files(testing_config):
                     api.test(outputs[0])
         else:
             assert not copy, (
-                "'info/test/test_files_folder/text.txt' not found in tar.bz2 but copying test source files. File list: %r"
-                % files
+                "'info/test/test_files_folder/text.txt' not found in tar.bz2 "
+                f"but copying test source files. File list: {files!r}"
             )
 
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -732,21 +732,6 @@ def test_relative_git_url_submodule_clone(testing_workdir, testing_config, monke
         #
         # Also, git is set to False here because it needs to be rebuilt with the longer prefix. As
         # things stand, my _b_env folder for this test contains more than 80 characters.
-        requirements = (
-            "requirements",
-            OrderedDict(
-                [
-                    (
-                        "build",
-                        [
-                            "git            # [False]",
-                            "m2-git         # [win]",
-                            "m2-filesystem  # [win]",
-                        ],
-                    )
-                ]
-            ),
-        )
 
         recipe_dir = os.path.join(testing_workdir, "recipe")
         if not os.path.exists(recipe_dir):
@@ -758,7 +743,13 @@ def test_relative_git_url_submodule_clone(testing_workdir, testing_config, monke
                 "version": "{{ GIT_DESCRIBE_TAG }}",
             },
             "source": {"git_url": toplevel, "git_tag": str(tag)},
-            **requirements,
+            "requirements": {
+                "build": [
+                    "git            # [False]",
+                    "m2-git         # [win]",
+                    "m2-filesystem  # [win]",
+                ],
+            },
             "build": {
                 "script": [
                     "git --no-pager submodule --quiet foreach git log -n 1 --pretty=format:%%s > "

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1398,7 +1398,7 @@ def test_recursion_layers(testing_config):
 @pytest.mark.sanity
 @pytest.mark.skipif(
     sys.platform != "win32",
-    reason=("spaces break openssl prefix " "replacement on *nix"),
+    reason="spaces break openssl prefix replacement on *nix",
 )
 def test_croot_with_spaces(testing_metadata, testing_workdir):
     testing_metadata.config.croot = os.path.join(testing_workdir, "space path")

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -99,8 +99,9 @@ def test_get_output_file_path_jinja2(testing_config):
     assert build_path == os.path.join(
         testing_config.croot,
         testing_config.host_subdir,
-        "conda-build-test-source-git-jinja2-1.20.2-"
-        "py{}{}_0_g262d444.tar.bz2".format(python, _hash),
+        "conda-build-test-source-git-jinja2-1.20.2-py{}{}_0_g262d444.tar.bz2".format(
+            python, _hash
+        ),
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -293,9 +293,7 @@ loggers:
 root:
   level: DEBUG
   handlers: [console]
-""".format(
-                __name__
-            )
+""".format(__name__)
         )
     cc_conda_build = mocker.patch.object(utils, "cc_conda_build")
     cc_conda_build.get.return_value = test_file


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`ruff format` is now a thing (see https://github.com/astral-sh/ruff/releases/tag/v0.1.2 and https://github.com/astral-sh/ruff/releases/tag/v0.1.3).

Removing the need for `black`.

Trimmed line-length down from 180 to 120 (removing this line-length deviation will result in 753 E501 lints, too much to do in one go).

Xref https://github.com/conda/conda/pull/13272

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
