### PR TITLE
[WIP] Centralize `yaml` configurations into `conda_build.yaml`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -23,13 +23,14 @@ from os.path import dirname, isdir, isfile, islink, join
 from pathlib import Path
 
 import conda_package_handling.api
-import yaml
 from bs4 import UnicodeDammit
 from conda import __version__ as conda_version
 from conda.base.context import context, reset_context
 from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
 from conda.models.channel import Channel
+
+from conda_build import yaml
 
 from . import __version__ as conda_build_version
 from . import environ, noarch_python, source, tarcheck, utils
@@ -882,7 +883,7 @@ def copy_recipe(m):
 
         # dump the full variant in use for this package to the recipe folder
         with open(os.path.join(recipe_dir, "conda_build_config.yaml"), "w") as f:
-            yaml.dump(m.config.variant, f)
+            yaml.safe_dump(m.config.variant, f)
 
 
 def copy_readme(m):
@@ -918,11 +919,12 @@ def jsonify_info_yamls(m):
                     except:
                         pass
                     with open(file) as i, open(dst, "w") as o:
-                        import yaml
-
-                        yaml = yaml.full_load(i)
                         json.dump(
-                            yaml, o, sort_keys=True, indent=2, separators=(",", ": ")
+                            yaml.safe_load(i),
+                            o,
+                            sort_keys=True,
+                            indent=2,
+                            separators=(",", ": "),
                         )
                         res.append(
                             join(os.path.basename(m.config.info_dir), ijd, bn + ".json")

--- a/conda_build/exceptions.py
+++ b/conda_build/exceptions.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import textwrap
 
+from .deprecations import deprecated
+
 SEPARATOR = "-" * 70
 
 indent = lambda s: textwrap.fill(textwrap.dedent(s))
@@ -42,6 +44,7 @@ class UnableToParse(YamlParsingError):
         return f"Error Message:\n--> {indent(orig)}\n\n"
 
 
+@deprecated("24.5", "24.7", addendum="Unused.")
 class UnableToParseMissingJinja2(UnableToParse):
     def error_body(self):
         return "\n".join(

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -29,18 +29,10 @@ from os.path import (
     realpath,
     relpath,
 )
+from typing import TYPE_CHECKING
 
 import requests
 import yaml
-
-# try to import C dumper
-try:
-    from yaml import CSafeDumper as SafeDumper
-except ImportError:
-    from yaml import SafeDumper
-
-from typing import TYPE_CHECKING
-
 from conda.common.io import dashlist
 
 from .. import source
@@ -564,7 +556,7 @@ def yaml_quote_string(string):
     Note that this function is NOT general.
     """
     return (
-        yaml.dump(string, indent=True, Dumper=SafeDumper)
+        yaml.safe_dump(string, indent=True)
         .replace("\n...\n", "")
         .replace("\n", "\n  ")
         .rstrip("\n ")

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -11,9 +11,9 @@ from copy import copy
 from functools import lru_cache
 from itertools import product
 
-import yaml
 from conda.base.context import context
 
+from . import yaml
 from .conda_interface import cc_conda_build
 from .utils import ensure_list, get_logger, islist, on_win, trim_empty_keys
 from .version import _parse as parse_version
@@ -136,7 +136,7 @@ def parse_config_file(path, config):
     with open(path) as f:
         contents = f.read()
     contents = select_lines(contents, get_selectors(config), variants_in_place=False)
-    content = yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
+    content = yaml.safe_load(contents) or {}
     trim_empty_keys(content)
     return content
 

--- a/conda_build/yaml.py
+++ b/conda_build/yaml.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import TYPE_CHECKING, overload
+
+from frozendict import frozendict
+from yaml import dump as _dump
+from yaml import load as _load
+from yaml.error import YAMLError  # noqa: F401
+
+try:
+    from yaml import CSafeDumper as _SafeDumper
+    from yaml import CSafeLoader as _SafeLoader
+except ImportError:
+    from yaml import SafeDumper as _SafeDumper  # type: ignore[assignment]
+    from yaml import SafeLoader as _SafeLoader  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from typing import Any, Self, TextIO
+
+
+class _NoAliasesDumper(_SafeDumper):
+    def ignore_aliases(self: Self, data: Any) -> bool:
+        return True
+
+
+_NoAliasesDumper.add_representer(set, _NoAliasesDumper.represent_list)
+_NoAliasesDumper.add_representer(tuple, _NoAliasesDumper.represent_list)
+_NoAliasesDumper.add_representer(OrderedDict, _NoAliasesDumper.represent_dict)
+_NoAliasesDumper.add_representer(frozendict, _NoAliasesDumper.represent_dict)
+
+
+@overload
+def safe_dump(data: Any, stream: None = None, **kwargs) -> str: ...
+
+
+@overload
+def safe_dump(data: Any, stream: TextIO, **kwargs) -> None: ...
+
+
+def safe_dump(
+    data: Any,
+    stream: TextIO | None = None,
+    *,
+    default_flow_style: bool = False,  # always serialize in the block style
+    indent: int = 2,
+    sort_keys: bool = False,  # prefer the manual ordering
+    **kwargs,
+) -> str | None:
+    return _dump(
+        data,
+        stream,
+        Dumper=_NoAliasesDumper,
+        default_flow_style=default_flow_style,
+        indent=indent,
+        **kwargs,
+    )
+
+
+class _StringifyNumbersLoader(_SafeLoader):
+    @classmethod
+    def remove_implicit_resolver(cls, tag):
+        if "yaml_implicit_resolvers" not in cls.__dict__:
+            cls.yaml_implicit_resolvers = {
+                k: v[:] for k, v in cls.yaml_implicit_resolvers.items()
+            }
+        for ch in tuple(cls.yaml_implicit_resolvers):
+            resolvers = [(t, r) for t, r in cls.yaml_implicit_resolvers[ch] if t != tag]
+            if resolvers:
+                cls.yaml_implicit_resolvers[ch] = resolvers
+            else:
+                del cls.yaml_implicit_resolvers[ch]
+
+    @classmethod
+    def remove_constructor(cls, tag):
+        if "yaml_constructors" not in cls.__dict__:
+            cls.yaml_constructors = cls.yaml_constructors.copy()
+        if tag in cls.yaml_constructors:
+            del cls.yaml_constructors[tag]
+
+
+_StringifyNumbersLoader.remove_implicit_resolver("tag:yaml.org,2002:float")
+_StringifyNumbersLoader.remove_implicit_resolver("tag:yaml.org,2002:int")
+_StringifyNumbersLoader.remove_constructor("tag:yaml.org,2002:float")
+_StringifyNumbersLoader.remove_constructor("tag:yaml.org,2002:int")
+
+
+def safe_load(stream: str | TextIO, *, stringify_numbers: bool = False) -> Any:
+    return _load(
+        stream,
+        _StringifyNumbersLoader if stringify_numbers else _SafeLoader,
+    )

--- a/tests/cli/test_main_inspect.py
+++ b/tests/cli/test_main_inspect.py
@@ -5,9 +5,8 @@ import re
 import sys
 
 import pytest
-import yaml
 
-from conda_build import api
+from conda_build import api, yaml
 from conda_build.cli import main_inspect
 from conda_build.utils import on_win
 
@@ -77,7 +76,7 @@ def test_inspect_hash_input(testing_metadata, testing_workdir, capfd):
     api.output_yaml(testing_metadata, "meta.yaml")
     output = api.build(testing_workdir, notest=True)[0]
     with open(os.path.join(testing_workdir, "conda_build_config.yaml"), "w") as f:
-        yaml.dump({"zlib": ["1.2.11"]}, f)
+        yaml.safe_dump({"zlib": ["1.2.11"]}, f)
     args = ["hash-inputs", output]
     main_inspect.execute(args)
     output, error = capfd.readouterr()

--- a/tests/cli/test_main_render.py
+++ b/tests/cli/test_main_render.py
@@ -4,9 +4,8 @@ import os
 import sys
 
 import pytest
-import yaml
 
-from conda_build import api
+from conda_build import api, yaml
 from conda_build.cli import main_render
 from conda_build.conda_interface import TemporaryDirectory
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING
 # for version
 import conda
 import pytest
-import yaml
 from binstar_client.commands import remove, show
 from binstar_client.errors import NotFound
 from conda.base.context import context, reset_context
@@ -32,7 +31,7 @@ from conda.common.compat import on_linux, on_mac, on_win
 from conda.exceptions import ClobberError, CondaError, CondaMultiError, LinkError
 from conda_index.api import update_index
 
-from conda_build import __version__, api, exceptions
+from conda_build import __version__, api, exceptions, yaml
 from conda_build.conda_interface import url_path
 from conda_build.config import Config
 from conda_build.exceptions import (
@@ -70,21 +69,6 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from conda_build.metadata import MetaData
-
-
-def represent_ordereddict(dumper, data):
-    value = []
-
-    for item_key, item_value in data.items():
-        node_key = dumper.represent_data(item_key)
-        node_value = dumper.represent_data(item_value)
-
-        value.append((node_key, node_value))
-
-    return yaml.nodes.MappingNode("tag:yaml.org,2002:map", value)
-
-
-yaml.add_representer(OrderedDict, represent_ordereddict)
 
 
 class AnacondaClientArgs:
@@ -782,7 +766,7 @@ def test_relative_git_url_submodule_clone(testing_workdir, testing_config, monke
         }
 
         with open(filename, "w") as outfile:
-            outfile.write(yaml.dump(data, default_flow_style=False, width=999999999))
+            outfile.write(yaml.safe_dump(data, width=999999999))
         # Reset the path because our broken, dummy `git` would cause `render_recipe`
         # to fail, while no `git` will cause the build_dependencies to be installed.
         monkeypatch.undo()
@@ -804,7 +788,7 @@ def test_noarch(testing_workdir):
             ]
         )
         with open(filename, "w") as outfile:
-            outfile.write(yaml.dump(data, default_flow_style=False, width=999999999))
+            outfile.write(yaml.safe_dump(data, width=999999999))
         output = api.get_output_file_paths(testing_workdir)[0]
         assert os.path.sep + "noarch" + os.path.sep in output or not noarch
         assert os.path.sep + "noarch" + os.path.sep not in output or noarch

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -10,11 +10,10 @@ import re
 from itertools import count, islice
 
 import pytest
-import yaml
 from conda.base.context import context
 from conda.common.compat import on_win
 
-from conda_build import api, render
+from conda_build import api, render, yaml
 from conda_build.conda_interface import cc_conda_build
 from conda_build.variants import validate_spec
 
@@ -219,7 +218,7 @@ def test_setting_condarc_vars_with_env_var_expansion(testing_workdir):
     python_versions = ["2.6", "3.4", "3.11"]
     config = {"python": python_versions, "bzip2": ["0.9", "1.0"]}
     with open(os.path.join("config", "conda_build_config.yaml"), "w") as f:
-        yaml.dump(config, f, default_flow_style=False)
+        yaml.safe_dump(config, f)
 
     cc_conda_build_backup = cc_conda_build.copy()
     # hacky equivalent of changing condarc

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -9,9 +9,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-import ruamel.yaml
 
-from conda_build import api
+from conda_build import api, yaml
 from conda_build.skeletons.pypi import (
     clean_license_name,
     convert_to_flat_list,
@@ -484,8 +483,7 @@ def test_pypi_section_order_preserved(tmp_path: Path):
         if not line.startswith("{%")
     ]
 
-    # The loader below preserves the order of entries...
-    recipe = ruamel.yaml.load("\n".join(lines), Loader=ruamel.yaml.RoundTripLoader)
+    recipe = yaml.safe_load("\n".join(lines))
 
     major_sections = list(recipe.keys())
     # Blank fields are omitted when skeletonizing, so prune any missing ones

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -8,10 +8,9 @@ import sys
 from pathlib import Path
 
 import pytest
-import yaml
 from conda.common.compat import on_mac
 
-from conda_build import api, exceptions
+from conda_build import api, exceptions, yaml
 from conda_build.utils import ensure_list, package_has_file
 from conda_build.variants import (
     combine_specs,
@@ -66,7 +65,7 @@ def test_python_variants(testing_workdir, testing_config, as_yaml):
     # write variants to disk
     if as_yaml:
         variants_path = Path(testing_workdir, "variant_example.yaml")
-        variants_path.write_text(yaml.dump(variants, default_flow_style=False))
+        variants_path.write_text(yaml.safe_dump(variants))
         testing_config.variant_config_files = [str(variants_path)]
 
     # render the metadata
@@ -501,19 +500,15 @@ def test_numpy_used_variable_looping():
 
 def test_exclusive_config_files():
     with open("conda_build_config.yaml", "w") as f:
-        yaml.dump({"abc": ["someval"], "cwd": ["someval"]}, f, default_flow_style=False)
+        yaml.safe_dump({"abc": ["someval"], "cwd": ["someval"]}, f)
     os.makedirs("config_dir")
     with open(os.path.join("config_dir", "config-0.yaml"), "w") as f:
-        yaml.dump(
-            {"abc": ["super_0"], "exclusive_0": ["0"], "exclusive_both": ["0"]},
-            f,
-            default_flow_style=False,
+        yaml.safe_dump(
+            {"abc": ["super_0"], "exclusive_0": ["0"], "exclusive_both": ["0"]}, f
         )
     with open(os.path.join("config_dir", "config-1.yaml"), "w") as f:
-        yaml.dump(
-            {"abc": ["super_1"], "exclusive_1": ["1"], "exclusive_both": ["1"]},
-            f,
-            default_flow_style=False,
+        yaml.safe_dump(
+            {"abc": ["super_1"], "exclusive_1": ["1"], "exclusive_both": ["1"]}, f
         )
     exclusive_config_files = (
         os.path.join("config_dir", "config-0.yaml"),
@@ -538,12 +533,10 @@ def test_exclusive_config_files():
 
 def test_exclusive_config_file():
     with open("conda_build_config.yaml", "w") as f:
-        yaml.dump({"abc": ["someval"], "cwd": ["someval"]}, f, default_flow_style=False)
+        yaml.safe_dump({"abc": ["someval"], "cwd": ["someval"]}, f)
     os.makedirs("config_dir")
     with open(os.path.join("config_dir", "config.yaml"), "w") as f:
-        yaml.dump(
-            {"abc": ["super"], "exclusive": ["someval"]}, f, default_flow_style=False
-        )
+        yaml.safe_dump({"abc": ["super"], "exclusive": ["someval"]}, f)
     output = api.render(
         os.path.join(variants_dir, "exclusive_config_file"),
         exclusive_config_file=os.path.join("config_dir", "config.yaml"),


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

PyYAML uses interesting defaults that we've often sought to override (e.g., `yaml.dump(default_flow_style=False)`). To ensure we do a better job of consistently applying the same standard to all of our `yaml.load`/`yaml.dump` calls we introduce `conda_build.yaml` with all of our customizations.

Extends https://github.com/conda/conda-build/pull/5284

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
