### PR TITLE
Remove `sys.exit` from `noarch_python` and add unittests

### DIFF
--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1582,7 +1582,7 @@ def filter_info_files(files_list, prefix):
 
 def rm_rf(path):
     from conda.core.prefix_data import delete_prefix_from_linked_data
-    from conda.gateways.disk.delete import rm_rf as rm_rf
+    from conda.gateways.disk.delete import rm_rf
 
     rm_rf(path)
     delete_prefix_from_linked_data(path)

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -1580,12 +1580,12 @@ def filter_info_files(files_list, prefix):
     )
 
 
-def rm_rf(path):
+def rm_rf(path: str | os.PathLike) -> None:
     from conda.core.prefix_data import delete_prefix_from_linked_data
     from conda.gateways.disk.delete import rm_rf
 
-    rm_rf(path)
-    delete_prefix_from_linked_data(path)
+    rm_rf(str(path))
+    delete_prefix_from_linked_data(str(path))
 
 
 # https://stackoverflow.com/a/31459386/1170370

--- a/tests/test_noarch_python.py
+++ b/tests/test_noarch_python.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import stat
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from conda_build.exceptions import CondaBuildUserError
+from conda_build.noarch_python import rewrite_script
+from conda_build.utils import bin_dirname, on_win
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    "before,after",
+    [
+        ("script.py", "script.py"),
+        ("script-script.py", "script" if on_win else "script-script.py"),
+    ],
+)
+def test_rewrite_script(tmp_path: Path, before: str, after: str) -> None:
+    """Test that a script file is rewritten to the python-scripts directory."""
+    script = tmp_path / bin_dirname / before
+    script.parent.mkdir()
+
+    # write some text to the script
+    script.write_text(text := uuid4().hex)
+
+    # change the permissions so we can check they are preserved
+    script.chmod(permissions := stat.S_IFREG | (0o444 if on_win else 0o456))
+
+    # rewrite the script to the python-scripts directory
+    rewrite_script(script.name, tmp_path)
+
+    # check that the original script has been removed
+    assert not script.exists()
+
+    # check that the script has been rewritten to the python-scripts directory,
+    # has the same text, and the same permissions
+    rewrite = tmp_path / "python-scripts" / after
+    assert rewrite.read_text() == text
+    assert rewrite.stat().st_mode == permissions
+
+
+def test_rewrite_script_binary(tmp_path: Path) -> None:
+    """Test that a binary file will raise an error."""
+    binary = tmp_path / bin_dirname / "binary"
+    binary.parent.mkdir()
+
+    # write some binary data to the script
+    binary.write_bytes(b"\x80\x81\x82\x83\x84\x85")
+
+    # try to rewrite the binary script to the python-scripts directory
+    with pytest.raises(CondaBuildUserError, match=r"package contains binary script"):
+        rewrite_script(binary.name, tmp_path)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

While working on https://github.com/conda/conda-build/pull/5255 found an opportunity to add unittests and do a small refactor to `conda_build.noarch_python.rewrite_script`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
