### PR TITLE
[DOC] Clarify `PREFIX` usage in environment variables

### DIFF
--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -196,7 +196,7 @@ defined only on Linux.
    :widths: 20 80
 
    * - LD_RUN_PATH
-     - ``<build prefix>/lib``.
+     - ``$PREFIX/lib``.
 
 
 .. _git-env:

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -92,7 +92,7 @@ inherited from the shell environment in which you invoke
      - Inherited from your shell environment and augmented with
        ``$PREFIX/bin``.
    * - PREFIX
-     - Build prefix to which the build script should install.
+     - Host prefix to which the build script should install.
    * - PKG_BUILDNUM
      - Build number of the package being built.
    * - PKG_NAME
@@ -110,11 +110,11 @@ inherited from the shell environment in which you invoke
        is installed only in the host prefix when it is listed as
        a host requirement.
    * - PY3K
-     - ``1`` when Python 3 is installed in the build prefix,
+     - ``1`` when Python 3 is installed in the host prefix,
        otherwise ``0``.
    * - R
-     - Path to the R executable in the build prefix. R is only
-       installed in the build prefix when it is listed as a build
+     - Path to the R executable in the host prefix. R is only
+       installed in the host prefix when it is listed as a build
        requirement.
    * - RECIPE_DIR
      - Directory of the recipe.
@@ -132,7 +132,7 @@ inherited from the shell environment in which you invoke
 
 Unix-style packages on Windows, which are usually statically
 linked to executables, are built in a special ``Library``
-directory under the build prefix. The environment variables
+directory under the host prefix. The environment variables
 listed in the following table are defined only on Windows.
 
 .. list-table::

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -142,15 +142,15 @@ listed in the following table are defined only on Windows.
      - Same as PREFIX, but as a Unix-style path, such as
        ``/cygdrive/c/path/to/prefix``.
    * - LIBRARY_BIN
-     - ``<build prefix>\Library\bin``.
+     - ``%PREFIX%\Library\bin``.
    * - LIBRARY_INC
-     - ``<build prefix>\Library\include``.
+     - ``%PREFIX%\Library\include``.
    * - LIBRARY_LIB
-     - ``<build prefix>\Library\lib``.
+     - ``%PREFIX%\Library\lib``.
    * - LIBRARY_PREFIX
-     - ``<build prefix>\Library``.
+     - ``%PREFIX%\Library``.
    * - SCRIPTS
-     - ``<build prefix>\Scripts``.
+     - ``%PREFIX%\Scripts``.
    * - VS_MAJOR
      - The major version number of the Visual Studio version
        activated within the build, such as ``9``.

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -53,6 +53,8 @@ inherited from the shell environment in which you invoke
        environment variable and  defaults to the architecture the
        interpreter running conda was
        compiled with.
+   * - BUILD_PREFIX
+     - Build prefix where command line tools are installed.
    * - CMAKE_GENERATOR
      - The CMake generator string for the current build
        environment. On Linux systems, this is always


### PR DESCRIPTION
Saying `<build prefix>` now implies `BUILD_PREFIX`, which isn't the case. AFAIK these have always been constructed based on `PREFIX`, which is the host environment. Guessing this is just leftover verbiage that needs a refresh.

Also make the same change for `LD_RUN_PATH`, which has the same issue.

Plus some other lines describing behavior in the prose.

<hr>

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
