### PR TITLE
Invalidate cache after adding/removing packages

### DIFF
--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -84,7 +84,7 @@ def which_package(
 
 
 def file_package_mapping(
-    prefix: str | os.PathLike | Path
+    prefix: str | os.PathLike | Path,
 ) -> dict[os.stat_result, set[PrefixRecord]]:
     """Map paths to package records."""
     prefix = Path(prefix)

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -226,7 +226,7 @@ def test_which_package_reuse_env(tmp_path: Path):
                 "build": "0",
                 "build_number": 0,
                 "channel": "packageB-channel",
-                "files": ["fileB", "fileB"],
+                "files": ["fileB"],
                 "name": "packageB",
                 "paths_data": {
                     "paths": [


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Alternative to #5138

When a package has been installed/removed the `$PREFIX/conda-meta` modified time is updated. We include this to invalidate the `which_package` cache whenever modifications occur to the environment.

Are there other environment changes we care about?

This change does not have any noticeable slowdown on `which_package`'s benchmark test.

Resolves #5136 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
