### PR TITLE
Fix `Config.override_channels` property

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -781,10 +781,12 @@ class Config:
     @deprecated(
         "24.5",
         "24.7",
-        addendum="Use `conda.base.context.context.override_channels` instead.",
+        addendum="Defer to `conda.base.context.context.channels` instead.",
     )
-    def override_channels(self):
-        return context.override_channels
+    def override_channels(self) -> bool:
+        return bool(
+            context._argparse_args and context._argparse_args.get("override_channels")
+        )
 
     def clean(self, remove_folders=True):
         # build folder is the whole burrito containing envs and source folders

--- a/news/5271-context
+++ b/news/5271-context
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Deprecate `conda_build.config.Config.override_channels`. Use `conda.base.context.context.override_channels` instead. (#5271)
+* Deprecate `conda_build.config.Config.override_channels`. Defer to `conda.base.context.context.channels` instead. (#5271)
 
 ### Docs
 

--- a/news/5271-context
+++ b/news/5271-context
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Deprecate `conda_build.config.Config.override_channels`. Defer to `conda.base.context.context.channels` instead. (#5271)
+* Deprecate `conda_build.config.Config.override_channels`. Defer to `conda.base.context.context.channels` instead. (#5271, #5324)
 
 ### Docs
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `Config.override_channels` property was set to fetch an invalid value from the context.

To test:

```bash
# without setting CLI arguments
python -Wd -c "from conda_build.config import Config; print(Config().override_channels)"

# with setting CLI arguments
python -Wd <<HEREDOC
from conda_build.config import Config
from conda.base.context import context
from argparse import Namespace
context.__init__(argparse_args=Namespace(override_channels=True))
print(Config().override_channels)
HEREDOC
```

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
