### PR TITLE
use actual platform-specific `perl` path during TEST stage

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -3235,7 +3235,7 @@ def _write_test_run_script(
             tf.write(
                 '"{perl}" "{test_file}"\n'.format(
                     perl=metadata.config.perl_bin(
-                        metadata.config.test_prefix, metadata.config.host_platform
+                        metadata.config.test_prefix, sys.platform
                     ),
                     test_file=join(metadata.config.test_dir, "run_test.pl"),
                 )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

In troubleshooting some failed win_64 CI builds for PRs submitted to conda-forge *staged-recipes* (https://github.com/conda-forge/staged-recipes/pull/25137), I believe I narrowed the failed tests to the fact that the path determined for `perl` in the code modified here was setting the wrong path. Specifically, although these are `noarch: generic` recipes, they are being tested by the `staged-recipes` CI on Windows in addition to Linux and OSX. Since the value of `metadata.config.host_platform` here is set to `noarch` but the [code that sets the path to `perl`](https://github.com/conda/conda-build/blob/465d386318cca048d660c3a5aa7088b076473ab5/conda_build/config.py#L567C3-L572C19) is testing `if platform.startswith("win"):`, the resulting path is incorrect.

I saw another issue and commit relating to the use of `host_platform` instead of `sys.platform` in another part of the codebase in order to enable cross-compiling. In this instance, I can't foresee a situation in which the command string being built up in `write_test_scripts` would be run by `test` on a platform different from that on which it was called.

I haven't performed the points below yet, but I will if the change proposed seems valid. I'd like to get feedback on the change first.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
