### PR TITLE
 Fix corrupted package cache for outputs in subpackage tests

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -48,6 +48,7 @@ from .conda_interface import (
     reset_context,
     root_dir,
 )
+from .config import Config
 from .deprecations import deprecated
 from .exceptions import BuildLockError, DependencyNeedsBuildingError
 from .features import feature_list
@@ -1269,7 +1270,7 @@ def get_pkg_dirs_locks(dirs, config):
     return [utils.get_lock(folder, timeout=config.timeout) for folder in dirs]
 
 
-def clean_pkg_cache(dist, config):
+def clean_pkg_cache(dist: str, config: Config) -> None:
     with utils.LoggingContext(logging.DEBUG if config.debug else logging.WARN):
         locks = get_pkg_dirs_locks([config.bldpkgs_dir] + pkgs_dirs, config)
         with utils.try_acquire_locks(locks, timeout=config.timeout):

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -16,10 +16,15 @@ from glob import glob
 from logging import getLogger
 from os.path import join, normpath
 
-from conda.base.constants import DEFAULTS_CHANNEL_NAME, UNKNOWN_CHANNEL
+from conda.base.constants import (
+    CONDA_PACKAGE_EXTENSIONS,
+    DEFAULTS_CHANNEL_NAME,
+    UNKNOWN_CHANNEL,
+)
 from conda.common.io import env_vars
 from conda.core.index import LAST_CHANNEL_URLS
 from conda.core.link import PrefixSetup, UnlinkLinkTransaction
+from conda.core.package_cache_data import PackageCacheData
 from conda.core.prefix_data import PrefixData
 from conda.models.channel import prioritize_channels
 
@@ -1262,6 +1267,29 @@ def create_env(
 
 def get_pkg_dirs_locks(dirs, config):
     return [utils.get_lock(folder, timeout=config.timeout) for folder in dirs]
+
+
+def clean_pkg_cache(dist, config):
+    with utils.LoggingContext(logging.DEBUG if config.debug else logging.WARN):
+        locks = get_pkg_dirs_locks([config.bldpkgs_dir] + pkgs_dirs, config)
+        with utils.try_acquire_locks(locks, timeout=config.timeout):
+            for pkgs_dir in pkgs_dirs:
+                if any(
+                    os.path.exists(os.path.join(pkgs_dir, f"{dist}{ext}"))
+                    for ext in ("", *CONDA_PACKAGE_EXTENSIONS)
+                ):
+                    log.debug(
+                        "Conda caching error: %s package remains in cache after removal",
+                        dist,
+                    )
+                    log.debug("manually removing to compensate")
+                    package_cache = PackageCacheData.first_writable([pkgs_dir])
+                    for cache_pkg_id in package_cache.query(dist):
+                        package_cache.remove(cache_pkg_id)
+
+        # Note that this call acquires the relevant locks, so this must be called
+        # outside the lock context above.
+        remove_existing_packages(pkgs_dirs, [dist], config)
 
 
 def remove_existing_packages(dirs, fns, config):

--- a/news/5184-fix-multi-output-package-corruption
+++ b/news/5184-fix-multi-output-package-corruption
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix corrupted package cache for outputs in subpackage tests. (#5184)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/metadata/outputs_overwrite_base_file/install.bat
+++ b/tests/test-recipes/metadata/outputs_overwrite_base_file/install.bat
@@ -1,0 +1,2 @@
+:: Always output 4 characters to properly test even if "SafetyError: ... incorrect size." is not triggered.
+< nul set /p="%PKG_NAME:~0,4%" > "%PREFIX%\file" & call;

--- a/tests/test-recipes/metadata/outputs_overwrite_base_file/install.sh
+++ b/tests/test-recipes/metadata/outputs_overwrite_base_file/install.sh
@@ -1,0 +1,2 @@
+## Always output 4 characters to properly test even if "SafetyError: ... incorrect size." is not triggered.
+printf '%.4s' "${PKG_NAME}" > "${PREFIX}/file"

--- a/tests/test-recipes/metadata/outputs_overwrite_base_file/meta.yaml
+++ b/tests/test-recipes/metadata/outputs_overwrite_base_file/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "outputs_overwrite_base_file" %}
+
+package:
+  name: {{ name }}
+  version: 1.0
+
+outputs:
+  - name: base-{{ name }}
+    script: install.sh  # [unix]
+    script: install.bat  # [win]
+
+  - name: first-{{ name }}
+    script: install.sh  # [unix]
+    script: install.bat  # [win]
+    requirements:
+      host:
+        - {{ pin_subpackage("base-" + name) }}
+      run:
+        - {{ pin_subpackage("base-" + name) }}
+    test:
+      commands:
+        - content="$(cat "${PREFIX}/file")"  # [unix]
+        - test "${content}" = base  # [unix]
+        - < "%PREFIX%\file%" set /p content=  # [win]
+        - if not "%content%" == "base" exit 1  # [win]
+
+  - name: second-{{ name }}
+    script: install.sh  # [unix]
+    script: install.bat  # [win]
+    requirements:
+      host:
+        - {{ pin_subpackage("base-" + name) }}
+      run:
+        - {{ pin_subpackage("base-" + name) }}
+    test:
+      commands:
+        - content="$(cat "${PREFIX}/file")"  # [unix]
+        - test "${content}" = "base"  # [unix]
+        - < "%PREFIX%\file%" set /p content=  # [win]
+        - if not "%content%" == "base" exit 1  # [win]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Fix corrupted package cache for outputs in subpackage tests

This re-introduces conda_build.environ.clean_pkg_cache with slight
changes to not use conda.models.dist.Dist and handle multiple pkgs_dirs
better.

Addresses https://github.com/conda/conda-build/issues/5179#issuecomment-1942172592

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- ~~[ ] Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
