### PR TITLE
Relax `package/version` check for multi `outputs`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1442,7 +1442,7 @@ class MetaData:
 
     def version(self) -> str:
         version = self.get_value("package/version", "")
-        if not version and self.final:
+        if not version and not self.get_section("outputs") and self.final:
             sys.exit("Error: package/version missing in: %r" % self.meta_path)
         version = str(version)
         check_bad_chrs(version, "package/version")

--- a/news/5096-relax-metadata-version-checks
+++ b/news/5096-relax-metadata-version-checks
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Relax `conda_build.metadata.MetaData.version` checks when `outputs` have been defined. (#5096)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/split-packages/_empty_outputs_requires_package_version/meta.yaml
+++ b/tests/test-recipes/split-packages/_empty_outputs_requires_package_version/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: _empty_outputs_requires_package_version
+  # when there are not outputs, package/version is required
+  # version: 0
+
+outputs:

--- a/tests/test-recipes/split-packages/_multi_outputs_without_package_version/meta.yaml
+++ b/tests/test-recipes/split-packages/_multi_outputs_without_package_version/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: _multi_outputs_without_package_version
+  # when there are outputs, package/version is not required
+  # version: 0
+
+outputs:
+  - name: a
+    version: 1
+  - name: b
+    version: 2
+  - name: c
+    version: 3

--- a/tests/test-recipes/split-packages/_order/meta.yaml
+++ b/tests/test-recipes/split-packages/_order/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: toplevel-ab
-  version: 0.0.1
+  version: 1
 
 outputs:
   - name: a

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -412,6 +412,9 @@ def dummy_executable(folder, exename):
     return exename
 
 
+@pytest.mark.skip(
+    reason="GitHub discontinued SVN, see https://github.com/conda/conda-build/issues/5098"
+)
 def test_checkout_tool_as_dependency(testing_workdir, testing_config, monkeypatch):
     # "hide" svn by putting a known bad one on PATH
     exename = dummy_executable(testing_workdir, "svn")

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -442,3 +442,20 @@ def test_build_string_does_not_incorrectly_add_hash(testing_config):
     assert len(output_files) == 4
     assert any("clang_variant-1.0-cling.tar.bz2" in f for f in output_files)
     assert any("clang_variant-1.0-default.tar.bz2" in f for f in output_files)
+
+
+def test_multi_outputs_without_package_version(testing_config):
+    # outputs without package/version is allowed
+    recipe = os.path.join(subpackage_dir, "_multi_outputs_without_package_version")
+    outputs = api.build(recipe, config=testing_config)
+    assert len(outputs) == 3
+    assert outputs[0].endswith("a-1-0.tar.bz2")
+    assert outputs[1].endswith("b-2-0.tar.bz2")
+    assert outputs[2].endswith("c-3-0.tar.bz2")
+
+
+def test_empty_outputs_requires_package_version(testing_config):
+    # no outputs means package/version is required
+    recipe = os.path.join(subpackage_dir, "_empty_outputs_requires_package_version")
+    with pytest.raises(SystemExit, match="package/version missing"):
+        api.build(recipe, config=testing_config)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Correcting conda-build issues identified for multi-outputs where the version is undefined (https://github.com/conda-forge/admin-requests/pull/890).

Leaving in the version checks in simple recipes but relaxes the requirements for recipes with multi-outputs.

Xref https://github.com/conda/conda-build/pull/5055
Resolves #5097 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
