### PR TITLE
Catch `LookupError` when getting development version

### DIFF
--- a/conda_build/__init__.py
+++ b/conda_build/__init__.py
@@ -9,9 +9,10 @@ except ImportError:
         from setuptools_scm import get_version
 
         __version__ = get_version(root="..", relative_to=__file__)
-    except (ImportError, OSError):
+    except (ImportError, OSError, LookupError):
         # ImportError: setuptools_scm isn't installed
         # OSError: git isn't installed
+        # LookupError: setuptools_scm unable to detect version
         # Conda-build abides by CEP-8 which specifies using CalVer, so the dev version is:
         #     YY.MM.MICRO.devN+gHASH[.dirty]
         __version__ = "0.0.0.dev0+placeholder"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Porting development version error handling improvement from conda (see https://github.com/conda/conda/pull/13539).

Xref https://github.com/conda/conda/pull/13764
Extends https://github.com/conda/conda-build/pull/5262

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
