### PR TITLE
purge _file_package_mapping cache when re-using prefixes for multiple outputs

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -47,6 +47,7 @@ from .config import Config
 from .create_test import create_all_test_files
 from .exceptions import CondaBuildException, DependencyNeedsBuildingError
 from .index import _delegated_update_index, get_build_index
+from .inspect_pkg import _file_package_mapping
 from .metadata import FIELDS, MetaData
 from .os_utils import external
 from .post import (
@@ -2770,6 +2771,11 @@ def build(
                             "Not creating new env for output - already exists from top-level"
                         )
                     else:
+                        # _file_package_mapping cache must be invalidated when env paths are re-used
+                        log.debug(
+                            "Re-using environment paths - Clearing file_package_mapping cache"
+                        )
+                        _file_package_mapping.cache_clear()
                         m.config._merge_build_host = m.build_is_host
 
                         utils.rm_rf(m.config.host_prefix)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The cache added in #5130 assumes files within a path prefix can never change once it's been used, which isn't reliably true, causing package builds with multiple outputs to fail when the cache is out of date (#5136). The primary reason being the host environment [is re-used](https://github.com/conda/conda-build/blob/c79640164a58317ff63c1c3ff78896d580df2303/conda_build/build.py#L2775-L2777) for subsequent outputs, after having been cached.

This PR avoids incorrect "not found in any packages" errors by clearing the cache at the point when multiple outputs recreate existing environments that may have been cached (closes #5136).

It's not clear to me if this is the best/right place to clear the cache, but it does work. Other logical places to clear the cache I could think of:

- in `post_build` or `check_overlinking`, which are the calls that _use_ the cached `which_package` results, at least that I could find.
- higher in the `for output in outputs` build iteration unconditionally, rather than conditional on the re-use, where it is now.

I haven't managed to create an automated test for this, but building [this multi-output recipe](https://gist.github.com/minrk/c0ebc71817be1064483ac572c43936c1) with `conda build . --error-overlinking` provokes the error in 3.28.3 and works after this PR, if someone with more familiarity with conda_build tests knows how to integrate it.

Another option would be to include the `lstat` result on the prefix itself in the cache key for `_file_package_mapping`. That would have the benefit of always invalidating the cache if the root package prefix directory is recreated, so `which_package` is more likely to be correct _wherever_ it is used. This is only sufficient, however, if the top-level prefix stat is modified (it is the case for #5136), not e.g. a deeper file change in the prefix (e.g. hypothetical `which_package(); install(); which_package()` in the same process, which I think will still produce incorrect results).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
