### PR TITLE
Ignore `TYPE_CHECKING` imports in coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ show_missing = true
 sort = "Miss"
 skip_covered = true
 omit = ["conda_build/skeletons/_example_skeleton.py"]
+exclude_lines = [
+  "if TYPE_CHECKING:",  # ignoring type checking imports
+]
 
 [tool.ruff]
 target-version = "py38"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We wish to dismiss messages like the following from PRs:

<img width="894" alt="Screenshot 2024-02-15 at 11 49 13" src="https://github.com/conda/conda-build/assets/4546435/ad6160d1-d759-4c0d-8d02-d524344c0c20">

Xref https://github.com/conda/conda/pull/13597

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
