### PR TITLE
Fix conda_index.index verbose DEBUG/INFO logging

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -312,19 +312,21 @@ def _delegated_update_index(
         dir_path = parent_path
         subdirs = [dirname]
 
-    return _update_index(
-        dir_path,
-        check_md5=check_md5,
-        channel_name=channel_name,
-        patch_generator=patch_generator,
-        threads=threads,
-        verbose=verbose,
-        progress=progress,
-        subdirs=subdirs,
-        warn=warn,
-        current_index_versions=current_index_versions,
-        debug=debug,
-    )
+    log_level = logging.DEBUG if debug else logging.INFO if verbose else logging.WARNING
+    with utils.LoggingContext(log_level):
+        return _update_index(
+            dir_path,
+            check_md5=check_md5,
+            channel_name=channel_name,
+            patch_generator=patch_generator,
+            threads=threads,
+            verbose=verbose,
+            progress=progress,
+            subdirs=subdirs,
+            warn=warn,
+            current_index_versions=current_index_versions,
+            debug=debug,
+        )
 
 
 # Everything below is deprecated to maintain API/feature compatibility.

--- a/news/5066-fix-conda_index-log-spam
+++ b/news/5066-fix-conda_index-log-spam
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix conda_index.index verbose DEBUG/INFO message logging. (#5066)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Log messages from `conda_index.index` get put out with high verbosity.
As an example, I built https://github.com/conda-forge/zlib-feedstock/tree/main
which yielded a build log with 936 lines -- 260 of those lines (about 28%) were `INFO`/`DEBUG` messages from `conda_index.index` like these:
<details>

```
DEBUG:conda_index.index:found subdirs {'linux-64', 'noarch'}
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/opt/conda/conda-bld, subdir=linux-64 db_filename=/opt/conda/conda-bld/linux-64/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index.sqlitecache:linux-64 listdir
DEBUG:conda_index.index.sqlitecache:linux-64 save fs state
DEBUG:conda_index.index:linux-64 find packages to extract
DEBUG:conda_index.index:linux-64 extract 1 packages
DEBUG:conda_index.index.sqlitecache:cache linux-64/libzlib-1.2.13-hd590300_5.tar.bz2
DEBUG:conda_index.index.sqlitecache:libzlib-1.2.13-hd590300_5.tar.bz2 early close
INFO:conda_index.index:linux-64 cached 64 KB from 1 packages at 1.0 MB/second
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/opt/conda/conda-bld, subdir=noarch db_filename=/opt/conda/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index.sqlitecache:noarch listdir
DEBUG:conda_index.index.sqlitecache:noarch save fs state
DEBUG:conda_index.index:noarch find packages to extract
DEBUG:conda_index.index:noarch extract 0 packages
INFO:conda_index.index:noarch cached 0 B from 0 packages at 0 B/second
INFO:conda_index.index:Subdir: linux-64 Gathering repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/opt/conda/conda-bld, subdir=linux-64 db_filename=/opt/conda/conda-bld/linux-64/.cache/cache.db cache_is_brand_new=False
INFO:conda_index.index:linux-64 Writing pre-patch repodata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/repodata_from_packages.json to /opt/conda/conda-bld/linux-64/repodata_from_packages.json
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/repodata_from_packages.json.bz2 to /opt/conda/conda-bld/linux-64/repodata_from_packages.json.bz2
DEBUG:conda_index.index:_maybe_remove /opt/conda/conda-bld/linux-64/repodata_from_packages.json.zst from /opt/conda/conda-bld/linux-64/repodata_from_packages.json.zst
INFO:conda_index.index:linux-64 Applying patch instructions
INFO:conda_index.index:linux-64 Writing patched repodata
DEBUG:conda_index.index:linux-64 write patched repodata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/repodata.json to /opt/conda/conda-bld/linux-64/repodata.json
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/repodata.json.bz2 to /opt/conda/conda-bld/linux-64/repodata.json.bz2
DEBUG:conda_index.index:_maybe_remove /opt/conda/conda-bld/linux-64/repodata.json.zst from /opt/conda/conda-bld/linux-64/repodata.json.zst
INFO:conda_index.index:linux-64 Building current_repodata subset
DEBUG:conda_index.index:linux-64 build current_repodata
INFO:conda_index.index:linux-64 Writing current_repodata subset
DEBUG:conda_index.index:linux-64 write current_repodata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/current_repodata.json to /opt/conda/conda-bld/linux-64/current_repodata.json
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/current_repodata.json.bz2 to /opt/conda/conda-bld/linux-64/current_repodata.json.bz2
DEBUG:conda_index.index:_maybe_remove /opt/conda/conda-bld/linux-64/current_repodata.json.zst from /opt/conda/conda-bld/linux-64/current_repodata.json.zst
INFO:conda_index.index:linux-64 Writing index HTML
DEBUG:conda_index.index:linux-64 write index.html
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/linux-64/index.html to /opt/conda/conda-bld/linux-64/index.html
DEBUG:conda_index.index:linux-64 finish
INFO:conda_index.index:Completed linux-64
INFO:conda_index.index:Subdir: noarch Gathering repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/opt/conda/conda-bld, subdir=noarch db_filename=/opt/conda/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
INFO:conda_index.index:noarch Writing pre-patch repodata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/noarch/repodata_from_packages.json to /opt/conda/conda-bld/noarch/repodata_from_packages.json
INFO:conda_index.index:noarch Applying patch instructions
INFO:conda_index.index:noarch Writing patched repodata
DEBUG:conda_index.index:noarch write patched repodata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/noarch/repodata.json to /opt/conda/conda-bld/noarch/repodata.json
INFO:conda_index.index:noarch Building current_repodata subset
DEBUG:conda_index.index:noarch build current_repodata
INFO:conda_index.index:noarch Writing current_repodata subset
DEBUG:conda_index.index:noarch write current_repodata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/noarch/current_repodata.json to /opt/conda/conda-bld/noarch/current_repodata.json
INFO:conda_index.index:noarch Writing index HTML
DEBUG:conda_index.index:noarch write index.html
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/noarch/index.html to /opt/conda/conda-bld/noarch/index.html
DEBUG:conda_index.index:noarch finish
INFO:conda_index.index:Completed noarch
DEBUG:conda_index.index:found subdirs {'linux-64', 'noarch'}
INFO:conda_index.index:Channeldata subdir: linux-64
DEBUG:conda_index.index:linux-64 read repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/opt/conda/conda-bld, subdir=linux-64 db_filename=/opt/conda/conda-bld/linux-64/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index:linux-64 channeldata finished
INFO:conda_index.index:Channeldata subdir: noarch
DEBUG:conda_index.index:noarch read repodata
DEBUG:conda_index.index.sqlitecache:CondaIndexCache channel_root=/opt/conda/conda-bld, subdir=noarch db_filename=/opt/conda/conda-bld/noarch/.cache/cache.db cache_is_brand_new=False
DEBUG:conda_index.index:noarch channeldata finished
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/index.html to /opt/conda/conda-bld/index.html
DEBUG:conda_index.index:write channeldata
DEBUG:conda_index.index:_maybe_write /opt/conda/conda-bld/channeldata.json to /opt/conda/conda-bld/channeldata.json
```
</details>

closes: gh-4939
### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
