### PR TITLE
reduce unset script_env variable to warning

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1923,9 +1923,12 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
                 val = var.split("=", 1)[1]
                 var = var.split("=", 1)[0]
             elif var not in os.environ:
-                raise ValueError(
-                    f"env var '{var}' specified in script_env, but is not set."
+                warnings.warn(
+                    "The environment variable '%s' specified in script_env is undefined."
+                    % var,
+                    UserWarning,
                 )
+                val = ""
             else:
                 val = os.environ[var]
             env_output[var] = val

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -491,7 +491,9 @@ def meta_vars(meta: MetaData, skip_build_id=False):
             value = os.getenv(var_name)
         if value is None:
             warnings.warn(
-                "The environment variable '%s' is undefined." % var_name, UserWarning
+                "The environment variable '%s' specified in script_env is undefined."
+                % var_name,
+                UserWarning,
             )
         else:
             d[var_name] = value

--- a/news/5105-script-env-warn
+++ b/news/5105-script-env-warn
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Relax script_env error in outputs when variable referenced in script_env is not defined.
+  This unifies current behavior with the top-level build. (#5105)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/split-packages/_build_script_missing_var/meta.yaml
+++ b/tests/test-recipes/split-packages/_build_script_missing_var/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: test_build_script_in_output
+  version: 1.0
+
+outputs:
+  - name: test_1
+    build:
+      script_env:
+        - TEST_FN_DOESNT_EXIST

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -336,6 +336,16 @@ def test_build_script_and_script_env(testing_config):
 
 
 @pytest.mark.sanity
+def test_build_script_and_script_env_warn_empty_script_env(testing_config):
+    recipe = os.path.join(subpackage_dir, "_build_script_missing_var")
+    with pytest.warns(
+        UserWarning,
+        match="The environment variable 'TEST_FN_DOESNT_EXIST' specified in script_env is undefined",
+    ):
+        api.build(recipe, config=testing_config)
+
+
+@pytest.mark.sanity
 @pytest.mark.skipif(sys.platform != "darwin", reason="only implemented for mac")
 def test_strong_run_exports_from_build_applies_to_host(testing_config):
     recipe = os.path.join(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The behavior of `script_env` was inconsistent between top-level and outputs. This PR makes outputs be less strict (warning, not failing) if a referenced variable is not set.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
