### PR TITLE
Port deprecated `conda.auxlib.packaging.get_version_from_git_tag` to `conda_build`

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -116,7 +116,11 @@ def md5_file(path: str | os.PathLike) -> str:
     return compute_sum(path, "md5")
 
 
-@deprecated("24.3", "24.5")
+@deprecated(
+    "24.3",
+    "24.5",
+    addendum="Use `conda_build.environ.get_version_from_git_tag` instead.",
+)
 def get_version_from_git_tag(tag):
     from .environ import get_version_from_git_tag
 

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -6,7 +6,6 @@ import configparser  # noqa: F401
 import os
 from functools import partial
 from importlib import import_module  # noqa: F401
-from re import compile
 
 from conda import __version__ as CONDA_VERSION  # noqa: F401
 from conda.base.context import context, determine_target_prefix, reset_context
@@ -117,20 +116,8 @@ def md5_file(path: str | os.PathLike) -> str:
     return compute_sum(path, "md5")
 
 
-GIT_DESCRIBE_REGEX = compile(
-    r"(?:[_-a-zA-Z]*)"
-    r"(?P<version>[a-zA-Z0-9.]+)"
-    r"(?:-(?P<post>\d+)-g(?P<hash>[0-9a-f]{7,}))$"
-)
-
-
 @deprecated("24.3", "24.5")
 def get_version_from_git_tag(tag):
-    """Return a PEP440-compliant version derived from the git status.
-    If that fails for any reason, return the changeset hash.
-    """
-    m = GIT_DESCRIBE_REGEX.match(tag)
-    if m is None:
-        return None
-    version, post_commit, hash = m.groups()
-    return version if post_commit == "0" else f"{version}.post{post_commit}+{hash}"
+    from .environ import get_version_from_git_tag
+
+    return get_version_from_git_tag(tag)

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -48,7 +48,6 @@ from .conda_interface import (
     TemporaryDirectory,
     context,
     create_default_packages,
-    get_version_from_git_tag,
     pkgs_dirs,
     reset_context,
     root_dir,
@@ -221,6 +220,24 @@ def verify_git_repo(
         log.debug(str(error))
         OK = False
     return OK
+
+
+GIT_DESCRIBE_REGEX = re.compile(
+    r"(?:[_-a-zA-Z]*)"
+    r"(?P<version>[a-zA-Z0-9.]+)"
+    r"(?:-(?P<post>\d+)-g(?P<hash>[0-9a-f]{7,}))$"
+)
+
+
+def get_version_from_git_tag(tag):
+    """Return a PEP440-compliant version derived from the git status.
+    If that fails for any reason, return the changeset hash.
+    """
+    m = GIT_DESCRIBE_REGEX.match(tag)
+    if m is None:
+        return None
+    version, post_commit, hash = m.groups()
+    return version if post_commit == "0" else f"{version}.post{post_commit}+{hash}"
 
 
 def get_git_info(git_exe, repo, debug):

--- a/news/5221-deprecate-get_version_from_git_tag
+++ b/news/5221-deprecate-get_version_from_git_tag
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Mark `conda_build.conda_interface.get_version_from_git_tag` as deprecated. (#5221)
+* Mark `conda_build.conda_interface.get_version_from_git_tag` as deprecated. Use `conda_build.environ.get_version_from_git_tag` instead. (#5221)
 
 ### Docs
 

--- a/news/5221-deprecate-get_version_from_git_tag
+++ b/news/5221-deprecate-get_version_from_git_tag
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Mark `conda_build.conda_interface.get_version_from_git_tag` as deprecated. (#5221)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

We were still using a minor helper function from the deprecated `conda.auxlib.packaging`. This wasn't caught until the conda canaries were rebuilt after the removal.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
