### PR TITLE
Fix testing config monkeypatch for concurrent test flakiness

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -15,7 +15,11 @@ from conda.common.io import dashlist
 
 from .. import api, build, source, utils
 from ..conda_interface import add_parser_channels, binstar_upload, cc_conda_build
-from ..config import get_channel_urls, get_or_merge_config, zstd_compression_level_default
+from ..config import (
+    get_channel_urls,
+    get_or_merge_config,
+    zstd_compression_level_default,
+)
 from ..deprecations import deprecated
 from ..utils import LoggingContext
 from .actions import KeyValueAction

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -15,7 +15,7 @@ from conda.common.io import dashlist
 
 from .. import api, build, source, utils
 from ..conda_interface import add_parser_channels, binstar_upload, cc_conda_build
-from ..config import Config, get_channel_urls, zstd_compression_level_default
+from ..config import get_channel_urls, get_or_merge_config, zstd_compression_level_default
 from ..deprecations import deprecated
 from ..utils import LoggingContext
 from .actions import KeyValueAction
@@ -514,7 +514,7 @@ def check_action(recipe, config):
 
 def execute(args):
     _parser, args = parse_args(args)
-    config = Config(**args.__dict__)
+    config = get_or_merge_config(None, **args.__dict__)
     build.check_external()
 
     # change globals in build module, see comment there as well

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -914,6 +914,8 @@ class Config:
 
 
 def _get_or_merge_config(config, variant=None, **kwargs):
+    # This function should only ever be called via get_or_merge_config.
+    # It only exists for us to monkeypatch a default config when running tests.
     if not config:
         config = Config(variant=variant)
     else:

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -913,8 +913,7 @@ class Config:
             self.clean(remove_folders=False)
 
 
-def get_or_merge_config(config, variant=None, **kwargs):
-    """Always returns a new object - never changes the config that might be passed in."""
+def _get_or_merge_config(config, variant=None, **kwargs):
     if not config:
         config = Config(variant=variant)
     else:
@@ -926,6 +925,11 @@ def get_or_merge_config(config, variant=None, **kwargs):
     if variant:
         config.variant.update(variant)
     return config
+
+
+def get_or_merge_config(config, variant=None, **kwargs):
+    """Always returns a new object - never changes the config that might be passed in."""
+    return _get_or_merge_config(config, variant=variant, **kwargs)
 
 
 def get_channel_urls(args):

