### PR TITLE
Create fixture to fetch MacOSX SDKs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -373,9 +373,7 @@ jobs:
       - name: Cache Conda
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
-          path: |
-            ~/conda_pkgs_dir
-            ~/macosx_sdks
+          path: ~/conda_pkgs_dir
           key: cache-${{ env.HASH }}
 
       - name: Setup Miniconda

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -337,7 +337,8 @@ jobs:
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
-    runs-on: macos-latest
+    # not all tests work on arm64
+    runs-on: macos-13
     defaults:
       run:
         # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -337,11 +337,7 @@ jobs:
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
-    # Old macOS needed for old SDK (see xcode step below)
-    # This is needed for some MACOSX_DEPLOYMENT_TARGET tests
-    # We could also install SDKs from a external provider in the future
-    # if we want to update this runner to a non-deprecated version
-    runs-on: macos-11
+    runs-on: macos-latest
     defaults:
       run:
         # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
@@ -376,7 +372,9 @@ jobs:
       - name: Cache Conda
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
         with:
-          path: ~/conda_pkgs_dir
+          path: |
+            ~/conda_pkgs_dir
+            ~/macosx_sdks
           key: cache-${{ env.HASH }}
 
       - name: Setup Miniconda
@@ -384,9 +382,6 @@ jobs:
         with:
           condarc-file: .github/condarc
           run-post: false  # skip post cleanup
