### PR TITLE
Deprecate `testing_env` fixture

### DIFF
--- a/news/5427-deprecate-testing_env
+++ b/news/5427-deprecate-testing_env
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate `tests.conftest.testing_env` fixture. Use `conda.testing.tmp_env` instead. (#5427)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_develop.py
+++ b/tests/cli/test_main_develop.py
@@ -1,30 +1,38 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-import os
+from __future__ import annotations
+
 import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from conda.gateways.connection.download import download
 
 from conda_build.cli import main_develop
 from conda_build.utils import get_site_packages, tar_xf
 
+if TYPE_CHECKING:
+    from conda.testing import TmpEnvFixture
 
-def test_develop(testing_env):
-    f = "https://pypi.io/packages/source/c/conda_version_test/conda_version_test-0.1.0-1.tar.gz"
-    download(f, "conda_version_test.tar.gz")
-    tar_xf("conda_version_test.tar.gz", testing_env)
-    extract_folder = "conda_version_test-0.1.0-1"
-    cwd = os.getcwd()
-    args = ["-p", testing_env, extract_folder]
-    main_develop.execute(args)
-    py_ver = ".".join((str(sys.version_info.major), str(sys.version_info.minor)))
-    with open(
-        os.path.join(get_site_packages(testing_env, py_ver), "conda.pth")
-    ) as f_pth:
-        assert cwd in f_pth.read()
-    args = ["--uninstall", "-p", testing_env, extract_folder]
-    main_develop.execute(args)
-    with open(
-        os.path.join(get_site_packages(testing_env, py_ver), "conda.pth")
-    ) as f_pth:
-        assert cwd not in f_pth.read()
+
+def test_develop(tmp_env: TmpEnvFixture) -> None:
+    py_ver = "%d.%d" % sys.version_info[:2]
+    with tmp_env(f"python={py_ver}") as prefix:
+        download(
+            "https://pypi.io/packages/source/c/conda_version_test/conda_version_test-0.1.0-1.tar.gz",
+            "conda_version_test.tar.gz",
+        )
+        tar_xf("conda_version_test.tar.gz", prefix)
+        extract_folder = "conda_version_test-0.1.0-1"
+
+        main_develop.execute([f"--prefix={prefix}", extract_folder])
+        assert (
+            str(Path.cwd())
+            in Path(get_site_packages(prefix, py_ver), "conda.pth").read_text()
+        )
+
+        main_develop.execute(["--uninstall", f"--prefix={prefix}", extract_folder])
+        assert (
+            str(Path.cwd())
+            not in Path(get_site_packages(prefix, py_ver), "conda.pth").read_text()
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,15 @@ from conda_build.config import (
     ignore_verify_codes_default,
     no_rewrite_stdout_env_default,
 )
+from conda_build.deprecations import deprecated
 from conda_build.metadata import MetaData
 from conda_build.utils import check_call_env, copy_into, prepend_bin_path
 from conda_build.variants import get_default_variant
+
+pytest_plugins = (
+    # Add testing fixtures and internal pytest plugins here
+    "conda.testing",
+)
 
 
 @pytest.hookimpl
@@ -173,6 +179,7 @@ def testing_metadata(request, testing_config):
 
 
 @pytest.fixture(scope="function")
+@deprecated("24.9", "24.11", addendum="Use `tmp_env` fixture instead.")
 def testing_env(testing_workdir, request, monkeypatch):
     env_path = os.path.join(testing_workdir, "env")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The `testing_env` fixture was minimally used and better replaced with `tmp_env` provided by `conda.testing`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
