### PR TITLE
Defer `.index._apply_instructions` and `.conda_interface.get_index` deprecations

### DIFF
--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -58,11 +58,13 @@ from conda.exports import (  # noqa: F401
     walk_prefix,
     win_path_to_unix,
 )
+from conda.exports import get_index as _get_index
 from conda.gateways.disk.read import compute_sum
 from conda.models.channel import get_conda_build_local_url  # noqa: F401
 
 from .deprecations import deprecated
 
+deprecated.constant("24.1.0", "24.5.0", "get_index", _get_index)
 # TODO: Go to references of all properties below and import them from `context` instead
 binstar_upload = context.binstar_upload
 default_python = context.default_python

--- a/news/5203-remove-deprecations
+++ b/news/5203-remove-deprecations
@@ -44,7 +44,6 @@
 * Remove `conda_build.index.REPODATA_FROM_PKGS_JSON_FN`. (#5203)
 * Remove `conda_build.index.CHANNELDATA_FIELDS`. (#5203)
 * Remove `conda_build.index._clear_newline_chars`. (#5203)
-* Remove `conda_build.index._apply_instructions`. (#5203)
 * Remove `conda_build.index._get_jinja2_environment`. (#5203)
 * Remove `conda_build.index._maybe_write`. (#5203)
 * Remove `conda_build.index._make_build_string`. (#5203)

--- a/news/5203-remove-deprecations
+++ b/news/5203-remove-deprecations
@@ -30,7 +30,6 @@
 * Remove `conda_build.conda_interface.display_actions`. (#5203)
 * Remove `conda_build.conda_interface.execute_actions`. (#5203)
 * Remove `conda_build.conda_interface.execute_plan`. (#5203)
-* Remove `conda_build.conda_interface.get_index`. (#5203)
 * Remove `conda_build.conda_interface.install_actions`. (#5203)
 * Remove `conda_build.conda_interface.linked`. (#5203)
 * Remove `conda_build.conda_interface.linked_data`. (#5203)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

- gh-5203 (I suppose unintentionally) removed `.index._apply_instructions` which is slated for deprecation in `24.5` at the earliest.
- I'd like to re-add `.conda_interface.get_index` for another release cycle since I didn't get to update downstream (conda-forge scripts, etc.) for this change, yet.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
