### PR TITLE
Replace `sys.exit` in `conda_build.build.handle_anaconda_upload`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -3977,7 +3977,10 @@ def build_tree(
     return list(built_packages.keys())
 
 
-def handle_anaconda_upload(paths, config):
+def handle_anaconda_upload(
+    paths: Iterable[str | os.PathLike | Path],
+    config: Config,
+) -> None:
     from .os_utils.external import find_executable
 
     paths = utils.ensure_list(paths)
@@ -4011,7 +4014,7 @@ def handle_anaconda_upload(paths, config):
             "# To have conda build upload to anaconda.org automatically, use\n"
             f"# {prompter}conda config --set anaconda_upload yes\n"
         )
-        no_upload_message += f"anaconda upload{joiner}" + joiner.join(paths)
+        no_upload_message += f"anaconda upload{joiner}" + joiner.join(map(str, paths))
 
     if not upload:
         print(no_upload_message)
@@ -4019,7 +4022,7 @@ def handle_anaconda_upload(paths, config):
 
     if not anaconda:
         print(no_upload_message)
-        sys.exit(
+        raise CondaBuildUserError(
             "Error: cannot locate anaconda command (required for upload)\n"
             "# Try:\n"
             f"# {prompter}conda install anaconda-client"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,6 +25,7 @@ from .utils import get_noarch_python_meta, metadata_dir
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+    from conda_build.config import Config
     from conda_build.metadata import MetaData
 
 
@@ -369,3 +370,14 @@ def test_wsl_unsupported(
             env={},
             stats={},
         )
+
+
+def test_handle_anaconda_upload(testing_config: Config, mocker: MockerFixture):
+    mocker.patch(
+        "conda_build.os_utils.external.find_executable",
+        return_value=None,
+    )
+    testing_config.anaconda_upload = True
+
+    with pytest.raises(CondaBuildUserError):
+        build.handle_anaconda_upload((), testing_config)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Replacing `sys.exit` call in `handle_anaconda_upload` with the new `CondaBuildUserError` exception for better error handling, along with a corresponding unit test. 

This work has been separated out from #5255
Xref #4209 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