-
-      - name: Xcode Install
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app
 
       - name: Conda Install
         run: >

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,7 +118,7 @@ def testing_config(
 
     variant = None
     if get_macosx_sdk:
-        sysroot, macosx_sdk_version = get_macosx_sdk
+        sysroot, _ = get_macosx_sdk
         variant = {"CONDA_BUILD_SYSROOT": [sysroot]}
 
     result = Config(variant=variant, **testing_config_kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,21 +208,19 @@ def testing_env(
 @pytest.fixture(
     scope="function",
     params=[
-        pytest.param({}, id="default MACOSX_DEPLOYMENT_TARGET"),
-        pytest.param(
-            {"MACOSX_DEPLOYMENT_TARGET": ["10.9"]},
-            id="override MACOSX_DEPLOYMENT_TARGET",
-        ),
+        pytest.param(False, id="default MACOSX_DEPLOYMENT_TARGET"),
+        pytest.param(True, id="override MACOSX_DEPLOYMENT_TARGET"),
     ]
     if on_mac
-    else [
-        pytest.param({}, id="no MACOSX_DEPLOYMENT_TARGET"),
-    ],
+    else [pytest.param(False, id="no MACOSX_DEPLOYMENT_TARGET")],
 )
-def variants_conda_build_sysroot(get_macosx_sdk: str, request: FixtureRequest):
-    if not on_mac:
-        return {}
-    return request.param
+def variants_conda_build_sysroot(
+    get_macosx_sdk: str,
+    request: FixtureRequest,
+) -> dict[str, str]:
+    if request.param:
+        return {"MACOSX_DEPLOYMENT_TARGET": os.environ["MACOSX_DEPLOYMENT_TARGET"]}
+    return {}
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,10 +312,7 @@ MACOSX_SDKS = {
 
 
 @pytest.fixture(scope="session")
-def get_macosx_sdk(
-    pytestconfig: PytestConfig,
-    tmp_path_factory: TempPathFactory,
-) -> str | None:
+def get_macosx_sdk(pytestconfig: PytestConfig) -> str | None:
     if not on_mac:
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,7 +350,7 @@ def get_macosx_sdk(pytestconfig: PytestConfig) -> str | None:
             for chunk in iter(lambda: path.read(8192), b""):
                 computed_sha256.update(chunk)
         if computed_sha256.hexdigest() != expected_sha256:
-            tarball_sdk.remove()
+            tarball_sdk.unlink()
             raise ValueError("SHA 256 mismatch for downloaded SDK")
 
         # extract the SDK

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from typing import Iterator
 
     from pytest import Config as PytestConfig
-    from pytest import TempPathFactory
+    from pytest import FixtureRequest, TempPathFactory
 
 
 @pytest.hookimpl
@@ -125,7 +125,11 @@ def testing_config(testing_workdir):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def default_testing_config(testing_config, monkeypatch, request):
+def default_testing_config(
+    testing_config: Config,
+    monkeypatch: MonkeyPatch,
+    request: FixtureRequest,
+):
     """Monkeypatch get_or_merge_config to use testing_config by default
 
     This requests fixture testing_config, thus implicitly testing_workdir, too.
@@ -156,7 +160,7 @@ def default_testing_config(testing_config, monkeypatch, request):
 
 
 @pytest.fixture(scope="function")
-def testing_metadata(request, testing_config):
+def testing_metadata(request: FixtureRequest, testing_config: Config):
     d = defaultdict(dict)
     d["package"]["name"] = request.function.__name__
     d["package"]["version"] = "1.0"
@@ -176,7 +180,11 @@ def testing_metadata(request, testing_config):
 
 
 @pytest.fixture(scope="function")
-def testing_env(testing_workdir, request, monkeypatch):
+def testing_env(
+    testing_workdir: str,
+    request: FixtureRequest,
+    monkeypatch: MonkeyPatch,
+):
     env_path = os.path.join(testing_workdir, "env")
 
     check_call_env(
@@ -211,28 +219,9 @@ def testing_env(testing_workdir, request, monkeypatch):
         pytest.param({}, id="no MACOSX_DEPLOYMENT_TARGET"),
     ],
 )
-def variants_conda_build_sysroot(monkeypatch, request):
+def variants_conda_build_sysroot(get_macosx_sdk: str, request: FixtureRequest):
     if not on_mac:
         return {}
-
-    monkeypatch.setenv(
-        "CONDA_BUILD_SYSROOT",
-        subprocess.run(
-            ["xcrun", "--sdk", "macosx", "--show-sdk-path"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip(),
-    )
-    monkeypatch.setenv(
-        "MACOSX_DEPLOYMENT_TARGET",
-        subprocess.run(
-            ["xcrun", "--sdk", "macosx", "--show-sdk-version"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip(),
-    )
     return request.param
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,19 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import hashlib
 import os
 import subprocess
 import sys
+import tarfile
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterator
+from typing import TYPE_CHECKING
 
 import pytest
+import requests
 from conda.common.compat import on_mac, on_win
 from conda_index.api import update_index
 from pytest import MonkeyPatch
@@ -32,9 +37,15 @@ from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, copy_into, prepend_bin_path
 from conda_build.variants import get_default_variant
 
+if TYPE_CHECKING:
+    from typing import Iterator
+
+    from pytest import Config as PytestConfig
+    from pytest import TempPathFactory
+
 
 @pytest.hookimpl
-def pytest_report_header(config: pytest.Config):
+def pytest_report_header(config: PytestConfig):
     # ensuring the expected development conda is being run
     expected = Path(__file__).parent.parent / "conda_build" / "__init__.py"
     assert expected.samefile(conda_build.__file__)
@@ -226,7 +237,7 @@ def variants_conda_build_sysroot(monkeypatch, request):
 
 
 @pytest.fixture(scope="session")
-def conda_build_test_recipe_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def conda_build_test_recipe_path(tmp_path_factory: TempPathFactory) -> Path:
     """Clone conda_build_test_recipe.
 
     This exposes the special dummy package "source code" used to test various git/svn/local recipe configurations.
@@ -243,7 +254,7 @@ def conda_build_test_recipe_path(tmp_path_factory: pytest.TempPathFactory) -> Pa
 @pytest.fixture
 def conda_build_test_recipe_envvar(
     conda_build_test_recipe_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: MonkeyPatch,
 ) -> str:
     """Exposes the cloned conda_build_test_recipe as an environment variable."""
     name = "CONDA_BUILD_TEST_RECIPE_PATH"
@@ -252,8 +263,114 @@ def conda_build_test_recipe_envvar(
 
 
 @pytest.fixture(scope="session")
-def empty_channel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def empty_channel(tmp_path_factory: TempPathFactory) -> Path:
     """Create a temporary, empty conda channel."""
     channel = tmp_path_factory.mktemp("empty_channel", numbered=False)
     update_index(channel)
     return channel
+
+
+MACOSX_SDKS = {
+    "13.3": {
+        "sha256": "71ae3a78ab1be6c45cf52ce44cb29a3cc27ed312c9f7884ee88e303a862a1404",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/13.3/MacOSX13.3.tar.xz",
+    },
+    "12.3": {
+        "sha256": "91c03be5399be04d8f6b773da13045525e01298c1dfff273b4e1f1e904ee5484",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/12.3/MacOSX12.3.tar.xz",
+    },
+    "11.3": {
+        "sha256": "d6604578f4ee3090d1c3efce1e5c336ecfd7be345d046c729189d631ea3b8ec6",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/11.3/MacOSX11.3.tar.bz2",
+    },
+    "11.1": {
+        "sha256": "68797baaacb52f56f713400de306a58a7ca00b05c3dc6d58f0a8283bcac721f8",
+        "url": "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.1.sdk.tar.xz",
+    },
+    "11.0": {
+        "sha256": "d3feee3ef9c6016b526e1901013f264467bb927865a03422a9cb925991cc9783",
+        "url": "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.0.sdk.tar.xz",
+    },
+    "10.15": {
+        "sha256": "bb548125ebf5cf4ae6c80d226f40ad39e155564ca78bc00554a2e84074d0180e",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.15/MacOSX10.15.tar.bz2",
+    },
+    "10.14": {
+        "sha256": "e0a9747ae9838aeac70430c005f9757587aa055c690383d91165cf7b4a80401d",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.14/MacOSX10.14.tar.bz2",
+    },
+    "10.13": {
+        "sha256": "27943fb63c35e262b2da1cb4cc60d7427702a40caf20ec15c9d773919c6e409b",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.13/MacOSX10.13.tar.bz2",
+    },
+    "10.12": {
+        "sha256": "fd4e1151056f34f76b5930cb45b9cd859414acbc3f6529c0c0ecaaf2566823ff",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.12/MacOSX10.12.tar.bz2",
+    },
+    "10.11": {
+        "sha256": "2e28c2eeb716236d89ea3d12a228e291bdab875c50f013a909f3592007f21484",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.11/MacOSX10.11.tar.bz2",
+    },
+    "10.10": {
+        "sha256": "9fae9028802bca2c2b953f1dcc51c71382eeab4ca28644a45bcdf072b56950b9",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.10/MacOSX10.10.tar.bz2",
+    },
+    "10.9": {
+        "sha256": "a119c169b39800b4646beed55ad450bbcdd01c7209ced71872f7ba644f7a5dee",
+        "url": "https://github.com/alexey-lysiuk/macos-sdk/releases/download/10.9/MacOSX10.9.tar.bz2",
+    },
+}
+
+
+@pytest.fixture(scope="session")
+def get_macosx_sdk(
+    pytestconfig: PytestConfig,
+    tmp_path_factory: TempPathFactory,
+) -> str | None:
+    if not on_mac:
+        return None
+
+    macosx_sdk_version = os.getenv("MACOSX_SDK_VERSION") or "10.9"
+    if os.getenv("CI"):
+        cache = Path.home() / "macosx_sdks"
+        cache.mkdir(exist_ok=True)
+    else:
+        cache = pytestconfig.cache.mkdir("macosx_sdks")
+    cached_sdk = cache / f"MacOSX{macosx_sdk_version}.sdk"
+
+    if not cached_sdk.exists():
+        try:
+            sdk = MACOSX_SDKS[macosx_sdk_version]
+        except KeyError:
+            # KeyError: unknown MacOSX SDK version
+            raise ValueError(f"Unknown MacOSX SDK version: {macosx_sdk_version}")
+
+        # download SDK and compute SHA 256
+        url = sdk["url"]
+        tarball_sdk = cache / url.rsplit("/", 1)[-1]
+        if not tarball_sdk.exists():
+            with requests.get(url, stream=True) as response:
+                response.raise_for_status()
+
+                with tarball_sdk.open("wb") as path:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            path.write(chunk)
+
+        # verify SDK's SHA 256
+        expected_sha256 = sdk["sha256"]
+        computed_sha256 = hashlib.sha256()
+        with tarball_sdk.open("rb") as path:
+            for chunk in iter(lambda: path.read(8192), b""):
+                computed_sha256.update(chunk)
+        if computed_sha256.hexdigest() != expected_sha256:
+            tarball_sdk.remove()
+            raise ValueError("SHA 256 mismatch for downloaded SDK")
+
+        # extract the SDK
+        tarfile.open(tarball_sdk).extractall(cached_sdk)
+
+    with MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("CONDA_BUILD_SYSROOT", str(cached_sdk))
+        monkeypatch.setenv("MACOSX_DEPLOYMENT_TARGET", macosx_sdk_version)
+        return macosx_sdk_version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,12 +37,11 @@ from conda_build.variants import get_default_variant
 if TYPE_CHECKING:
     from typing import Iterator
 
-    from pytest import Config as PytestConfig
     from pytest import FixtureRequest, TempPathFactory
 
 
 @pytest.hookimpl
-def pytest_report_header(config: PytestConfig):
+def pytest_report_header(config: pytest.Config):
     # ensuring the expected development conda is being run
     expected = Path(__file__).parent.parent / "conda_build" / "__init__.py"
     assert expected.samefile(conda_build.__file__)
@@ -91,7 +90,7 @@ def testing_homedir() -> Iterator[Path]:
 
 @pytest.fixture(scope="function")
 def testing_config(
-    testing_workdir: str | os.PathLike | Path,
+    testing_workdir: str,
     get_macosx_sdk: None | tuple[str, str],
 ) -> Config:
     def boolify(v):
@@ -270,7 +269,7 @@ def empty_channel(tmp_path_factory: TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="session")
-def get_macosx_sdk(pytestconfig: PytestConfig) -> None | tuple[str, str]:
+def get_macosx_sdk() -> None | tuple[str, str]:
     if not on_mac:
         return None
 

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -830,9 +830,7 @@ def test_disable_pip(testing_metadata):
 
 
 @pytest.mark.sanity
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="rpath fixup not done on Windows."
-)
+@pytest.mark.skipif(on_win, reason="rpath fixup not done on Windows.")
 def test_rpath_unix(
     testing_config: Config,
     variants_conda_build_sysroot: dict,
@@ -1786,7 +1784,7 @@ def test_overdepending_detection(
         api.build(recipe, config=testing_config, variants=variants_conda_build_sysroot)
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only test (at present)")
+@pytest.mark.skipif(not on_mac, reason="macOS-only test (at present)")
 def test_macos_tbd_handling(
     testing_config: Config,
     variants_conda_build_sysroot: dict,

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -836,7 +836,6 @@ def test_disable_pip(testing_metadata):
 def test_rpath_unix(
     testing_config: Config,
     variants_conda_build_sysroot: dict,
-    get_macosx_sdk: str,
 ) -> None:
     testing_config.activate = True
     api.build(
@@ -1711,7 +1710,6 @@ def test_overlinking_detection(
     testing_config: Config,
     testing_workdir: str,
     variants_conda_build_sysroot: dict,
-    get_macosx_sdk: str,
 ):
     testing_config.activate = True
     testing_config.error_overlinking = True
@@ -1746,7 +1744,6 @@ def test_overlinking_detection_ignore_patterns(
     testing_config: Config,
     testing_workdir: str,
     variants_conda_build_sysroot: dict,
-    get_macosx_sdk: str,
 ):
     testing_config.activate = True
     testing_config.error_overlinking = True
@@ -1779,7 +1776,6 @@ def test_overlinking_detection_ignore_patterns(
 def test_overdepending_detection(
     testing_config: Config,
     variants_conda_build_sysroot: dict,
-    get_macosx_sdk: str,
 ):
     testing_config.activate = True
     testing_config.error_overlinking = True
@@ -1794,7 +1790,6 @@ def test_overdepending_detection(
 def test_macos_tbd_handling(
     testing_config: Config,
     variants_conda_build_sysroot: dict,
-    get_macosx_sdk: str,
 ):
     """
     Test path handling after installation... The test case uses a Hello World

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -833,7 +833,11 @@ def test_disable_pip(testing_metadata):
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="rpath fixup not done on Windows."
 )
-def test_rpath_unix(testing_config, variants_conda_build_sysroot):
+def test_rpath_unix(
+    testing_config: Config,
+    variants_conda_build_sysroot: dict,
+    get_macosx_sdk: str,
+) -> None:
     testing_config.activate = True
     api.build(
         os.path.join(metadata_dir, "_rpath"),
@@ -1704,7 +1708,10 @@ def test_provides_features_metadata(testing_config):
 
 
 def test_overlinking_detection(
-    testing_config, testing_workdir, variants_conda_build_sysroot
+    testing_config: Config,
+    testing_workdir: str,
+    variants_conda_build_sysroot: dict,
+    get_macosx_sdk: str,
 ):
     testing_config.activate = True
     testing_config.error_overlinking = True
@@ -1736,7 +1743,10 @@ def test_overlinking_detection(
 
 
 def test_overlinking_detection_ignore_patterns(
-    testing_config, testing_workdir, variants_conda_build_sysroot
+    testing_config: Config,
+    testing_workdir: str,
+    variants_conda_build_sysroot: dict,
+    get_macosx_sdk: str,
 ):
     testing_config.activate = True
     testing_config.error_overlinking = True
@@ -1766,7 +1776,11 @@ def test_overlinking_detection_ignore_patterns(
     rm_rf(dest_bat)
 
 
-def test_overdepending_detection(testing_config, variants_conda_build_sysroot):
+def test_overdepending_detection(
+    testing_config: Config,
+    variants_conda_build_sysroot: dict,
+    get_macosx_sdk: str,
+):
     testing_config.activate = True
     testing_config.error_overlinking = True
     testing_config.error_overdepending = True
@@ -1777,7 +1791,11 @@ def test_overdepending_detection(testing_config, variants_conda_build_sysroot):
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only test (at present)")
-def test_macos_tbd_handling(testing_config, variants_conda_build_sysroot):
+def test_macos_tbd_handling(
+    testing_config: Config,
+    variants_conda_build_sysroot: dict,
+    get_macosx_sdk: str,
+):
     """
     Test path handling after installation... The test case uses a Hello World
     example in C/C++ for testing the installation of C libraries...


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `macos-11` GitHub runner is deprecated and slated to be discontinued on June 28th. GitHub appears to have begun their customary brownouts to aid in detecting any remaining usages.

With inspiration from conda-forge's SDK download script (https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/f3c9863319df2c75f05d378df47b2154473e46a4/recipe/download_osx_sdk.sh) we have created a pytest fixture to download (and cache) the necessary MacOS SDK.

Resolves #5378

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
