### PR TITLE
Validate `run_constrained` specs

### DIFF
--- a/news/5359-validate-run-constrained
+++ b/news/5359-validate-run-constrained
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Validate `run_constrained` dependencies to prevent faulty specs reaching final repodata. (#5047 via #5359)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/metadata/_run_constrained_error/meta.yaml
+++ b/tests/test-recipes/metadata/_run_constrained_error/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: test_run_constrained_error
+  version: 1.0
+
+requirements:
+  run_constrained:
+    # obtained from https://github.com/conda-forge/willow-feedstock/blob/67d9ac1c5232295ccaac41b131e3982a335b365b/recipe/meta.yaml#L29
+    - pillow-heif  >=0.10.0,<1.0.0<py312|>=0.13.0,<1.0.0>=py312
+    - {{ 'another-package' }} {{ '>=0.20.0,<2.0.0<py310|>=0.23.0,<2.0.0>=py310' }}
+  

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -41,6 +41,7 @@ from conda_build.exceptions import (
     DependencyNeedsBuildingError,
     OverDependingError,
     OverLinkingError,
+    RecipeError,
 )
 from conda_build.os_utils.external import find_executable
 from conda_build.render import finalize_metadata
@@ -1462,6 +1463,12 @@ def test_run_constrained_stores_constrains_info(testing_config):
     assert "constrains" in info_contents
     assert len(info_contents["constrains"]) == 1
     assert info_contents["constrains"][0] == "bzip2  1.*"
+
+
+def test_run_constrained_is_validated(testing_config: Config):
+    recipe = os.path.join(metadata_dir, "_run_constrained_error")
+    with pytest.raises(RecipeError):
+        api.build(recipe, config=testing_config)
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #5047

conda-build allows to include `run_constrained` items in the recipe content. These are sometimes not checked because they only affect the solver if the constrained name happens to be present in the test environment. As a result, faulty lines might get sneak all the way into the final repodata.json. 

When the rules finally kick in, you get a solver error. One current example comes in the [`willow` recipe, which constrains `pillow-heif`](https://github.com/conda-forge/willow-feedstock/blob/67d9ac1c5232295ccaac41b131e3982a335b365b/recipe/meta.yaml#L29).

That line is not a valid `MatchSpec`:

```
>>> from conda.models.match_spec import MatchSpec
>>> MatchSpec("pillow-heif >=0.10.0,<1.0.0<py312|>=0.13.0,<1.0.0>=py312")
Traceback (most recent call last):
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 43, in __call__
    return cls._cache_[arg]
KeyError: '>=0.10.0,<1.0.0<py312|>=0.13.0,<1.0.0>=py312'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 43, in __call__
    return cls._cache_[arg]
KeyError: '<1.0.0<py312'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 43, in __call__
    return cls._cache_[arg]
KeyError: '1.0.0<py312'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/match_spec.py", line 54, in __call__
    return super().__call__(**parsed)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/match_spec.py", line 177, in __init__
    self._match_components = self._build_components(**kwargs)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/match_spec.py", line 412, in _build_components
    return frozendict(_make_component(key, value) for key, value in kwargs.items())
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/_vendor/frozendict/__init__.py", line 21, in __init__
    self._dict = self.dict_cls(*args, **kwargs)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/match_spec.py", line 412, in <genexpr>
    return frozendict(_make_component(key, value) for key, value in kwargs.items())
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/match_spec.py", line 426, in _make_component
    matcher = _implementors[field_name](value)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 45, in __call__
    val = cls._cache_[arg] = super().__call__(arg)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 522, in __init__
    vspec_str, matcher, is_exact = self.get_matcher(vspec)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 532, in get_matcher
    tup = tuple(VersionSpec(s) for s in vspec_tree[1:])
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 532, in <genexpr>
    tup = tuple(VersionSpec(s) for s in vspec_tree[1:])
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 48, in __call__
    return super().__call__(arg)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 522, in __init__
    vspec_str, matcher, is_exact = self.get_matcher(vspec)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 532, in get_matcher
    tup = tuple(VersionSpec(s) for s in vspec_tree[1:])
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 532, in <genexpr>
    tup = tuple(VersionSpec(s) for s in vspec_tree[1:])
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 45, in __call__
    val = cls._cache_[arg] = super().__call__(arg)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 522, in __init__
    vspec_str, matcher, is_exact = self.get_matcher(vspec)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 576, in get_matcher
    self.matcher_vo = VersionOrder(vo_str)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 45, in __call__
    val = cls._cache_[arg] = super().__call__(arg)
  File "/Users/jrodriguez/.local/anaconda/lib/python3.9/site-packages/conda/models/version.py", line 171, in __init__
    raise InvalidVersionSpec(vstr, "invalid character(s)")
conda.exceptions.InvalidVersionSpec: Invalid version '1.0.0<py312': invalid character(s)
```

This PR adds a check for all `run_constrained` item to make sure they don't ever reach a final package without getting it addressed.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [X] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
