### PR TITLE
Finish conda interface deprecations

### DIFF
--- a/conda_build/bdist_conda.py
+++ b/conda_build/bdist_conda.py
@@ -4,6 +4,7 @@ import configparser
 import sys
 import time
 from collections import defaultdict
+from io import StringIO
 
 from setuptools.command.install import install
 from setuptools.dist import Distribution
@@ -11,7 +12,7 @@ from setuptools.errors import BaseError, OptionError
 
 from . import api
 from .build import handle_anaconda_upload
-from .conda_interface import StringIO, spec_from_line
+from .conda_interface import spec_from_line
 from .config import Config
 from .deprecations import deprecated
 from .metadata import MetaData

--- a/conda_build/bdist_conda.py
+++ b/conda_build/bdist_conda.py
@@ -6,13 +6,13 @@ import time
 from collections import defaultdict
 from io import StringIO
 
+from conda.cli.common import spec_from_line
 from setuptools.command.install import install
 from setuptools.dist import Distribution
 from setuptools.errors import BaseError, OptionError
 
 from . import api
 from .build import handle_anaconda_upload
-from .conda_interface import spec_from_line
 from .config import Config
 from .deprecations import deprecated
 from .metadata import MetaData

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -27,6 +27,7 @@ import yaml
 from bs4 import UnicodeDammit
 from conda import __version__ as conda_version
 from conda.auxlib.entity import EntityEncoder
+from conda.base.constants import PREFIX_PLACEHOLDER
 from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
@@ -37,11 +38,7 @@ from conda.models.match_spec import MatchSpec
 
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
-from .conda_interface import (
-    env_path_backup_var_exists,
-    prefix_placeholder,
-    url_path,
-)
+from .conda_interface import env_path_backup_var_exists, url_path
 from .config import Config
 from .create_test import create_all_test_files
 from .deprecations import deprecated
@@ -194,7 +191,7 @@ def have_prefix_files(files, prefix):
     """
 
     prefix_bytes = prefix.encode(utils.codec)
-    prefix_placeholder_bytes = prefix_placeholder.encode(utils.codec)
+    prefix_placeholder_bytes = PREFIX_PLACEHOLDER.encode(utils.codec)
     searches = {prefix: prefix_bytes}
     if utils.on_win:
         # some windows libraries use unix-style path separators
@@ -205,7 +202,7 @@ def have_prefix_files(files, prefix):
         double_backslash_prefix = prefix.replace("\\", "\\\\")
         double_backslash_prefix_bytes = double_backslash_prefix.encode(utils.codec)
         searches[double_backslash_prefix] = double_backslash_prefix_bytes
-    searches[prefix_placeholder] = prefix_placeholder_bytes
+    searches[PREFIX_PLACEHOLDER] = prefix_placeholder_bytes
     min_prefix = min(len(k) for k, _ in searches.items())
 
     # mm.find is incredibly slow, so ripgrep is used to pre-filter the list.
@@ -1148,13 +1145,13 @@ def get_files_with_prefix(m, replacements, files_in, prefix):
             prefix[0].upper() + prefix[1:],
             prefix[0].lower() + prefix[1:],
             prefix_u,
-            prefix_placeholder.replace("\\", "'"),
-            prefix_placeholder.replace("/", "\\"),
+            PREFIX_PLACEHOLDER.replace("\\", "'"),
+            PREFIX_PLACEHOLDER.replace("/", "\\"),
         ]
         # some python/json files store an escaped version of prefix
         pfx_variants.extend([pfx.replace("\\", "\\\\") for pfx in pfx_variants])
     else:
-        pfx_variants = (prefix, prefix_placeholder)
+        pfx_variants = (prefix, PREFIX_PLACEHOLDER)
     # replacing \ with \\ here is for regex escaping
     re_test = (
         b"("

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -39,7 +39,6 @@ from conda.utils import url_path
 
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
-from .conda_interface import env_path_backup_var_exists
 from .config import Config
 from .create_test import create_all_test_files
 from .deprecations import deprecated
@@ -2411,8 +2410,6 @@ def build(
     with utils.path_prepended(m.config.build_prefix):
         env = environ.get_dict(m=m)
     env["CONDA_BUILD_STATE"] = "BUILD"
-    if env_path_backup_var_exists:
-        env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
 
     # this should be a no-op if source is already here
     if m.needs_source_for_render:
@@ -3442,8 +3439,6 @@ def test(
         env.update(environ.get_dict(m=metadata, prefix=config.test_prefix))
         env["CONDA_BUILD_STATE"] = "TEST"
         env["CONDA_BUILD"] = "1"
-        if env_path_backup_var_exists:
-            env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
 
     if not metadata.config.activate or metadata.name() == "conda":
         # prepend bin (or Scripts) directory
@@ -3526,8 +3521,6 @@ def test(
         env = dict(os.environ.copy())
         env.update(environ.get_dict(m=metadata, prefix=metadata.config.test_prefix))
         env["CONDA_BUILD_STATE"] = "TEST"
-        if env_path_backup_var_exists:
-            env["CONDA_PATH_BACKUP"] = os.environ["CONDA_PATH_BACKUP"]
 
     if config.test_run_post:
         from .utils import get_installed_packages

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -26,6 +26,7 @@ import conda_package_handling.api
 import yaml
 from bs4 import UnicodeDammit
 from conda import __version__ as conda_version
+from conda.auxlib.entity import EntityEncoder
 from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
@@ -34,7 +35,6 @@ from conda.models.channel import Channel
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
 from .conda_interface import (
-    EntityEncoder,
     FileMode,
     MatchSpec,
     PathType,

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -32,11 +32,11 @@ from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
 from conda.models.channel import Channel
 from conda.models.enums import FileMode, PathType
+from conda.models.match_spec import MatchSpec
 
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
 from .conda_interface import (
-    MatchSpec,
     TemporaryDirectory,
     env_path_backup_var_exists,
     prefix_placeholder,
@@ -2350,8 +2350,6 @@ def create_build_envs(m: MetaData, notest):
             )
     except DependencyNeedsBuildingError as e:
         # subpackages are not actually missing.  We just haven't built them yet.
-        from .conda_interface import MatchSpec
-
         other_outputs = (
             m.other_outputs.values()
             if hasattr(m, "other_outputs")

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -35,10 +35,11 @@ from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.channel import Channel
 from conda.models.enums import FileMode, PathType
 from conda.models.match_spec import MatchSpec
+from conda.utils import url_path
 
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
-from .conda_interface import env_path_backup_var_exists, url_path
+from .conda_interface import env_path_backup_var_exists
 from .config import Config
 from .create_test import create_all_test_files
 from .deprecations import deprecated

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -30,6 +30,7 @@ from conda.auxlib.entity import EntityEncoder
 from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.channel import Channel
 from conda.models.enums import FileMode, PathType
 from conda.models.match_spec import MatchSpec
@@ -37,7 +38,6 @@ from conda.models.match_spec import MatchSpec
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
 from .conda_interface import (
-    TemporaryDirectory,
     env_path_backup_var_exists,
     prefix_placeholder,
     url_path,

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -31,13 +31,12 @@ from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
 from conda.models.channel import Channel
+from conda.models.enums import FileMode, PathType
 
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
 from .conda_interface import (
-    FileMode,
     MatchSpec,
-    PathType,
     TemporaryDirectory,
     env_path_backup_var_exists,
     prefix_placeholder,

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -14,10 +14,11 @@ from typing import TYPE_CHECKING
 
 from conda.auxlib.ish import dals
 from conda.base.context import context
+from conda.cli.helpers import add_parser_channels
 from conda.common.io import dashlist
 
 from .. import api, build, source, utils
-from ..conda_interface import add_parser_channels, cc_conda_build
+from ..conda_interface import cc_conda_build
 from ..config import (
     get_channel_urls,
     get_or_merge_config,

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -28,10 +28,8 @@ from .actions import KeyValueAction
 from .main_render import get_render_parser
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
-
-    from ..conda_interface import ArgumentParser
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:

--- a/conda_build/cli/main_convert.py
+++ b/conda_build/cli/main_convert.py
@@ -7,10 +7,9 @@ from os.path import abspath, expanduser
 from typing import TYPE_CHECKING
 
 from .. import api
-from ..conda_interface import ArgumentParser
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
 logging.basicConfig(level=logging.INFO)
@@ -41,6 +40,8 @@ install on Mac OS X):
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
+    from conda.cli.conda_argparse import ArgumentParser
+
     parser = ArgumentParser(
         prog="conda convert",
         description="""

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -8,16 +8,18 @@ from typing import TYPE_CHECKING
 from conda.base.context import context, determine_target_prefix
 
 from .. import api
-from ..conda_interface import ArgumentParser, add_parser_prefix
+from ..conda_interface import add_parser_prefix
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
 logging.basicConfig(level=logging.INFO)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
