### PR TITLE
Replace `sys.exit` calls in `conda_build/inspect_pkg.py`

### DIFF
--- a/conda_build/inspect_pkg.py
+++ b/conda_build/inspect_pkg.py
@@ -20,6 +20,7 @@ from conda.core.index import get_index
 from conda.core.prefix_data import PrefixData
 from conda.models.records import PrefixRecord
 
+from .exceptions import CondaBuildUserError
 from .os_utils.ldd import (
     get_linkages,
     get_package_obj_files,
@@ -219,9 +220,13 @@ def inspect_linkages(
     sysroot: str = "",
 ) -> str:
     if not packages and not untracked and not all_packages:
-        sys.exit("At least one package or --untracked or --all must be provided")
+        raise CondaBuildUserError(
+            "At least one package or --untracked or --all must be provided"
+        )
     elif on_win:
-        sys.exit("Error: conda inspect linkages is only implemented in Linux and OS X")
+        raise CondaBuildUserError(
+            "`conda inspect linkages` is only implemented on Linux and macOS"
+        )
 
     prefix = Path(prefix)
     installed = {prec.name: prec for prec in PrefixData(str(prefix)).iter_records()}
@@ -237,7 +242,7 @@ def inspect_linkages(
         if name == untracked_package:
             obj_files = get_untracked_obj_files(prefix)
         elif name not in installed:
-            sys.exit(f"Package {name} is not installed in {prefix}")
+            raise CondaBuildUserError(f"Package {name} is not installed in {prefix}")
         else:
             obj_files = get_package_obj_files(installed[name], prefix)
 
@@ -308,7 +313,9 @@ def inspect_objects(
     groupby: str = "package",
 ):
     if not on_mac:
-        sys.exit("Error: conda inspect objects is only implemented in OS X")
+        raise CondaBuildUserError(
+            "`conda inspect objects` is only implemented on macOS"
+        )
 
     prefix = Path(prefix)
     installed = {prec.name: prec for prec in PrefixData(str(prefix)).iter_records()}

--- a/tests/cli/test_main_inspect.py
+++ b/tests/cli/test_main_inspect.py
@@ -9,6 +9,7 @@ import yaml
 
 from conda_build import api
 from conda_build.cli import main_inspect
+from conda_build.exceptions import CondaBuildUserError
 from conda_build.utils import on_win
 
 from ..utils import metadata_dir
@@ -23,7 +24,7 @@ def test_inspect_linkages(testing_workdir, capfd):
     # get a package that has known object output
     args = ["linkages", "python"]
     if on_win:
-        with pytest.raises(SystemExit) as exc:
+        with pytest.raises(CondaBuildUserError) as exc:
             main_inspect.execute(args)
             assert "conda inspect linkages is only implemented in Linux and OS X" in exc
     else:
@@ -36,7 +37,7 @@ def test_inspect_objects(testing_workdir, capfd):
     # get a package that has known object output
     args = ["objects", "python"]
     if sys.platform != "darwin":
-        with pytest.raises(SystemExit) as exc:
+        with pytest.raises(CondaBuildUserError) as exc:
             main_inspect.execute(args)
             assert "conda inspect objects is only implemented in OS X" in exc
     else:

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -6,11 +6,12 @@ import sys
 import pytest
 
 from conda_build import api
+from conda_build.exceptions import CondaBuildUserError
 
 
 def test_inspect_linkages():
     if sys.platform == "win32":
-        with pytest.raises(SystemExit) as exc:
+        with pytest.raises(CondaBuildUserError) as exc:
             out_string = api.inspect_linkages("python")
             assert "conda inspect linkages is only implemented in Linux and OS X" in exc
     else:
@@ -20,7 +21,7 @@ def test_inspect_linkages():
 
 def test_inspect_objects():
     if sys.platform != "darwin":
-        with pytest.raises(SystemExit) as exc:
+        with pytest.raises(CondaBuildUserError) as exc:
             out_string = api.inspect_objects("python")
             assert "conda inspect objects is only implemented in OS X" in exc
     else:

--- a/tests/test_inspect_pkg.py
+++ b/tests/test_inspect_pkg.py
@@ -10,8 +10,9 @@ from uuid import uuid4
 import pytest
 from conda.core.prefix_data import PrefixData
 
-from conda_build.inspect_pkg import which_package
-from conda_build.utils import on_win
+from conda_build.exceptions import CondaBuildUserError
+from conda_build.inspect_pkg import inspect_linkages, inspect_objects, which_package
+from conda_build.utils import on_mac, on_win
 
 
 def test_which_package(tmp_path: Path):
@@ -271,3 +272,26 @@ def test_which_package_battery(tmp_path: Path):
 
     # missing files should return no packages
     assert not len(list(which_package(tmp_path / "missing", tmp_path)))
+
+
+def test_inspect_linkages_no_packages():
+    with pytest.raises(CondaBuildUserError):
+        inspect_linkages([])
+
+
+@pytest.mark.skipif(not on_win, reason="inspect_linkages is available")
+def test_inspect_linkages_on_win():
+    with pytest.raises(CondaBuildUserError):
+        inspect_linkages(["packages"])
+
+
+@pytest.mark.skipif(on_win, reason="inspect_linkages is not available")
+def test_inspect_linkages_not_installed():
+    with pytest.raises(CondaBuildUserError):
+        inspect_linkages(["not_installed_pkg"])
+
+
+@pytest.mark.skipif(on_mac, reason="inspect_objects is only available on macOS")
+def test_inspect_objects_not_on_mac():
+    with pytest.raises(CondaBuildUserError):
+        inspect_objects([])


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Replacing `sys.exit` call in a few functions in `conda_build/inspect_pkgs.py` with the new `CondaBuildUserError` exception for better error handling, along with corresponding unit tests. 

The changes in this PR are separated out from work previously done by @kenodegard in #5255
Xref #4209 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
