### PR TITLE
`which_package` to yield unique collection of package records

### DIFF
--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -73,9 +73,8 @@ def which_package(
     path = prefix / path
 
     for prec in PrefixData(str(prefix)).iter_records():
-        for file in prec["files"]:
-            if samefile(prefix / file, path):
-                yield prec
+        if any(samefile(prefix / file, path) for file in prec["files"]):
+            yield prec
 
 
 def print_object_info(info, key):

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -1187,9 +1187,7 @@ def _lookup_in_prefix_packages(
     if len(precs_in_reqs) == 1:
         _print_msg(
             errors,
-            "{}: {} found in {}{}".format(
-                info_prelude, n_dso_p, precs_in_reqs[0], and_also
-            ),
+            f"{info_prelude}: {n_dso_p} found in {precs_in_reqs[0]}{and_also}",
             verbose=verbose,
         )
     elif in_whitelist:
@@ -1201,25 +1199,20 @@ def _lookup_in_prefix_packages(
     elif len(precs_in_reqs) == 0 and len(precs) > 0:
         _print_msg(
             errors,
-            "{}: {} found in {}{}".format(
-                msg_prelude, n_dso_p, [prec.name for prec in precs], and_also
-            ),
+            f"{msg_prelude}: {n_dso_p} found in {[str(prec) for prec in precs]}{and_also}",
             verbose=verbose,
         )
         _print_msg(
             errors,
-            "{}: .. but {} not in reqs/run, (i.e. it is overlinking)"
-            " (likely) or a missing dependency (less likely)".format(
-                msg_prelude, [prec.name for prec in precs]
-            ),
+            f"{msg_prelude}: .. but {[str(prec) for prec in precs]} not in reqs/run, "
+            "(i.e. it is overlinking) (likely) or a missing dependency (less likely)",
             verbose=verbose,
         )
     elif len(precs_in_reqs) > 1:
         _print_msg(
             errors,
-            "{}: {} found in multiple packages in run/reqs: {}{}".format(
-                warn_prelude, in_prefix_dso, precs_in_reqs, and_also
-            ),
+            f"{warn_prelude}: {in_prefix_dso} found in multiple packages in run/reqs: "
+            f"{[str(prec) for prec in precs_in_reqs]}{and_also}",
             verbose=verbose,
         )
     else:

--- a/news/5108-fix-which_package
+++ b/news/5108-fix-which_package
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `conda_build.inspect_pkg.which_package` so it does not return duplicate package records. (#5108)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/5108-fix-which_package
+++ b/news/5108-fix-which_package
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * Fix `conda_build.inspect_pkg.which_package` so it does not return duplicate package records. (#5108)
+* Fix `conda_build.post._lookup_in_prefix_packages` to display `str(PackageRecord)` instead of `repr(PackageRecord)`. (#5108)
 
 ### Deprecations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,6 @@ from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, copy_into, prepend_bin_path
 from conda_build.variants import get_default_variant
 
-pytest_plugins = ["conda.testing"]
-
 
 @pytest.fixture(scope="function")
 def testing_workdir(monkeypatch: MonkeyPatch, tmp_path: Path) -> Iterator[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, copy_into, prepend_bin_path
 from conda_build.variants import get_default_variant
 
+pytest_plugins = ["conda.testing"]
+
 
 @pytest.fixture(scope="function")
 def testing_workdir(monkeypatch: MonkeyPatch, tmp_path: Path) -> Iterator[str]:

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 from conda import __version__ as conda_version
 from conda.core.prefix_data import PrefixData
@@ -9,18 +12,89 @@ from packaging.version import Version, parse
 
 from conda_build.inspect_pkg import which_package
 
-if TYPE_CHECKING := False:
-    from conda.testing import TmpEnvFixture
-
 
 @pytest.mark.skipif(
     parse(conda_version) < Version("23.5.0"),
     reason="tmp_env fixture first available in conda 23.5.0",
 )
-def test_which_package(tmp_env: TmpEnvFixture):
-    with tmp_env("ca-certificates") as prefix:
-        pd = PrefixData(prefix)
-        prec = pd.get("ca-certificates")
-        precs = list(which_package(prefix / prec.files[0], prefix))
-        assert len(precs) == 1
-        assert precs[0] == prec
+def test_which_package(tmp_path: Path):
+    # create a dummy environment
+    (tmp_path / "conda-meta").mkdir()
+    (tmp_path / "conda-meta" / "history").touch()
+    # a dummy package with a unique file (softlink) and a shared file (shared)
+    (tmp_path / "conda-meta" / "packageA-1-0.json").write_text(
+        json.dumps(
+            {
+                "build": "0",
+                "build_number": 0,
+                "channel": "packageA-channel",
+                "files": ["softlink", "shared"],
+                "name": "packageA",
+                "paths_data": {
+                    "paths": [
+                        {
+                            "_path": "softlink",
+                            "path_type": "softlink",
+                            "size_in_bytes": 0,
+                        },
+                        {
+                            "_path": "shared",
+                            "path_type": "hardlink",
+                            "size_in_bytes": 0,
+                        },
+                    ],
+                    "paths_version": 1,
+                },
+                "version": "1",
+            }
+        )
+    )
+    # a dummy package with a unique file (hardlink) and a shared file (shared)
+    (tmp_path / "conda-meta" / "packageB-1-0.json").write_text(
+        json.dumps(
+            {
+                "build": "0",
+                "build_number": 0,
+                "channel": "packageB-channel",
+                "files": ["hardlink", "shared"],
+                "name": "packageB",
+                "paths_data": {
+                    "paths": [
+                        {
+                            "_path": "hardlink",
+                            "path_type": "hardlink",
+                            "size_in_bytes": 0,
+                        },
+                        {
+                            "_path": "shared",
+                            "path_type": "hardlink",
+                            "size_in_bytes": 0,
+                        },
+                    ],
+                    "paths_version": 1,
+                },
+                "version": "1",
+            }
+        )
+    )
+
+    # fetch package records
+    pd = PrefixData(tmp_path)
+    precA = pd.get("packageA")
+    precB = pd.get("packageB")
+
+    # test returned package records given a path
+    precs_missing = list(which_package(tmp_path / "missing", tmp_path))
+    assert not precs_missing
+
+    precs_softlink = list(which_package(tmp_path / "softlink", tmp_path))
+    assert len(precs_softlink) == 1
+    assert precs_softlink[0] == precA
+
+    precs_hardlink = list(which_package(tmp_path / "hardlink", tmp_path))
+    assert len(precs_hardlink) == 1
+    assert precs_hardlink[0] == precB
+
+    precs_shared = list(which_package(tmp_path / "shared", tmp_path))
+    assert len(precs_shared) == 2
+    assert precs_shared == [precB, precA]

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -97,4 +97,4 @@ def test_which_package(tmp_path: Path):
 
     precs_shared = list(which_package(tmp_path / "shared", tmp_path))
     assert len(precs_shared) == 2
-    assert precs_shared == [precB, precA]
+    assert set(precs_shared) == {precA, precB}

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from conda.core.prefix_data import PrefixData
+from conda.testing import TmpEnvFixture
+
+from conda_build.inspect_pkg import which_package
+
+
+def test_which_package(tmp_env: TmpEnvFixture):
+    with tmp_env("ca-certificates") as prefix:
+        pd = PrefixData(prefix)
+        prec = pd.get("ca-certificates")
+        precs = list(which_package(prefix / prec.files[0], prefix))
+        assert len(precs) == 1
+        assert precs[0] == prec

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -1,11 +1,22 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import pytest
+from conda import __version__ as conda_version
 from conda.core.prefix_data import PrefixData
-from conda.testing import TmpEnvFixture
+from packaging.version import Version, parse
 
 from conda_build.inspect_pkg import which_package
 
+if TYPE_CHECKING := False:
+    from conda.testing import TmpEnvFixture
 
+
+@pytest.mark.skipif(
+    parse(conda_version) < Version("23.5.0"),
+    reason="tmp_env fixture first available in conda 23.5.0",
+)
 def test_which_package(tmp_env: TmpEnvFixture):
     with tmp_env("ca-certificates") as prefix:
         pd = PrefixData(prefix)

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -5,18 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-from conda import __version__ as conda_version
 from conda.core.prefix_data import PrefixData
-from packaging.version import Version, parse
 
 from conda_build.inspect_pkg import which_package
 
 
-@pytest.mark.skipif(
-    parse(conda_version) < Version("23.5.0"),
-    reason="tmp_env fixture first available in conda 23.5.0",
-)
 def test_which_package(tmp_path: Path):
     # create a dummy environment
     (tmp_path / "conda-meta").mkdir()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The refactor of `which_package` accidentally resulted in the same package record being returned multiple times (once for each _file_ collision). This results in misleading build warnings.

Instead we only want to return a unique set of package records.

Resolves https://github.com/conda/conda-build/issues/5106

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
