### PR TITLE
Disable pkgs cache on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,6 +212,9 @@ jobs:
 
       - name: Cache conda
         uses: actions/cache@v3
+        # TODO: Extraction is incredibly slow on Windows. 
+        # Reenable once fixed. See https://github.com/actions/cache/issues/752
+        if: false
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.TIMESTAMP }}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

conda-build's CI uses `actions/cache` to restore the pkgs cache conda uses to provision the environments. On Unix this takes a few seconds, but on Windows this goes all they way to 6-10mins! Apparently it's caused by tar's slowness (see https://github.com/actions/cache/issues/752).

If this is to save time, I'd say it's not fitting that purpose. If it's to save Anaconda some traffic, then feel free to close.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
