### PR TITLE
CI adjustments for conda-libmamba-solver as default

### DIFF
--- a/news/5059-ci-conda-libmamba-solver
+++ b/news/5059-ci-conda-libmamba-solver
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Mark Unicode tests as incompatible with `libmamba`. (#5059)

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -196,41 +197,40 @@ def test_build_multiple_recipes(testing_metadata, testing_workdir, testing_confi
     main_build.execute(args)
 
 
-def test_build_output_folder(testing_workdir, testing_metadata, capfd):
+def test_build_output_folder(testing_workdir, testing_metadata, tmp_path: Path):
     api.output_yaml(testing_metadata, "meta.yaml")
-    with TemporaryDirectory() as tmp:
-        out = os.path.join(tmp, "out")
-        args = [
-            testing_workdir,
-            "--no-build-id",
-            "--croot",
-            tmp,
-            "--no-activate",
-            "--no-anaconda-upload",
-            "--output-folder",
-            out,
-        ]
-        output = main_build.execute(args)[0]
-        assert os.path.isfile(
-            os.path.join(
-                out, testing_metadata.config.host_subdir, os.path.basename(output)
-            )
-        )
+
+    out = tmp_path / "out"
+    out.mkdir(parents=True)
+
+    args = [
+        testing_workdir,
+        "--no-build-id",
+        "--croot",
+        str(tmp_path),
+        "--no-activate",
+        "--no-anaconda-upload",
+        "--output-folder",
+        str(out),
+    ]
+    output = main_build.execute(args)[0]
+    assert (
+        out / testing_metadata.config.host_subdir / os.path.basename(output)
+    ).is_file()
 
 
-def test_build_source(testing_workdir):
-    with TemporaryDirectory() as tmp:
-        args = [
-            os.path.join(metadata_dir, "_pyyaml_find_header"),
-            "--source",
-            "--no-build-id",
-            "--croot",
-            tmp,
-            "--no-activate",
-            "--no-anaconda-upload",
-        ]
-        main_build.execute(args)
-        assert os.path.isfile(os.path.join(tmp, "work", "setup.py"))
+def test_build_source(testing_workdir, tmp_path: Path):
+    args = [
+        os.path.join(metadata_dir, "_pyyaml_find_header"),
+        "--source",
+        "--no-build-id",
+        "--croot",
+        str(tmp_path),
+        "--no-activate",
+        "--no-anaconda-upload",
+    ]
+    main_build.execute(args)
+    assert (tmp_path / "work" / "setup.py").is_file()
 
 
 @pytest.mark.serial

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -197,17 +197,17 @@ def test_build_multiple_recipes(testing_metadata, testing_workdir, testing_confi
     main_build.execute(args)
 
 
-def test_build_output_folder(testing_workdir, testing_metadata, tmp_path: Path):
+def test_build_output_folder(testing_workdir: str, testing_metadata):
     api.output_yaml(testing_metadata, "meta.yaml")
 
-    out = tmp_path / "out"
+    out = Path(testing_workdir, "out")
     out.mkdir(parents=True)
 
     args = [
         testing_workdir,
         "--no-build-id",
         "--croot",
-        str(tmp_path),
+        testing_workdir,
         "--no-activate",
         "--no-anaconda-upload",
         "--output-folder",
@@ -219,18 +219,18 @@ def test_build_output_folder(testing_workdir, testing_metadata, tmp_path: Path):
     ).is_file()
 
 
-def test_build_source(testing_workdir, tmp_path: Path):
+def test_build_source(testing_workdir: str):
     args = [
         os.path.join(metadata_dir, "_pyyaml_find_header"),
         "--source",
         "--no-build-id",
         "--croot",
-        str(tmp_path),
+        testing_workdir,
         "--no-activate",
         "--no-anaconda-upload",
     ]
     main_build.execute(args)
-    assert (tmp_path / "work" / "setup.py").is_file()
+    assert Path(testing_workdir, "work", "setup.py").is_file()
 
 
 @pytest.mark.serial

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -30,8 +30,8 @@ from conda_build import __version__, api, exceptions
 from conda_build.conda_interface import (
     CondaError,
     LinkError,
-    context,
     cc_conda_build,
+    context,
     reset_context,
     url_path,
 )

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -30,6 +30,7 @@ from conda_build import __version__, api, exceptions
 from conda_build.conda_interface import (
     CondaError,
     LinkError,
+    context,
     cc_conda_build,
     reset_context,
     url_path,
@@ -123,6 +124,9 @@ def test_recipe_builds(
     #   ``source_setup_py_data_subdir`` reproduces the problem.
     if recipe.name == "source_setup_py_data_subdir":
         pytest.xfail("Issue related to #3754 on conda-build.")
+    elif recipe.name == "unicode_all_over" and context.solver == "libmamba":
+        pytest.xfail("Unicode package names not supported in libmamba.")
+
     # These variables are defined solely for testing purposes,
     # so they can be checked within build scripts
     testing_config.activate = True


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

conda 23.10.0 requires conda-libmamba-solver and has `solver=libmamba` as default, so conda-build's CI is going to be using it now.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
