### PR TITLE
fix: make sure to catch jinja2 vars used in single-line `for` and `set` statements

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -748,12 +748,18 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         conditional_regex = (
             r"(?:^|[^\{])\{%\s*(?:el)?if\s*.*" + v_regex + r"\s*(?:[^%]*?)?%\}"
         )
+        for_regex = (
+            r"(?:^|[^\{])\{%\s*for\s*.*\s*in\s*" + v_regex + r"(?:[^%]*?)?%\}"
+        )
+        set_regex = (
+            r"(?:^|[^\{])\{%\s*set\s*.*\s*=\s*.*" + v_regex + r"(?:[^%]*?)?%\}"
+        )
         # plain req name, no version spec.  Look for end of line after name, or comment or selector
         requirement_regex = rf"^\s+\-\s+{v_req_regex}\s*(?:\s[\[#]|$)"
         if selectors_only:
             all_res.insert(0, selector_regex)
         else:
-            all_res.extend([variant_regex, requirement_regex, conditional_regex])
+            all_res.extend([variant_regex, requirement_regex, conditional_regex, for_regex, set_regex])
         # consolidate all re's into one big one for speedup
         all_res = r"|".join(all_res)
         if any(re.search(all_res, line) for line in variant_lines):

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -746,14 +746,14 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         variant_regex = rf"\{{\s*(?:pin_[a-z]+\(\s*?['\"])?{v_regex}[^'\"]*?\}}\}}"
         selector_regex = rf"^[^#\[]*?\#?\s\[[^\]]*?(?<![_\w\d]){v_regex}[=\s<>!\]]"
         # NOTE: why use a regex instead of the jinja2 parser/AST?
-        # Once can ask the jinj2 parser for undefined variables, but conda-build moves whole
+        # One can ask the jinj2 parser for undefined variables, but conda-build moves whole
         # blocks of text around when searching for variables and applies selectors to the text.
         # So the text  reaches this function is not necessarily valid jinja2 syntax. :/
         conditional_regex = (
             r"(?:^|[^\{])\{%\s*(?:el)?if\s*.*" + v_regex + r"\s*(?:[^%]*?)?%\}"
         )
-        # TODO: this `for` regex won't catch some common cases like lists pof vars or multiline
-        # jinja2 blocks.
+        # TODO: this `for` regex won't catch some common cases like lists of vars, multiline
+        # jinja2 blocks, if filters on the for loop, etc.
         for_regex = r"(?:^|[^\{])\{%\s*for\s*.*\s*in\s*" + v_regex + r"(?:[^%]*?)?%\}"
         set_regex = r"(?:^|[^\{])\{%\s*set\s*.*\s*=\s*.*" + v_regex + r"(?:[^%]*?)?%\}"
         # plain req name, no version spec.  Look for end of line after name, or comment or selector

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -745,9 +745,15 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         v_req_regex = "[-_]".join(map(re.escape, v.split("_")))
         variant_regex = rf"\{{\s*(?:pin_[a-z]+\(\s*?['\"])?{v_regex}[^'\"]*?\}}\}}"
         selector_regex = rf"^[^#\[]*?\#?\s\[[^\]]*?(?<![_\w\d]){v_regex}[=\s<>!\]]"
+        # NOTE: why use a regex instead of the jinja2 parser/AST?
+        # Once can ask the jinj2 parser for undefined variables, but conda-build moves whole
+        # blocks of text around when searching for variables and applies selectors to the text.
+        # So the text  reaches this function is not necessarily valid jinja2 syntax. :/
         conditional_regex = (
             r"(?:^|[^\{])\{%\s*(?:el)?if\s*.*" + v_regex + r"\s*(?:[^%]*?)?%\}"
         )
