### PR TITLE
Deprecate `noarch_python_build_age`

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .conda_interface import cc_conda_build, url_path
+from .deprecations import deprecated
 from .utils import (
     get_build_folders,
     get_conda_operation_locks,
@@ -52,7 +53,7 @@ filename_hashing_default = "true"
 _src_cache_root_default = None
 error_overlinking_default = "false"
 error_overdepending_default = "false"
-noarch_python_build_age_default = 0
+deprecated.constant("24.5", "24.7", "noarch_python_build_age_default", 0)
 enable_static_default = "false"
 no_rewrite_stdout_env_default = "false"
 ignore_verify_codes_default = []
@@ -151,12 +152,6 @@ def _get_default_settings():
                 "error_overdepending", error_overdepending_default
             ).lower()
             == "true",
-        ),
-        Setting(
-            "noarch_python_build_age",
-            cc_conda_build.get(
-                "noarch_python_build_age", noarch_python_build_age_default
-            ),
         ),
         Setting(
             "enable_static",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,6 @@ from conda_build.config import (
     filename_hashing_default,
     ignore_verify_codes_default,
     no_rewrite_stdout_env_default,
-    noarch_python_build_age_default,
 )
 from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, copy_into, prepend_bin_path
@@ -99,7 +98,6 @@ def testing_config(testing_workdir):
         _src_cache_root=_src_cache_root_default,
         error_overlinking=boolify(error_overlinking_default),
         error_overdepending=boolify(error_overdepending_default),
-        noarch_python_build_age=noarch_python_build_age_default,
         enable_static=boolify(enable_static_default),
         no_rewrite_stdout_env=boolify(no_rewrite_stdout_env_default),
         ignore_verify_codes=ignore_verify_codes_default,
@@ -111,7 +109,6 @@ def testing_config(testing_workdir):
     assert result.no_rewrite_stdout_env is False
     assert result._src_cache_root is None
     assert result.src_cache_root == testing_workdir
-    assert result.noarch_python_build_age == 0
     return result
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Resolves #5297 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
