### PR TITLE
Restore pre-`3.28` behavior for `which_package`

### DIFF
--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -76,7 +76,7 @@ def which_package(
     # On Windows, be lenient and allow case-insensitive path comparisons.
     # NOTE: On macOS, although case-insensitive filesystem is default, still
     #       require case-sensitive matches (i.e., normcase on macOS is a no-op).
-    normcase_path = normcase(str(path).replace(os.sep, "/"))
+    normcase_path = normcase(path)
 
     for prec in PrefixData(str(prefix)).iter_records():
         files = prec["files"]

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from functools import lru_cache
 from itertools import groupby
 from operator import itemgetter
-from os.path import abspath, basename, dirname, exists, join
+from os.path import abspath, basename, dirname, exists, join, normcase
 from pathlib import Path
 from typing import Iterable, Literal
 
@@ -67,43 +67,21 @@ def which_package(
     Given the path (of a (presumably) conda installed file) iterate over
     the conda packages the file came from.  Usually the iteration yields
     only one package.
-
-    We use lstat since a symlink doesn't clobber the file it points to.
     """
-    prefix = Path(prefix)
-
-    # historically, path was relative to prefix, just to be safe we append to prefix
-    # get lstat before calling _file_package_mapping in case path doesn't exist
     try:
-        lstat = (prefix / path).lstat()
-    except FileNotFoundError:
-        # FileNotFoundError: path doesn't exist
-        return
-    else:
-        yield from _file_package_mapping(prefix).get(lstat, ())
+        path = Path(path).relative_to(prefix)
+    except ValueError:
+        # If path is already relative to prefix, we get a ValueError.
+        pass
+    # On Windows, be lenient and allow case-insensitive path comparisons.
+    # NOTE: On macOS, although case-insensitive filesystem is default, still
+    #       require case-sensitive matches (i.e., normcase on macOS is a no-op).
+    normcase_path = normcase(str(path).replace(os.sep, "/"))
 
-
-@lru_cache(maxsize=None)
-def _file_package_mapping(prefix: Path) -> dict[os.stat_result, set[PrefixRecord]]:
-    """Map paths to package records.
-
-    We use lstat since a symlink doesn't clobber the file it points to.
-    """
-    mapping: dict[os.stat_result, set[PrefixRecord]] = {}
     for prec in PrefixData(str(prefix)).iter_records():
-        for file in prec["files"]:
-            # packages are capable of removing files installed by other dependencies from
-            # the build prefix, in those cases lstat will fail, while which_package wont
-            # return the correct package(s) in such a condition we choose to not worry about
-            # it since this file to package lookup exists primarily to detect clobbering
-            try:
-                lstat = (prefix / file).lstat()
-            except FileNotFoundError:
-                # FileNotFoundError: path doesn't exist
-                continue
-            else:
-                mapping.setdefault(lstat, set()).add(prec)
-    return mapping
+        files = prec["files"]
+        if normcase_path in (normcase(file) for file in files):
+            yield prec
 
 
 def print_object_info(info, key):

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -71,7 +71,7 @@ def which_package(
     try:
         path = Path(path).relative_to(prefix)
     except ValueError:
-        # If path is already relative to prefix, we get a ValueError.
+        # ValueError: path is already relative to prefix
         pass
     # On Windows, be lenient and allow case-insensitive path comparisons.
     # NOTE: On macOS, although case-insensitive filesystem is default, still
@@ -79,8 +79,7 @@ def which_package(
     normcase_path = normcase(path)
 
     for prec in PrefixData(str(prefix)).iter_records():
-        files = prec["files"]
-        if normcase_path in (normcase(file) for file in files):
+        if normcase_path in (normcase(file) for file in prec["files"]):
             yield prec
 
 

--- a/news/5141-fix-which_package
+++ b/news/5141-fix-which_package
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Fix linking check regressions by restoring pre-3.28 behavior for which_package. (#5141)
+* Fix linking check regressions by restoring pre-3.28 behavior for `conda_build.inspect_pkg.which_package`. (#5141)
 
 ### Deprecations
 

--- a/news/5141-fix-which_package
+++ b/news/5141-fix-which_package
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix linking check regressions by restoring pre-3.28 behavior for which_package. (#5141)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,7 +227,13 @@ def conda_build_test_recipe_path(tmp_path_factory: pytest.TempPathFactory) -> Pa
     # clone conda_build_test_recipe locally
     repo = tmp_path_factory.mktemp("conda_build_test_recipe", numbered=False)
     subprocess.run(
-        ["git", "clone", "https://github.com/conda/conda_build_test_recipe", str(repo)],
+        [
+            "git",
+            "clone",
+            "https://github.com/conda/conda_build_test_recipe",
+            "--branch=1.21.11",
+            str(repo),
+        ],
         check=True,
     )
     return repo

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -212,10 +212,14 @@ def test_which_package_battery(tmp_path: Path):
 
             assert len(list(which_package(path, tmp_path))) == 1
 
-    # removed files should return no packages
-    # this occurs when, e.g., a package removes files installed by another package
+    # removed files should still return a package
+    # this occurs when, e.g., a build script removes files installed by another package
+    # (The opposite case with files really missing from the run environment,
+    # e.g., due to a post-install script removing them, is less likely and not
+    # covered.)
+    #  covered here.)
     for file in removed:
-        assert not len(list(which_package(tmp_path / file, tmp_path)))
+        assert len(list(which_package(tmp_path / file, tmp_path))) == 1
 
     # missing files should return no packages
     assert not len(list(which_package(tmp_path / "missing", tmp_path)))

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -11,6 +11,7 @@ import pytest
 from conda.core.prefix_data import PrefixData
 
 from conda_build.inspect_pkg import which_package
+from conda_build.utils import on_win
 
 
 def test_which_package(tmp_path: Path):
@@ -128,7 +129,11 @@ def test_which_package(tmp_path: Path):
     precs_missing = list(which_package(tmp_path / "missing", tmp_path))
     assert not precs_missing
 
-    precs_hardlinkA = list(which_package(tmp_path / "hardlinkA", tmp_path))
+    if on_win:
+        # On Windows, be lenient and allow case-insensitive path comparisons.
+        precs_hardlinkA = list(which_package(tmp_path / "Hardlinka", tmp_path))
+    else:
+        precs_hardlinkA = list(which_package(tmp_path / "hardlinkA", tmp_path))
     assert len(precs_hardlinkA) == 1
     assert set(precs_hardlinkA) == {precA}
 

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -129,11 +129,15 @@ def test_which_package(tmp_path: Path):
     precs_missing = list(which_package(tmp_path / "missing", tmp_path))
     assert not precs_missing
 
+    precs_Hardlinka = list(which_package(tmp_path / "Hardlinka", tmp_path))
     if on_win:
         # On Windows, be lenient and allow case-insensitive path comparisons.
-        precs_hardlinkA = list(which_package(tmp_path / "Hardlinka", tmp_path))
+        assert len(precs_Hardlinka) == 1
+        assert set(precs_Hardlinka) == {precA}
     else:
-        precs_hardlinkA = list(which_package(tmp_path / "hardlinkA", tmp_path))
+        assert not precs_Hardlinka
+
+    precs_hardlinkA = list(which_package(tmp_path / "hardlinkA", tmp_path))
     assert len(precs_hardlinkA) == 1
     assert set(precs_hardlinkA) == {precA}
 
@@ -214,10 +218,8 @@ def test_which_package_battery(tmp_path: Path):
 
     # removed files should still return a package
     # this occurs when, e.g., a build script removes files installed by another package
-    # (The opposite case with files really missing from the run environment,
-    # e.g., due to a post-install script removing them, is less likely and not
-    # covered.)
-    #  covered here.)
+    # (post-install scripts removing files from the run environment is less
+    # likely and not covered)
     for file in removed:
         assert len(list(which_package(tmp_path / file, tmp_path))) == 1
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fix linking check regressions by restoring pre-`3.28` behavior for `which_package`.

Fixes gh-5136.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
