### PR TITLE
Replace `sys.exit` call in `conda_build.build.tests_failed`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -3553,7 +3553,12 @@ def test(
     return True
 
 
-def tests_failed(package_or_metadata, move_broken, broken_dir, config):
+def tests_failed(
+    package_or_metadata: str | os.PathLike | Path | MetaData,
+    move_broken: bool,
+    broken_dir: str | os.PathLike | Path,
+    config: Config,
+) -> None:
     """
     Causes conda to exit if any of the given package's tests failed.
 
@@ -3581,7 +3586,7 @@ def tests_failed(package_or_metadata, move_broken, broken_dir, config):
         _delegated_update_index(
             os.path.dirname(os.path.dirname(pkg)), verbose=config.debug, threads=1
         )
-    sys.exit("TESTS FAILED: " + os.path.basename(pkg))
+    raise CondaBuildUserError("TESTS FAILED: " + os.path.basename(pkg))
 
 
 @deprecated(

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -16,7 +16,7 @@ from conda_build.config import (
     Config,
     zstd_compression_level_default,
 )
-from conda_build.exceptions import DependencyNeedsBuildingError
+from conda_build.exceptions import CondaBuildUserError, DependencyNeedsBuildingError
 from conda_build.os_utils.external import find_executable
 from conda_build.utils import get_build_folders, on_win, package_has_file
 
@@ -165,7 +165,7 @@ def test_build_long_test_prefix_default_enabled(mocker, testing_workdir):
     main_build.execute(args)
 
     args.append("--no-long-test-prefix")
-    with pytest.raises(SystemExit):
+    with pytest.raises(CondaBuildUserError):
         main_build.execute(args)
 
 
@@ -483,7 +483,7 @@ def test_test_extra_dep(testing_metadata):
     main_build.execute(args)
 
     # missing click dep will fail tests
-    with pytest.raises(SystemExit):
+    with pytest.raises(CondaBuildUserError):
         args = [output, "-t"]
         # extra_deps will add it in
         main_build.execute(args)

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -38,6 +38,7 @@ from conda_build.config import Config
 from conda_build.exceptions import (
     BuildScriptException,
     CondaBuildException,
+    CondaBuildUserError,
     DependencyNeedsBuildingError,
     OverDependingError,
     OverLinkingError,
@@ -279,7 +280,7 @@ def test_no_include_recipe_meta_yaml(testing_metadata, testing_config):
     )[0]
     assert not package_has_file(output_file, "info/recipe/meta.yaml")
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(CondaBuildUserError):
         # we are testing that even with the recipe excluded, we still get the tests in place
         output_file = api.build(
             os.path.join(metadata_dir, "_no_include_recipe"), config=testing_config
@@ -545,7 +546,7 @@ def test_skip_existing_url(testing_metadata, testing_workdir, capfd):
 
 def test_failed_tests_exit_build(testing_config):
     """https://github.com/conda/conda-build/issues/1112"""
-    with pytest.raises(SystemExit, match="TESTS FAILED"):
+    with pytest.raises(CondaBuildUserError, match="TESTS FAILED"):
         api.build(
             os.path.join(metadata_dir, "_test_failed_test_exits"), config=testing_config
         )
@@ -1808,7 +1809,7 @@ def test_downstream_tests(testing_config):
     upstream = os.path.join(metadata_dir, "_test_downstreams/upstream")
     downstream = os.path.join(metadata_dir, "_test_downstreams/downstream")
     api.build(downstream, config=testing_config, notest=True)
-    with pytest.raises(SystemExit):
+    with pytest.raises(CondaBuildUserError):
         api.build(upstream, config=testing_config)
 
 

--- a/tests/test_api_test.py
+++ b/tests/test_api_test.py
@@ -9,6 +9,7 @@ import os
 import pytest
 
 from conda_build import api
+from conda_build.exceptions import CondaBuildUserError
 
 from .utils import metadata_dir
 
@@ -63,5 +64,5 @@ def test_api_extra_dep(testing_metadata):
     api.test(output, config=testing_metadata.config, extra_deps=["click"])
 
     # missing click dep will fail tests
-    with pytest.raises(SystemExit):
+    with pytest.raises(CondaBuildUserError):
         api.test(output, config=testing_metadata.config)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -369,3 +369,13 @@ def test_wsl_unsupported(
             env={},
             stats={},
         )
+
+
+def test_tests_failed(testing_metadata: MetaData, tmp_path: Path):
+    with pytest.raises(CondaBuildUserError):
+        build.tests_failed(
+            package_or_metadata=testing_metadata,
+            move_broken=True,
+            broken_dir=tmp_path,
+            config=testing_metadata.config,
+        )

--- a/tests/test_subpackages.py
+++ b/tests/test_subpackages.py
@@ -11,6 +11,7 @@ import pytest
 from conda.base.context import context
 
 from conda_build import api, utils
+from conda_build.exceptions import CondaBuildUserError
 from conda_build.metadata import MetaDataTuple
 from conda_build.render import finalize_metadata
 
@@ -292,7 +293,7 @@ def test_per_output_tests(testing_config):
 @pytest.mark.sanity
 def test_per_output_tests_script(testing_config):
     recipe_dir = os.path.join(subpackage_dir, "_output_test_script")
-    with pytest.raises(SystemExit):
+    with pytest.raises(CondaBuildUserError):
         api.build(recipe_dir, config=testing_config)
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Replacing `sys.exit` call in `tests_failed()` in `build.py` with the new `CondaBuildUserError` exception for better error handling, along with a corresponding unit test. 

This work has been separated out from #5255
Xref #4209 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
