### PR TITLE
Replace `sys.exit` in `copy_readme`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -46,6 +46,7 @@ from .deprecations import deprecated
 from .exceptions import (
     BuildScriptException,
     CondaBuildException,
+    CondaBuildUserError,
     DependencyNeedsBuildingError,
 )
 from .index import _delegated_update_index, get_build_index
@@ -779,7 +780,7 @@ def copy_readme(m):
     if readme:
         src = join(m.config.work_dir, readme)
         if not isfile(src):
-            sys.exit(f"Error: no readme file: {readme}")
+            raise CondaBuildUserError(f"`about/readme` file ({readme}) doesn't exist")
         dst = join(m.config.info_dir, readme)
         utils.copy_into(src, dst, m.config.timeout, locking=m.config.locking)
         if os.path.split(readme)[1] not in {"README.md", "README.rst", "README"}:

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -775,7 +775,7 @@ def copy_recipe(m):
             yaml.dump(m.config.variant, f)
 
 
-def copy_readme(m):
+def copy_readme(m: MetaData):
     readme = m.get_value("about/readme")
     if readme:
         src = join(m.config.work_dir, readme)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -12,12 +12,17 @@ import os
 import sys
 from contextlib import nullcontext
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from conda_build import api, build
+from conda_build.exceptions import CondaBuildUserError
 
 from .utils import get_noarch_python_meta, metadata_dir
+
+if TYPE_CHECKING:
+    from conda_build.metadata import MetaData
 
 
 def test_build_preserves_PATH(testing_config):
@@ -329,3 +334,14 @@ def test_guess_interpreter(
 def test_check_external():
     with pytest.deprecated_call():
         build.check_external()
+
+
+@pytest.mark.parametrize("readme", ["README.md", "README.rst", "README"])
+def test_copy_readme(testing_metadata: MetaData, readme: str):
+    testing_metadata.meta["about"]["readme"] = readme
+    with pytest.raises(CondaBuildUserError):
+        build.copy_readme(testing_metadata)
+
+    Path(testing_metadata.config.work_dir, readme).touch()
+    build.copy_readme(testing_metadata)
+    assert Path(testing_metadata.config.info_dir, readme).exists()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Replacing `sys.exit` call in `copy_readme` with the new `CondaBuildUserError` exception for better downstream error handling. Add missing unit test.

Depends on #5353
Xref #4209 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