+        # TODO: this `for` regex won't catch some common cases like lists pof vars or multiline
+        # jinja2 blocks.
         for_regex = r"(?:^|[^\{])\{%\s*for\s*.*\s*in\s*" + v_regex + r"(?:[^%]*?)?%\}"
         set_regex = r"(?:^|[^\{])\{%\s*set\s*.*\s*=\s*.*" + v_regex + r"(?:[^%]*?)?%\}"
         # plain req name, no version spec.  Look for end of line after name, or comment or selector

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -748,18 +748,22 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         conditional_regex = (
             r"(?:^|[^\{])\{%\s*(?:el)?if\s*.*" + v_regex + r"\s*(?:[^%]*?)?%\}"
         )
-        for_regex = (
-            r"(?:^|[^\{])\{%\s*for\s*.*\s*in\s*" + v_regex + r"(?:[^%]*?)?%\}"
-        )
-        set_regex = (
-            r"(?:^|[^\{])\{%\s*set\s*.*\s*=\s*.*" + v_regex + r"(?:[^%]*?)?%\}"
-        )
+        for_regex = r"(?:^|[^\{])\{%\s*for\s*.*\s*in\s*" + v_regex + r"(?:[^%]*?)?%\}"
+        set_regex = r"(?:^|[^\{])\{%\s*set\s*.*\s*=\s*.*" + v_regex + r"(?:[^%]*?)?%\}"
         # plain req name, no version spec.  Look for end of line after name, or comment or selector
         requirement_regex = rf"^\s+\-\s+{v_req_regex}\s*(?:\s[\[#]|$)"
         if selectors_only:
             all_res.insert(0, selector_regex)
         else:
-            all_res.extend([variant_regex, requirement_regex, conditional_regex, for_regex, set_regex])
+            all_res.extend(
+                [
+                    variant_regex,
+                    requirement_regex,
+                    conditional_regex,
+                    for_regex,
+                    set_regex,
+                ]
+            )
         # consolidate all re's into one big one for speedup
         all_res = r"|".join(all_res)
         if any(re.search(all_res, line) for line in variant_lines):

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -746,7 +746,7 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         variant_regex = rf"\{{\s*(?:pin_[a-z]+\(\s*?['\"])?{v_regex}[^'\"]*?\}}\}}"
         selector_regex = rf"^[^#\[]*?\#?\s\[[^\]]*?(?<![_\w\d]){v_regex}[=\s<>!\]]"
         # NOTE: why use a regex instead of the jinja2 parser/AST?
