### PR TITLE
Deprecate `HashableDict` in favor of `frozendict`

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -10,24 +10,18 @@ import re
 import time
 from functools import partial
 from io import StringIO, TextIOBase
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import jinja2
 import yaml
-
-try:
-    import tomllib  # Python 3.11
-except:
-    import tomli as tomllib
-
-from typing import TYPE_CHECKING
+from frozendict import deepfreeze
 
 from . import _load_setup_py_data
 from .environ import get_dict as get_environ
 from .exceptions import CondaBuildException
 from .render import get_env_dependencies
 from .utils import (
-    HashableDict,
     apply_pin_expressions,
     check_call_env,
     copy_into,
@@ -37,6 +31,11 @@ from .utils import (
     rm_rf,
 )
 from .variants import DEFAULT_COMPILERS
+
+try:
+    import tomllib  # Python 3.11
+except:
+    import tomli as tomllib
 
 if TYPE_CHECKING:
     from typing import IO, Any
@@ -298,7 +297,7 @@ def pin_compatible(
         # There are two cases considered here (so far):
         # 1. Good packages that follow semver style (if not philosophy).  For example, 1.2.3
         # 2. Evil packages that cram everything alongside a single major version.  For example, 9b
-        key = (m.name(), HashableDict(m.config.variant))
+        key = (m.name(), deepfreeze(m.config.variant))
         if key in cached_env_dependencies:
             pins = cached_env_dependencies[key]
         else:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1408,7 +1408,7 @@ def get_installed_packages(path):
     return installed
 
 
-@deprecated("24.5", "24.7", addendum="Use `frozendict` instead.")
+@deprecated("24.5", "24.7", addendum="Use `frozendict.deepfreeze` instead.")
 def _convert_lists_to_sets(_dict):
     for k, v in _dict.items():
         if hasattr(v, "keys"):
@@ -1421,7 +1421,7 @@ def _convert_lists_to_sets(_dict):
     return _dict
 
 
-@deprecated("24.5", "24.7", addendum="Use `frozendict` instead.")
+@deprecated("24.5", "24.7", addendum="Use `frozendict.deepfreeze` instead.")
 class HashableDict(dict):
     """use hashable frozen dictionaries for resources and resource types so that they can be in sets"""
 
@@ -1433,7 +1433,7 @@ class HashableDict(dict):
         return hash(json.dumps(self, sort_keys=True))
 
 
-@deprecated("24.5", "24.7", addendum="Use `frozendict` instead.")
+@deprecated("24.5", "24.7", addendum="Use `frozendict.deepfreeze` instead.")
 def represent_hashabledict(dumper, data):
     value = []
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -70,6 +70,7 @@ from .conda_interface import (
     win_path_to_unix,
 )
 from .conda_interface import rm_rf as _rm_rf
+from .deprecations import deprecated
 from .exceptions import BuildLockError
 
 if TYPE_CHECKING:
@@ -1407,6 +1408,7 @@ def get_installed_packages(path):
     return installed
 
 
+@deprecated("24.5", "24.7", addendum="Use `frozendict` instead.")
 def _convert_lists_to_sets(_dict):
     for k, v in _dict.items():
         if hasattr(v, "keys"):
@@ -1419,6 +1421,7 @@ def _convert_lists_to_sets(_dict):
     return _dict
 
 
+@deprecated("24.5", "24.7", addendum="Use `frozendict` instead.")
 class HashableDict(dict):
     """use hashable frozen dictionaries for resources and resource types so that they can be in sets"""
 
@@ -1430,6 +1433,7 @@ class HashableDict(dict):
         return hash(json.dumps(self, sort_keys=True))
 
 
+@deprecated("24.5", "24.7", addendum="Use `frozendict` instead.")
 def represent_hashabledict(dumper, data):
     value = []
 

--- a/news/5284-deprecate-HashableDict
+++ b/news/5284-deprecate-HashableDict
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate `conda_build.utils.HashableDict`. Use `frozendict` instead. (#5284)
+* Deprecate `conda_build.utils._convert_lists_to_sets`. Use `frozendict` instead. (#5284)
+* Deprecate `conda_build.utils.represent_hashabledict`. Use `frozendict` instead. (#5284)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/5284-deprecate-HashableDict
+++ b/news/5284-deprecate-HashableDict
@@ -8,9 +8,9 @@
 
 ### Deprecations
 
-* Deprecate `conda_build.utils.HashableDict`. Use `frozendict` instead. (#5284)
-* Deprecate `conda_build.utils._convert_lists_to_sets`. Use `frozendict` instead. (#5284)
-* Deprecate `conda_build.utils.represent_hashabledict`. Use `frozendict` instead. (#5284)
+* Deprecate `conda_build.utils.HashableDict`. Use `frozendict.deepfreeze` instead. (#5284)
+* Deprecate `conda_build.utils._convert_lists_to_sets`. Use `frozendict.deepfreeze` instead. (#5284)
+* Deprecate `conda_build.utils.represent_hashabledict`. Use `frozendict.deepfreeze` instead. (#5284)
 
 ### Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "conda-index >=0.4.0",
   "conda-package-handling >=1.3",
   "filelock",
+  "frozendict >=1.2",
   "jinja2",
   "jsonschema >=4.19",
   "libarchive-c",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "conda-index >=0.4.0",
   "conda-package-handling >=1.3",
   "filelock",
-  "frozendict >=1.2",
+  "frozendict >=2.4.2",
   "jinja2",
   "jsonschema >=4.19",
   "libarchive-c",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - conda-index >=0.4.0
     - conda-package-handling >=1.3
     - filelock
-    - frozendict >=1.2
+    - frozendict >=2.4.2
     - jinja2
     - jsonschema >=4.19
     - m2-patch >=2.6               # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - conda-index >=0.4.0
     - conda-package-handling >=1.3
     - filelock
+    - frozendict >=1.2
     - jinja2
     - jsonschema >=4.19
     - m2-patch >=2.6               # [win]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,7 @@ conda-index >=0.4.0
 conda-libmamba-solver  # ensure we use libmamba
 conda-package-handling >=1.3
 filelock
-frozendict >=1.2
+frozendict >=2.4.2
 jinja2
 jsonschema >=4.19
 menuinst >=2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,7 @@ conda-index >=0.4.0
 conda-libmamba-solver  # ensure we use libmamba
 conda-package-handling >=1.3
 filelock
+frozendict >=1.2
 jinja2
 jsonschema >=4.19
 menuinst >=2

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from frozendict import deepfreeze
 
 from conda_build import jinja_context
-from conda_build.utils import HashableDict
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -99,7 +99,7 @@ def test_pin_subpackage_exact(testing_metadata):
     testing_metadata.meta["outputs"] = [output_dict]
     fm = testing_metadata.get_output_metadata(output_dict)
     testing_metadata.other_outputs = {
-        (name, HashableDict(testing_metadata.config.variant)): (output_dict, fm)
+        (name, deepfreeze(testing_metadata.config.variant)): (output_dict, fm)
     }
     pin = jinja_context.pin_subpackage(testing_metadata, name, exact=True)
     assert len(pin.split()) == 3
@@ -111,7 +111,7 @@ def test_pin_subpackage_expression(testing_metadata):
     testing_metadata.meta["outputs"] = [output_dict]
     fm = testing_metadata.get_output_metadata(output_dict)
     testing_metadata.other_outputs = {
-        (name, HashableDict(testing_metadata.config.variant)): (output_dict, fm)
+        (name, deepfreeze(testing_metadata.config.variant)): (output_dict, fm)
     }
     pin = jinja_context.pin_subpackage(testing_metadata, name)
     assert len(pin.split()) == 2


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Instead of using a customized `HashableDict` implementation we can just use the `frozendict` library (which `conda` already depends on). Using `frozendict` also means we can avoid calling `deepcopy` (`frozendict` takes care of this for us).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