--- a/tests/cli/test_main_metapackage.py
+++ b/tests/cli/test_main_metapackage.py
@@ -15,8 +15,7 @@ def test_metapackage(testing_config, testing_workdir):
     main_metapackage.execute(args)
     test_path = glob(
         os.path.join(
-            sys.prefix,
-            "conda-bld",
+            testing_config.croot,
             testing_config.host_subdir,
             "metapackage_test-1.0-0.tar.bz2",
         )
@@ -38,8 +37,7 @@ def test_metapackage_build_number(testing_config, testing_workdir):
     main_metapackage.execute(args)
     test_path = glob(
         os.path.join(
-            sys.prefix,
-            "conda-bld",
+            testing_config.croot,
             testing_config.host_subdir,
             "metapackage_test_build_number-1.0-1.tar.bz2",
         )
@@ -61,8 +59,7 @@ def test_metapackage_build_string(testing_config, testing_workdir):
     main_metapackage.execute(args)
     test_path = glob(
         os.path.join(
-            sys.prefix,
-            "conda-bld",
+            testing_config.croot,
             testing_config.host_subdir,
             "metapackage_test_build_string-1.0-frank*.tar.bz2",
         )
@@ -88,8 +85,7 @@ def test_metapackage_metadata(testing_config, testing_workdir):
 
     test_path = glob(
         os.path.join(
-            sys.prefix,
-            "conda-bld",
+            testing_config.croot,
             testing_config.host_subdir,
             "metapackage_testing_metadata-1.0-0.tar.bz2",
         )

--- a/tests/cli/test_main_metapackage.py
+++ b/tests/cli/test_main_metapackage.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 import os
-import sys
 from glob import glob
 
 from conda_build.cli import main_metapackage

--- a/tests/cli/test_main_render.py
+++ b/tests/cli/test_main_render.py
@@ -66,13 +66,12 @@ def test_render_without_channel_fails(tmp_path):
     ), f"Expected to get only base package name because it should not be found, but got :{required_package_string}"
 
 
-def test_render_output_build_path(testing_workdir, testing_metadata, capfd, caplog):
+def test_render_output_build_path(testing_workdir, testing_config, testing_metadata, capfd, caplog):
     api.output_yaml(testing_metadata, "meta.yaml")
     args = ["--output", testing_workdir]
     main_render.execute(args)
     test_path = os.path.join(
-        sys.prefix,
-        "conda-bld",
+        testing_config.croot,
         testing_metadata.config.host_subdir,
         "test_render_output_build_path-1.0-1.tar.bz2",
     )
@@ -82,15 +81,14 @@ def test_render_output_build_path(testing_workdir, testing_metadata, capfd, capl
 
 
 def test_render_output_build_path_and_file(
-    testing_workdir, testing_metadata, capfd, caplog
+    testing_workdir, testing_config, testing_metadata, capfd, caplog
 ):
     api.output_yaml(testing_metadata, "meta.yaml")
     rendered_filename = "out.yaml"
     args = ["--output", "--file", rendered_filename, testing_workdir]
     main_render.execute(args)
     test_path = os.path.join(
-        sys.prefix,
-        "conda-bld",
+        testing_config.croot,
         testing_metadata.config.host_subdir,
         "test_render_output_build_path_and_file-1.0-1.tar.bz2",
     )

--- a/tests/cli/test_main_render.py
+++ b/tests/cli/test_main_render.py
@@ -66,7 +66,9 @@ def test_render_without_channel_fails(tmp_path):
     ), f"Expected to get only base package name because it should not be found, but got :{required_package_string}"
 
 
-def test_render_output_build_path(testing_workdir, testing_config, testing_metadata, capfd, caplog):
+def test_render_output_build_path(
+    testing_workdir, testing_config, testing_metadata, capfd, caplog
+):
     api.output_yaml(testing_metadata, "meta.yaml")
     args = ["--output", testing_workdir]
     main_render.execute(args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from conda.common.compat import on_mac, on_win
 import conda_build.config
 from conda_build.config import (
     Config,
+    _get_or_merge_config,
     _src_cache_root_default,
     conda_pkg_format_default,
     enable_static_default,
@@ -21,7 +22,6 @@ from conda_build.config import (
     error_overlinking_default,
     exit_on_verify_error_default,
     filename_hashing_default,
-    get_or_merge_config,
     ignore_verify_codes_default,
     no_rewrite_stdout_env_default,
     noarch_python_build_age_default,
@@ -121,11 +121,11 @@ def default_testing_config(testing_config, monkeypatch, request):
         return
 
     def get_or_merge_testing_config(config, variant=None, **kwargs):
-        return get_or_merge_config(config or testing_config, variant, **kwargs)
+        return _get_or_merge_config(config or testing_config, variant, **kwargs)
 
     monkeypatch.setattr(
         conda_build.config,
-        "get_or_merge_config",
+        "_get_or_merge_config",
         get_or_merge_testing_config,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def testing_config(testing_workdir):
     def boolify(v):
         return v == "true"
 
-    result = Config(
+    testing_config_kwargs = dict(
         croot=testing_workdir,
         anaconda_upload=False,
         verbose=True,
@@ -102,6 +102,8 @@ def testing_config(testing_workdir):
         exit_on_verify_error=exit_on_verify_error_default,
         conda_pkg_format=conda_pkg_format_default,
     )
+    result = Config(**testing_config_kwargs)
+    result._testing_config_kwargs = testing_config_kwargs
     assert result.no_rewrite_stdout_env is False
     assert result._src_cache_root is None
     assert result.src_cache_root == testing_workdir
@@ -121,7 +123,11 @@ def default_testing_config(testing_config, monkeypatch, request):
         return
 
     def get_or_merge_testing_config(config, variant=None, **kwargs):
-        return _get_or_merge_config(config or testing_config, variant, **kwargs)
+        merged_kwargs = {}
+        if not config:
+            merged_kwargs.update(testing_config._testing_config_kwargs)
+        merged_kwargs.update(kwargs)
+        return _get_or_merge_config(config, variant, **merged_kwargs)
 
     monkeypatch.setattr(
         conda_build.config,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,6 @@ def testing_config(testing_workdir):
         verbose=True,
         activate=False,
         debug=False,
-        variant=None,
         test_run_post=False,
         # These bits ensure that default values are used instead of any
         # present in ~/.condarc
@@ -102,7 +101,7 @@ def testing_config(testing_workdir):
         exit_on_verify_error=exit_on_verify_error_default,
         conda_pkg_format=conda_pkg_format_default,
     )
-    result = Config(**testing_config_kwargs)
+    result = Config(variant=None, **testing_config_kwargs)
     result._testing_config_kwargs = testing_config_kwargs
     assert result.no_rewrite_stdout_env is False
     assert result._src_cache_root is None


### PR DESCRIPTION
The default_testing_config monkeypatching fixture was added in gh-4653 but did not consider "from .config import get_or_merge_config" cases in which get_or_merge_config is already bound and thus not patched.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->
I noticed flaky tests again in gh-5066.
This is essentially a follow-up to gh-4653 (... about a year later....).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
