### PR TITLE
Fix `conda_build.os_utils.liefldd.ensure_binary` to handle `None`

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -43,10 +43,12 @@ def is_string(s):
 # these are to be avoided, or if not avoided they
 # should be passed a binary when possible as that
 # will prevent having to parse it multiple times.
-def ensure_binary(file: str | os.PathLike | Path | lief.Binary) -> lief.Binary | None:
+def ensure_binary(
+    file: str | os.PathLike | Path | lief.Binary | None,
+) -> lief.Binary | None:
     if isinstance(file, lief.Binary):
         return file
-    elif not Path(file).exists():
+    elif not file or not Path(file).exists():
         return None
     try:
         return lief.parse(str(file))
@@ -525,9 +527,9 @@ def inspect_linkages_lief(
             todo.pop(0)
             filename2 = element[0]
             binary = element[1]
-            uniqueness_key = get_uniqueness_key(binary)
             if not binary:
                 continue
+            uniqueness_key = get_uniqueness_key(binary)
             if uniqueness_key not in already_seen:
                 parent_exe_dirname = None
                 if binary.format == lief.EXE_FORMATS.PE:

--- a/news/5124-fix-ensure_binary-None-handling
+++ b/news/5124-fix-ensure_binary-None-handling
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Update `conda_build.os_utils.liefldd.ensure_binary` to handle `None` inputs. (#5123 via #5124)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves #5123

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
