### PR TITLE
Replace `sys.exit` calls in `conda_build/metadata.py`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1408,12 +1408,11 @@ class MetaData:
     ):
         """variant contains key-value mapping for additional functions and values
         for jinja2 variables"""
-        # undefined_jinja_vars is refreshed by self.parse again
-        undefined_jinja_vars = ()
         # store the "final" state that we think we're in.  reloading the meta.yaml file
         #   can reset it (to True)
         final = self.final
-        # always parse again at least once.
+
+        # always parse again at least once
         self.parse_again(
             permit_undefined_jinja=True,
             allow_no_other_outputs=allow_no_other_outputs,
@@ -1421,6 +1420,8 @@ class MetaData:
         )
         self.final = final
 
+        # recursively parse again so long as each iteration has fewer undefined jinja variables
+        undefined_jinja_vars = ()
         while set(undefined_jinja_vars) != set(self.undefined_jinja_vars):
             undefined_jinja_vars = self.undefined_jinja_vars
             self.parse_again(
@@ -1429,18 +1430,8 @@ class MetaData:
                 bypass_env_check=bypass_env_check,
             )
             self.final = final
-        if undefined_jinja_vars:
-            self.parse_again(
-                permit_undefined_jinja=False,
-                allow_no_other_outputs=allow_no_other_outputs,
-                bypass_env_check=bypass_env_check,
-            )
-            sys.exit(
-                f"Undefined Jinja2 variables remain ({self.undefined_jinja_vars}).  Please enable "
-                "source downloading and try again."
-            )
 
