### PR TITLE
Fix excessive memory use in `inspect_linkages_lief`

### DIFF
--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -596,7 +596,7 @@ def inspect_linkages_lief(
                     if recurse:
                         if os.path.exists(resolved[0]):
                             todo.append([resolved[0], lief.parse(resolved[0])])
-                already_seen.add(get_uniqueness_key(filename2, binary2))
+                already_seen.add(uniqueness_key)
     return results
 
 

--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -505,13 +505,13 @@ def inspect_linkages_lief(
         for element in todo:
             todo.pop(0)
             filename2 = element[0]
-            binary = element[1]
-            if not binary:
+            binary2 = element[1]
+            if not binary2:
                 continue
-            uniqueness_key = get_uniqueness_key(filename2, binary)
+            uniqueness_key = get_uniqueness_key(filename2, binary2)
             if uniqueness_key not in already_seen:
                 parent_exe_dirname = None
-                if binary.format == EXE_FORMATS.PE:
+                if binary2.format == EXE_FORMATS.PE:
                     tmp_filename = filename2
                     while tmp_filename:
                         if (
@@ -527,17 +527,17 @@ def inspect_linkages_lief(
                 if ".pyd" in filename2 or (os.sep + "DLLs" + os.sep) in filename2:
                     parent_exe_dirname = envroot.replace(os.sep, "/") + "/DLLs"
                 rpaths_by_binary[filename2] = get_rpaths(
-                    binary, parent_exe_dirname, envroot.replace(os.sep, "/"), sysroot
+                    binary2, parent_exe_dirname, envroot.replace(os.sep, "/"), sysroot
                 )
                 tmp_filename = filename2
                 rpaths_transitive = []
-                if binary.format == EXE_FORMATS.PE:
+                if binary2.format == EXE_FORMATS.PE:
                     rpaths_transitive = rpaths_by_binary[tmp_filename]
                 else:
                     while tmp_filename:
                         rpaths_transitive[:0] = rpaths_by_binary[tmp_filename]
                         tmp_filename = parents_by_filename[tmp_filename]
-                libraries = get_libraries(binary)
+                libraries = get_libraries(binary2)
                 if filename2 in libraries:  # Happens on macOS, leading to cycles.
                     libraries.remove(filename2)
                 # RPATH is implicit everywhere except macOS, make it explicit to simplify things.
@@ -546,14 +546,14 @@ def inspect_linkages_lief(
                         "$RPATH/" + lib
                         if not lib.startswith("/")
                         and not lib.startswith("$")
-                        and binary.format != EXE_FORMATS.MACHO  # noqa
+                        and binary2.format != EXE_FORMATS.MACHO  # noqa
                         else lib
                     )
                     for lib in libraries
                 ]
                 for lib, orig in zip(libraries, these_orig):
                     resolved = _get_resolved_location(
-                        binary,
+                        binary2,
                         orig,
                         exedir,
                         exedir,
@@ -568,7 +568,7 @@ def inspect_linkages_lief(
                     # can be run case-sensitively if the user wishes.
                     #
                     """
-                    if binary.format == EXE_FORMATS.PE:
+                    if binary2.format == EXE_FORMATS.PE:
                         import random
                         path_fixed = (
                             os.path.dirname(path_fixed)
@@ -596,7 +596,7 @@ def inspect_linkages_lief(
                     if recurse:
                         if os.path.exists(resolved[0]):
                             todo.append([resolved[0], lief.parse(resolved[0])])
-                already_seen.add(get_uniqueness_key(filename2, binary))
+                already_seen.add(get_uniqueness_key(filename2, binary2))
     return results
 
 

--- a/conda_build/os_utils/liefldd.py
+++ b/conda_build/os_utils/liefldd.py
@@ -353,12 +353,12 @@ def _get_path_dirs(prefix):
     yield "/".join((prefix, "bin"))
 
 
-def get_uniqueness_key(file):
+def get_uniqueness_key(filename, file):
     binary = ensure_binary(file)
     if not binary:
         return EXE_FORMATS.UNKNOWN
     elif binary.format == EXE_FORMATS.MACHO:
-        return str(file)
+        return filename
     elif binary.format == EXE_FORMATS.ELF and (  # noqa
         binary.type == lief.ELF.ELF_CLASS.CLASS32
         or binary.type == lief.ELF.ELF_CLASS.CLASS64
@@ -369,8 +369,8 @@ def get_uniqueness_key(file):
         ]
         if result:
             return result[0]
-        return str(file)
-    return str(file)
+        return filename
+    return filename
 
 
 def _get_resolved_location(
@@ -508,7 +508,7 @@ def inspect_linkages_lief(
             binary = element[1]
             if not binary:
                 continue
-            uniqueness_key = get_uniqueness_key(binary)
+            uniqueness_key = get_uniqueness_key(filename2, binary)
             if uniqueness_key not in already_seen:
                 parent_exe_dirname = None
                 if binary.format == EXE_FORMATS.PE:
@@ -596,7 +596,7 @@ def inspect_linkages_lief(
                     if recurse:
                         if os.path.exists(resolved[0]):
                             todo.append([resolved[0], lief.parse(resolved[0])])
-                already_seen.add(get_uniqueness_key(binary))
+                already_seen.add(get_uniqueness_key(filename2, binary))
     return results
 
 

--- a/news/5348-fix-excessive-memory-use-in-inspect_linkages_lief
+++ b/news/5348-fix-excessive-memory-use-in-inspect_linkages_lief
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+*  Fix excessive memory use in `inspect_linkages_lief` (#5267 via #5348)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

introduced in gh-5228 which replaced `binary.name` with `str(file)`.
The former returns the path to the binary whereas the latter returns the
contents of the parsed binary, naturally causing high memory usage.
That semantic change was unintended (misread upstream changes).
Since binary's path is no longer part of the object, pass it separately.

Fixes gh-5267

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
