### PR TITLE
Correct `conda-index` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "beautifulsoup4",
   "chardet",
   "conda >=22.11",
-  "conda-index",
+  "conda-index >=0.4.0",
   "conda-package-handling >=1.3",
   "filelock",
   "jinja2",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - beautifulsoup4
     - chardet
     - conda >=22.11.0
-    - conda-index
+    - conda-index >=0.4.0
     - conda-package-handling >=1.3
     - filelock
     - jinja2


### PR DESCRIPTION
### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Since the `conda index` subcommand/entrypoint was deprecated and removed (see https://github.com/conda/conda-build/pull/5151) from `conda-build` we need to explicitly depend on the `conda-index>=0.4.0` package for the `conda index` subcommand.

Other relevant discussions:
- https://github.com/conda/conda-build/pull/5158#discussion_r1471435596
- https://github.com/AnacondaRecipes/conda-build-feedstock/pull/41#discussion_r1491516034

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