+    from conda.cli.conda_argparse import ArgumentParser
+
     parser = ArgumentParser(
         prog="conda develop",
         description="""

--- a/conda_build/cli/main_develop.py
+++ b/conda_build/cli/main_develop.py
@@ -6,9 +6,9 @@ import logging
 from typing import TYPE_CHECKING
 
 from conda.base.context import context, determine_target_prefix
+from conda.cli.helpers import add_parser_prefix
 
 from .. import api
-from ..conda_interface import add_parser_prefix
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -9,9 +9,9 @@ from pprint import pprint
 from typing import TYPE_CHECKING
 
 from conda.base.context import context, determine_target_prefix
+from conda.cli.helpers import add_parser_prefix
 
 from .. import api
-from ..conda_interface import add_parser_prefix
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace

--- a/conda_build/cli/main_inspect.py
+++ b/conda_build/cli/main_inspect.py
@@ -11,16 +11,18 @@ from typing import TYPE_CHECKING
 from conda.base.context import context, determine_target_prefix
 
 from .. import api
-from ..conda_interface import ArgumentParser, add_parser_prefix
+from ..conda_interface import add_parser_prefix
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
 logging.basicConfig(level=logging.INFO)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
+    from conda.cli.conda_argparse import ArgumentParser
+
     parser = ArgumentParser(
         prog="conda inspect",
         description="Tools for inspecting conda packages.",

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -9,16 +9,18 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
-from ..conda_interface import ArgumentParser, add_parser_channels
+from ..conda_interface import add_parser_channels
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
 logging.basicConfig(level=logging.INFO)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
+    from conda.cli.conda_argparse import ArgumentParser
+
     parser = ArgumentParser(
         prog="conda metapackage",
         description="""

--- a/conda_build/cli/main_metapackage.py
+++ b/conda_build/cli/main_metapackage.py
@@ -7,9 +7,9 @@ import logging
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
+from conda.cli.helpers import add_parser_channels
 
 from .. import api
-from ..conda_interface import add_parser_channels
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -8,10 +8,11 @@ from pprint import pprint
 from typing import TYPE_CHECKING
 
 import yaml
+from conda.cli.helpers import add_parser_channels
 from yaml.parser import ParserError
 
 from .. import __version__, api
-from ..conda_interface import add_parser_channels, cc_conda_build
+from ..conda_interface import cc_conda_build
 from ..config import get_channel_urls, get_or_merge_config
 from ..utils import LoggingContext
 from ..variants import get_package_variants, set_language_env_vars

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -8,11 +8,11 @@ from pprint import pprint
 from typing import TYPE_CHECKING
 
 import yaml
+from conda.base.context import context
 from conda.cli.helpers import add_parser_channels
 from yaml.parser import ParserError
 
 from .. import __version__, api
-from ..conda_interface import cc_conda_build
 from ..config import get_channel_urls, get_or_merge_config
 from ..utils import LoggingContext
 from ..variants import get_package_variants, set_language_env_vars
@@ -141,7 +141,7 @@ source to try fill in related template variables.",
         "--old-build-string",
         dest="filename_hashing",
         action="store_false",
-        default=cc_conda_build.get("filename_hashing", "true").lower() == "true",
+        default=context.conda_build.get("filename_hashing", "true").lower() == "true",
         help=(
             "Disable hash additions to filenames to distinguish package "
             "variants from one another. NOTE: any filename collisions are "

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -11,13 +11,13 @@ import yaml
 from yaml.parser import ParserError
 
 from .. import __version__, api
-from ..conda_interface import ArgumentParser, add_parser_channels, cc_conda_build
+from ..conda_interface import add_parser_channels, cc_conda_build
 from ..config import get_channel_urls, get_or_merge_config
 from ..utils import LoggingContext
 from ..variants import get_package_variants, set_language_env_vars
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
 log = logging.getLogger(__name__)
@@ -43,7 +43,9 @@ class ParseYAMLArgument(argparse.Action):
             )
 
 
-def get_render_parser():
+def get_render_parser() -> ArgumentParser:
+    from conda.cli.conda_argparse import ArgumentParser
+
     p = ArgumentParser(
         prog="conda render",
         description="""

--- a/conda_build/cli/main_skeleton.py
+++ b/conda_build/cli/main_skeleton.py
@@ -10,11 +10,10 @@ from importlib import import_module
 from typing import TYPE_CHECKING
 
 from .. import api
-from ..conda_interface import ArgumentParser
 from ..config import Config
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from typing import Sequence
 
 thisdir = os.path.dirname(os.path.abspath(__file__))
@@ -22,6 +21,8 @@ logging.basicConfig(level=logging.INFO)
 
 
 def parse_args(args: Sequence[str] | None) -> tuple[ArgumentParser, Namespace]:
+    from conda.cli.conda_argparse import ArgumentParser
+
     parser = ArgumentParser(
         prog="conda skeleton",
         description="""

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -26,7 +26,6 @@ from conda.exceptions import NoPackagesFoundError as _NoPackagesFoundError
 from conda.exceptions import PaddingError as _PaddingError
 from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
 from conda.exports import (  # noqa: F401
-    Channel,
     Completer,
     CondaSession,
     EntityEncoder,
@@ -62,6 +61,7 @@ from conda.exports import (  # noqa: F401
 )
 from conda.exports import get_index as _get_index
 from conda.gateways.disk.read import compute_sum as _compute_sum
+from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
 
 from .deprecations import deprecated
@@ -86,6 +86,14 @@ deprecated.constant(
     "add_parser_prefix",
     _add_parser_prefix,
     addendum="Use `conda.cli.helpers.add_parser_prefix` instead.",
+)
+
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "Channel",
+    _Channel,
+    addendum="Use `conda.models.channel.Channel` instead.",
 )
 
 deprecated.constant(
@@ -292,7 +300,7 @@ deprecated.constant(
     "24.5",
     "24.7",
     "get_conda_channel",
-    Channel.from_value,
+    _Channel.from_value,
     addendum="Use `conda.models.channel.Channel.from_value` instead.",
 )
 

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -40,7 +40,6 @@ from conda.exports import (  # noqa: F401
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
     symlink_conda,  # unused
-    url_path,
     walk_prefix,
     win_path_to_unix,
 )
@@ -62,6 +61,7 @@ from conda.models.version import normalized_version as _normalized_version
 from conda.resolve import Resolve as _Resolve
 from conda.utils import human_bytes as _human_bytes
 from conda.utils import unix_path_to_win as _unix_path_to_win
+from conda.utils import url_path as _url_path
 
 from .deprecations import deprecated
 from .utils import rm_rf as _rm_rf
@@ -242,6 +242,13 @@ deprecated.constant(
     "untracked",
     _untracked,
     addendum="Use `conda.misc.untracked` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "url_path",
+    _url_path,
+    addendum="Use `conda.utils.url_path` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -29,12 +29,10 @@ from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
 from conda.exports import (  # noqa: F401
     Completer,  # unused
     CondaSession,  # unused
-    FileMode,
     InstalledPackages,
     MatchSpec,
     NoPackagesFound,
     PackageRecord,
-    PathType,
     Resolve,
     StringIO,
     TemporaryDirectory,
@@ -63,6 +61,8 @@ from conda.exports import get_index as _get_index
 from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
+from conda.models.enums import FileMode as _FileMode
+from conda.models.enums import PathType as _PathType
 
 from .deprecations import deprecated
 
@@ -94,6 +94,20 @@ deprecated.constant(
     "Channel",
     _Channel,
     addendum="Use `conda.models.channel.Channel` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "FileMode",
+    _FileMode,
+    addendum="Use `conda.models.enums.FileMode` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "PathType",
+    _PathType,
+    addendum="Use `conda.models.enums.PathType` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -519,7 +519,13 @@ deprecated.constant(
     _partial(_determine_target_prefix, _context),
     addendum="Use `conda.base.context.context.target_prefix` instead.",
 )
-cc_conda_build = _context.conda_build if hasattr(_context, "conda_build") else {}
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "cc_conda_build",
+    _context.conda_build,
+    addendum="Use `conda.base.context.context.conda_build` instead.",
+)
 
 deprecated.constant(
     "24.5",

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -34,7 +34,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    human_bytes,
     input,
     lchmod,
     normalized_version,
@@ -63,6 +62,7 @@ from conda.models.match_spec import MatchSpec as _MatchSpec
 from conda.models.records import PackageRecord as _PackageRecord
 from conda.models.version import VersionOrder as _VersionOrder
 from conda.resolve import Resolve as _Resolve
+from conda.utils import human_bytes as _human_bytes
 
 from .deprecations import deprecated
 
@@ -172,6 +172,13 @@ deprecated.constant(
     "_toposort",
     __toposort,
     addendum="Use `conda.common.toposort._toposort` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "human_bytes",
+    _human_bytes,
+    addendum="Use `conda.utils.human_bytes` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -36,7 +36,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    rm_rf,
     spec_from_line,
     specs_from_args,
     specs_from_url,
@@ -65,6 +64,7 @@ from conda.resolve import Resolve as _Resolve
 from conda.utils import human_bytes as _human_bytes
 
 from .deprecations import deprecated
+from .utils import rm_rf as _rm_rf
 
 deprecated.constant(
     "24.5",
@@ -200,6 +200,13 @@ deprecated.constant(
     "prefix_placeholder",
     _PREFIX_PLACEHOLDER,
     addendum="Use `conda.base.constants.PREFIX_PLACEHOLDER` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "rm_rf",
+    _rm_rf,
+    addendum="Use `conda_build.utils.rm_rf` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -32,7 +32,6 @@ from conda.exports import (  # noqa: F401
     CondaSession,  # unused
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
-    TmpDownload,
     Unsatisfiable,
     VersionOrder,
     _toposort,
@@ -54,6 +53,7 @@ from conda.exports import (  # noqa: F401
     win_path_to_unix,
 )
 from conda.exports import get_index as _get_index
+from conda.gateways.connection.download import TmpDownload as _TmpDownload
 from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
 from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.models.channel import Channel as _Channel
@@ -144,6 +144,13 @@ deprecated.constant(
     "TemporaryDirectory",
     _TemporaryDirectory,
     addendum="Use `conda.gateways.disk.create.TemporaryDirectory` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "TmpDownload",
+    _TmpDownload,
+    addendum="Use `conda.gateways.connection.download.TmpDownload` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -16,6 +16,9 @@ from conda.base.context import context as _context
 from conda.base.context import determine_target_prefix as _determine_target_prefix
 from conda.base.context import non_x86_machines as _non_x86_linux_machines
 from conda.base.context import reset_context as _reset_context
+from conda.cli.common import spec_from_line as _spec_from_line
+from conda.cli.common import specs_from_args as _specs_from_args
+from conda.cli.common import specs_from_url as _specs_from_url
 from conda.cli.conda_argparse import ArgumentParser as _ArgumentParser
 from conda.cli.helpers import add_parser_channels as _add_parser_channels
 from conda.cli.helpers import add_parser_prefix as _add_parser_prefix
@@ -36,9 +39,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    spec_from_line,
-    specs_from_args,
-    specs_from_url,
     symlink_conda,
     unix_path_to_win,
     untracked,
@@ -207,6 +207,27 @@ deprecated.constant(
     "rm_rf",
     _rm_rf,
     addendum="Use `conda_build.utils.rm_rf` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "spec_from_line",
+    _spec_from_line,
+    addendum="Use `conda.cli.common.spec_from_line` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "specs_from_args",
+    _specs_from_args,
+    addendum="Use `conda.cli.common.specs_from_args` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "specs_from_url",
+    _specs_from_url,
+    addendum="Use `conda.cli.common.specs_from_url` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -32,7 +32,6 @@ from conda.exports import (  # noqa: F401
     CondaSession,  # unused
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
-    TemporaryDirectory,
     TmpDownload,
     Unsatisfiable,
     VersionOrder,
@@ -55,6 +54,7 @@ from conda.exports import (  # noqa: F401
     win_path_to_unix,
 )
 from conda.exports import get_index as _get_index
+from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
 from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
@@ -131,13 +131,19 @@ deprecated.constant(
     _EntityEncoder,
     addendum="Use `conda.auxlib.entity.EntityEncoder` instead.",
 )
-
 deprecated.constant(
     "24.5",
     "24.7",
     "Resolve",
     _Resolve,
     addendum="Use `conda.resolve.Resolve` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "TemporaryDirectory",
+    _TemporaryDirectory,
+    addendum="Use `conda.gateways.disk.create.TemporaryDirectory` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -40,7 +40,6 @@ from conda.exports import (  # noqa: F401
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
     symlink_conda,  # unused
-    untracked,
     url_path,
     walk_prefix,
     win_path_to_unix,
@@ -51,6 +50,7 @@ from conda.gateways.connection.download import download as _download
 from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
 from conda.gateways.disk.link import lchmod as _lchmod
 from conda.gateways.disk.read import compute_sum as _compute_sum
+from conda.misc import untracked as _untracked
 from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
 from conda.models.enums import FileMode as _FileMode
@@ -235,6 +235,13 @@ deprecated.constant(
     "unix_path_to_win",
     _unix_path_to_win,
     addendum="Use `conda.utils.unix_path_to_win` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "untracked",
+    _untracked,
+    addendum="Use `conda.misc.untracked` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -35,7 +35,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    lchmod,
     normalized_version,
     prefix_placeholder,
     rm_rf,
@@ -53,6 +52,7 @@ from conda.exports import get_index as _get_index
 from conda.gateways.connection.download import TmpDownload as _TmpDownload
 from conda.gateways.connection.download import download as _download
 from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
+from conda.gateways.disk.link import lchmod as _lchmod
 from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
@@ -179,6 +179,13 @@ deprecated.constant(
     "human_bytes",
     _human_bytes,
     addendum="Use `conda.utils.human_bytes` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "lchmod",
+    _lchmod,
+    addendum="Use `conda.gateways.disk.link.lchmod` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -31,7 +31,6 @@ from conda.exports import (  # noqa: F401
     CondaSession,  # unused
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
-    Resolve,
     StringIO,
     TemporaryDirectory,
     TmpDownload,
@@ -63,6 +62,7 @@ from conda.models.enums import FileMode as _FileMode
 from conda.models.enums import PathType as _PathType
 from conda.models.match_spec import MatchSpec as _MatchSpec
 from conda.models.records import PackageRecord as _PackageRecord
+from conda.resolve import Resolve as _Resolve
 
 from .deprecations import deprecated
 
@@ -130,6 +130,14 @@ deprecated.constant(
     "EntityEncoder",
     _EntityEncoder,
     addendum="Use `conda.auxlib.entity.EntityEncoder` instead.",
+)
+
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "Resolve",
+    _Resolve,
+    addendum="Use `conda.resolve.Resolve` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -35,7 +35,6 @@ from conda.exports import (  # noqa: F401
     Unsatisfiable,
     VersionOrder,
     _toposort,
-    download,
     human_bytes,
     input,
     lchmod,
@@ -54,6 +53,7 @@ from conda.exports import (  # noqa: F401
 )
 from conda.exports import get_index as _get_index
 from conda.gateways.connection.download import TmpDownload as _TmpDownload
+from conda.gateways.connection.download import download as _download
 from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
 from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.models.channel import Channel as _Channel
@@ -151,6 +151,13 @@ deprecated.constant(
     "TmpDownload",
     _TmpDownload,
     addendum="Use `conda.gateways.connection.download.TmpDownload` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "download",
+    _download,
+    addendum="Use `conda.gateways.connection.download.download` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -8,6 +8,7 @@ from functools import partial as _partial
 from importlib import import_module as _import_module
 
 from conda import __version__
+from conda.auxlib.entity import EntityEncoder as _EntityEncoder
 from conda.base.context import context as _context
 from conda.base.context import determine_target_prefix as _determine_target_prefix
 from conda.base.context import non_x86_machines as _non_x86_linux_machines
@@ -26,9 +27,8 @@ from conda.exceptions import NoPackagesFoundError as _NoPackagesFoundError
 from conda.exceptions import PaddingError as _PaddingError
 from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
 from conda.exports import (  # noqa: F401
-    Completer,
-    CondaSession,
-    EntityEncoder,
+    Completer,  # unused
+    CondaSession,  # unused
     FileMode,
     InstalledPackages,
     MatchSpec,
@@ -94,6 +94,14 @@ deprecated.constant(
     "Channel",
     _Channel,
     addendum="Use `conda.models.channel.Channel` instead.",
+)
+
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "EntityEncoder",
+    _EntityEncoder,
+    addendum="Use `conda.auxlib.entity.EntityEncoder` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -22,8 +22,8 @@ from conda.exceptions import LockError as _LockError
 from conda.exceptions import NoPackagesFoundError as _NoPackagesFoundError
 from conda.exceptions import PaddingError as _PaddingError
 from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
+from conda.exports import ArgumentParser as _ArgumentParser
 from conda.exports import (  # noqa: F401
-    ArgumentParser,
     Channel,
     Completer,
     CondaSession,
@@ -65,6 +65,14 @@ from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
 
 from .deprecations import deprecated
+
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "ArgumentParser",
+    _ArgumentParser,
+    addendum="Use `conda.cli.conda_argparse.ArgumentParser` instead.",
+)
 
 deprecated.constant(
     "24.5",

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -33,18 +33,15 @@ from conda.exceptions import LinkError as _LinkError
 from conda.exceptions import LockError as _LockError
 from conda.exceptions import NoPackagesFoundError as _NoPackagesFoundError
 from conda.exceptions import PaddingError as _PaddingError
+from conda.exceptions import ResolvePackageNotFound as _ResolvePackageNotFound
 from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
-from conda.exports import (  # noqa: F401
-    Completer,  # unused
-    CondaSession,  # unused
-    InstalledPackages,  # unused
-    NoPackagesFound,  # unused
-    Unsatisfiable,  # unused
-    symlink_conda,  # unused
-)
+from conda.exports import Completer as _Completer
+from conda.exports import InstalledPackages as _InstalledPackages
 from conda.exports import get_index as _get_index
+from conda.exports import symlink_conda as _symlink_conda
 from conda.gateways.connection.download import TmpDownload as _TmpDownload
 from conda.gateways.connection.download import download as _download
+from conda.gateways.connection.session import CondaSession as _CondaSession
 from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
 from conda.gateways.disk.link import lchmod as _lchmod
 from conda.gateways.disk.read import compute_sum as _compute_sum
@@ -65,6 +62,50 @@ from conda.utils import url_path as _url_path
 
 from .deprecations import deprecated
 from .utils import rm_rf as _rm_rf
+
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "Completer",
+    _Completer,
+    addendum="Unused.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "CondaSession",
+    _CondaSession,
+    addendum="Use `conda.gateways.connection.session.CondaSession` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "InstalledPackages",
+    _InstalledPackages,
+    addendum="Unused.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "NoPackagesFound",
+    _ResolvePackageNotFound,
+    addendum="Use `conda.exceptions.ResolvePackageNotFound` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "Unsatisfiable",
+    _UnsatisfiableError,
+    addendum="Use `conda.exceptions.UnsatisfiableError` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "symlink_conda",
+    _symlink_conda,
+    addendum="Unused.",
+)
+
 
 deprecated.constant(
     "24.5",

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -12,6 +12,9 @@ from conda.base.context import context as _context
 from conda.base.context import determine_target_prefix as _determine_target_prefix
 from conda.base.context import non_x86_machines as _non_x86_linux_machines
 from conda.base.context import reset_context as _reset_context
+from conda.cli.conda_argparse import ArgumentParser as _ArgumentParser
+from conda.cli.helpers import add_parser_channels as _add_parser_channels
+from conda.cli.helpers import add_parser_prefix as _add_parser_prefix
 from conda.core.package_cache_data import (
     ProgressiveFetchExtract as _ProgressiveFetchExtract,
 )
@@ -22,7 +25,6 @@ from conda.exceptions import LockError as _LockError
 from conda.exceptions import NoPackagesFoundError as _NoPackagesFoundError
 from conda.exceptions import PaddingError as _PaddingError
 from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
-from conda.exports import ArgumentParser as _ArgumentParser
 from conda.exports import (  # noqa: F401
     Channel,
     Completer,
@@ -41,8 +43,6 @@ from conda.exports import (  # noqa: F401
     Unsatisfiable,
     VersionOrder,
     _toposort,
-    add_parser_channels,
-    add_parser_prefix,
     download,
     human_bytes,
     input,
@@ -72,6 +72,20 @@ deprecated.constant(
     "ArgumentParser",
     _ArgumentParser,
     addendum="Use `conda.cli.conda_argparse.ArgumentParser` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "add_parser_channels",
+    _add_parser_channels,
+    addendum="Use `conda.cli.helpers.add_parser_channels` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "add_parser_prefix",
+    _add_parser_prefix,
+    addendum="Use `conda.cli.helpers.add_parser_prefix` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -11,6 +11,7 @@ from io import StringIO as _StringIO
 
 from conda import __version__
 from conda.auxlib.entity import EntityEncoder as _EntityEncoder
+from conda.base.constants import PREFIX_PLACEHOLDER as _PREFIX_PLACEHOLDER
 from conda.base.context import context as _context
 from conda.base.context import determine_target_prefix as _determine_target_prefix
 from conda.base.context import non_x86_machines as _non_x86_linux_machines
@@ -35,7 +36,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    prefix_placeholder,
     rm_rf,
     spec_from_line,
     specs_from_args,
@@ -193,6 +193,13 @@ deprecated.constant(
     "lchmod",
     _lchmod,
     addendum="Use `conda.gateways.disk.link.lchmod` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "prefix_placeholder",
+    _PREFIX_PLACEHOLDER,
+    addendum="Use `conda.base.constants.PREFIX_PLACEHOLDER` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -29,8 +29,7 @@ from conda.exceptions import UnsatisfiableError as _UnsatisfiableError
 from conda.exports import (  # noqa: F401
     Completer,  # unused
     CondaSession,  # unused
-    InstalledPackages,
-    MatchSpec,
+    InstalledPackages,  # unused
     NoPackagesFound,
     PackageRecord,
     Resolve,
@@ -63,6 +62,7 @@ from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
 from conda.models.enums import FileMode as _FileMode
 from conda.models.enums import PathType as _PathType
+from conda.models.match_spec import MatchSpec as _MatchSpec
 
 from .deprecations import deprecated
 
@@ -108,6 +108,13 @@ deprecated.constant(
     "PathType",
     _PathType,
     addendum="Use `conda.models.enums.PathType` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "MatchSpec",
+    _MatchSpec,
+    addendum="Use `conda.models.match_spec.MatchSpec` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -30,8 +30,7 @@ from conda.exports import (  # noqa: F401
     Completer,  # unused
     CondaSession,  # unused
     InstalledPackages,  # unused
-    NoPackagesFound,
-    PackageRecord,
+    NoPackagesFound,  # unused
     Resolve,
     StringIO,
     TemporaryDirectory,
@@ -63,6 +62,7 @@ from conda.models.channel import get_conda_build_local_url as _get_conda_build_l
 from conda.models.enums import FileMode as _FileMode
 from conda.models.enums import PathType as _PathType
 from conda.models.match_spec import MatchSpec as _MatchSpec
+from conda.models.records import PackageRecord as _PackageRecord
 
 from .deprecations import deprecated
 
@@ -115,6 +115,13 @@ deprecated.constant(
     "MatchSpec",
     _MatchSpec,
     addendum="Use `conda.models.match_spec.MatchSpec` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "PackageRecord",
+    _PackageRecord,
+    addendum="Use `conda.models.records.PackageRecord` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -35,7 +35,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    normalized_version,
     prefix_placeholder,
     rm_rf,
     spec_from_line,
@@ -61,6 +60,7 @@ from conda.models.enums import PathType as _PathType
 from conda.models.match_spec import MatchSpec as _MatchSpec
 from conda.models.records import PackageRecord as _PackageRecord
 from conda.models.version import VersionOrder as _VersionOrder
+from conda.models.version import normalized_version as _normalized_version
 from conda.resolve import Resolve as _Resolve
 from conda.utils import human_bytes as _human_bytes
 
@@ -129,6 +129,13 @@ deprecated.constant(
     "VersionOrder",
     _VersionOrder,
     addendum="Use `conda.models.version.VersionOrder` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "normalized_version",
+    _normalized_version,
+    addendum="Use `conda.models.version.normalized_version` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -39,8 +39,7 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    symlink_conda,
-    unix_path_to_win,
+    symlink_conda,  # unused
     untracked,
     url_path,
     walk_prefix,
@@ -62,6 +61,7 @@ from conda.models.version import VersionOrder as _VersionOrder
 from conda.models.version import normalized_version as _normalized_version
 from conda.resolve import Resolve as _Resolve
 from conda.utils import human_bytes as _human_bytes
+from conda.utils import unix_path_to_win as _unix_path_to_win
 
 from .deprecations import deprecated
 from .utils import rm_rf as _rm_rf
@@ -228,6 +228,13 @@ deprecated.constant(
     "specs_from_url",
     _specs_from_url,
     addendum="Use `conda.cli.common.specs_from_url` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "unix_path_to_win",
+    _unix_path_to_win,
+    addendum="Use `conda.utils.unix_path_to_win` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -22,6 +22,7 @@ from conda.cli.common import specs_from_url as _specs_from_url
 from conda.cli.conda_argparse import ArgumentParser as _ArgumentParser
 from conda.cli.helpers import add_parser_channels as _add_parser_channels
 from conda.cli.helpers import add_parser_prefix as _add_parser_prefix
+from conda.common.path import win_path_to_unix as _win_path_to_unix
 from conda.common.toposort import _toposort as __toposort
 from conda.core.package_cache_data import (
     ProgressiveFetchExtract as _ProgressiveFetchExtract,
@@ -40,7 +41,6 @@ from conda.exports import (  # noqa: F401
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
     symlink_conda,  # unused
-    win_path_to_unix,
 )
 from conda.exports import get_index as _get_index
 from conda.gateways.connection.download import TmpDownload as _TmpDownload
@@ -256,6 +256,13 @@ deprecated.constant(
     "walk_prefix",
     _walk_prefix,
     addendum="Use `conda.misc.walk_prefix` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "win_path_to_unix",
+    _win_path_to_unix,
+    addendum="Use `conda.common.path.win_path_to_unix` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -535,9 +535,13 @@ deprecated.constant(
     addendum="Use `conda.models.channel.Channel.from_value` instead.",
 )
 
-# When deactivating envs (e.g. switching from root to build/test) this env var is used,
-# except the PR that removed this has been reverted (for now) and Windows doesn't need it.
-env_path_backup_var_exists = _os.getenv("CONDA_PATH_BACKUP")
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "env_path_backup_var_exists",
+    _os.getenv("CONDA_PATH_BACKUP"),
+    addendum="Unused.",
+)
 
 
 @deprecated(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -32,8 +32,7 @@ from conda.exports import (  # noqa: F401
     CondaSession,  # unused
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
-    Unsatisfiable,
-    VersionOrder,
+    Unsatisfiable,  # unused
     _toposort,
     human_bytes,
     input,
@@ -62,6 +61,7 @@ from conda.models.enums import FileMode as _FileMode
 from conda.models.enums import PathType as _PathType
 from conda.models.match_spec import MatchSpec as _MatchSpec
 from conda.models.records import PackageRecord as _PackageRecord
+from conda.models.version import VersionOrder as _VersionOrder
 from conda.resolve import Resolve as _Resolve
 
 from .deprecations import deprecated
@@ -122,6 +122,13 @@ deprecated.constant(
     "PackageRecord",
     _PackageRecord,
     addendum="Use `conda.models.records.PackageRecord` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "VersionOrder",
+    _VersionOrder,
+    addendum="Use `conda.models.version.VersionOrder` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -17,6 +17,7 @@ from conda.base.context import reset_context as _reset_context
 from conda.cli.conda_argparse import ArgumentParser as _ArgumentParser
 from conda.cli.helpers import add_parser_channels as _add_parser_channels
 from conda.cli.helpers import add_parser_prefix as _add_parser_prefix
+from conda.common.toposort import _toposort as __toposort
 from conda.core.package_cache_data import (
     ProgressiveFetchExtract as _ProgressiveFetchExtract,
 )
@@ -33,7 +34,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    _toposort,
     human_bytes,
     input,
     lchmod,
@@ -165,6 +165,13 @@ deprecated.constant(
     "download",
     _download,
     addendum="Use `conda.gateways.connection.download.download` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "_toposort",
+    __toposort,
+    addendum="Use `conda.common.toposort._toposort` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import configparser as _configparser
 import os as _os
+from builtins import input as _input
 from functools import partial as _partial
 from importlib import import_module as _import_module
 from io import StringIO as _StringIO
@@ -34,7 +35,6 @@ from conda.exports import (  # noqa: F401
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
-    input,
     lchmod,
     normalized_version,
     prefix_placeholder,
@@ -209,6 +209,13 @@ deprecated.constant(
     "StringIO",
     _StringIO,
     addendum="Use `io.StringIO` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "input",
+    _input,
+    addendum="Use `input` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -40,7 +40,6 @@ from conda.exports import (  # noqa: F401
     NoPackagesFound,  # unused
     Unsatisfiable,  # unused
     symlink_conda,  # unused
-    walk_prefix,
     win_path_to_unix,
 )
 from conda.exports import get_index as _get_index
@@ -50,6 +49,7 @@ from conda.gateways.disk.create import TemporaryDirectory as _TemporaryDirectory
 from conda.gateways.disk.link import lchmod as _lchmod
 from conda.gateways.disk.read import compute_sum as _compute_sum
 from conda.misc import untracked as _untracked
+from conda.misc import walk_prefix as _walk_prefix
 from conda.models.channel import Channel as _Channel
 from conda.models.channel import get_conda_build_local_url as _get_conda_build_local_url
 from conda.models.enums import FileMode as _FileMode
@@ -249,6 +249,13 @@ deprecated.constant(
     "url_path",
     _url_path,
     addendum="Use `conda.utils.url_path` instead.",
+)
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "walk_prefix",
+    _walk_prefix,
+    addendum="Use `conda.misc.walk_prefix` instead.",
 )
 
 deprecated.constant(

--- a/conda_build/conda_interface.py
+++ b/conda_build/conda_interface.py
@@ -6,6 +6,7 @@ import configparser as _configparser
 import os as _os
 from functools import partial as _partial
 from importlib import import_module as _import_module
+from io import StringIO as _StringIO
 
 from conda import __version__
 from conda.auxlib.entity import EntityEncoder as _EntityEncoder
@@ -31,7 +32,6 @@ from conda.exports import (  # noqa: F401
     CondaSession,  # unused
     InstalledPackages,  # unused
     NoPackagesFound,  # unused
-    StringIO,
     TemporaryDirectory,
     TmpDownload,
     Unsatisfiable,
@@ -162,6 +162,14 @@ deprecated.constant(
     _import_module,
     addendum="Use `importlib.import_module` instead.",
 )
+deprecated.constant(
+    "24.5",
+    "24.7",
+    "StringIO",
+    _StringIO,
+    addendum="Use `io.StringIO` instead.",
+)
+
 deprecated.constant(
     "24.5",
     "24.7",

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 from conda.utils import url_path
 
-from .conda_interface import cc_conda_build
 from .utils import (
     get_build_folders,
     get_conda_operation_locks,
@@ -111,14 +110,16 @@ def _get_default_settings():
         Setting("test_run_post", False),
         Setting(
             "filename_hashing",
-            cc_conda_build.get("filename_hashing", filename_hashing_default).lower()
+            context.conda_build.get(
+                "filename_hashing", filename_hashing_default
+            ).lower()
             == "true",
         ),
         Setting("keep_old_work", False),
         Setting(
             "_src_cache_root",
-            abspath(expanduser(expandvars(cc_conda_build.get("cache_dir"))))
-            if cc_conda_build.get("cache_dir")
+            abspath(expanduser(expandvars(cache_dir)))
+            if (cache_dir := context.conda_build.get("cache_dir"))
             else _src_cache_root_default,
         ),
         Setting("copy_test_source_files", True),
@@ -143,30 +144,32 @@ def _get_default_settings():
         #    cli/main_build.py that this default will switch in conda-build 4.0.
         Setting(
             "error_overlinking",
-            cc_conda_build.get("error_overlinking", error_overlinking_default).lower()
+            context.conda_build.get(
+                "error_overlinking", error_overlinking_default
+            ).lower()
             == "true",
         ),
         Setting(
             "error_overdepending",
-            cc_conda_build.get(
+            context.conda_build.get(
                 "error_overdepending", error_overdepending_default
             ).lower()
             == "true",
         ),
         Setting(
             "noarch_python_build_age",
-            cc_conda_build.get(
+            context.conda_build.get(
                 "noarch_python_build_age", noarch_python_build_age_default
             ),
         ),
         Setting(
             "enable_static",
-            cc_conda_build.get("enable_static", enable_static_default).lower()
+            context.conda_build.get("enable_static", enable_static_default).lower()
             == "true",
         ),
         Setting(
             "no_rewrite_stdout_env",
-            cc_conda_build.get(
+            context.conda_build.get(
                 "no_rewrite_stdout_env", no_rewrite_stdout_env_default
             ).lower()
             == "true",
@@ -205,11 +208,13 @@ def _get_default_settings():
         Setting("verify", True),
         Setting(
             "ignore_verify_codes",
-            cc_conda_build.get("ignore_verify_codes", ignore_verify_codes_default),
+            context.conda_build.get("ignore_verify_codes", ignore_verify_codes_default),
         ),
         Setting(
             "exit_on_verify_error",
-            cc_conda_build.get("exit_on_verify_error", exit_on_verify_error_default),
+            context.conda_build.get(
+                "exit_on_verify_error", exit_on_verify_error_default
+            ),
         ),
         # Recipes that have no host section, only build, should bypass the build/host line.
         # This is to make older recipes still work with cross-compiling.  True cross-compiling
@@ -227,17 +232,17 @@ def _get_default_settings():
         Setting("_pip_cache_dir", None),
         Setting(
             "zstd_compression_level",
-            cc_conda_build.get(
+            context.conda_build.get(
                 "zstd_compression_level", zstd_compression_level_default
             ),
         ),
         # this can be set to different values (currently only 2 means anything) to use package formats
         Setting(
             "conda_pkg_format",
-            cc_conda_build.get("pkg_format", conda_pkg_format_default),
+            context.conda_build.get("pkg_format", conda_pkg_format_default),
         ),
         Setting("suppress_variables", False),
-        Setting("build_id_pat", cc_conda_build.get("build_id_pat", "{n}_{t}")),
+        Setting("build_id_pat", context.conda_build.get("build_id_pat", "{n}_{t}")),
     ]
 
 
@@ -450,7 +455,7 @@ class Config:
         """This is where source caches and work folders live"""
         if not self._croot:
             _bld_root_env = os.getenv("CONDA_BLD_PATH")
-            _bld_root_rc = cc_conda_build.get("root-dir")
+            _bld_root_rc = context.conda_build.get("root-dir")
             if _bld_root_env:
                 self._croot = abspath(expanduser(_bld_root_env))
             elif _bld_root_rc:

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -17,8 +17,9 @@ from os.path import abspath, expanduser, expandvars, join
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
+from conda.utils import url_path
 
-from .conda_interface import cc_conda_build, url_path
+from .conda_interface import cc_conda_build
 from .utils import (
     get_build_folders,
     get_conda_operation_locks,

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -38,12 +38,12 @@ from conda.exceptions import (
     PaddingError,
     UnsatisfiableError,
 )
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.channel import Channel, prioritize_channels
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
 
 from . import utils
-from .conda_interface import TemporaryDirectory
 from .deprecations import deprecated
 from .exceptions import BuildLockError, DependencyNeedsBuildingError
 from .features import feature_list

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -38,11 +38,11 @@ from conda.exceptions import (
     PaddingError,
     UnsatisfiableError,
 )
-from conda.models.channel import prioritize_channels
+from conda.models.channel import Channel, prioritize_channels
 from conda.models.match_spec import MatchSpec
 
 from . import utils
-from .conda_interface import Channel, PackageRecord, TemporaryDirectory
+from .conda_interface import PackageRecord, TemporaryDirectory
 from .deprecations import deprecated
 from .exceptions import BuildLockError, DependencyNeedsBuildingError
 from .features import feature_list

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -40,9 +40,10 @@ from conda.exceptions import (
 )
 from conda.models.channel import Channel, prioritize_channels
 from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
 
 from . import utils
-from .conda_interface import PackageRecord, TemporaryDirectory
+from .conda_interface import TemporaryDirectory
 from .deprecations import deprecated
 from .exceptions import BuildLockError, DependencyNeedsBuildingError
 from .features import feature_list

--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -11,10 +11,10 @@ from os.path import dirname
 from conda.base.context import context
 from conda.core.index import get_index
 from conda.exceptions import CondaHTTPError
+from conda.utils import url_path
 from conda_index.index import update_index as _update_index
 
 from . import utils
-from .conda_interface import url_path
 from .deprecations import deprecated
 from .utils import (
     CONDA_PACKAGE_EXTENSION_V1,

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -15,13 +15,11 @@ from typing import TYPE_CHECKING
 
 from conda.api import Solver
 from conda.base.context import context
+from conda.cli.common import specs_from_args
 from conda.core.index import get_index
 from conda.core.prefix_data import PrefixData
 from conda.models.records import PrefixRecord
 
-from .conda_interface import (
-    specs_from_args,
-)
 from .os_utils.ldd import (
     get_linkages,
     get_package_obj_files,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -18,9 +18,9 @@ from typing import TYPE_CHECKING, overload
 from bs4 import UnicodeDammit
 from conda.base.context import context
 from conda.gateways.disk.read import compute_sum
+from conda.models.match_spec import MatchSpec
 
 from . import exceptions, utils, variants
-from .conda_interface import MatchSpec
 from .config import Config, get_or_merge_config
 from .features import feature_list
 from .license_family import ensure_valid_license_family

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -815,7 +815,7 @@ def toposort(output_metadata_map):
     will naturally lead to non-overlapping files in each package and also
     the correct files being present during the install and test procedures,
     provided they are run in this order."""
-    from .conda_interface import _toposort
+    from conda.common.toposort import _toposort
 
     # We only care about the conda packages built by this recipe. Non-conda
     # packages get sorted to the end.

--- a/conda_build/os_utils/ldd.py
+++ b/conda_build/os_utils/ldd.py
@@ -9,7 +9,8 @@ from os.path import basename
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ..conda_interface import untracked
+from conda.misc import untracked
+
 from ..utils import on_linux, on_mac
 from .macho import otool
 from .pyldd import codefile_class, inspect_linkages, machofile

--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -13,6 +13,8 @@ from functools import partial
 from pathlib import Path
 from subprocess import PIPE, Popen
 
+from conda.models.version import VersionOrder
+
 from ..utils import on_mac, on_win, rec_glob
 from .external import find_executable
 
@@ -963,7 +965,6 @@ def get_static_lib_exports_dumpbin(filename):
                     results.append((result, version))
                 except:
                     pass
-        from ..conda_interface import VersionOrder
 
         results = sorted(results, key=lambda x: VersionOrder(x[1]))
         dumpbin_exe = results[-1][0]

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -38,10 +38,10 @@ from conda.core.prefix_data import PrefixData
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.link import lchmod
 from conda.gateways.disk.read import compute_sum
+from conda.misc import walk_prefix
 from conda.models.records import PrefixRecord
 
 from . import utils
-from .conda_interface import walk_prefix
 from .exceptions import OverDependingError, OverLinkingError, RunPathError
 from .inspect_pkg import which_package
 from .os_utils import external, macho

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -36,11 +36,12 @@ from typing import TYPE_CHECKING
 
 from conda.core.prefix_data import PrefixData
 from conda.gateways.disk.create import TemporaryDirectory
+from conda.gateways.disk.link import lchmod
 from conda.gateways.disk.read import compute_sum
 from conda.models.records import PrefixRecord
 
 from . import utils
-from .conda_interface import lchmod, walk_prefix
+from .conda_interface import walk_prefix
 from .exceptions import OverDependingError, OverLinkingError, RunPathError
 from .inspect_pkg import which_package
 from .os_utils import external, macho

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -35,15 +35,12 @@ from subprocess import CalledProcessError, call, check_output
 from typing import TYPE_CHECKING
 
 from conda.core.prefix_data import PrefixData
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 from conda.models.records import PrefixRecord
 
 from . import utils
-from .conda_interface import (
-    TemporaryDirectory,
-    lchmod,
-    walk_prefix,
-)
+from .conda_interface import lchmod, walk_prefix
 from .exceptions import OverDependingError, OverLinkingError, RunPathError
 from .inspect_pkg import which_package
 from .os_utils import external, macho

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 from conda.base.context import context
+from conda.cli.common import specs_from_url
 from conda.core.package_cache_data import ProgressiveFetchExtract
 from conda.exceptions import UnsatisfiableError
 from conda.gateways.disk.create import TemporaryDirectory
@@ -33,7 +34,6 @@ from conda.models.records import PackageRecord
 from conda.models.version import VersionOrder
 
 from . import environ, exceptions, source, utils
-from .conda_interface import specs_from_url
 from .exceptions import DependencyNeedsBuildingError
 from .index import get_build_index
 from .metadata import MetaData, combine_top_level_metadata_with_output

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -30,6 +30,7 @@ from conda.core.package_cache_data import ProgressiveFetchExtract
 from conda.exceptions import UnsatisfiableError
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.records import PackageRecord
+from conda.models.version import VersionOrder
 
 from . import environ, exceptions, source, utils
 from .conda_interface import specs_from_url
@@ -807,8 +808,6 @@ def distribute_variants(
     # which python version we prefer. `python_age` can use used to tweak which
     # python gets used here.
     if metadata.noarch or metadata.noarch_python:
-        from .conda_interface import VersionOrder
-
         age = int(
             metadata.get_value(
                 "build/noarch_python_build_age", metadata.config.noarch_python_build_age

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -29,9 +29,10 @@ import yaml
 from conda.base.context import context
 from conda.core.package_cache_data import ProgressiveFetchExtract
 from conda.exceptions import UnsatisfiableError
+from conda.models.records import PackageRecord
 
 from . import environ, exceptions, source, utils
-from .conda_interface import PackageRecord, TemporaryDirectory, specs_from_url
+from .conda_interface import TemporaryDirectory, specs_from_url
 from .exceptions import DependencyNeedsBuildingError
 from .index import get_build_index
 from .metadata import MetaData, combine_top_level_metadata_with_output

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -10,7 +10,6 @@ import string
 import subprocess
 import sys
 import tarfile
-import tempfile
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from functools import lru_cache
@@ -29,10 +28,11 @@ import yaml
 from conda.base.context import context
 from conda.core.package_cache_data import ProgressiveFetchExtract
 from conda.exceptions import UnsatisfiableError
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.records import PackageRecord
 
 from . import environ, exceptions, source, utils
-from .conda_interface import TemporaryDirectory, specs_from_url
+from .conda_interface import specs_from_url
 from .exceptions import DependencyNeedsBuildingError
 from .index import get_build_index
 from .metadata import MetaData, combine_top_level_metadata_with_output
@@ -944,7 +944,7 @@ def open_recipe(recipe: str | os.PathLike | Path) -> Iterator[Path]:
         yield recipe
     elif recipe.suffixes in [[".tar"], [".tar", ".gz"], [".tgz"], [".tar", ".bz2"]]:
         # extract the recipe to a temporary directory
-        with tempfile.TemporaryDirectory() as tmp, tarfile.open(recipe, "r:*") as tar:
+        with TemporaryDirectory() as tmp, tarfile.open(recipe, "r:*") as tar:
             tar.extractall(path=tmp)
             yield Path(tmp)
     elif recipe.suffix == ".yaml":

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -21,12 +21,12 @@ from os.path import basename, dirname, exists, join
 import requests
 from conda.core.index import get_index
 from conda.exceptions import CondaError, CondaHTTPError
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.match_spec import MatchSpec
 from conda.resolve import Resolve
 
 from .. import environ
 from ..conda_interface import (
-    TemporaryDirectory,
     TmpDownload,
     download,
 )

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -22,10 +22,10 @@ import requests
 from conda.core.index import get_index
 from conda.exceptions import CondaError, CondaHTTPError
 from conda.models.match_spec import MatchSpec
+from conda.resolve import Resolve
 
 from .. import environ
 from ..conda_interface import (
-    Resolve,
     TemporaryDirectory,
     TmpDownload,
     download,

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -21,15 +21,13 @@ from os.path import basename, dirname, exists, join
 import requests
 from conda.core.index import get_index
 from conda.exceptions import CondaError, CondaHTTPError
+from conda.gateways.connection.download import TmpDownload
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.match_spec import MatchSpec
 from conda.resolve import Resolve
 
 from .. import environ
-from ..conda_interface import (
-    TmpDownload,
-    download,
-)
+from ..conda_interface import download
 from ..config import Config, get_or_merge_config
 from ..utils import check_call_env, on_linux, on_win
 from ..variants import get_default_variant

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -21,13 +21,12 @@ from os.path import basename, dirname, exists, join
 import requests
 from conda.core.index import get_index
 from conda.exceptions import CondaError, CondaHTTPError
-from conda.gateways.connection.download import TmpDownload
+from conda.gateways.connection.download import TmpDownload, download
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.match_spec import MatchSpec
 from conda.resolve import Resolve
 
 from .. import environ
-from ..conda_interface import download
 from ..config import Config, get_or_merge_config
 from ..utils import check_call_env, on_linux, on_win
 from ..variants import get_default_variant

--- a/conda_build/skeletons/cpan.py
+++ b/conda_build/skeletons/cpan.py
@@ -21,10 +21,10 @@ from os.path import basename, dirname, exists, join
 import requests
 from conda.core.index import get_index
 from conda.exceptions import CondaError, CondaHTTPError
+from conda.models.match_spec import MatchSpec
 
 from .. import environ
 from ..conda_interface import (
-    MatchSpec,
     Resolve,
     TemporaryDirectory,
     TmpDownload,

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -42,9 +42,10 @@ except ImportError:
 from typing import TYPE_CHECKING
 
 from conda.common.io import dashlist
+from conda.gateways.disk.create import TemporaryDirectory
 
 from .. import source
-from ..conda_interface import TemporaryDirectory, cc_conda_build
+from ..conda_interface import cc_conda_build
 from ..config import get_or_merge_config
 from ..license_family import allowed_license_families, guess_license_family
 from ..metadata import MetaData

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -41,11 +41,11 @@ except ImportError:
 
 from typing import TYPE_CHECKING
 
+from conda.base.context import context
 from conda.common.io import dashlist
 from conda.gateways.disk.create import TemporaryDirectory
 
 from .. import source
-from ..conda_interface import cc_conda_build
 from ..config import get_or_merge_config
 from ..license_family import allowed_license_families, guess_license_family
 from ..metadata import MetaData
@@ -455,7 +455,7 @@ def add_parser(repos):
     cran.add_argument(
         "-m",
         "--variant-config-files",
-        default=cc_conda_build.get("skeleton_config_yaml", None),
+        default=context.conda_build.get("skeleton_config_yaml", None),
         help="""Variant config file to add.  These yaml files can contain
         keys such as `cran_mirror`.  Only one can be provided here.""",
     )

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -25,10 +25,11 @@ import yaml
 from conda.base.context import context
 from conda.gateways.connection.download import download
 from conda.gateways.disk.read import compute_sum
+from conda.modules.version import normalized_version
 from conda.utils import human_bytes
 from requests.packages.urllib3.util.url import parse_url
 
-from ..conda_interface import normalized_version, spec_from_line
+from ..conda_interface import spec_from_line
 from ..config import Config
 from ..environ import create_env
 from ..license_family import allowed_license_families, guess_license_family

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -25,14 +25,10 @@ import yaml
 from conda.base.context import context
 from conda.gateways.connection.download import download
 from conda.gateways.disk.read import compute_sum
+from conda.utils import human_bytes
 from requests.packages.urllib3.util.url import parse_url
 
-from ..conda_interface import (
-    human_bytes,
-    input,
-    normalized_version,
-    spec_from_line,
-)
+from ..conda_interface import input, normalized_version, spec_from_line
 from ..config import Config
 from ..environ import create_env
 from ..license_family import allowed_license_families, guess_license_family

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -23,13 +23,13 @@ import pkginfo
 import requests
 import yaml
 from conda.base.context import context
+from conda.cli.common import spec_from_line
 from conda.gateways.connection.download import download
 from conda.gateways.disk.read import compute_sum
 from conda.modules.version import normalized_version
 from conda.utils import human_bytes
 from requests.packages.urllib3.util.url import parse_url
 
-from ..conda_interface import spec_from_line
 from ..config import Config
 from ..environ import create_env
 from ..license_family import allowed_license_families, guess_license_family

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -23,11 +23,11 @@ import pkginfo
 import requests
 import yaml
 from conda.base.context import context
+from conda.gateways.connection.download import download
 from conda.gateways.disk.read import compute_sum
 from requests.packages.urllib3.util.url import parse_url
 
 from ..conda_interface import (
-    download,
     human_bytes,
     input,
     normalized_version,

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 from collections import OrderedDict, defaultdict
+from io import StringIO
 from os import chdir, getcwd, listdir, makedirs
 from os.path import abspath, exists, isdir, isfile, join
 from shutil import copy2
@@ -26,7 +27,6 @@ from conda.gateways.disk.read import compute_sum
 from requests.packages.urllib3.util.url import parse_url
 
 from ..conda_interface import (
-    StringIO,
     download,
     human_bytes,
     input,

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -28,7 +28,7 @@ from conda.gateways.disk.read import compute_sum
 from conda.utils import human_bytes
 from requests.packages.urllib3.util.url import parse_url
 
-from ..conda_interface import input, normalized_version, spec_from_line
+from ..conda_interface import normalized_version, spec_from_line
 from ..config import Config
 from ..environ import create_env
 from ..license_family import allowed_license_families, guess_license_family

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -16,10 +16,11 @@ from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 from conda.exceptions import CondaHTTPError
+from conda.gateways.connection.download import download
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 
-from .conda_interface import download, url_path
+from .conda_interface import url_path
 from .exceptions import MissingDependency
 from .os_utils import external
 from .utils import (

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -16,9 +16,10 @@ from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 from conda.exceptions import CondaHTTPError
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 
-from .conda_interface import TemporaryDirectory, download, url_path
+from .conda_interface import download, url_path
 from .exceptions import MissingDependency
 from .os_utils import external
 from .utils import (

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -19,8 +19,8 @@ from conda.exceptions import CondaHTTPError
 from conda.gateways.connection.download import download
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
+from conda.utils import url_path
 
-from .conda_interface import url_path
 from .exceptions import MissingDependency
 from .os_utils import external
 from .utils import (

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -66,7 +66,6 @@ from conda.models.records import PackageRecord
 from conda.models.version import VersionOrder
 from conda.utils import unix_path_to_win
 
-from .conda_interface import cc_conda_build
 from .deprecations import deprecated
 from .exceptions import BuildLockError
 
@@ -1679,10 +1678,8 @@ def reset_deduplicator():
 
 def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers=True):
     config_file = None
-    if cc_conda_build.get("log_config_file"):
-        config_file = abspath(
-            expanduser(expandvars(cc_conda_build.get("log_config_file")))
-        )
+    if log_config_file := context.conda_build.get("log_config_file"):
+        config_file = abspath(expanduser(expandvars(log_config_file)))
     # by loading config file here, and then only adding handlers later, people
     # should be able to override conda-build's logger settings here.
     if config_file:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -69,7 +69,7 @@ from .conda_interface import (
     unix_path_to_win,
     win_path_to_unix,
 )
-from .conda_interface import rm_rf as _rm_rf
+from .deprecations import deprecated
 from .exceptions import BuildLockError
 
 if TYPE_CHECKING:
@@ -1617,8 +1617,13 @@ def filter_info_files(files_list, prefix):
     )
 
 
-def rm_rf(path, config=None):
-    return _rm_rf(path)
+@deprecated.argument("24.5", "24.7", "config")
+def rm_rf(path):
+    from conda.core.prefix_data import delete_prefix_from_linked_data
+    from conda.gateways.disk.delete import rm_rf as rm_rf
+
+    rm_rf(path)
+    delete_prefix_from_linked_data(path)
 
 
 # https://stackoverflow.com/a/31459386/1170370

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -58,9 +58,9 @@ from conda.exceptions import CondaHTTPError
 from conda.gateways.disk.read import compute_sum
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
 
 from .conda_interface import (
-    PackageRecord,
     StringIO,
     TemporaryDirectory,
     VersionOrder,

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -62,9 +62,9 @@ from conda.gateways.disk.read import compute_sum
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
+from conda.models.version import VersionOrder
 
 from .conda_interface import (
-    VersionOrder,
     cc_conda_build,
     unix_path_to_win,
     win_path_to_unix,

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -63,10 +63,10 @@ from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
 from conda.models.version import VersionOrder
+from conda.utils import unix_path_to_win
 
 from .conda_interface import (
     cc_conda_build,
-    unix_path_to_win,
     win_path_to_unix,
 )
 from .deprecations import deprecated

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -56,13 +56,13 @@ from conda.base.constants import (
 )
 from conda.base.context import context
 from conda.exceptions import CondaHTTPError
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 from conda.models.channel import Channel
 from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
 
 from .conda_interface import (
-    TemporaryDirectory,
     VersionOrder,
     cc_conda_build,
     download,

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -56,6 +56,7 @@ from conda.base.constants import (
 )
 from conda.base.context import context
 from conda.exceptions import CondaHTTPError
+from conda.gateways.connection.download import download
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 from conda.models.channel import Channel
@@ -65,7 +66,6 @@ from conda.models.records import PackageRecord
 from .conda_interface import (
     VersionOrder,
     cc_conda_build,
-    download,
     unix_path_to_win,
     win_path_to_unix,
 )

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -55,6 +55,7 @@ from conda.base.constants import (
     KNOWN_SUBDIRS,
 )
 from conda.base.context import context
+from conda.common.path import win_path_to_unix
 from conda.exceptions import CondaHTTPError
 from conda.gateways.connection.download import download
 from conda.gateways.disk.create import TemporaryDirectory
@@ -65,10 +66,7 @@ from conda.models.records import PackageRecord
 from conda.models.version import VersionOrder
 from conda.utils import unix_path_to_win
 
-from .conda_interface import (
-    cc_conda_build,
-    win_path_to_unix,
-)
+from .conda_interface import cc_conda_build
 from .deprecations import deprecated
 from .exceptions import BuildLockError
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -23,6 +23,7 @@ import urllib.request as urllib
 from collections import OrderedDict, defaultdict
 from functools import lru_cache
 from glob import glob
+from io import StringIO
 from itertools import filterfalse
 from json.decoder import JSONDecodeError
 from locale import getpreferredencoding
@@ -61,7 +62,6 @@ from conda.models.match_spec import MatchSpec
 from conda.models.records import PackageRecord
 
 from .conda_interface import (
-    StringIO,
     TemporaryDirectory,
     VersionOrder,
     cc_conda_build,

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -14,7 +14,6 @@ from itertools import product
 import yaml
 from conda.base.context import context
 
-from .conda_interface import cc_conda_build
 from .utils import ensure_list, get_logger, islist, on_win, trim_empty_keys
 from .version import _parse as parse_version
 
@@ -224,8 +223,8 @@ def find_config_files(metadata_or_path, config):
 
     if not files and not config.ignore_system_variants:
         # user config
-        if cc_conda_build.get("config_file"):
-            cfg = resolve(cc_conda_build["config_file"])
+        if config_file := context.conda_build.get("config_file"):
+            cfg = resolve(config_file)
         else:
             cfg = resolve(os.path.join("~", "conda_build_config.yaml"))
         if os.path.isfile(cfg):

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -11,7 +11,6 @@ import pytest
 
 from conda_build import api
 from conda_build.cli import main_build, main_render
-from conda_build.conda_interface import TemporaryDirectory
 from conda_build.config import (
     Config,
     zstd_compression_level_default,
@@ -264,20 +263,19 @@ def test_purge(testing_workdir, testing_metadata):
 
 
 @pytest.mark.serial
-def test_purge_all(testing_workdir, testing_metadata):
+def test_purge_all(
+    testing_workdir: str, testing_metadata: MetaData, tmp_path: Path
+) -> None:
     """
     purge-all clears out build folders as well as build packages in the osx-64 folders and such
     """
     api.output_yaml(testing_metadata, "meta.yaml")
-    with TemporaryDirectory() as tmpdir:
-        testing_metadata.config.croot = tmpdir
-        outputs = api.build(
-            testing_workdir, config=testing_metadata.config, notest=True
-        )
-        args = ["purge-all", "--croot", tmpdir]
-        main_build.execute(args)
-        assert not get_build_folders(testing_metadata.config.croot)
-        assert not any(os.path.isfile(fn) for fn in outputs)
+    testing_metadata.config.croot = str(tmp_path)
+    outputs = api.build(testing_workdir, config=testing_metadata.config, notest=True)
+    args = ["purge-all", f"--croot={tmp_path}"]
+    main_build.execute(args)
+    assert not get_build_folders(testing_metadata.config.croot)
+    assert not any(os.path.isfile(fn) for fn in outputs)
 
 
 @pytest.mark.serial

--- a/tests/cli/test_main_convert.py
+++ b/tests/cli/test_main_convert.py
@@ -3,9 +3,9 @@
 import os
 
 import pytest
+from conda.gateways.connection.download import download
 
 from conda_build.cli import main_convert
-from conda_build.conda_interface import download
 from conda_build.tarcheck import TarCheck
 from conda_build.utils import on_win
 

--- a/tests/cli/test_main_develop.py
+++ b/tests/cli/test_main_develop.py
@@ -3,8 +3,9 @@
 import os
 import sys
 
+from conda.gateways.connection.download import download
+
 from conda_build.cli import main_develop
-from conda_build.conda_interface import download
 from conda_build.utils import get_site_packages, tar_xf
 
 

--- a/tests/cli/test_main_render.py
+++ b/tests/cli/test_main_render.py
@@ -1,47 +1,51 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 
 from conda_build import api
 from conda_build.cli import main_render
-from conda_build.conda_interface import TemporaryDirectory
 
 from ..utils import metadata_dir
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def test_render_add_channel():
+
+def test_render_add_channel(tmp_path: Path) -> None:
     """This recipe requires the conda_build_test_requirement package, which is
     only on the conda_build_test channel. This verifies that the -c argument
     works for rendering."""
-    with TemporaryDirectory() as tmpdir:
-        rendered_filename = os.path.join(tmpdir, "out.yaml")
-        args = [
-            "-c",
-            "conda_build_test",
-            os.path.join(metadata_dir, "_recipe_requiring_external_channel"),
-            "--file",
-            rendered_filename,
-        ]
-        main_render.execute(args)
-        with open(rendered_filename) as rendered_file:
-            rendered_meta = yaml.safe_load(rendered_file)
-        required_package_string = [
-            pkg
-            for pkg in rendered_meta["requirements"]["build"]
-            if "conda_build_test_requirement" in pkg
-        ][0]
-        required_package_details = required_package_string.split(" ")
-        assert len(required_package_details) > 1, (
-            "Expected version number on successful "
-            f"rendering, but got only {required_package_details}"
-        )
-        assert (
-            required_package_details[1] == "1.0"
-        ), f"Expected version number 1.0 on successful rendering, but got {required_package_details[1]}"
+    rendered_filename = os.path.join(tmp_path, "out.yaml")
+    args = [
+        "-c",
+        "conda_build_test",
+        os.path.join(metadata_dir, "_recipe_requiring_external_channel"),
+        "--file",
+        rendered_filename,
+    ]
+    main_render.execute(args)
+    with open(rendered_filename) as rendered_file:
+        rendered_meta = yaml.safe_load(rendered_file)
+    required_package_string = [
+        pkg
+        for pkg in rendered_meta["requirements"]["build"]
+        if "conda_build_test_requirement" in pkg
+    ][0]
+    required_package_details = required_package_string.split(" ")
+    assert len(required_package_details) > 1, (
+        "Expected version number on successful "
+        f"rendering, but got only {required_package_details}"
+    )
+    assert (
+        required_package_details[1] == "1.0"
+    ), f"Expected version number 1.0 on successful rendering, but got {required_package_details[1]}"
 
 
 def test_render_without_channel_fails(tmp_path):

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -30,10 +30,10 @@ from binstar_client.errors import NotFound
 from conda.base.context import context, reset_context
 from conda.common.compat import on_linux, on_mac, on_win
 from conda.exceptions import ClobberError, CondaError, CondaMultiError, LinkError
+from conda.utils import url_path
 from conda_index.api import update_index
 
 from conda_build import __version__, api, exceptions
-from conda_build.conda_interface import url_path
 from conda_build.config import Config
 from conda_build.exceptions import (
     CondaBuildException,

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -7,9 +7,9 @@ import os
 import tarfile
 
 import pytest
+from conda.gateways.connection.download import download
 
 from conda_build import api
-from conda_build.conda_interface import download
 from conda_build.utils import on_win, package_has_file
 
 from .utils import assert_package_consistency, metadata_dir

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,9 +4,10 @@ import json
 from pathlib import Path
 
 import pytest
+from conda.auxlib.entity import EntityEncoder
 
 from conda_build._link import pyc_f
-from conda_build.conda_interface import EntityEncoder, PathType
+from conda_build.conda_interface import PathType
 
 
 @pytest.mark.parametrize(

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 import pytest
 from conda.auxlib.entity import EntityEncoder
+from conda.models.enums import PathType
 
 from conda_build._link import pyc_f
-from conda_build.conda_interface import PathType
 
 
 @pytest.mark.parametrize(

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -5,10 +5,10 @@ import subprocess
 import tarfile
 
 import pytest
+from conda.gateways.disk.create import TemporaryDirectory
 from conda.gateways.disk.read import compute_sum
 
 from conda_build import source
-from conda_build.conda_interface import TemporaryDirectory
 from conda_build.source import download_to_cache
 from conda_build.utils import reset_deduplicator
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -204,8 +204,11 @@ root:
   handlers: [console]
 """
         )
-    cc_conda_build = mocker.patch.object(utils, "cc_conda_build")
-    cc_conda_build.get.return_value = test_file
+    mocker.patch(
+        "conda.base.context.Context.conda_build",
+        new_callable=mocker.PropertyMock,
+        return_value={"log_config_file": test_file},
+    )
     log = utils.get_logger(__name__)
     # default log level is INFO, but our config file should set level to DEBUG
     log.warn("test message")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,10 +8,9 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from conda.base.context import context, reset_context
+from conda.base.context import reset_context
 from conda.common.compat import on_mac
 
-from conda_build.conda_interface import cc_conda_build
 from conda_build.metadata import MetaData
 
 if TYPE_CHECKING:
@@ -153,7 +152,3 @@ def get_noarch_python_meta(meta):
 
 def reset_config(search_path=None):
     reset_context(search_path)
-    cc_conda_build.clear()
-    cc_conda_build.update(
-        context.conda_build if hasattr(context, "conda_build") else {}
-    )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Marking remaining attributes of `conda_build.conda_interface` as deprecated in `24.5` and slated for removal in `24.7`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
