### PR TITLE
Tests: Fix get_or_merge_testing_config for cli tests

### DIFF
--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import re
-import sys
 from pathlib import Path
 
 import pytest
@@ -104,8 +103,7 @@ def test_build_output_build_path(
     args = ["--output", testing_workdir]
     main_build.execute(args)
     test_path = os.path.join(
-        sys.prefix,
-        "conda-bld",
+        testing_config.croot,
         testing_config.host_subdir,
         "test_build_output_build_path-1.0-1.tar.bz2",
     )
@@ -125,7 +123,7 @@ def test_build_output_build_path_multiple_recipes(
     main_build.execute(args)
 
     test_path = lambda pkg: os.path.join(
-        sys.prefix, "conda-bld", testing_config.host_subdir, pkg
+        testing_config.croot, testing_config.host_subdir, pkg
     )
     test_paths = [
         test_path("test_build_output_build_path_multiple_recipes-1.0-1.tar.bz2"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,11 +118,17 @@ def default_testing_config(testing_config, monkeypatch, request):
         return
 
     def get_or_merge_testing_config(config, variant=None, **kwargs):
-        merged_kwargs = {}
         if not config:
-            merged_kwargs.update(testing_config._testing_config_kwargs)
-        merged_kwargs.update(kwargs)
-        return _get_or_merge_config(config, variant, **merged_kwargs)
+            # If no existing config, override kwargs that are None with testing config defaults.
+            # (E.g., "croot" is None if called via "(..., *args.__dict__)" in cli.main_build.)
+            kwargs.update(
+                {
+                    key: value
+                    for key, value in testing_config._testing_config_kwargs.items()
+                    if kwargs.get(key) is None
+                }
+            )
+        return _get_or_merge_config(config, variant, **kwargs)
 
     monkeypatch.setattr(
         conda_build.config,

--- a/tests/test-recipes/metadata/entry_points/meta.yaml
+++ b/tests/test-recipes/metadata/entry_points/meta.yaml
@@ -20,3 +20,7 @@ requirements:
     - setuptools
   run:
     - python
+
+# Ensure we get different build strings for concurrently tested packages.
+extra:
+  dummy: '{{ pytest_name is defined }}'

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1655,7 +1655,9 @@ def test_provides_features_metadata(testing_config):
     assert index["provides_features"] == {"test2": "also_ok"}
 
 
-def test_overlinking_detection(testing_config, testing_workdir, variants_conda_build_sysroot):
+def test_overlinking_detection(
+    testing_config, testing_workdir, variants_conda_build_sysroot
+):
     testing_config.activate = True
     testing_config.error_overlinking = True
     testing_config.verify = False

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1655,14 +1655,15 @@ def test_provides_features_metadata(testing_config):
     assert index["provides_features"] == {"test2": "also_ok"}
 
 
-# using different MACOSX_DEPLOYMENT_TARGET in parallel causes some SDK race condition
-# https://github.com/conda/conda-build/issues/4708
-@pytest.mark.serial
-def test_overlinking_detection(testing_config, variants_conda_build_sysroot):
+def test_overlinking_detection(testing_config, testing_workdir, variants_conda_build_sysroot):
     testing_config.activate = True
     testing_config.error_overlinking = True
     testing_config.verify = False
-    recipe = os.path.join(metadata_dir, "_overlinking_detection")
+    recipe = os.path.join(testing_workdir, "recipe")
+    copy_into(
+        os.path.join(metadata_dir, "_overlinking_detection"),
+        recipe,
+    )
     dest_sh = os.path.join(recipe, "build.sh")
     dest_bat = os.path.join(recipe, "bld.bat")
     copy_into(
@@ -1684,17 +1685,17 @@ def test_overlinking_detection(testing_config, variants_conda_build_sysroot):
     rm_rf(dest_bat)
 
 
-# using different MACOSX_DEPLOYMENT_TARGET in parallel causes some SDK race condition
-# https://github.com/conda/conda-build/issues/4708
-@pytest.mark.serial
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_overlinking_detection_ignore_patterns(
-    testing_config, variants_conda_build_sysroot
+    testing_config, testing_workdir, variants_conda_build_sysroot
 ):
     testing_config.activate = True
     testing_config.error_overlinking = True
     testing_config.verify = False
-    recipe = os.path.join(metadata_dir, "_overlinking_detection_ignore_patterns")
+    recipe = os.path.join(testing_workdir, "recipe")
+    copy_into(
+        os.path.join(metadata_dir, "_overlinking_detection_ignore_patterns"),
+        recipe,
+    )
     dest_sh = os.path.join(recipe, "build.sh")
     dest_bat = os.path.join(recipe, "bld.bat")
     copy_into(

--- a/tests/test_api_build_conda_v2.py
+++ b/tests/test_api_build_conda_v2.py
@@ -10,7 +10,9 @@ from .utils import metadata_dir
 
 
 @pytest.mark.parametrize("pkg_format,pkg_ext", [(None, ".tar.bz2"), ("2", ".conda")])
-def test_conda_pkg_format(pkg_format, pkg_ext, testing_config, monkeypatch, capfd, request):
+def test_conda_pkg_format(
+    pkg_format, pkg_ext, testing_config, monkeypatch, capfd, request
+):
     """Conda package format "2" builds .conda packages."""
 
     # Build the "entry_points" recipe, which contains a test pass for package.
@@ -24,7 +26,9 @@ def test_conda_pkg_format(pkg_format, pkg_ext, testing_config, monkeypatch, capf
     monkeypatch.setenv("CONDA_TEST_VAR_2", "conda_test_2")
 
     variants = {"pytest_name": [request.node.name]}
-    (output_file,) = api.get_output_file_paths(recipe, config=testing_config, variants=variants)
+    (output_file,) = api.get_output_file_paths(
+        recipe, config=testing_config, variants=variants
+    )
     assert output_file.endswith(pkg_ext)
 
     api.build(recipe, config=testing_config, variants=variants)

--- a/tests/test_api_build_conda_v2.py
+++ b/tests/test_api_build_conda_v2.py
@@ -10,7 +10,7 @@ from .utils import metadata_dir
 
 
 @pytest.mark.parametrize("pkg_format,pkg_ext", [(None, ".tar.bz2"), ("2", ".conda")])
-def test_conda_pkg_format(pkg_format, pkg_ext, testing_config, monkeypatch, capfd):
+def test_conda_pkg_format(pkg_format, pkg_ext, testing_config, monkeypatch, capfd, request):
     """Conda package format "2" builds .conda packages."""
 
     # Build the "entry_points" recipe, which contains a test pass for package.
@@ -23,10 +23,11 @@ def test_conda_pkg_format(pkg_format, pkg_ext, testing_config, monkeypatch, capf
     monkeypatch.setenv("CONDA_TEST_VAR", "conda_test")
     monkeypatch.setenv("CONDA_TEST_VAR_2", "conda_test_2")
 
-    (output_file,) = api.get_output_file_paths(recipe, config=testing_config)
+    variants = {"pytest_name": [request.node.name]}
+    (output_file,) = api.get_output_file_paths(recipe, config=testing_config, variants=variants)
     assert output_file.endswith(pkg_ext)
 
-    api.build(recipe, config=testing_config)
+    api.build(recipe, config=testing_config, variants=variants)
     assert os.path.exists(output_file)
 
     out, err = capfd.readouterr()

--- a/tests/test_api_build_conda_v2.py
+++ b/tests/test_api_build_conda_v2.py
@@ -25,6 +25,8 @@ def test_conda_pkg_format(
     monkeypatch.setenv("CONDA_TEST_VAR", "conda_test")
     monkeypatch.setenv("CONDA_TEST_VAR_2", "conda_test_2")
 
+    # Recipe "entry_points" is used in other test -> add test-specific variant
+    # (change build hash) to avoid clashes in package cache from other tests.
     variants = {"pytest_name": [request.node.name]}
     (output_file,) = api.get_output_file_paths(
         recipe, config=testing_config, variants=variants

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -196,6 +196,8 @@ def test_convert_platform_to_others(base_platform, package):
 )
 def test_convert_from_unix_to_win_creates_entry_points(testing_config, request):
     recipe_dir = os.path.join(metadata_dir, "entry_points")
+    # Recipe "entry_points" is used in other test -> add test-specific variant
+    # (change build hash) to avoid clashes in package cache from other tests.
     variants = {"pytest_name": [request.node.name]}
     fn = api.build(recipe_dir, config=testing_config, variants=variants)[0]
     for platform in ["win-64", "win-32"]:

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -194,9 +194,10 @@ def test_convert_platform_to_others(base_platform, package):
 @pytest.mark.skipif(
     on_win, reason="we create the pkg to be converted in *nix; don't run on win."
 )
-def test_convert_from_unix_to_win_creates_entry_points(testing_config):
+def test_convert_from_unix_to_win_creates_entry_points(testing_config, request):
     recipe_dir = os.path.join(metadata_dir, "entry_points")
-    fn = api.build(recipe_dir, config=testing_config)[0]
+    variants = {"pytest_name": [request.node.name]}
+    fn = api.build(recipe_dir, config=testing_config, variants=variants)[0]
     for platform in ["win-64", "win-32"]:
         api.convert(fn, platforms=[platform], force=True)
         converted_fn = os.path.join(platform, os.path.basename(fn))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

`cli.main_build.execute` (et al.) call the function with `**args.__dict__` with args having default values (e.g., `croot=None`) via `parse_args`.

Follow-up to gh-5068.
See https://github.com/conda/conda-build/pull/5066#issuecomment-1817033741

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