-        # One can ask the jinj2 parser for undefined variables, but conda-build moves whole
+        # One can ask the jinja2 parser for undefined variables, but conda-build moves whole
         # blocks of text around when searching for variables and applies selectors to the text.
         # So the text that reaches this function is not necessarily valid jinja2 syntax. :/
         conditional_regex = (

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -748,7 +748,7 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         # NOTE: why use a regex instead of the jinja2 parser/AST?
         # One can ask the jinj2 parser for undefined variables, but conda-build moves whole
         # blocks of text around when searching for variables and applies selectors to the text.
-        # So the text  reaches this function is not necessarily valid jinja2 syntax. :/
+        # So the text that reaches this function is not necessarily valid jinja2 syntax. :/
         conditional_regex = (
             r"(?:^|[^\{])\{%\s*(?:el)?if\s*.*" + v_regex + r"\s*(?:[^%]*?)?%\}"
         )

--- a/news/5447-jinja2-for-set-vars
+++ b/news/5447-jinja2-for-set-vars
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Variables used in jinja2 ``for`` and ``set`` statements are now properly included in the variant
+  matrix for some edge cases. (#5447)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/5447-jinja2-for-set-vars
+++ b/news/5447-jinja2-for-set-vars
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Variables used in single-line jinja2 ``for`` and ``set`` statements are now properly included in the variant
+* Variables used in single-line jinja2 `for` and `set` statements are now properly included in the variant
   matrix for some edge cases. (#5447)
 
 ### Deprecations

--- a/tests/test-recipes/variants/jinja2_used_variables/conda_build_config.yaml
+++ b/tests/test-recipes/variants/jinja2_used_variables/conda_build_config.yaml
@@ -1,0 +1,27 @@
+CLANG_VERSION:
+  - 16.0.6
+  - 17.0.6
+  - 18.1.8
+  - 19.1.0.rc1
+
+VCVER:
+  - 14.3
+  - 14.2
+CL_VERSION:
+  - 19.40.33808
+  - 19.29.30139
+
+BLAH:
+  - a
+  - b
+
+FOO:
+  - cdf
+
+FOOBAR:
+  - hgf
+
+zip_keys:
+  -
+    - VCVER
+    - CL_VERSION

--- a/tests/test-recipes/variants/jinja2_used_variables/meta.yaml
+++ b/tests/test-recipes/variants/jinja2_used_variables/meta.yaml
@@ -1,0 +1,42 @@
+{% if CLANG_VERSION is not defined %}
+{% set CLANG_VERSION = "16.0.6" %}
+{% set CL_VERSION = "19.29" %}
+{% set VCVER = "" %}
+{% set FOO = "" %}
+{% set FOOBAR = "" %}
+{% endif %}
+{% set clang_major = CLANG_VERSION.split(".")[0] %}
+{% set cl_minor = CL_VERSION.split(".")[1] %}
+{% set vc_major = VCVER.split(".")[0] %}
+
+package:
+  name: clang-win-activation
+  version: {{ CLANG_VERSION }}
+
+build:
+  number: 0
+  {% if clang_major|int == 16 and cl_minor|int >= 40 %}
+  skip: true
+  {% endif %}
+
+outputs:
+  - name: clang_win-64
+    build:
+      run_exports:
+        strong:
+          - vc >={{ VCVER }}
+    requirements:
+      run:
+        - clang {{ CLANG_VERSION }}.*
+
+    tests:
+      commands:
+        {% for var in FOO.split() %}
+        - echo {{ var }}
+        {% endfor %}
+
+tests:
+  commands:
+    {% for var in FOOBAR.split() %}
+    - echo {{ var }}
+    {% endfor %}

--- a/tests/test-recipes/variants/jinja2_used_variables/meta.yaml
+++ b/tests/test-recipes/variants/jinja2_used_variables/meta.yaml
@@ -29,13 +29,13 @@ outputs:
       run:
         - clang {{ CLANG_VERSION }}.*
 
-    tests:
+    test:
       commands:
         {% for var in FOO.split() %}
         - echo {{ var }}
         {% endfor %}
 
-tests:
+test:
   commands:
     {% for var in FOOBAR.split() %}
     - echo {{ var }}

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -426,6 +426,36 @@ def test_get_used_loop_vars():
     }
 
 
+def test_get_used_loop_vars_jinja2():
+    metadata = api.render(
+        os.path.join(variants_dir, "jinja2_used_variables"),
+        finalize=False,
+        bypass_env_check=True,
+    )
+    # 4 CLANG_VERSION values x 2 VCVER values - one skipped because of jinja2 conditionals
+    assert len(metadata) == 7
+    for m, _, _ in metadata:
+        assert m.get_used_loop_vars(force_top_level=False) == {"CLANG_VERSION", "VCVER"}
+        assert m.get_used_loop_vars(force_top_level=True) == {
+            "CL_VERSION",
+            "CLANG_VERSION",
+            "VCVER",
+        }
+        assert m.get_used_vars(force_top_level=False) == {
+            "CLANG_VERSION",
+            "VCVER",
+            "FOO",
+            "target_platform",
+        }
+        assert m.get_used_vars(force_top_level=True) == {
+            "CLANG_VERSION",
+            "CL_VERSION",
+            "VCVER",
+            "FOO",
+            "target_platform",
+        }
+
+
 def test_reprovisioning_source():
     api.render(os.path.join(variants_dir, "20_reprovision_source"))
 

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -452,6 +452,7 @@ def test_get_used_loop_vars_jinja2():
             "CL_VERSION",
             "VCVER",
             "FOO",
+            "FOOBAR",
             "target_platform",
         }
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR adds two regexes to catch variables used in single-line jinja2 `for` and `set` statements. These have been missed for a long time and appear to be the cause of at least one bug. I have not gone through the bug tracker, but I have a hunch this PR might fix other bugs related to similar situations I've seen in the past.

closes #5445 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
