### PR TITLE
Add `TCH` & `T10` lints and sync `conda.deprecations`

### DIFF
--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-from argparse import Namespace
 from os.path import abspath, expanduser
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from .. import api
 from ..conda_interface import ArgumentParser
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 logging.basicConfig(level=logging.INFO)
 

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import logging
 import sys
-from argparse import ArgumentParser
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from .. import api
 from ..utils import on_win
 from . import validators as valid
 from .main_render import get_render_parser
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
 
 logging.basicConfig(level=logging.INFO)
 

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import logging
-from argparse import Namespace
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from conda.base.context import context, determine_target_prefix
 
 from .. import api
 from ..conda_interface import ArgumentParser, add_parser_prefix
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 logging.basicConfig(level=logging.INFO)
 

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import logging
 import sys
-from argparse import Namespace
 from os.path import expanduser
 from pprint import pprint
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from conda.base.context import context, determine_target_prefix
 
 from .. import api
 from ..conda_interface import ArgumentParser, add_parser_prefix
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 logging.basicConfig(level=logging.INFO)
 

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -7,12 +7,14 @@ import logging
 import os
 import pkgutil
 import sys
-from argparse import Namespace
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from .. import api
 from ..conda_interface import ArgumentParser
 from ..config import Config
+
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
 logging.basicConfig(level=logging.INFO)

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -13,7 +13,7 @@ import shutil
 import time
 from collections import namedtuple
 from os.path import abspath, expanduser, expandvars, join
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .conda_interface import (
     binstar_upload,
@@ -32,6 +32,9 @@ from .utils import (
     rm_rf,
 )
 from .variants import get_default_variant
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 invocation_time = ""
 

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -9,9 +9,12 @@ import json
 import os
 from os.path import basename, exists, isfile, join
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from .metadata import MetaData
 from .utils import copy_into, ensure_list, on_win, rm_rf
+
+if TYPE_CHECKING:
+    from .metadata import MetaData
 
 
 def create_files(m: MetaData, test_dir: Path) -> bool:

--- a/conda_build/deprecations.py
+++ b/conda_build/deprecations.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 
 import sys
 import warnings
-from argparse import Action
 from functools import wraps
 from types import ModuleType
-from typing import Any, Callable
+from typing import TYPE_CHECKING
 
-from packaging.version import Version, parse
+if TYPE_CHECKING:
+    from argparse import Action
+    from typing import Any, Callable
+
+    from packaging.version import Version
 
 from . import __version__
 
@@ -22,17 +25,52 @@ class DeprecatedError(RuntimeError):
 # inspired by deprecation (https://deprecation.readthedocs.io/en/latest/) and
 # CPython's warnings._deprecated
 class DeprecationHandler:
-    _version: Version
+    _version: str | None
+    _version_tuple: tuple[int, ...] | None
+    _version_object: Version | None
 
-    def __init__(self, version: Version | str):
+    def __init__(self, version: str):
         """Factory to create a deprecation handle for the specified version.
 
         :param version: The version to compare against when checking deprecation statuses.
         """
+        self._version = version
+        # Try to parse the version string as a simple tuple[int, ...] to avoid
+        # packaging.version import and costlier version comparisons.
+        self._version_tuple = self._get_version_tuple(version)
+        self._version_object = None
+
+    @staticmethod
+    def _get_version_tuple(version: str) -> tuple[int, ...] | None:
+        """Return version as non-empty tuple of ints if possible, else None.
+
+        :param version: Version string to parse.
+        """
         try:
-            self._version = parse(version)
-        except TypeError:
-            self._version = parse("0.0.0.dev0+placeholder")
+            return tuple(int(part) for part in version.strip().split(".")) or None
+        except (AttributeError, ValueError):
+            return None
+
+    def _version_less_than(self, version: str) -> bool:
+        """Test whether own version is less than the given version.
+
+        :param version: Version string to compare against.
+        """
+        if self._version_tuple:
+            if version_tuple := self._get_version_tuple(version):
+                return self._version_tuple < version_tuple
+
+        # If self._version or version could not be represented by a simple
+        # tuple[int, ...], do a more elaborate version parsing and comparison.
+        # Avoid this import otherwise to reduce import time for conda activate.
+        from packaging.version import parse
+
+        if self._version_object is None:
+            try:
+                self._version_object = parse(self._version)
+            except TypeError:
+                self._version_object = parse("0.0.0.dev0+placeholder")
+        return self._version_object < parse(version)
 
     def __call__(
         self,
@@ -281,16 +319,33 @@ class DeprecationHandler:
         :param stack: The stacklevel increment.
         :return: The module and module name.
         """
-        import inspect  # expensive
-
         try:
             frame = sys._getframe(2 + stack)
-            module = inspect.getmodule(frame)
-            if module is not None:
-                return (module, module.__name__)
         except IndexError:
             # IndexError: 2 + stack is out of range
             pass
+        else:
+            # Shortcut finding the module by manually inspecting loaded modules.
+            try:
+                filename = frame.f_code.co_filename
+            except AttributeError:
+                # AttributeError: frame.f_code.co_filename is undefined
+                pass
+            else:
+                for module in sys.modules.values():
+                    if not isinstance(module, ModuleType):
+                        continue
+                    if not hasattr(module, "__file__"):
+                        continue
+                    if module.__file__ == filename:
+                        return (module, module.__name__)
+
+            # If above failed, do an expensive import and costly getmodule call.
+            import inspect
+
+            module = inspect.getmodule(frame)
+            if module is not None:
+                return (module, module.__name__)
 
         raise DeprecatedError("unable to determine the calling module")
 
@@ -309,14 +364,11 @@ class DeprecationHandler:
         :param addendum: Additional messaging. Useful to indicate what to do instead.
         :return: The warning category (if applicable) and the message.
         """
-        deprecate_version = parse(deprecate_in)
-        remove_version = parse(remove_in)
-
         category: type[Warning] | None
-        if self._version < deprecate_version:
+        if self._version_less_than(deprecate_in):
             category = PendingDeprecationWarning
             warning = f"is pending deprecation and will be removed in {remove_in}."
-        elif self._version < remove_version:
+        elif self._version_less_than(remove_in):
             category = DeprecationWarning
             warning = f"is deprecated and will be removed in {remove_in}."
         else:

--- a/conda_build/os_utils/ldd.py
+++ b/conda_build/os_utils/ldd.py
@@ -2,20 +2,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 from functools import lru_cache
 from os.path import basename
 from pathlib import Path
-from typing import Iterable
-
-from conda.models.records import PrefixRecord
+from typing import TYPE_CHECKING, Iterable
 
 from ..conda_interface import untracked
 from ..utils import on_linux, on_mac
 from .macho import otool
 from .pyldd import codefile_class, inspect_linkages, machofile
+
+if TYPE_CHECKING:
+    import os
+
+    from conda.models.records import PrefixRecord
 
 LDD_RE = re.compile(r"\s*(.*?)\s*=>\s*(.*?)\s*\(.*\)")
 LDD_NOT_FOUND_RE = re.compile(r"\s*(.*?)\s*=>\s*not found")

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -32,7 +32,7 @@ from os.path import (
 )
 from pathlib import Path
 from subprocess import CalledProcessError, call, check_output
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from conda.core.prefix_data import PrefixData
 from conda.models.records import PrefixRecord
@@ -46,7 +46,6 @@ from .conda_interface import (
 )
 from .exceptions import OverDependingError, OverLinkingError, RunPathError
 from .inspect_pkg import which_package
-from .metadata import MetaData
 from .os_utils import external, macho
 from .os_utils.liefldd import (
     get_exports_memoized,
@@ -64,6 +63,9 @@ from .os_utils.pyldd import (
     machofile,
 )
 from .utils import on_mac, on_win, prefix_files
+
+if TYPE_CHECKING:
+    from .metadata import MetaData
 
 filetypes_for_platform = {
     "win": (DLLfile, EXEfile),

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -41,7 +41,7 @@ from os.path import (
 )
 from pathlib import Path
 from threading import Thread
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import conda_package_handling.api
 import filelock
@@ -55,7 +55,6 @@ from conda.base.constants import (
 )
 from conda.core.prefix_data import PrefixData
 from conda.models.dist import Dist
-from conda.models.records import PrefixRecord
 
 from .conda_interface import (
     CondaHTTPError,
@@ -78,6 +77,9 @@ from .conda_interface import (
 from .conda_interface import rm_rf as _rm_rf
 from .deprecations import deprecated
 from .exceptions import BuildLockError
+
+if TYPE_CHECKING:
+    from conda.models.records import PrefixRecord
 
 on_win = sys.platform == "win32"
 on_mac = sys.platform == "darwin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,9 @@ target-version = "py38"
 # UP = pyupgrade
 # ISC = flake8-implicit-str-concat
 # TCH = flake8-type-checking
+# T10 = flake8-debugger
 # see also https://docs.astral.sh/ruff/rules/
-select = ["E", "W", "F", "I", "UP", "ISC", "TCH"]
+select = ["E", "W", "F", "I", "UP", "ISC", "TCH", "T10"]
 # E402 module level import not at top of file
 # E722 do not use bare 'except'
 # E731 do not assign a lambda expression, use a def

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,9 @@ skip_covered = true
 omit = ["conda_build/skeletons/_example_skeleton.py"]
 
 [tool.ruff]
-pycodestyle = {max-line-length = 120}
+target-version = "py38"
+
+[tool.ruff.lint]
 # E, W = pycodestyle errors and warnings
 # F = pyflakes
 # I = isort
@@ -105,7 +107,7 @@ select = ["E", "W", "F", "I", "UP", "ISC"]
 # E722 do not use bare 'except'
 # E731 do not assign a lambda expression, use a def
 ignore = ["E402", "E722", "E731"]
-target-version = "py38"
+pycodestyle = {max-line-length = 120}
 pydocstyle = {convention = "pep257"}
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,9 @@ target-version = "py38"
 # I = isort
 # UP = pyupgrade
 # ISC = flake8-implicit-str-concat
+# TCH = flake8-type-checking
 # see also https://docs.astral.sh/ruff/rules/
-select = ["E", "W", "F", "I", "UP", "ISC"]
+select = ["E", "W", "F", "I", "UP", "ISC", "TCH"]
 # E402 module level import not at top of file
 # E722 do not use bare 'except'
 # E731 do not assign a lambda expression, use a def

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from pytest import FixtureRequest, MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda_build import api
 from conda_build.cli import main_build, main_render
@@ -18,12 +18,16 @@ from conda_build.config import (
     zstd_compression_level_default,
 )
 from conda_build.exceptions import DependencyNeedsBuildingError
-from conda_build.metadata import MetaData
 from conda_build.os_utils.external import find_executable
 from conda_build.utils import get_build_folders, on_win, package_has_file
 
 from ..utils import metadata_dir
 from ..utils import reset_config as _reset_config
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda_build.metadata import MetaData
 
 
 @pytest.mark.sanity

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -18,6 +18,7 @@ from contextlib import nullcontext
 from glob import glob
 from pathlib import Path
 from shutil import which
+from typing import TYPE_CHECKING
 
 # for version
 import conda
@@ -29,7 +30,6 @@ from conda.common.compat import on_linux, on_mac, on_win
 from conda.exceptions import ClobberError, CondaMultiError
 from conda_index.api import update_index
 from pytest import FixtureRequest, MonkeyPatch
-from pytest_mock import MockerFixture
 
 from conda_build import __version__, api, exceptions
 from conda_build.conda_interface import (
@@ -46,7 +46,6 @@ from conda_build.exceptions import (
     OverDependingError,
     OverLinkingError,
 )
-from conda_build.metadata import MetaData
 from conda_build.os_utils.external import find_executable
 from conda_build.render import finalize_metadata
 from conda_build.utils import (
@@ -70,6 +69,11 @@ from .utils import (
     metadata_path,
     reset_config,
 )
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from conda_build.metadata import MetaData
 
 
 def represent_ordereddict(dumper, data):

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -6,12 +6,12 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import ruamel.yaml
 
 from conda_build import api
-from conda_build.config import Config
 from conda_build.skeletons.pypi import (
     clean_license_name,
     convert_to_flat_list,
@@ -27,6 +27,10 @@ from conda_build.skeletons.pypi import (
 )
 from conda_build.utils import on_win
 from conda_build.version import _parse as parse_version
+
+if TYPE_CHECKING:
+    from conda_build.config import Config
+
 
 SYMPY_URL = (
     "https://files.pythonhosted.org/packages/7d/23/70fa970c07f0960f7543af982d2554be805e1034b9dcee9cb3082ce80f80/sympy-1.10.tar.gz"

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -261,5 +261,8 @@ def test_topic_remove(deprecated_v3: DeprecationHandler):
 
 def test_version_fallback():
     """Test that conda_build can run even if deprecations can't parse the version."""
-    version = DeprecationHandler(None)._version  # type: ignore
+    deprecated = DeprecationHandler(None)  # type: ignore
+    assert deprecated._version_less_than("0")
+    assert deprecated._version_tuple is None
+    version = deprecated._version_object  # type: ignore
     assert version.major == version.minor == version.micro == 0

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from conda_build import jinja_context
 from conda_build.utils import HashableDict
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_pin_default(testing_metadata, mocker):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
 
 from conda_build import api, render
-from conda_build.metadata import MetaData
 from conda_build.utils import CONDA_PACKAGE_EXTENSION_V1
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conda_build.metadata import MetaData
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Enable more lints:
- `TCH` lints ([flake8-type-checking-tch](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch))
- `T10` lints ([flake8-debugger](https://docs.astral.sh/ruff/rules/#flake8-debugger-t10))

And sync improved `conda.deprecations` (see https://github.com/conda/conda/pull/13568) to `conda_build.deprecations`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
