### PR TITLE
Report fully rendered recipe to stdout

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -59,6 +59,7 @@ from .render import (
     execute_download_actions,
     expand_outputs,
     output_yaml,
+    render_metadata_tuples,
     render_recipe,
     reparse,
     try_download,
@@ -2425,6 +2426,14 @@ def build(
         # Write out metadata for `conda debug`, making it obvious that this is what it is, must be done
         # after try_download()
         output_yaml(m, os.path.join(m.config.work_dir, "metadata_conda_debug.yaml"))
+        if m.config.verbose:
+            m_copy = m.copy()
+            for om, _, _ in render_metadata_tuples([(m_copy, False, False)], m_copy.config):
+                print("", "Rendered as:", "```yaml", output_yaml(om).rstrip(), "```", "", sep="\n")
+                # Each iteration returns the whole meta yaml, and then we are supposed to remove
+                # the outputs we don't want. Instead we just take the first and print it fully
+                break
+            del m_copy
 
         # get_dir here might be just work, or it might be one level deeper,
         #    dependening on the source.

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -27,7 +27,7 @@ import yaml
 from conda.base.context import context
 from conda.cli.common import specs_from_url
 from conda.core.package_cache_data import ProgressiveFetchExtract
-from conda.exceptions import UnsatisfiableError
+from conda.exceptions import NoPackagesFoundError, UnsatisfiableError
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.records import PackageRecord
 from conda.models.version import VersionOrder
@@ -998,6 +998,58 @@ def render_recipe(
                 allow_no_other_outputs=True,
                 bypass_env_check=bypass_env_check,
             )
+
+def render_metadata_tuples(
+    metadata_tuples: Iterable[MetaDataTuple],
+    config: Config,
+    permit_unsatisfiable_variants: bool = True,
+    finalize: bool = True,
+    bypass_env_check: bool = False
+) -> list[MetaDataTuple]:
+    output_metas: dict[tuple[str, str, tuple[tuple[str, str], ...]], MetaDataTuple] = {}
+    for meta, download, render_in_env in metadata_tuples:
+        if not meta.skip() or not config.trim_skip:
+            for od, om in meta.get_output_metadata_set(
+                permit_unsatisfiable_variants=permit_unsatisfiable_variants,
+                permit_undefined_jinja=not finalize,
+                bypass_env_check=bypass_env_check,
+            ):
+                if not om.skip() or not config.trim_skip:
+                    if "type" not in od or od["type"] == "conda":
+                        if finalize and not om.final:
+                            try:
+                                om = finalize_metadata(
+                                    om,
+                                    permit_unsatisfiable_variants=permit_unsatisfiable_variants,
+                                )
+                            except (DependencyNeedsBuildingError, NoPackagesFoundError):
+                                if not permit_unsatisfiable_variants:
+                                    raise
+
+                        # remove outputs section from output objects for simplicity
+                        if not om.path and (outputs := om.get_section("outputs")):
+                            om.parent_outputs = outputs
+                            del om.meta["outputs"]
+
+                        output_metas[
+                            om.dist(),
+                            om.config.variant.get("target_platform"),
+                            tuple(
+                                (var, om.config.variant[var])
+                                for var in om.get_used_vars()
+                            ),
+                        ] = MetaDataTuple(om, download, render_in_env)
+                    else:
+                        output_metas[
+                            f"{om.type}: {om.name()}",
+                            om.config.variant.get("target_platform"),
+                            tuple(
+                                (var, om.config.variant[var])
+                                for var in om.get_used_vars()
+                            ),
+                        ] = MetaDataTuple(om, download, render_in_env)
+
+    return list(output_metas.values())
 
 
 # Keep this out of the function below so it can be imported by other modules.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #3798


<details>

<summary>Example output</summary>

```
python -mconda build tests/test-recipes/metadata/outputs_overwrite_base_file
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Adding in variants from internal_defaults
Attempting to finalize metadata for base-outputs_overwrite_base_file
Attempting to finalize metadata for first-outputs_overwrite_base_file
Attempting to finalize metadata for second-outputs_overwrite_base_file
BUILD START: ['base-outputs_overwrite_base_file-1.0-0.tar.bz2', 'first-outputs_overwrite_base_file-1.0-0.tar.bz2', 'second-outputs_overwrite_base_file-1.0-0.tar.bz2']

Rendered as:
```yaml
package:
  name: base-outputs_overwrite_base_file
  version: '1.0'
build:
  noarch: false
  noarch_python: false
  script: install.sh
requirements:
  build: []
  run: []
outputs:
  - name: base-outputs_overwrite_base_file
    script: install.sh
  - name: first-outputs_overwrite_base_file
    requirements:
      host:
        - base-outputs_overwrite_base_file >=1.0,<2.0a0
      run:
        - base-outputs_overwrite_base_file >=1.0,<2.0a0
    script: install.sh
    test:
      commands:
        - content="$(cat "${PREFIX}/file")"
        - test "${content}" = base
  - name: second-outputs_overwrite_base_file
    requirements:
      host:
        - base-outputs_overwrite_base_file >=1.0,<2.0a0
      run:
        - base-outputs_overwrite_base_file >=1.0,<2.0a0
    script: install.sh
    test:
      commands:
        - content="$(cat "${PREFIX}/file")"
        - test "${content}" = "base"
extra:
  copy_test_source_files: true
  final: true
  parent_recipe:
    name: outputs_overwrite_base_file
    path: /Users/jrodriguez/devel/conda-build/tests/test-recipes/metadata/outputs_overwrite_base_file
    version: '1.0'
```

source tree in: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work
Packaging base-outputs_overwrite_base_file
Packaging base-outputs_overwrite_base_file-1.0-0

Resource usage statistics from bundling base-outputs_overwrite_base_file:
   Process count: 1
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 2.1M
   Disk usage: 16B
   Time elapsed: 0:00:02.0


number of files: 1
Fixing permissions
INFO :: Time taken to mark (prefix)
        0 replacements in 0 files was 0.02 seconds
Package verification results:
-----------------------------
/var/folders/1b/z374sygs1s96t_xxxv0hr3lr0000gn/T/tmp09ey0n99/base-outputs_overwrite_base_file-1.0-0.tar.bz2: C1115 Found invalid license "None" in info/index.json
Packaging first-outputs_overwrite_base_file
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p


The following NEW packages will be INSTALLED:

    base-outputs_overwrite_base_file: 1.0-0 local

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done

Resource usage statistics from bundling first-outputs_overwrite_base_file:
   Process count: 2
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 9.0M
   Disk usage: 16B
   Time elapsed: 0:00:02.0


number of files: 0
Fixing permissions
INFO :: Time taken to mark (prefix)
        0 replacements in 0 files was 0.00 seconds
Package verification results:
-----------------------------
/var/folders/1b/z374sygs1s96t_xxxv0hr3lr0000gn/T/tmp4qi2fr5z/first-outputs_overwrite_base_file-1.0-0.tar.bz2: C1115 Found invalid license "None" in info/index.json
Packaging second-outputs_overwrite_base_file
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p


The following NEW packages will be INSTALLED:

    base-outputs_overwrite_base_file: 1.0-0 local

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done

Resource usage statistics from bundling second-outputs_overwrite_base_file:
   Process count: 2
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 6.0M
   Disk usage: 16B
   Time elapsed: 0:00:02.0


number of files: 0
Fixing permissions
INFO :: Time taken to mark (prefix)
        0 replacements in 0 files was 0.00 seconds
Package verification results:
-----------------------------
/var/folders/1b/z374sygs1s96t_xxxv0hr3lr0000gn/T/tmp_rwu_c8c/second-outputs_overwrite_base_file-1.0-0.tar.bz2: C1115 Found invalid license "None" in info/index.json
TEST START: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/base-outputs_overwrite_base_file-1.0-0.tar.bz2
WARNING: Multiple meta files found. The meta.yaml file in the base directory (/var/folders/1b/z374sygs1s96t_xxxv0hr3lr0000gn/T/tmp01qk8lro/info/recipe) will be used.
Nothing to test for: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/base-outputs_overwrite_base_file-1.0-0.tar.bz2
TEST START: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/first-outputs_overwrite_base_file-1.0-0.tar.bz2
WARNING: Multiple meta files found. The meta.yaml file in the base directory (/var/folders/1b/z374sygs1s96t_xxxv0hr3lr0000gn/T/tmpa3vobxah/info/recipe) will be used.
Renaming work directory '/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work' to '/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work_moved_first-outputs_overwrite_base_file-1.0-0_osx-arm64'
shutil.move(work)=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work, dest=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work_moved_first-outputs_overwrite_base_file-1.0-0_osx-arm64)
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh


The following NEW packages will be INSTALLED:

    base-outputs_overwrite_base_file:  1.0-0 local
    first-outputs_overwrite_base_file: 1.0-0 local

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
export PREFIX=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh
export SRC_DIR=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/test_tmp
++ cat /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/file
+ content=base
+ test base = base
+ exit 0

Resource usage statistics from testing first-outputs_overwrite_base_file:
   Process count: 2
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 5.1M
   Disk usage: 24B
   Time elapsed: 0:00:02.1


TEST END: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/first-outputs_overwrite_base_file-1.0-0.tar.bz2
TEST START: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/second-outputs_overwrite_base_file-1.0-0.tar.bz2
WARNING: Multiple meta files found. The meta.yaml file in the base directory (/var/folders/1b/z374sygs1s96t_xxxv0hr3lr0000gn/T/tmpjz8gztqw/info/recipe) will be used.
Renaming work directory '/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work' to '/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work_moved_second-outputs_overwrite_base_file-1.0-0_osx-arm64'
shutil.move(work)=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work, dest=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work_moved_second-outputs_overwrite_base_file-1.0-0_osx-arm64)
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh


The following NEW packages will be INSTALLED:

    base-outputs_overwrite_base_file:   1.0-0 local
    second-outputs_overwrite_base_file: 1.0-0 local

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
export PREFIX=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh
export SRC_DIR=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/test_tmp
++ cat /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/file
+ content=base
+ test base = base
+ exit 0

Resource usage statistics from testing second-outputs_overwrite_base_file:
   Process count: 2
   CPU time: Sys=0:00:00.0, User=0:00:00.0
   Memory: 5.1M
   Disk usage: 24B
   Time elapsed: 0:00:02.0


TEST END: /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/second-outputs_overwrite_base_file-1.0-0.tar.bz2
Renaming work directory '/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work' to '/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work_moved_outputs_overwrite_base_file-1.0-0_osx-arm64_main_build_loop'
shutil.move(work)=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work, dest=/Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/outputs_overwrite_base_file_1715947692957/work_moved_outputs_overwrite_base_file-1.0-0_osx-arm64_main_build_loop)
# Automatic uploading is disabled
# If you want to upload package(s) to anaconda.org later, type:


# To have conda build upload to anaconda.org automatically, use
# conda config --set anaconda_upload yes
anaconda upload \
    /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/base-outputs_overwrite_base_file-1.0-0.tar.bz2 \
    /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/first-outputs_overwrite_base_file-1.0-0.tar.bz2 \
    /Users/jrodriguez/.local/anaconda/envs/conda-build-dev/conda-bld/osx-arm64/second-outputs_overwrite_base_file-1.0-0.tar.bz2
anaconda_upload is not set.  Not uploading wheels: []

INFO :: The inputs making up the hashes for the built packages are as follows:
{
  "base-outputs_overwrite_base_file-1.0-0.tar.bz2": {
    "recipe": {}
  },
  "first-outputs_overwrite_base_file-1.0-0.tar.bz2": {
    "recipe": {}
  },
  "second-outputs_overwrite_base_file-1.0-0.tar.bz2": {
    "recipe": {}
  }
}


####################################################################################
Resource usage summary:

Total time: 0:01:06.1
CPU usage: sys=0:00:00.0, user=0:00:00.1
Maximum memory usage observed: 9.0M
Total disk usage observed (not including envs): 96B


####################################################################################
```

</details>

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
