### PR TITLE
Fix a few more logger.warn calls

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -4073,11 +4073,11 @@ def handle_pypi_upload(wheels, config):
             try:
                 utils.check_call_env(args + [f])
             except:
-                utils.get_logger(__name__).warn(
+                utils.get_logger(__name__).warning(
                     "wheel upload failed - is twine installed?"
                     "  Is this package registered?"
                 )
-                utils.get_logger(__name__).warn(f"Wheel file left in {f}")
+                utils.get_logger(__name__).warning(f"Wheel file left in {f}")
 
     else:
         print(f"anaconda_upload is not set.  Not uploading wheels: {wheels}")

--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -258,7 +258,7 @@ def inspect_linkages(
                 if relative:
                     precs = list(which_package(relative, prefix))
                     if len(precs) > 1:
-                        get_logger(__name__).warn(
+                        get_logger(__name__).warning(
                             "Warning: %s comes from multiple packages: %s",
                             path,
                             comma_join(map(str, precs)),

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -199,7 +199,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
     if not np:
         np = defaults["numpy"]
         if config.verbose:
-            utils.get_logger(__name__).warn(
+            utils.get_logger(__name__).warning(
                 "No numpy version specified in conda_build_config.yaml.  "
                 "Falling back to default numpy value of {}".format(defaults["numpy"])
             )
@@ -995,7 +995,7 @@ def _toposort_outputs(output_tuples: list[OutputTuple]) -> list[OutputTuple]:
             non_conda_outputs.append(output_tuple)
         else:
             # TODO: is it even possible to get here? and if so should we silently ignore or error?
-            utils.get_logger(__name__).warn("Found an output without a name, skipping")
+            utils.get_logger(__name__).warning("Found an output without a name, skipping")
 
     # Iterate over conda packages, creating a mapping of package names to their
     # dependencies to be used in toposort
@@ -2326,7 +2326,7 @@ class MetaData:
             output = output_matches[output_index] if output_matches else ""
         except ValueError:
             if not self.path and self.meta.get("extra", {}).get("parent_recipe"):
-                utils.get_logger(__name__).warn(
+                utils.get_logger(__name__).warning(
                     f"Didn't match any output in raw metadata.  Target value was: {output_name}"
                 )
                 output = ""

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -995,7 +995,9 @@ def _toposort_outputs(output_tuples: list[OutputTuple]) -> list[OutputTuple]:
             non_conda_outputs.append(output_tuple)
         else:
             # TODO: is it even possible to get here? and if so should we silently ignore or error?
-            utils.get_logger(__name__).warning("Found an output without a name, skipping")
+            utils.get_logger(__name__).warning(
+                "Found an output without a name, skipping"
+            )
 
     # Iterate over conda packages, creating a mapping of package names to their
     # dependencies to be used in toposort

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1318,7 +1318,7 @@ def find_recipe(path: str) -> str:
 
     metas = [m for m in VALID_METAS if os.path.isfile(os.path.join(path, m))]
     if len(metas) == 1:
-        get_logger(__name__).warn(
+        get_logger(__name__).warning(
             "Multiple meta files found. "
             f"The {metas[0]} file in the base directory ({path}) "
             "will be used."


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

In #5364 I missed a few calls to `.warn` because they were chained with our own `get_logger` function.
This PR takes care of those.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Still nothing here applies.

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
