### PR TITLE
Add `upload.yml` workflow

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,55 @@
+name: Upload release
+
+on:
+  # https://docs.github.com/en/webhooks/webhook-events-and-payloads#release
+  release:
+    types: [published]
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.ref_name || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  # create source archive and upload it to the published release
+  # URL to the archive: https://github.com/conda/<repo>/releases/download/<tag>/<repo>-<tag>.tar.gz
+  upload:
+    if: '!github.event.repository.fork'
+    runs-on: ubuntu-latest
+    env:
+      ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.ref_name }}
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Create Release Directory
+        run: mkdir -p release
+
+      - name: Archive Source
+        run: >
+          git archive
+          --prefix="${{ env.ARCHIVE_NAME }}/"
+          --output="release/${{ env.ARCHIVE_NAME }}.tar.gz"
+          HEAD
+
+      - name: Compute Checksum
+        run: >
+          sha256sum "release/${{ env.ARCHIVE_NAME }}.tar.gz"
+          | awk '{print $1}'
+          > "release/${{ env.ARCHIVE_NAME }}.tar.gz.sha256sum"
+
+      - name: Upload Archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release upload
+          --clobber "${{ github.ref_name }}"
+          --repo "${{ github.repository }}"
+          release/*


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Port conda's `upload.yml` workflow that has been successfully used for three releases now to produce release tarballs with static sha256 hashes.

This will prevent the sha256 race condition that occurs when using GitHub's auto-generated release tarballs (see https://github.com/AnacondaRecipes/conda-build-feedstock/pull/44 and https://github.com/conda-forge/conda-build-feedstock/pull/226).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->

Fixes https://github.com/conda/conda-build/issues/5340