### PR TITLE
Allow custom chunk size for regex calls on Windows

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -353,7 +353,15 @@ def regex_files_rg(
     ]
     args_len = len(b" ".join(args_base))
     file_lists = list(
-        chunks(prefix_files, (32760 if utils.on_win else 131071) - args_len)
+        chunks(
+            prefix_files,
+            (
+                float(os.environ.get("CONDA_BLD_REGEX_CHUNK_SIZE", 32760))
+                if utils.on_win
+                else 131071
+            )
+            - args_len,
+        )
     )
     for file_list in file_lists:
         args = args_base[:] + file_list

--- a/news/regex_chunk_size_on_windows
+++ b/news/regex_chunk_size_on_windows
@@ -1,3 +1,3 @@
 ### Bug fixes
 
-* Fix build error on Windows, when paths are too long, or package contains too many files, by allowing users to set the chunk size for regex operation on Windows using environment variable `CONDA_BLD_REGEX_CHUNK_SIZE`. 
+* Fix build error on Windows, when paths are too long, or package contains too many files, by allowing users to set the chunk size for regex operation on Windows using environment variable `CONDA_BLD_REGEX_CHUNK_SIZE`.

--- a/news/regex_chunk_size_on_windows
+++ b/news/regex_chunk_size_on_windows
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix build error on Windows, when paths are too long, or package contains too many files, by allowing users to set the chunk size for regex operation on Windows using environment variable `CONDA_BLD_REGEX_CHUNK_SIZE`. 


### PR DESCRIPTION
allow customization using env var to cover corner cases with many nested folders

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix build error on Windows, when paths are too long, or package contains too many files, by allowing users to set the chunk size for regex operation on Windows using environment variable `CONDA_BLD_REGEX_CHUNK_SIZE`. 

I don't know what's the best way to pass this configuration value.
Maybe we could also add a try/catch around the regex call to give a hint if it fails.

Fixes #5122 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~~Add / update necessary tests?~~
- [ ] ~~Add / update outdated documentation?~~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
