### PR TITLE
perf: only set level if needed

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1653,7 +1653,8 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
         logging.config.dictConfig(config_dict)
         level = config_dict.get("loggers", {}).get(name, {}).get("level", level)
     log = logging.getLogger(name)
-    log.setLevel(level)
+    if log.getEffectiveLevel() != level:
+        log.setLevel(level)
     if dedupe:
         log.addFilter(dedupe_filter)
 

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1653,7 +1653,7 @@ def get_logger(name, level=logging.INFO, dedupe=True, add_stdout_stderr_handlers
         logging.config.dictConfig(config_dict)
         level = config_dict.get("loggers", {}).get(name, {}).get("level", level)
     log = logging.getLogger(name)
-    if log.getEffectiveLevel() != level:
+    if log.level != level:
         log.setLevel(level)
     if dedupe:
         log.addFilter(dedupe_filter)

--- a/news/5384-test-log-level
+++ b/news/5384-test-log-level
@@ -1,0 +1,3 @@
+### Enhancements
+
+* Reduced performance overheads of logging. (#4384)

--- a/news/5384-test-log-level
+++ b/news/5384-test-log-level
@@ -1,3 +1,3 @@
 ### Enhancements
 
-* Reduced performance overheads of logging. (#4384)
+* Reduced performance overheads of logging. (#5384)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR tries to address #5382 by only calling `setLevel` if needed. I am trying it instead of #5383 since it is less intrusive and I am seeing odd test failures in that PR.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->


closes #5383 
closes #5382 