### PR TITLE
catch the more general `ImportError` if menuinst cannot be imported

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -1753,7 +1753,7 @@ def check_menuinst_json(files, prefix) -> None:
     try:
         import jsonschema
         from menuinst.utils import data_path
-    except ModuleNotFoundError as exc:
+    except ImportError as exc:
         log.warning(
             "Found 'Menu/*.json' files but couldn't validate: %s",
             ", ".join(json_files),

--- a/news/5116-menuinst-importerror
+++ b/news/5116-menuinst-importerror
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Catch the more general `ImportError` instead of `ModuleNotFoundError`, so we do handle the cases where `menuinst 1.x` is found. (#5116)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

If `menuinst` v1 is present in the `base` environment, `ModuleNotFoundError` won't be raised. Instead the more general `ImportError` is thrown. Catch that one instead.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
