### PR TITLE
Move CLI's logging initialization into a dedicated module

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -19,6 +19,7 @@ import sys
 import time
 import warnings
 from collections import OrderedDict, deque
+from logging import getLogger
 from os.path import dirname, isdir, isfile, islink, join
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -93,6 +94,8 @@ if on_win:
 
 if TYPE_CHECKING:
     from typing import Any, Iterable
+
+log = getLogger(__name__)
 
 if "bsd" in sys.platform:
     shell_path = "/bin/sh"
@@ -924,7 +927,6 @@ def copy_test_source_files(m, destination):
                             clobber=True,
                         )
                     except OSError as e:
-                        log = utils.get_logger(__name__)
                         log.warning(
                             f"Failed to copy {f} into test files.  Error was: {str(e)}"
                         )
@@ -1304,7 +1306,6 @@ def write_about_json(m):
         extra = m.get_section("extra")
         # Add burn-in information to extra
         if m.config.extra_meta:
-            log = utils.get_logger(__name__)
             log.info(
                 "Adding the following extra-meta data to about.json: %s",
                 m.config.extra_meta,
@@ -1611,7 +1612,6 @@ def post_process_files(m: MetaData, initial_prefix_files):
         if not os.path.exists(os.path.join(host_prefix, f)):
             missing.append(f)
     if len(missing):
-        log = utils.get_logger(__name__)
         log.warning(
             f"The install/build script(s) for {package_name} deleted the following "
             f"files (from dependencies) from the prefix:\n{missing}\n"
@@ -1683,7 +1683,6 @@ def bundle_conda(
     new_prefix_files: set[str] = set(),
     **kw,
 ):
-    log = utils.get_logger(__name__)
     log.info("Packaging %s", metadata.dist())
     get_all_replacements(metadata.config)
     files = output.get("files", [])
@@ -2176,7 +2175,6 @@ def _write_activation_text(script_path, m):
         elif os.path.splitext(script_path)[1].lower() == ".sh":
             _write_sh_activation_text(fh, m)
         else:
-            log = utils.get_logger(__name__)
             log.warning(
                 f"not adding activation to {script_path} - I don't know how to do so for "
                 "this file type"
@@ -2317,7 +2315,6 @@ def build(
         print(utils.get_skip_message(m))
         return default_return
 
-    log = utils.get_logger(__name__)
     host_precs = []
     build_precs = []
     output_metas = []
@@ -2918,8 +2915,6 @@ def _construct_metadata_for_test_from_package(package, config):
     #    This is still necessary for computing the hash correctly though
     config.variant = hash_input
 
-    log = utils.get_logger(__name__)
-
     # get absolute file location
     local_pkg_location = os.path.normpath(os.path.abspath(os.path.dirname(package)))
 
@@ -3125,7 +3120,6 @@ def _write_test_run_script(
     shell_files,
     trace,
 ):
-    log = utils.get_logger(__name__)
     with open(test_run_script, "w") as tf:
         tf.write(
             '{source} "{test_env_script}"\n'.format(
@@ -3284,7 +3278,6 @@ def test(
     :param m: Package's metadata.
     :type m: Metadata
     """
-    log = utils.get_logger(__name__)
     # we want to know if we're dealing with package input.  If so, we can move the input on success.
     hash_input = {}
 
@@ -3568,7 +3561,6 @@ def tests_failed(
     dest = join(broken_dir, os.path.basename(pkg))
 
     if move_broken:
-        log = utils.get_logger(__name__)
         try:
             shutil.move(pkg, dest)
             log.warning(
@@ -3719,7 +3711,6 @@ def build_tree(
                                     )
                                 ]
                             )
-                            log = utils.get_logger(__name__)
                             # downstreams can be a dict, for adding capability for worker labels
                             if hasattr(downstreams, "keys"):
                                 downstreams = list(downstreams.keys())
@@ -4059,11 +4050,11 @@ def handle_pypi_upload(wheels, config):
             try:
                 utils.check_call_env(args + [f])
             except:
-                utils.get_logger(__name__).warning(
+                log.warning(
                     "wheel upload failed - is twine installed?"
                     "  Is this package registered?"
                 )
-                utils.get_logger(__name__).warning(f"Wheel file left in {f}")
+                log.warning(f"Wheel file left in {f}")
 
     else:
         print(f"anaconda_upload is not set.  Not uploading wheels: {wheels}")

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import logging
 import os
 import random
 import re
@@ -19,7 +20,6 @@ import sys
 import time
 import warnings
 from collections import OrderedDict, deque
-from logging import getLogger
 from os.path import dirname, isdir, isfile, islink, join
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -95,7 +95,7 @@ if on_win:
 if TYPE_CHECKING:
     from typing import Any, Iterable
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 if "bsd" in sys.platform:
     shell_path = "/bin/sh"

--- a/conda_build/cli/logging.py
+++ b/conda_build/cli/logging.py
@@ -15,7 +15,6 @@ from yaml import safe_load
 
 if TYPE_CHECKING:
     from logging import Logger, LogRecord
-    from typing import Self
 
 
 # https://stackoverflow.com/a/31459386/1170370
@@ -45,10 +44,6 @@ class DuplicateFilter(Filter):
             return record.msg not in self.msgs
         finally:
             self.msgs.add(record.msg)
-
-    @classmethod
-    def clear(cls: type[Self]) -> None:
-        cls.msgs.clear()
 
 
 def init_logging(log: Logger) -> None:

--- a/conda_build/cli/logging.py
+++ b/conda_build/cli/logging.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import os
+import os.path
+import sys
+from logging import INFO, WARNING, Filter, Formatter, StreamHandler, getLogger
+from logging.config import dictConfig
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from conda.base.context import context
+from yaml import safe_load
+
+if TYPE_CHECKING:
+    from logging import Logger, LogRecord
+    from typing import Self
+
+
+# https://stackoverflow.com/a/31459386/1170370
+class LessThanFilter(Filter):
+    def __init__(self, exclusive_maximum: int, name: str = "") -> None:
+        super().__init__(name)
+        self.max_level = exclusive_maximum
+
+    def filter(self, record: LogRecord) -> bool:
+        return record.levelno < self.max_level
+
+
+class GreaterThanFilter(Filter):
+    def __init__(self, exclusive_minimum: int, name: str = "") -> None:
+        super().__init__(name)
+        self.min_level = exclusive_minimum
+
+    def filter(self, record: LogRecord) -> bool:
+        return record.levelno > self.min_level
+
+
+class DuplicateFilter(Filter):
+    msgs: set[str] = set()
+
+    def filter(self, record: LogRecord) -> bool:
+        try:
+            return record.msg not in self.msgs
+        finally:
+            self.msgs.add(record.msg)
+
+    @classmethod
+    def clear(cls: type[Self]) -> None:
+        cls.msgs.clear()
+
+
+def init_logging(log: Logger) -> None:
+    """
+    Default initialization of logging for conda-build CLI.
+
+    When using conda-build as a CLI tool (not as a library) we wish to limit logging to
+    avoid duplication and to otherwise offer some default behavior.
+    """
+    config_file = context.conda_build.get("log_config_file")
+    if config_file:
+        config_file = os.path.expandvars(config_file)
+        dictConfig(safe_load(Path(config_file).expanduser().resolve().read_text()))
+
+    # we don't want propagation in CLI, but we do want it in tests
+    # this is a pytest limitation: https://github.com/pytest-dev/pytest/issues/3697
+    getLogger("conda_build").propagate = "PYTEST_CURRENT_TEST" in os.environ
+
+    if not log.handlers:
+        log.addHandler(stdout := StreamHandler(sys.stdout))
+        stdout.addFilter(LessThanFilter(WARNING))
+        stdout.addFilter(DuplicateFilter())
+        stdout.setFormatter(Formatter("%(levelname)s: %(message)s"))
+
+        log.addHandler(stderr := StreamHandler(sys.stderr))
+        stderr.addFilter(GreaterThanFilter(INFO))
+        stderr.addFilter(DuplicateFilter())
+        stderr.setFormatter(Formatter("%(levelname)s: %(message)s"))

--- a/conda_build/cli/logging.py
+++ b/conda_build/cli/logging.py
@@ -63,6 +63,12 @@ def init_logging() -> None:
 
     log = logging.getLogger("conda_build")
 
+    # historically conda_build has defaulted the logging to INFO and so all of the
+    # log.info is viewed as default output, until we convert all of the existing
+    # log.info to standard print statements we will need to continue defaulting to INFO
+    if log.level == logging.NOTSET:
+        log.setLevel(logging.INFO)
+
     # we don't want propagation in CLI, but we do want it in tests
     # this is a pytest limitation: https://github.com/pytest-dev/pytest/issues/3697
     log.propagate = "PYTEST_CURRENT_TEST" in os.environ

--- a/conda_build/cli/logging.py
+++ b/conda_build/cli/logging.py
@@ -53,6 +53,9 @@ def init_logging() -> None:
     When using conda-build as a CLI tool (not as a library) we wish to limit logging to
     avoid duplication and to otherwise offer some default behavior.
     """
+    # undo conda messing with the root logger
+    logging.getLogger(None).setLevel(logging.WARNING)
+
     config_file = context.conda_build.get("log_config_file")
     if config_file:
         config_file = Path(os.path.expandvars(config_file)).expanduser().resolve()

--- a/conda_build/cli/logging.py
+++ b/conda_build/cli/logging.py
@@ -14,7 +14,7 @@ from conda.base.context import context
 from yaml import safe_load
 
 if TYPE_CHECKING:
-    from logging import Logger, LogRecord
+    from logging import LogRecord
 
 
 # https://stackoverflow.com/a/31459386/1170370
@@ -46,7 +46,7 @@ class DuplicateFilter(Filter):
             self.msgs.add(record.msg)
 
 
-def init_logging(log: Logger) -> None:
+def init_logging() -> None:
     """
     Default initialization of logging for conda-build CLI.
 
@@ -58,9 +58,11 @@ def init_logging(log: Logger) -> None:
         config_file = os.path.expandvars(config_file)
         dictConfig(safe_load(Path(config_file).expanduser().resolve().read_text()))
 
+    log = getLogger("conda_build")
+
     # we don't want propagation in CLI, but we do want it in tests
     # this is a pytest limitation: https://github.com/pytest-dev/pytest/issues/3697
-    getLogger("conda_build").propagate = "PYTEST_CURRENT_TEST" in os.environ
+    log.propagate = "PYTEST_CURRENT_TEST" in os.environ
 
     if not log.handlers:
         log.addHandler(stdout := StreamHandler(sys.stdout))

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -535,7 +535,7 @@ def check_action(recipe, config):
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 import warnings
 from glob import glob
 from itertools import chain
+from logging import CRITICAL, getLogger
 from os.path import abspath, expanduser, expandvars
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -35,6 +35,8 @@ except ImportError:
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
+
+log = getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
@@ -509,7 +511,7 @@ def check_recipe(path_list):
 
 
 def output_action(recipe, config):
-    with LoggingContext(logging.CRITICAL + 1):
+    with LoggingContext(CRITICAL + 1):
         config.verbose = False
         config.debug = False
         paths = api.get_output_file_paths(recipe, config=config)
@@ -531,6 +533,10 @@ def check_action(recipe, config):
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -24,6 +24,7 @@ from ..config import (
 )
 from ..utils import LoggingContext
 from .actions import KeyValueAction
+from .logging import init_logging
 from .main_render import get_render_parser
 
 try:
@@ -533,8 +534,6 @@ def check_action(recipe, config):
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     _, parsed = parse_args(args)

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 import warnings
 from glob import glob
 from itertools import chain
-from logging import CRITICAL, getLogger
 from os.path import abspath, expanduser, expandvars
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
@@ -511,7 +511,7 @@ def check_recipe(path_list):
 
 
 def output_action(recipe, config):
-    with LoggingContext(CRITICAL + 1):
+    with LoggingContext(logging.CRITICAL + 1):
         config.verbose = False
         config.debug = False
         paths = api.get_output_file_paths(recipe, config=config)

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -129,7 +129,7 @@ all.""",
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from os.path import abspath, expanduser
 from typing import TYPE_CHECKING
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 epilog = """
 
@@ -127,6 +127,10 @@ all.""",
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
-from ..conda_interface import ArgumentParser
 from .logging import init_logging
 
 if TYPE_CHECKING:

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
+from ..conda_interface import ArgumentParser
+from .logging import init_logging
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
@@ -127,8 +129,6 @@ all.""",
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     _, parsed = parse_args(args)

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from logging import getLogger
+import logging
 from os.path import abspath, expanduser
 from typing import TYPE_CHECKING
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 epilog = """
 

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import logging
 import sys
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser
     from typing import Sequence
 
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 
 def get_parser() -> ArgumentParser:
@@ -94,6 +94,10 @@ Set up environments and activation scripts to debug your build or test phase.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     parser = get_parser()
     parsed = parser.parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -96,7 +96,7 @@ Set up environments and activation scripts to debug your build or test phase.
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     parser = get_parser()
     parsed = parser.parse_args(args)

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -11,6 +11,7 @@ from conda.base.context import context
 from .. import api
 from ..utils import on_win
 from . import validators as valid
+from .logging import init_logging
 from .main_render import get_render_parser
 
 if TYPE_CHECKING:
@@ -94,8 +95,6 @@ Set up environments and activation scripts to debug your build or test phase.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     parser = get_parser()

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import logging
 import sys
-from logging import getLogger
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def get_parser() -> ArgumentParser:

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from logging import getLogger
+import logging
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
+from ..conda_interface import ArgumentParser
+from .logging import init_logging
 
 try:
     from conda.cli.helpers import add_parser_prefix
@@ -87,8 +89,6 @@ This works by creating a conda.pth file in site-packages.""",
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     _, parsed = parse_args(args)

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -89,7 +89,7 @@ This works by creating a conda.pth file in site-packages.""",
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
-from ..conda_interface import ArgumentParser
 from .logging import init_logging
 
 try:

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import logging
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
@@ -87,6 +87,10 @@ This works by creating a conda.pth file in site-packages.""",
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
+from ..conda_interface import ArgumentParser
+from .logging import init_logging
 
 try:
     from conda.cli.helpers import add_parser_prefix
@@ -195,8 +197,6 @@ Tools for investigating conda channels.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     parser, parsed = parse_args(args)

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import logging
 import sys
-from logging import getLogger
 from os.path import expanduser
 from pprint import pprint
 from typing import TYPE_CHECKING
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import logging
 import sys
+from logging import getLogger
 from os.path import expanduser
 from pprint import pprint
 from typing import TYPE_CHECKING
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
@@ -195,6 +195,10 @@ Tools for investigating conda channels.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     parser, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -197,7 +197,7 @@ Tools for investigating conda channels.
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     parser, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
-from ..conda_interface import ArgumentParser
 from .logging import init_logging
 
 try:

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
+from ..conda_interface import ArgumentParser
+from .logging import init_logging
 
 try:
     from conda.cli.helpers import add_parser_channels
@@ -121,8 +123,6 @@ command line with the conda metapackage command.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     _, parsed = parse_args(args)

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -123,7 +123,7 @@ command line with the conda metapackage command.
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from logging import getLogger
+import logging
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-import logging
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
@@ -121,6 +121,10 @@ command line with the conda metapackage command.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
-from ..conda_interface import ArgumentParser
 from .logging import init_logging
 
 try:

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -203,7 +203,7 @@ def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from logging import CRITICAL, INFO, basicConfig, getLogger
+import logging
 from pprint import pprint
 from typing import TYPE_CHECKING
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 # see: https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
@@ -236,14 +236,14 @@ def execute(args: Sequence[str] | None = None) -> int:
         )
 
     if parsed.output:
-        with LoggingContext(CRITICAL + 1):
+        with LoggingContext(logging.CRITICAL + 1):
             paths = api.get_output_file_paths(metadata_tuples, config=config)
             print("\n".join(sorted(paths)))
         if parsed.file:
             m = metadata_tuples[-1][0]
             api.output_yaml(m, parsed.file, suppress_outputs=True)
     else:
-        basicConfig(level=INFO)
+        logging.basicConfig(level=logging.INFO)
         for m, _, _ in metadata_tuples:
             print("--------------")
             print("Hash contents:")

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -15,6 +15,7 @@ from .. import __version__, api
 from ..config import get_channel_urls, get_or_merge_config
 from ..utils import LoggingContext
 from ..variants import get_package_variants, set_language_env_vars
+from .logging import init_logging
 
 try:
     from conda.cli.helpers import add_parser_channels
@@ -201,8 +202,6 @@ def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     _, parsed = parse_args(args)

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-import logging
+from logging import CRITICAL, INFO, basicConfig, getLogger
 from pprint import pprint
 from typing import TYPE_CHECKING
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
-log = logging.getLogger(__name__)
+log = getLogger(__name__)
 
 
 # see: https://stackoverflow.com/questions/29986185/python-argparse-dict-arg
@@ -201,6 +201,10 @@ def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     _, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 
@@ -232,14 +236,14 @@ def execute(args: Sequence[str] | None = None) -> int:
         )
 
     if parsed.output:
-        with LoggingContext(logging.CRITICAL + 1):
+        with LoggingContext(CRITICAL + 1):
             paths = api.get_output_file_paths(metadata_tuples, config=config)
             print("\n".join(sorted(paths)))
         if parsed.file:
             m = metadata_tuples[-1][0]
             api.output_yaml(m, parsed.file, suppress_outputs=True)
     else:
-        logging.basicConfig(level=logging.INFO)
+        basicConfig(level=INFO)
         for m, _, _ in metadata_tuples:
             print("--------------")
             print("Hash contents:")

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import logging
 import os
 import pkgutil
 import sys
 from importlib import import_module
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from typing import Sequence
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
@@ -53,6 +53,10 @@ options available.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
+    from .logging import init_logging
+
+    init_logging(log)
+
     parser, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)
 

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -55,7 +55,7 @@ options available.
 def execute(args: Sequence[str] | None = None) -> int:
     from .logging import init_logging
 
-    init_logging(log)
+    init_logging()
 
     parser, parsed = parse_args(args)
     context.__init__(argparse_args=parsed)

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -13,6 +13,7 @@ from conda.base.context import context
 
 from .. import api
 from ..config import Config
+from .logging import init_logging
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
@@ -53,8 +54,6 @@ options available.
 
 
 def execute(args: Sequence[str] | None = None) -> int:
-    from .logging import init_logging
-
     init_logging()
 
     parser, parsed = parse_args(args)

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import logging
 import os
 import pkgutil
 import sys
 from importlib import import_module
-from logging import getLogger
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from typing import Sequence
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -7,6 +7,7 @@ Module to store conda build settings.
 from __future__ import annotations
 
 import copy
+import logging
 import math
 import os
 import pickle
@@ -14,7 +15,6 @@ import re
 import shutil
 import time
 from collections import namedtuple
-from logging import getLogger
 from os.path import abspath, expanduser, expandvars, join
 from typing import TYPE_CHECKING
 
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 invocation_time = ""
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import time
 from collections import namedtuple
+from logging import getLogger
 from os.path import abspath, expanduser, expandvars, join
 from typing import TYPE_CHECKING
 
@@ -23,7 +24,6 @@ from conda.utils import url_path
 from .utils import (
     get_build_folders,
     get_conda_operation_locks,
-    get_logger,
     on_win,
     rm_rf,
 )
@@ -32,6 +32,8 @@ from .variants import get_default_variant
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
+
+log = getLogger(__name__)
 
 invocation_time = ""
 
@@ -324,7 +326,6 @@ class Config:
 
     @arch.setter
     def arch(self, value):
-        log = get_logger(__name__)
         log.warning(
             "Setting build arch. This is only useful when pretending to be on another "
             "arch, such as for rendering necessary dependencies on a non-native arch. "
@@ -340,7 +341,6 @@ class Config:
 
     @platform.setter
     def platform(self, value):
-        log = get_logger(__name__)
         log.warning(
             "Setting build platform. This is only useful when "
             "pretending to be on another platform, such as "
@@ -839,7 +839,7 @@ class Config:
             and e_type is None
             and not getattr(self, "keep_old_work")
         ):
-            get_logger(__name__).info(
+            log.info(
                 "--dirty flag and --keep-old-work not specified. "
                 "Removing build/test folder after successful build/test.\n"
             )

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import multiprocessing
 import os
 import platform
@@ -13,7 +14,6 @@ import warnings
 from collections import defaultdict
 from functools import lru_cache
 from glob import glob
-from logging import DEBUG, WARNING, getLogger
 from os.path import join, normpath
 from typing import TYPE_CHECKING
 
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
         LINK: list[PackageRecord]
 
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 # these are things that we provide env vars for more explicitly.  This list disables the
 #    pass-through of variant values to env vars for these keys.
@@ -838,14 +838,14 @@ def get_install_actions(
     global cached_precs
     global last_index_ts
 
-    conda_log_level = WARNING
+    conda_log_level = logging.WARNING
     specs = list(specs)
     if specs:
         specs.extend(context.create_default_packages)
     if verbose or debug:
         capture = contextlib.nullcontext
         if debug:
-            conda_log_level = DEBUG
+            conda_log_level = logging.DEBUG
     else:
         capture = utils.capture
     for feature, value in feature_list:
@@ -988,7 +988,7 @@ def create_env(
         for entry in glob(os.path.join(prefix, "*")):
             utils.rm_rf(entry)
 
-    with utils.LoggingContext(DEBUG if config.debug else WARNING):
+    with utils.LoggingContext(logging.DEBUG if config.debug else logging.WARNING):
         # if os.path.isdir(prefix):
         #     utils.rm_rf(prefix)
 
@@ -1184,7 +1184,7 @@ def get_pkg_dirs_locks(dirs, config):
 
 
 def clean_pkg_cache(dist: str, config: Config) -> None:
-    with utils.LoggingContext(DEBUG if config.debug else WARNING):
+    with utils.LoggingContext(logging.DEBUG if config.debug else logging.WARNING):
         locks = get_pkg_dirs_locks((config.bldpkgs_dir, *context.pkgs_dirs), config)
         with utils.try_acquire_locks(locks, timeout=config.timeout):
             for pkgs_dir in context.pkgs_dirs:

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import os
 import logging
+import os
 from os.path import dirname
 
 from conda.base.context import context

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import os
-from logging import CRITICAL, DEBUG, INFO, WARNING, getLogger
+import logging
 from os.path import dirname
 
 from conda.base.context import context
@@ -12,7 +12,7 @@ from conda_index.index import update_index as _update_index
 
 from . import utils
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 local_index_timestamp = 0
@@ -73,11 +73,11 @@ def get_build_index(
 
         loggers = utils.LoggingContext.default_loggers + [__name__]
         if debug:
-            log_level = DEBUG
+            log_level = logging.DEBUG
         elif verbose:
-            log_level = WARNING
+            log_level = logging.WARNING
         else:
-            log_level = CRITICAL + 1
+            log_level = logging.CRITICAL + 1
         with utils.LoggingContext(log_level, loggers=loggers):
             # this is where we add the "local" channel.  It's a little smarter than conda, because
             #     conda does not know about our output_folder when it is not the default setting.
@@ -157,11 +157,11 @@ def _delegated_update_index(
         subdirs = [dirname]
 
     if debug:
-        log_level = DEBUG
+        log_level = logging.DEBUG
     elif verbose:
-        log_level = INFO
+        log_level = logging.INFO
     else:
-        log_level = WARNING
+        log_level = logging.WARNING
     with utils.LoggingContext(log_level):
         return _update_index(
             dir_path,

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from collections import defaultdict
 from itertools import groupby
-from logging import getLogger
 from operator import itemgetter
 from os.path import abspath, basename, dirname, exists, join, normcase
 from pathlib import Path
@@ -41,7 +41,7 @@ from .utils import (
 if TYPE_CHECKING:
     from typing import Iterable, Literal
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def which_package(

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -7,6 +7,7 @@ import os
 import sys
 from collections import defaultdict
 from itertools import groupby
+from logging import getLogger
 from operator import itemgetter
 from os.path import abspath, basename, dirname, exists, join, normcase
 from pathlib import Path
@@ -31,7 +32,6 @@ from .os_utils.macho import get_rpaths, human_filetype
 from .utils import (
     comma_join,
     ensure_list,
-    get_logger,
     on_linux,
     on_mac,
     on_win,
@@ -41,7 +41,7 @@ from .utils import (
 if TYPE_CHECKING:
     from typing import Iterable, Literal
 
-log = get_logger(__name__)
+log = getLogger(__name__)
 
 
 def which_package(
@@ -263,7 +263,7 @@ def inspect_linkages(
                 if relative:
                     precs = list(which_package(relative, prefix))
                     if len(precs) > 1:
-                        get_logger(__name__).warning(
+                        log.warning(
                             "Warning: %s comes from multiple packages: %s",
                             path,
                             comma_join(map(str, precs)),

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -9,11 +9,11 @@ import os
 import pathlib
 import re
 import time
+import warnings
 from functools import partial
 from io import StringIO, TextIOBase
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
-from warnings import warn
 
 import jinja2
 import yaml
@@ -213,7 +213,7 @@ def load_setuptools(
     recipe_dir=None,
     permit_undefined_jinja=True,
 ):
-    warn(
+    warnings.warn(
         "conda_build.jinja_context.load_setuptools is pending deprecation in a future release. "
         "Use conda_build.jinja_context.load_setup_py_data instead.",
         PendingDeprecationWarning,

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -10,6 +10,7 @@ import re
 import time
 from functools import partial
 from io import StringIO, TextIOBase
+from logging import getLogger
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 from warnings import warn
@@ -28,7 +29,6 @@ from .utils import (
     copy_into,
     ensure_valid_spec,
     get_installed_packages,
-    get_logger,
     rm_rf,
 )
 from .variants import DEFAULT_COMPILERS
@@ -41,7 +41,7 @@ except:
 if TYPE_CHECKING:
     from typing import IO, Any
 
-log = get_logger(__name__)
+log = getLogger(__name__)
 
 
 class UndefinedNeverFail(jinja2.Undefined):

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 import os
 import pathlib
 import re
 import time
 from functools import partial
 from io import StringIO, TextIOBase
-from logging import getLogger
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 from warnings import warn
@@ -41,7 +41,7 @@ except:
 if TYPE_CHECKING:
     from typing import IO, Any
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class UndefinedNeverFail(jinja2.Undefined):

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import logging
 import os
 import re
 import sys
@@ -14,7 +15,6 @@ from collections import OrderedDict
 from functools import lru_cache
 from os.path import isdir, isfile, join
 from typing import TYPE_CHECKING, NamedTuple, overload
-from logging import getLogger
 
 import yaml
 from bs4 import UnicodeDammit
@@ -68,7 +68,7 @@ except ImportError:
         "files of conda recipes)"
     )
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 try:
     Loader = yaml.CLoader

--- a/conda_build/os_utils/macho.py
+++ b/conda_build/os_utils/macho.py
@@ -5,11 +5,14 @@ import re
 import stat
 import sys
 from itertools import islice
+from logging import getLogger
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen, check_output
 
 from .. import utils
 from ..utils import on_mac
 from .external import find_preferably_prefixed_executable
+
+log = getLogger(__name__)
 
 NO_EXT = (
     ".py",
@@ -182,7 +185,6 @@ def find_apple_cctools_executable(name, build_prefix, nofail=False):
                             .splitlines()[0]
                         )
                     except Exception as e:
-                        log = utils.get_logger(__name__)
                         log.error(
                             f"ERROR :: Found `{tool}` but is is an Apple Xcode stub executable\n"
                             f"and it returned an error:\n{e.output}"
@@ -257,7 +259,6 @@ def _chmod(filename, mode):
     try:
         os.chmod(filename, mode)
     except (OSError, utils.PermissionError) as e:
-        log = utils.get_logger(__name__)
         log.warning(str(e))
 
 

--- a/conda_build/os_utils/macho.py
+++ b/conda_build/os_utils/macho.py
@@ -1,18 +1,18 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+import logging
 import os
 import re
 import stat
 import sys
 from itertools import islice
-from logging import getLogger
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen, check_output
 
 from .. import utils
 from ..utils import on_mac
 from .external import find_preferably_prefixed_executable
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 NO_EXT = (
     ".py",

--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import argparse
 import glob
-import logging
 import os
 import re
 import struct
 import sys
 from functools import partial
+from logging import getLogger
 from pathlib import Path
 
-from ..utils import ensure_list, get_logger, on_linux, on_mac, on_win
+from ..utils import ensure_list, on_linux, on_mac, on_win
 
-logging.basicConfig(level=logging.INFO)
+log = getLogger(__name__)
 
 
 '''
@@ -690,7 +690,7 @@ class elfheader:
         (self.shstrndx,) = struct.unpack(endian + "H", file.read(2))
         loc = file.tell()
         if loc != self.ehsize:
-            get_logger(__name__).warning(f"file.tell()={loc} != ehsize={self.ehsize}")
+            log.warning(f"file.tell()={loc} != ehsize={self.ehsize}")
 
     def __str__(self):
         return (
@@ -1088,7 +1088,7 @@ def _inspect_linkages_this(filename, sysroot: str = "", arch="native"):
         except IncompleteRead:
             # the file was incomplete, can occur if a package ships a test file
             # which looks like an ELF file but is not.  Orange3 does this.
-            get_logger(__name__).warning(f"problems inspecting linkages for {filename}")
+            log.warning(f"problems inspecting linkages for {filename}")
             return None, [], []
         dirname = os.path.dirname(filename)
         results = cf.get_resolved_shared_libraries(dirname, dirname, sysroot)

--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import argparse
 import glob
+import logging
 import os
 import re
 import struct
 import sys
 from functools import partial
-from logging import getLogger
 from pathlib import Path
 
 from ..utils import ensure_list, on_linux, on_mac, on_win
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 '''

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -16,6 +16,7 @@ from fnmatch import filter as fnmatch_filter
 from fnmatch import fnmatch
 from fnmatch import translate as fnmatch_translate
 from functools import partial
+from logging import getLogger
 from os.path import (
     basename,
     dirname,
@@ -67,6 +68,8 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from .metadata import MetaData
+
+log = getLogger(__name__)
 
 filetypes_for_platform = {
     "win": (DLLfile, EXEfile),
@@ -1421,7 +1424,6 @@ def check_overlinking_impl(
                 sysroot_files.append(replaced)
             diffs = set(orig_sysroot_files) - set(sysroot_files)
             if diffs:
-                log = utils.get_logger(__name__)
                 log.warning(
                     "Partially parsed some '.tbd' files in sysroot %s, pretending .tbds are their install-names\n"
                     "Adding support to 'conda-build' for parsing these in 'liefldd.py' would be easy and useful:\n"
@@ -1630,7 +1632,6 @@ def post_process_shared_lib(m, f, files, host_prefix=None):
         )
     elif codefile == machofile:
         if m.config.host_platform != "osx":
-            log = utils.get_logger(__name__)
             log.warning(
                 "Found Mach-O file but patching is only supported on macOS, skipping: %s",
                 path,
@@ -1666,7 +1667,6 @@ def fix_permissions(files, prefix):
             try:
                 lchmod(path, new_mode)
             except (OSError, utils.PermissionError) as e:
-                log = utils.get_logger(__name__)
                 log.warning(str(e))
 
 
@@ -1687,7 +1687,6 @@ def check_menuinst_json(files, prefix) -> None:
         return
 
     print("Validating Menu/*.json files")
-    log = utils.get_logger(__name__, dedupe=False)
     try:
         import jsonschema
         from menuinst.utils import data_path

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import locale
+import logging
 import os
 import re
 import shutil
@@ -16,7 +17,6 @@ from fnmatch import filter as fnmatch_filter
 from fnmatch import fnmatch
 from fnmatch import translate as fnmatch_translate
 from functools import partial
-from logging import getLogger
 from os.path import (
     basename,
     dirname,
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
 
     from .metadata import MetaData
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 filetypes_for_platform = {
     "win": (DLLfile, EXEfile),

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -13,6 +13,7 @@ import tarfile
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from functools import lru_cache
+from logging import getLogger
 from os.path import (
     isabs,
     isdir,
@@ -52,6 +53,8 @@ if TYPE_CHECKING:
     from typing import Any, Iterable, Iterator
 
     from .config import Config
+
+log = getLogger(__name__)
 
 
 def odict_representer(dumper, data):
@@ -738,7 +741,6 @@ def finalize_metadata(
 
         if build_unsat or host_unsat:
             m.final = False
-            log = utils.get_logger(__name__)
             log.warning(
                 f"Returning non-final recipe for {m.dist()}; one or more dependencies "
                 "was unsatisfiable:"

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import random
 import re
@@ -13,7 +14,6 @@ import tarfile
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from functools import lru_cache
-from logging import getLogger
 from os.path import (
     isabs,
     isdir,
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
     from .config import Config
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def odict_representer(dumper, data):

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import locale
+import logging
 import os
 import re
 import shutil
 import sys
 import tempfile
 import time
-from logging import getLogger
 from os.path import abspath, basename, exists, expanduser, isdir, isfile, join, normpath
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -42,7 +42,7 @@ from .utils import (
 if TYPE_CHECKING:
     from typing import Iterable
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 git_submod_re = re.compile(r"(?:.+)\.(.+)\.(?:.+)\s(.+)")
 ext_re = re.compile(r"(.*?)(\.(?:tar\.)?[^.]+)$")

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import tempfile
 import time
+from logging import getLogger
 from os.path import abspath, basename, exists, expanduser, isdir, isfile, join, normpath
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -32,7 +33,6 @@ from .utils import (
     copy_into,
     decompressible_exts,
     ensure_list,
-    get_logger,
     on_win,
     rm_rf,
     safe_print_unicode,
@@ -42,7 +42,7 @@ from .utils import (
 if TYPE_CHECKING:
     from typing import Iterable
 
-log = get_logger(__name__)
+log = getLogger(__name__)
 
 git_submod_re = re.compile(r"(?:.+)\.(.+)\.(?:.+)\s(.+)")
 ext_re = re.compile(r"(.*?)(\.(?:tar\.)?[^.]+)$")
@@ -636,7 +636,7 @@ def get_repository_info(recipe_path):
                 time.ctime(os.path.getmtime(join(recipe_path, "meta.yaml"))),
             )
     except CalledProcessError:
-        get_logger(__name__).debug("Failed to checkout source in " + recipe_path)
+        log.debug("Failed to checkout source in " + recipe_path)
         return "{}, last modified {}".format(
             recipe_path, time.ctime(os.path.getmtime(join(recipe_path, "meta.yaml")))
         )

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1667,7 +1667,7 @@ getLogger("conda.gateways.disk.test").setLevel(WARNING)
 def reset_deduplicator():
     """Most of the time, we want the deduplication.  There are some cases (tests especially)
     where we want to be able to control the duplication."""
-    _DuplicateFilter.clear()
+    _DuplicateFilter.msgs.clear()
 
 
 @deprecated("24.5", "24.7", addendum="Use `conda.cli.logging.init_logging` instead.")

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1650,14 +1650,6 @@ deprecated.constant(
     _level_formatter := logging.Formatter("%(levelname)s: %(message)s"),
 )
 
-# set filelock's logger to only show warnings by default
-logging.getLogger("filelock").setLevel(logging.WARNING)
-
-# quiet some of conda's less useful output
-logging.getLogger("conda.core.linked_data").setLevel(logging.WARNING)
-logging.getLogger("conda.gateways.disk.delete").setLevel(logging.WARNING)
-logging.getLogger("conda.gateways.disk.test").setLevel(logging.WARNING)
-
 
 @deprecated(
     "24.5",

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -69,17 +69,6 @@ from conda.utils import unix_path_to_win
 from .cli.logging import DuplicateFilter as _DuplicateFilter
 from .cli.logging import GreaterThanFilter as _GreaterThanFilter
 from .cli.logging import LessThanFilter as _LessThanFilter
-from .conda_interface import (
-    PackageRecord,
-    StringIO,
-    TemporaryDirectory,
-    VersionOrder,
-    cc_conda_build,
-    download,
-    unix_path_to_win,
-    win_path_to_unix,
-)
-from .conda_interface import rm_rf as _rm_rf
 from .deprecations import deprecated
 from .exceptions import BuildLockError
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -14,15 +14,18 @@ from functools import lru_cache
 from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING
+from logging import getLogger
 
 import yaml
 from conda.base.context import context
 
-from .utils import ensure_list, get_logger, islist, on_win, trim_empty_keys
+from .utils import ensure_list, islist, on_win, trim_empty_keys
 from .version import _parse as parse_version
 
 if TYPE_CHECKING:
     from typing import Any, Iterable
+
+log = getLogger(__name__)
 
 DEFAULT_VARIANTS = {
     "python": f"{sys.version_info.major}.{sys.version_info.minor}",
@@ -263,7 +266,6 @@ def _combine_spec_dictionaries(
     for spec_source, spec in specs.items():
         if spec:
             if log_output:
-                log = get_logger(__name__)
                 log.info(f"Adding in variants from {spec_source}")
             for k, v in spec.items():
                 if not keys or k in keys:
@@ -496,7 +498,6 @@ def filter_by_key_value(variants, key, values, source_name):
             if variant.get(key) is not None and variant.get(key) in values:
                 reduced_variants.append(variant)
             else:
-                log = get_logger(__name__)
                 log.debug(
                     f"Filtering variant with key {key} not matching target value(s) "
                     f"({values}) from {source_name}, actual {variant.get(key)}"

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -5,6 +5,7 @@ ending up with a configuration matrix"""
 
 from __future__ import annotations
 
+import logging
 import os.path
 import re
 import sys
@@ -14,7 +15,6 @@ from functools import lru_cache
 from itertools import product
 from pathlib import Path
 from typing import TYPE_CHECKING
-from logging import getLogger
 
 import yaml
 from conda.base.context import context
@@ -25,7 +25,7 @@ from .version import _parse as parse_version
 if TYPE_CHECKING:
     from typing import Any, Iterable
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 DEFAULT_VARIANTS = {
     "python": f"{sys.version_info.major}.{sys.version_info.minor}",

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+import logging
 import os
 import pprint
-from logging import getLogger
 from os.path import dirname, isdir, isfile, join
 
 # importing setuptools patches distutils so that it knows how to find VC for python 2.7
@@ -28,7 +28,7 @@ from .utils import (
 )
 from .variants import get_default_variant, set_language_env_vars
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 VS_VERSION_STRING = {
     "8.0": "Visual Studio 8 2005",

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import os
 import pprint
+from logging import getLogger
 from os.path import dirname, isdir, isfile, join
 
 # importing setuptools patches distutils so that it knows how to find VC for python 2.7
@@ -22,11 +23,12 @@ from . import environ
 from .utils import (
     check_call_env,
     copy_into,
-    get_logger,
     path_prepended,
     write_bat_activation_text,
 )
 from .variants import get_default_variant, set_language_env_vars
+
+log = getLogger(__name__)
 
 VS_VERSION_STRING = {
     "8.0": "Visual Studio 8 2005",
@@ -101,7 +103,6 @@ def msvc_env_cmd(bits, config, override=None):
     # TODO: this function will likely break on `win-arm64`. However, unless
     # there's clear user demand, it's not clear that we should invest the
     # effort into updating a known deprecated function for a new platform.
-    log = get_logger(__name__)
     log.warning(
         "Using legacy MSVC compiler setup.  This will be removed in conda-build 4.0. "
         "If this recipe does not use a compiler, this message is safe to ignore.  "

--- a/news/5275-logging
+++ b/news/5275-logging
@@ -1,0 +1,27 @@
+### Enhancements
+
+* Only customize logging for conda-build's CLI. Do not mess with logging initialization when using conda-build as a library. (#5275)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate `conda_build.utils.reset_deduplicator`. Use `conda_build.cli.logging.DuplicateFilter.msgs.clear` instead. (#5275)
+* Deprecate `conda_build.utils.get_logger`. Use `conda.cli.logging.init_logging` instead. (#5275)
+* Deprecate `conda_build.utils.LessThanFilter`. Use `conda.cli.logging.LessThanFilter` instead. (#5275)
+* Deprecate `conda_build.utils.GreaterThanFilter`. Use `conda.cli.logging.GreaterThanFilter` instead. (#5275)
+* Deprecate `conda_build.utils.DuplicateFilter`. Use `conda.cli.logging.DuplicateFilter` instead. (#5275)
+* Deprecate `conda_build.utils.dedupe_filter`. Use `conda.cli.logging.DuplicateFilter()` instead. (#5275)
+* Deprecate `conda_build.utils.info_debug_stdout_filter`. Use `conda.cli.logging.LessThanFilter(WARNING)` instead. (#5275)
+* Deprecate `conda_build.utils.warning_error_stderr_filter`. Use `conda.cli.logging.GreaterThanFilter(INFO)` instead. (#5275)
+* Deprecate `conda_build.utils.level_formatter`. Unused. (#5275)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -7,6 +7,7 @@ This module tests the build API.  These are high-level integration tests.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -16,7 +17,6 @@ import uuid
 from collections import OrderedDict
 from contextlib import nullcontext
 from glob import glob
-from logging import INFO
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
@@ -91,7 +91,9 @@ yaml.add_representer(OrderedDict, represent_ordereddict)
 
 
 class AnacondaClientArgs:
-    def __init__(self, specs, token=None, site=None, log_level=INFO, force=False):
+    def __init__(
+        self, specs, token=None, site=None, log_level=logging.INFO, force=False
+    ):
         from binstar_client.utils import parse_specs
 
         self.specs = [parse_specs(specs)]
@@ -1878,7 +1880,7 @@ def test_extra_meta(testing_config, caplog):
     recipe_dir = os.path.join(metadata_dir, "_extra_meta")
     extra_meta_data = {"foo": "bar"}
     testing_config.extra_meta = extra_meta_data
-    caplog.set_level(INFO)
+    caplog.set_level(logging.INFO)
     outputs = api.build(recipe_dir, config=testing_config)
     about = json.loads(package_has_file(outputs[0], "info/about.json"))
     assert "foo" in about["extra"] and about["extra"]["foo"] == "bar"

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -7,7 +7,6 @@ This module tests the build API.  These are high-level integration tests.
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import subprocess
@@ -17,6 +16,7 @@ import uuid
 from collections import OrderedDict
 from contextlib import nullcontext
 from glob import glob
+from logging import INFO
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
@@ -91,9 +91,7 @@ yaml.add_representer(OrderedDict, represent_ordereddict)
 
 
 class AnacondaClientArgs:
-    def __init__(
-        self, specs, token=None, site=None, log_level=logging.INFO, force=False
-    ):
+    def __init__(self, specs, token=None, site=None, log_level=INFO, force=False):
         from binstar_client.utils import parse_specs
 
         self.specs = [parse_specs(specs)]
@@ -1880,6 +1878,7 @@ def test_extra_meta(testing_config, caplog):
     recipe_dir = os.path.join(metadata_dir, "_extra_meta")
     extra_meta_data = {"foo": "bar"}
     testing_config.extra_meta = extra_meta_data
+    caplog.set_level(INFO)
     outputs = api.build(recipe_dir, config=testing_config)
     about = json.loads(package_has_file(outputs[0], "info/about.json"))
     assert "foo" in about["extra"] and about["extra"]["foo"] == "bar"

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -9,8 +9,8 @@ from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 
 from conda_build import source
+from conda_build.cli.logging import DuplicateFilter
 from conda_build.source import download_to_cache
-from conda_build.utils import reset_deduplicator
 
 from .utils import thisdir
 
@@ -198,5 +198,5 @@ def test_append_hash_to_fn(testing_metadata):
     testing_metadata.meta["source"] = [
         {"folder": "f1", "url": os.path.join(thisdir, "archives", "a.tar.bz2")}
     ]
-    reset_deduplicator()
+    DuplicateFilter.msgs.clear()
     source.provide(testing_metadata)

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -13,6 +13,7 @@ from conda.base.context import context
 from conda_build import api, utils
 from conda_build.exceptions import BuildScriptException, CondaBuildUserError
 from conda_build.metadata import MetaDataTuple
+from conda_build.cli.logging import DuplicateFilter
 from conda_build.render import finalize_metadata
 
 from .utils import get_valid_recipes, subpackage_dir
@@ -273,7 +274,7 @@ def test_subpackage_hash_inputs(testing_config):
 
 def test_overlapping_files(testing_config, caplog):
     recipe_dir = os.path.join(subpackage_dir, "_overlapping_files")
-    utils.reset_deduplicator()
+    DuplicateFilter.msgs.clear()
     outputs = api.build(recipe_dir, config=testing_config)
     assert len(outputs) == 3
     assert sum(int("Exact overlap" in rec.message) for rec in caplog.records) == 1

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -11,9 +11,9 @@ import pytest
 from conda.base.context import context
 
 from conda_build import api, utils
+from conda_build.cli.logging import DuplicateFilter
 from conda_build.exceptions import BuildScriptException, CondaBuildUserError
 from conda_build.metadata import MetaDataTuple
-from conda_build.cli.logging import DuplicateFilter
 from conda_build.render import finalize_metadata
 
 from .utils import get_valid_recipes, subpackage_dir

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,8 +160,8 @@ def test_filter_files():
 
 @pytest.mark.serial
 def test_logger_filtering(caplog: LogCaptureFixture, capsys: CaptureFixture) -> None:
-    log = getLogger(__name__)
-    init_logging(log)
+    log = getLogger("conda_build.tests")
+    init_logging()
     caplog.set_level(DEBUG)
 
     log.debug("test debug message")
@@ -216,7 +216,7 @@ def test_logger_config_from_file(
                     }
                 },
                 "loggers": {
-                    __name__: {
+                    "conda_build": {
                         "level": "WARN",
                         "handlers": ["console"],
                         "propagate": False,
@@ -233,8 +233,8 @@ def test_logger_config_from_file(
         return_value={"log_config_file": test_file},
     )
 
-    log = getLogger(__name__)
-    init_logging(log)
+    log = getLogger("conda_build.tests")
+    init_logging()
 
     # default log level is INFO, but our config file should set level to DEBUG
     log.warning("test message")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+import logging
 import os
 import subprocess
 import sys
-from logging import DEBUG, StreamHandler, getLogger
 from pathlib import Path
 from typing import NamedTuple
 
@@ -160,9 +160,9 @@ def test_filter_files():
 
 @pytest.mark.serial
 def test_logger_filtering(caplog: LogCaptureFixture, capsys: CaptureFixture) -> None:
-    log = getLogger("conda_build.tests")
+    log = logging.getLogger("conda_build.tests")
     init_logging()
-    caplog.set_level(DEBUG)
+    caplog.set_level(logging.DEBUG)
 
     log.debug("test debug message")
     log.info("test info message")
@@ -187,8 +187,8 @@ def test_logger_filtering(caplog: LogCaptureFixture, capsys: CaptureFixture) -> 
     assert out.count("test duplicate message") == 1
 
     # cleanup
-    log.removeHandler(StreamHandler(sys.stdout))
-    log.removeHandler(StreamHandler(sys.stderr))
+    log.removeHandler(logging.StreamHandler(sys.stdout))
+    log.removeHandler(logging.StreamHandler(sys.stderr))
 
 
 def test_logger_config_from_file(
@@ -233,7 +233,7 @@ def test_logger_config_from_file(
         return_value={"log_config_file": test_file},
     )
 
-    log = getLogger("conda_build.tests")
+    log = logging.getLogger("conda_build.tests")
     init_logging()
 
     # default log level is INFO, but our config file should set level to DEBUG


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Refactor `conda_build.utils.get_logger` into `conda_build.cli.logging.init_logging` and only call this initializer when the conda-build CLI entrypoints are invoked. When using conda-build as a library we do not set any logging defaults.

Resolves #5274
Xref #5415

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
