### PR TITLE
Avoid encoding error when warning about error in ensure_binary

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -46,7 +46,7 @@ def ensure_binary(
     try:
         return lief.parse(str(file))
     except BaseException:
-        print(f"WARNING: liefldd: failed to ensure_binary({file})")
+        print(f"WARNING: liefldd: failed to ensure_binary({file!r})")
         return None
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

openmpi builds on conda-forge are failing at https://github.com/conda-forge/openmpi-feedstock/pull/142

The source of the issue (still unclear) is an invalid utf-8 path, but the intended error handling doesn't safely catch errors.

The problem is in the _logs_ of the failure to parse then raise because the warning itself fails to be formatted:

```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/conda_build/os_utils/liefldd.py", line 54, in ensure_binary
    return lief.parse(str(file))
TypeError: '/home/conda/feedstock_root/build_artifacts/openmpi-mpi_1707395567538/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold/lib/\x01\udce4\x05'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/bin/conda-mambabuild", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 256, in main
    call_conda_build(action, config)
  File "/opt/conda/lib/python3.10/site-packages/boa/cli/mambabuild.py", line 228, in call_conda_build
    result = api.build(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/api.py", line 254, in build
    return build_tree(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 3789, in build_tree
    packages_from_this = build(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 2877, in build
    newly_built_packages = bundlers[pkg_type](output_d, m, env, stats)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 2004, in bundle_conda
    files = post_process_files(metadata, initial_files)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/build.py", line 1815, in post_process_files
    post_build(m, new_files, build_python=python)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/post.py", line 1818, in post_build
    post_process_shared_lib(m, f, prefix_files, host_prefix)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/post.py", line 1680, in post_process_shared_lib
    mk_relative_linux(
  File "/opt/conda/lib/python3.10/site-packages/conda_build/post.py", line 612, in mk_relative_linux
    existing2, _, _ = get_rpaths_raw(elf)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/os_utils/liefldd.py", line 206, in get_rpathy_thing_raw_partial
    binary = ensure_binary(file)
  File "/opt/conda/lib/python3.10/site-packages/conda_build/os_utils/liefldd.py", line 56, in ensure_binary
    print(f"WARNING: liefldd: failed to ensure_binary({file})")
UnicodeEncodeError: 'utf-8' codec can't encode character '\udce4' in position 303: surrogates not allowed
```

This PR makes sure that the log line is safe and can proceed