### PR TITLE
Add `test_guess_interpreter`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2894,16 +2894,22 @@ def build(
     return new_pkgs
 
 
+INTERPRETER_BASH = ("bash.exe", "-el") if on_win else ("bash", "-e")
+INTERPRETER_BAT = (os.getenv("COMSPEC", "cmd.exe"), "/d", "/c")
+INTERPRETER_POWERSHELL = ("powershell", "-ExecutionPolicy", "ByPass", "-File")
+INTERPRETER_PYTHON = ("python",)
+
+
 def guess_interpreter(script_filename):
     # -l is needed for MSYS2 as the login scripts set some env. vars (TMP, TEMP)
     # Since the MSYS2 installation is probably a set of conda packages we do not
     # need to worry about system environmental pollution here. For that reason I
     # do not pass -l on other OSes.
     extensions_to_run_commands = {
-        ".sh": ["bash.exe", "-el"] if utils.on_win else ["bash", "-e"],
-        ".bat": [os.environ.get("COMSPEC", "cmd.exe"), "/d", "/c"],
-        ".ps1": ["powershell", "-executionpolicy", "bypass", "-File"],
-        ".py": ["python"],
+        ".sh": INTERPRETER_BASH,
+        ".bat": INTERPRETER_BAT,
+        ".ps1": INTERPRETER_POWERSHELL,
+        ".py": INTERPRETER_PYTHON,
     }
     file_ext = os.path.splitext(script_filename)[1]
     for ext, command in extensions_to_run_commands.items():

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -17,6 +17,7 @@ import sys
 import time
 import warnings
 from collections import OrderedDict, deque
+from logging import getLogger
 from os.path import dirname, isdir, isfile, islink, join
 
 import conda_package_handling.api
@@ -1847,7 +1848,9 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
         interpreter = output.get("script_interpreter")
         if not interpreter:
             args = list(guess_interpreter(output["script"]))
+            getLogger("testing").debug("guess_interpreter yields: %s", args)
             args[0] = external.find_executable(args[0], metadata.config.build_prefix)
+            getLogger("testing").debug("find_executable yields: %s", args[0])
             if not args[0]:
                 log.error(
                     "Did not find an interpreter to run %s, looked for %s",

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1846,20 +1846,15 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
 
         interpreter = output.get("script_interpreter")
         if not interpreter:
-            interpreter_and_args = guess_interpreter(output["script"])
-            interpreter_and_args[0] = external.find_executable(
-                interpreter_and_args[0], metadata.config.build_prefix
-            )
-            if not interpreter_and_args[0]:
+            args = guess_interpreter(output["script"])
+            args[0] = external.find_executable(args[0], metadata.config.build_prefix)
+            if not args[0]:
                 log.error(
                     "Did not find an interpreter to run {}, looked for {}".format(
-                        output["script"], interpreter_and_args[0]
+                        output["script"], args[0]
                     )
                 )
-            if (
-                "system32" in interpreter_and_args[0]
-                and "bash" in interpreter_and_args[0]
-            ):
+            if "system32" in args[0] and "bash" in args[0]:
                 print(
                     "ERROR :: WSL bash.exe detected, this will not work (PRs welcome!). Please\n"
                     "         use MSYS2 packages. Add `m2-base` and more (depending on what your"
@@ -1867,7 +1862,7 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
                 )
                 sys.exit(1)
         else:
-            interpreter_and_args = interpreter.split(" ")
+            args = interpreter.split(" ")
 
         initial_files = utils.prefix_files(metadata.config.host_prefix)
         env_output = env.copy()
@@ -1903,7 +1898,7 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
 
         bundle_stats = {}
         utils.check_call_env(
-            interpreter_and_args + [dest_file],
+            [*args, dest_file],
             cwd=metadata.config.work_dir,
             env=env_output,
             stats=bundle_stats,
@@ -2110,11 +2105,11 @@ def bundle_wheel(output, metadata: MetaData, env, stats):
         env["TOP_PKG_VERSION"] = env["PKG_VERSION"]
         env["PKG_VERSION"] = metadata.version()
         env["PKG_NAME"] = metadata.name()
-        interpreter_and_args = guess_interpreter(dest_file)
+        args = guess_interpreter(dest_file)
 
         bundle_stats = {}
         utils.check_call_env(
-            interpreter_and_args + [dest_file],
+            [*args, dest_file],
             cwd=metadata.config.work_dir,
             env=env,
             stats=bundle_stats,

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1850,9 +1850,9 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
             args[0] = external.find_executable(args[0], metadata.config.build_prefix)
             if not args[0]:
                 log.error(
-                    "Did not find an interpreter to run {}, looked for {}".format(
-                        output["script"], args[0]
-                    )
+                    "Did not find an interpreter to run %s, looked for %s",
+                    output["script"],
+                    args[0],
                 )
             if "system32" in args[0] and "bash" in args[0]:
                 print(

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -17,7 +17,6 @@ import sys
 import time
 import warnings
 from collections import OrderedDict, deque
-from logging import getLogger
 from os.path import dirname, isdir, isfile, islink, join
 
 import conda_package_handling.api
@@ -1848,9 +1847,7 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
         interpreter = output.get("script_interpreter")
         if not interpreter:
             args = list(guess_interpreter(output["script"]))
-            getLogger("testing").debug("guess_interpreter yields: %s", args)
             args[0] = external.find_executable(args[0], metadata.config.build_prefix)
-            getLogger("testing").debug("find_executable yields: %s", args[0])
             if not args[0]:
                 log.error(
                     "Did not find an interpreter to run %s, looked for %s",

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1846,7 +1846,7 @@ def bundle_conda(output, metadata: MetaData, env, stats, **kw):
 
         interpreter = output.get("script_interpreter")
         if not interpreter:
-            args = guess_interpreter(output["script"])
+            args = list(guess_interpreter(output["script"]))
             args[0] = external.find_executable(args[0], metadata.config.build_prefix)
             if not args[0]:
                 log.error(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -331,10 +331,10 @@ def test_rewrite_output(testing_config, capsys):
         ("foo.bat.other", NotImplementedError, None),
         ("foo.ps1.other", NotImplementedError, None),
         ("foo.py.other", NotImplementedError, None),
-        ("foo.sh_what", None, build.INTERPRETER_BASH),  # not valid
-        ("foo.bat_what", None, build.INTERPRETER_BAT),  # not valid
-        ("foo.ps1_what", None, build.INTERPRETER_POWERSHELL),  # not valid
-        ("foo.py_what", None, build.INTERPRETER_PYTHON),  # not valid
+        ("foo.sh_what", NotImplementedError, None),
+        ("foo.bat_what", NotImplementedError, None),
+        ("foo.ps1_what", NotImplementedError, None),
+        ("foo.py_what", NotImplementedError, None),
     ],
 )
 def test_guess_interpreter(


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While working on https://github.com/conda/conda-build/pull/5255 found that `conda_build.build.guess_interpreter` actually guesses incorrectly for certain extensions (e.g., `.sh_what`, `.bat_what`, `.ps1_what`, `.py_what`).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