-        # always parse again at the end, too.
+        # always parse again at the end without permit_undefined_jinja
         self.parse_again(
             permit_undefined_jinja=False,
             allow_no_other_outputs=allow_no_other_outputs,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -773,28 +773,18 @@ def _git_clean(source_meta):
     and complain.
     """
 
-    git_rev_tags_old = ("git_branch", "git_tag")
     git_rev = "git_rev"
 
-    git_rev_tags = (git_rev,) + git_rev_tags_old
-
-    has_rev_tags = tuple(bool(source_meta.get(tag, "")) for tag in git_rev_tags)
-    if sum(has_rev_tags) > 1:
-        msg = "Error: multiple git_revs:"
-        msg += ", ".join(
-            f"{key}" for key, has in zip(git_rev_tags, has_rev_tags) if has
-        )
-        sys.exit(msg)
+    keys = [key for key in (git_rev, "git_branch", "git_tag") if key in source_meta]
+    if not keys:
+        # git_branch, git_tag, nor git_rev specified, return as-is
+        return source_meta
+    elif len(keys) > 1:
+        raise CondaBuildUserError(f"Multiple git_revs: {', '.join(keys)}")
 
     # make a copy of the input so we have no side-effects
     ret_meta = source_meta.copy()
-    # loop over the old versions
-    for key, has in zip(git_rev_tags[1:], has_rev_tags[1:]):
-        # update if needed
-        if has:
-            ret_meta[git_rev_tags[0]] = ret_meta[key]
-        # and remove
-        ret_meta.pop(key, None)
+    ret_meta[git_rev] = ret_meta.pop(keys[0])
 
     return ret_meta
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -26,6 +26,7 @@ from .config import Config, get_or_merge_config
 from .deprecations import deprecated
 from .exceptions import (
     CondaBuildException,
+    CondaBuildUserError,
     DependencyNeedsBuildingError,
     RecipeError,
     UnableToParse,
@@ -343,12 +344,12 @@ def select_lines(text: str, namespace: dict[str, Any], variants_in_place: bool) 
                     if value:
                         lines.append(line)
                 except Exception as e:
-                    sys.exit(
-                        f"Error: Invalid selector in meta.yaml line {i + 1}:\n"
-                        f"offending line:\n"
-                        f"{line}\n"
+                    raise CondaBuildUserError(
+                        f"Invalid selector in meta.yaml line {i + 1}:\n"
+                        f"offending selector:\n"
+                        f"  [{selector}]\n"
                         f"exception:\n"
-                        f"{e.__class__.__name__}: {e}\n"
+                        f"  {e.__class__.__name__}: {e}\n"
                     )
     return "\n".join(lines) + "\n"
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -15,6 +15,7 @@ from functools import lru_cache
 from os.path import isfile, join
 from typing import TYPE_CHECKING, NamedTuple, overload
 
+import yaml
 from bs4 import UnicodeDammit
 from conda.base.context import context
 from conda.gateways.disk.read import compute_sum
@@ -30,7 +31,6 @@ from .exceptions import (
     DependencyNeedsBuildingError,
     RecipeError,
     UnableToParse,
-    UnableToParseMissingJinja2,
 )
 from .features import feature_list
 from .license_family import ensure_valid_license_family
@@ -59,13 +59,6 @@ if TYPE_CHECKING:
     OutputDict = dict[str, Any]
     OutputTuple = tuple[OutputDict, "MetaData"]
 
-try:
-    import yaml
-except ImportError:
-    sys.exit(
-        "Error: could not import yaml (required to read meta.yaml "
-        "files of conda recipes)"
-    )
 
 try:
     Loader = yaml.CLoader
@@ -358,13 +351,6 @@ def yamlize(data):
     try:
         return yaml.load(data, Loader=StringifyNumbersLoader)
     except yaml.error.YAMLError as e:
-        if "{{" in data:
-            try:
-                import jinja2
-
-                jinja2  # Avoid pyflakes failure: 'jinja2' imported but unused
-            except ImportError:
-                raise UnableToParseMissingJinja2(original=e)
         print("Problematic recipe:", file=sys.stderr)
         print(data, file=sys.stderr)
         raise UnableToParse(original=e)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -797,15 +797,16 @@ def _str_version(package_meta):
     return package_meta
 
 
-def check_bad_chrs(s, field):
-    bad_chrs = "=@#$%^&*:;\"'\\|<>?/ "
+def check_bad_chrs(value: str, field: str) -> None:
+    bad_chrs = set("=@#$%^&*:;\"'\\|<>?/ ")
     if field in ("package/version", "build/string"):
-        bad_chrs += "-"
+        bad_chrs.add("-")
     if field != "package/version":
-        bad_chrs += "!"
-    for c in bad_chrs:
-        if c in s:
-            sys.exit(f"Error: bad character '{c}' in {field}: {s}")
+        bad_chrs.add("!")
+    if invalid := bad_chrs.intersection(value):
+        raise CondaBuildUserError(
+            f"Bad character(s) ({''.join(sorted(invalid))}) in {field}: {value}."
+        )
 
 
 def get_package_version_pin(build_reqs, name):

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -38,6 +38,7 @@ from conda_build.config import Config
 from conda_build.exceptions import (
     BuildScriptException,
     CondaBuildException,
+    CondaBuildUserError,
     DependencyNeedsBuildingError,
     OverDependingError,
     OverLinkingError,
@@ -503,7 +504,7 @@ def test_recursive_fail(testing_config):
 
 @pytest.mark.sanity
 def test_jinja_typo(testing_config):
-    with pytest.raises(SystemExit, match="GIT_DSECRIBE_TAG"):
+    with pytest.raises(CondaBuildUserError, match="GIT_DSECRIBE_TAG"):
         api.build(
             os.path.join(fail_dir, "source_git_jinja2_oops"), config=testing_config
         )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -620,9 +620,6 @@ def test_parse_until_resolved(testing_metadata: MetaData, tmp_path: Path) -> Non
 
     with pytest.raises(
         CondaBuildUserError,
-        match=(
-            rf"Failed to render jinja template in {recipe}:\n"
-            r"'UNDEFINED' is undefined"
-        ),
+        match=("Failed to render jinja template"),
     ):
         testing_metadata.parse_until_resolved()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,6 +15,7 @@ from packaging.version import Version
 
 from conda_build import api
 from conda_build.config import Config
+from conda_build.exceptions import CondaBuildUserError
 from conda_build.metadata import (
     FIELDS,
     OPTIONALLY_ITERABLE_FIELDS,
@@ -549,3 +550,11 @@ def test_get_section(testing_metadata: MetaData):
             assert isinstance(section, list)
         else:
             assert isinstance(section, dict)
+
+
+def test_select_lines_invalid():
+    with pytest.raises(
+        CondaBuildUserError,
+        match=r"Invalid selector in meta\.yaml",
+    ):
+        select_lines("text # [{bad]", {}, variants_in_place=True)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -206,6 +206,7 @@ def test_clobber_section_data(testing_metadata):
 
 
 @pytest.mark.serial
+@pytest.mark.filterwarnings("ignore", category=PendingDeprecationWarning)
 def test_build_bootstrap_env_by_name(testing_metadata):
     assert not any(
         "git" in pkg for pkg in testing_metadata.meta["requirements"].get("build", [])
@@ -224,6 +225,7 @@ def test_build_bootstrap_env_by_name(testing_metadata):
         subprocess.check_call(cmd.split())
 
 
+@pytest.mark.filterwarnings("ignore", category=PendingDeprecationWarning)
 def test_build_bootstrap_env_by_path(testing_metadata):
     assert not any(
         "git" in pkg for pkg in testing_metadata.meta["requirements"].get("build", [])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Replacing `sys.exit` call in a few functions in `conda_build/metadata.py` with the new `CondaBuildUserError` exception for better error handling, along with corresponding unit tests. 

The changes in this PR are separated out from work previously done by @kenodegard in #5255
Xref #4209 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
