### PR TITLE
flatten requirements lists

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -525,6 +525,16 @@ def _target(language, config, permit_undefined_jinja=False, component="compiler"
     if version:
         package = f"{package} {version}"
         package = ensure_valid_spec(package, warn=False)
+
+    stdlib_key = f"{language}_stdlib"
+    if config.variant and config.variant.get(stdlib_key):
+        stdlib_package_prefix = config.variant.get(stdlib_key)
+        stdlib_version = config.variant.get(stdlib_key + "_version")
+        stdlib = f"{stdlib_package_prefix}_{target_platform}"
+        if stdlib_version:
+            stdlib = f"{stdlib} {stdlib_version}"
+        return f"[{package}, {stdlib}]"
+
     return package
 
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -233,7 +233,7 @@ def ns_cfg(config: Config) -> dict[str, bool]:
 #                 NON-bracket chars, and capture the contents"
 # - (?(2)[^\(\)]*)$ means "allow trailing characters iff group 2 (#.*) was found."
 #                 Skip markdown link syntax.
-sel_pat = re.compile(r"(.+?)\s*(#.*)?\[([^\[\]]+)\](?(2)[^\(\)]*)$")
+sel_pat = re.compile(r"(.+?)\s*(#.*)\[([^\[\]]+)\](?(2)[^\(\)]*)$")
 
 
 # this function extracts the variable name from a NameError exception, it has the form of:
@@ -1056,8 +1056,8 @@ def trim_build_only_deps(metadata, requirements_used):
     # filter out things that occur only in run requirements.  These don't actually affect the
     #     outcome of the package.
     output_reqs = utils.expand_reqs(metadata.meta.get("requirements", {}))
-    build_reqs = utils.ensure_list(output_reqs.get("build", []))
-    host_reqs = utils.ensure_list(output_reqs.get("host", []))
+    build_reqs = utils.ensure_list(output_reqs.get("build", []), flatten=True)
+    host_reqs = utils.ensure_list(output_reqs.get("host", []), flatten=True)
     run_reqs = output_reqs.get("run", [])
     build_reqs = {req.split()[0].replace("-", "_") for req in build_reqs if req}
     host_reqs = {req.split()[0].replace("-", "_") for req in host_reqs if req}
@@ -1467,7 +1467,7 @@ class MetaData:
             )
 
     def get_depends_top_and_out(self, typ):
-        meta_requirements = ensure_list(self.get_value("requirements/" + typ, []))[:]
+        meta_requirements = ensure_list(self.get_value("requirements/" + typ, []), flatten=True)[:]
         req_names = {req.split()[0] for req in meta_requirements if req}
         extra_reqs = []
         # this is for the edge case of requirements for top-level being also partially defined in a similarly named output

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -471,7 +471,7 @@ def add_upstream_pins(m: MetaData, permit_unsatisfiable_variants, exclude_patter
     if m.is_cross:
         # this must come before we read upstream pins, because it will enforce things
         #      like vc version from the compiler.
-        host_reqs = utils.ensure_list(m.get_value("requirements/host"))
+        host_reqs = utils.ensure_list(m.get_value("requirements/host"), flatten=True)
         # ensure host_reqs is present, so in-place modification below is actually in-place
         requirements = m.meta.setdefault("requirements", {})
         requirements["host"] = host_reqs


### PR DESCRIPTION
This is a precursor to flatten requirement lists to be able to implement a Jinja function that returns multiple packages.

The idea is that we could use `{{ compiler('c') }}` to return a compiler & stdlib combination as two packages.

