### PR TITLE
Fix `MetaData.get_section` handling for "source" & "outputs"

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1565,8 +1565,6 @@ def create_info_files(m, replacements, files, prefix):
     write_no_link(m, files)
 
     sources = m.get_section("source")
-    if hasattr(sources, "keys"):
-        sources = [sources]
 
     with open(join(m.config.info_dir, "git"), "w", encoding="utf-8") as fo:
         for src in sources:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1564,13 +1564,11 @@ def create_info_files(m, replacements, files, prefix):
 
     write_no_link(m, files)
 
-    sources = m.get_section("source")
-
     with open(join(m.config.info_dir, "git"), "w", encoding="utf-8") as fo:
-        for src in sources:
-            if src.get("git_url"):
+        for source_dict in m.get_section("source"):
+            if source_dict.get("git_url"):
                 source.git_info(
-                    os.path.join(m.config.work_dir, src.get("folder", "")),
+                    os.path.join(m.config.work_dir, source_dict.get("folder", "")),
                     m.config.build_prefix,
                     git=None,
                     verbose=m.config.verbose,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1388,26 +1388,26 @@ class MetaData:
         :return: The named value from meta.yaml
         """
         names = name.split("/")
+        assert len(names) in (2, 3), "Bad field name: " + name
         if len(names) == 2:
             section, key = names
             index = None
         elif len(names) == 3:
             section, index, key = names
-            if section not in OPTIONALLY_ITERABLE_FIELDS:
-                raise ValueError(f"Section is not indexable: {section}")
+            assert section in OPTIONALLY_ITERABLE_FIELDS, (
+                "Section is not a list: " + section
+            )
             index = int(index)
-        else:
-            raise ValueError(f"Bad field name: {name}")
 
         # get correct default
         if autotype and default is None and FIELDS.get(section, {}).get(key):
             default = FIELDS[section][key]()
 
         section_data = self.get_section(section)
-        if isinstance(section_data, dict) and index:
-            raise ValueError(
-                f"Got non-zero index ({index}), but section {section} is not a list."
-            )
+        if isinstance(section_data, dict):
+            assert (
+                not index
+            ), f"Got non-zero index ({index}), but section {section} is not a list."
         elif isinstance(section_data, list):
             # The 'source' section can be written a list, in which case the name
             # is passed in with an index, e.g. get_value('source/0/git_url')
@@ -1422,8 +1422,9 @@ class MetaData:
                 section_data = {}
             else:
                 section_data = section_data[index]
-                if not isinstance(section_data, dict):
-                    raise ValueError(f"Expected {name} to be a dict")
+                assert isinstance(
+                    section_data, dict
+                ), f"Expected {section}/{index} to be a dict"
 
         value = section_data.get(key, default)
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -13,6 +13,7 @@ import warnings
 from collections import OrderedDict
 from functools import lru_cache
 from os.path import isfile, join
+from typing import Literal, overload
 
 from bs4 import UnicodeDammit
 
@@ -45,9 +46,6 @@ try:
     Loader = yaml.CLoader
 except AttributeError:
     Loader = yaml.Loader
-
-if TYPE_CHECKING := False:
-    from typing import Literal, overload
 
 
 class StringifyNumbersLoader(Loader):
@@ -1319,6 +1317,9 @@ class MetaData:
     @classmethod
     def fromstring(cls, metadata, config=None, variant=None):
         m = super().__new__(cls)
+        m.path = ""
+        m._meta_path = ""
+        m.requirements_path = ""
         config = config or Config(variant=variant)
         m.meta = parse(metadata, config=config, path="")
         m.config = config
@@ -1335,8 +1336,7 @@ class MetaData:
         m._meta_path = ""
         m.requirements_path = ""
         m.meta = sanitize(metadata)
-        config = config or Config(variant=variant)
-        m.config = config
+        m.config = config or Config(variant=variant)
         m.undefined_jinja_vars = []
         m.final = False
         return m
@@ -1404,7 +1404,7 @@ class MetaData:
             default = FIELDS[section][key]()
 
         section_data = self.get_section(section)
-        if isinstance(section_data, dict) and not index:
+        if isinstance(section_data, dict) and index:
             raise ValueError(
                 f"Got non-zero index ({index}), but section {section} is not a list."
             )

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -2009,7 +2009,7 @@ class MetaData:
         return len(matches) > 0
 
     @property
-    def uses_vcs_in_meta(self) -> Literal["git" | "svn" | "mercurial"] | None:
+    def uses_vcs_in_meta(self) -> Literal["git", "svn", "mercurial"] | None:
         """returns name of vcs used if recipe contains metadata associated with version control systems.
         If this metadata is present, a download/copy will be forced in parse_or_try_download.
         """
@@ -2029,7 +2029,7 @@ class MetaData:
         return vcs
 
     @property
-    def uses_vcs_in_build(self) -> Literal["git" | "svn" | "mercurial"] | None:
+    def uses_vcs_in_build(self) -> Literal["git", "svn", "mercurial"] | None:
         # TODO :: Re-work this. Is it even useful? We can declare any vcs in our build deps.
         build_script = "bld.bat" if on_win else "build.sh"
         build_script = os.path.join(self.path, build_script)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1316,9 +1316,8 @@ class MetaData:
     @classmethod
     def fromstring(cls, metadata, config=None, variant=None):
         m = super().__new__(cls)
-        if not config:
-            config = Config()
-        m.meta = parse(metadata, config=config, path="", variant=variant)
+        config = config or Config(variant=variant)
+        m.meta = parse(metadata, config=config, path="")
         m.config = config
         m.parse_again(permit_undefined_jinja=True)
         return m
@@ -1333,14 +1332,10 @@ class MetaData:
         m._meta_path = ""
         m.requirements_path = ""
         m.meta = sanitize(metadata)
-
-        if not config:
-            config = Config(variant=variant)
-
+        config = config or Config(variant=variant)
         m.config = config
         m.undefined_jinja_vars = []
         m.final = False
-
         return m
 
     def get_section(self, section):

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -721,17 +721,17 @@ def finalize_metadata(
         # if source/path is relative, then the output package makes no sense at all.  The next
         #   best thing is to hard-code the absolute path.  This probably won't exist on any
         #   system other than the original build machine, but at least it will work there.
-        if source_path := m.get_value("source/path"):
-            if not isabs(source_path):
-                m.meta["source"]["path"] = normpath(join(m.path, source_path))
+        for source_dict in m.get_section("source"):
+            if (source_path := source_dict.get("path")) and not isabs(source_path):
+                source_dict["path"] = normpath(join(m.path, source_path))
             elif (
-                (git_url := m.get_value("source/git_url"))
+                (git_url := source_dict.get("git_url"))
                 # absolute paths are not relative paths
                 and not isabs(git_url)
                 # real urls are not relative paths
                 and ":" not in git_url
             ):
-                m.meta["source"]["git_url"] = normpath(join(m.path, git_url))
+                source_dict["git_url"] = normpath(join(m.path, git_url))
 
         m.meta.setdefault("build", {})
 

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -1027,13 +1027,11 @@ def provide(metadata):
       - unpack
       - apply patches (if any)
     """
-    dicts = metadata.get_section("source")
-    if not os.path.isdir(metadata.config.build_folder):
-        os.makedirs(metadata.config.build_folder)
+    os.makedirs(metadata.config.build_folder, exist_ok=True)
     git = None
 
     try:
-        for source_dict in dicts:
+        for source_dict in metadata.get_section("source"):
             folder = source_dict.get("folder")
             src_dir = os.path.join(metadata.config.work_dir, folder if folder else "")
             if any(k in source_dict for k in ("fn", "url")):

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -1027,15 +1027,10 @@ def provide(metadata):
       - unpack
       - apply patches (if any)
     """
-    meta = metadata.get_section("source")
+    dicts = metadata.get_section("source")
     if not os.path.isdir(metadata.config.build_folder):
         os.makedirs(metadata.config.build_folder)
     git = None
-
-    if hasattr(meta, "keys"):
-        dicts = [meta]
-    else:
-        dicts = meta
 
     try:
         for source_dict in dicts:

--- a/news/5112-fix-multiple-sources
+++ b/news/5112-fix-multiple-sources
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix finalizing recipes with multiple sources. (#5112)
+* Fix finalizing recipes with multiple sources. (#5111 via #5112)
 
 ### Deprecations
 

--- a/news/5112-fix-multiple-sources
+++ b/news/5112-fix-multiple-sources
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Update `conda_build.metadata.MetaData.get_section` to always return lists for "source" and "outputs". (#5112)
+
+### Bug fixes
+
+* Fix finalizing recipes with multiple sources. (#5112)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/metadata/source_multiple/meta.yaml
+++ b/tests/test-recipes/metadata/source_multiple/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0
 
 source:
-  - path: "{{ environ.get('CONDA_BUILD_TEST_RECIPE_PATH') }}"
+  - path: {{ environ.get('CONDA_BUILD_TEST_RECIPE_PATH') }}
 
   - git_url: https://github.com/conda/conda_build_test_recipe
     git_tag: 1.20.2

--- a/tests/test-recipes/metadata/source_multiple/meta.yaml
+++ b/tests/test-recipes/metadata/source_multiple/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0
 
 source:
-  - path: {{ environ.get('CONDA_BUILD_TEST_RECIPE_PATH') }}
+  - path: "{{ environ.get('CONDA_BUILD_TEST_RECIPE_PATH') }}"
 
   - git_url: https://github.com/conda/conda_build_test_recipe
     git_tag: 1.20.2

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,6 +15,8 @@ from pytest import MonkeyPatch
 from conda_build import api
 from conda_build.config import Config
 from conda_build.metadata import (
+    FIELDS,
+    OPTIONALLY_ITERABLE_FIELDS,
     MetaData,
     _hash_dependencies,
     get_selectors,
@@ -23,7 +25,7 @@ from conda_build.metadata import (
 )
 from conda_build.utils import DEFAULT_SUBDIRS
 
-from .utils import metadata_dir, thisdir
+from .utils import metadata_dir, metadata_path, thisdir
 
 
 def test_uses_vcs_in_metadata(testing_workdir, testing_metadata):
@@ -459,3 +461,22 @@ def test_get_selectors(
         # override with True values
         **{key: True for key in expected},
     }
+
+
+def test_fromstring():
+    MetaData.fromstring((metadata_path / "source_multiple" / "meta.yaml").read_text())
+
+
+def test_fromdict():
+    MetaData.fromdict(
+        yamlize((metadata_path / "source_multiple" / "meta.yaml").read_text())
+    )
+
+
+def test_get_section(testing_metadata: MetaData):
+    for name in FIELDS:
+        section = testing_metadata.get_section(name)
+        if name in OPTIONALLY_ITERABLE_FIELDS:
+            assert isinstance(section, list)
+        else:
+            assert isinstance(section, dict)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -464,12 +464,12 @@ def test_get_selectors(
 
 
 def test_fromstring():
-    MetaData.fromstring((metadata_path / "source_multiple" / "meta.yaml").read_text())
+    MetaData.fromstring((metadata_path / "multiple_sources" / "meta.yaml").read_text())
 
 
 def test_fromdict():
     MetaData.fromdict(
-        yamlize((metadata_path / "source_multiple" / "meta.yaml").read_text())
+        yamlize((metadata_path / "multiple_sources" / "meta.yaml").read_text())
     )
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The recipe format supports 9 fields, all of which are expected to be `dict` except "source" and "outputs" which can be either a single `dict` or a `list` of `dict`.

Previously this distinction had to be uniquely handled throughout out the code, e.g.:

https://github.com/conda/conda-build/blob/061063f10c51162707c7c5253daa39b2752fcfcc/conda_build/build.py#L1567-L1569

It instead makes more sense for the `MetaData.get_section` to auto handle this sanitization for us and to always return a `list` of `dict` for "source" and "outputs".

Resolves #5111 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
