### PR TITLE
Remove `sys.exit` calls from `convert.py`

### DIFF
--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -18,6 +18,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .exceptions import CondaBuildUserError
 from .utils import ensure_list, filter_info_files, walk
 
 if TYPE_CHECKING:
@@ -821,10 +822,12 @@ def conda_convert(
         sys.exit()
 
     if not show_imports and len(platforms) == 0:
-        sys.exit("Error: --platform option required for conda package conversion.")
+        raise CondaBuildUserError(
+            "Error: --platform option required for conda package conversion."
+        )
 
     if len(retrieve_c_extensions(file_path)) > 0 and not force:
-        sys.exit(
+        raise CondaBuildUserError(
             f"WARNING: Package {os.path.basename(file_path)} contains C extensions; skipping conversion. "
             "Use -f to force conversion."
         )

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -12,7 +12,6 @@ import json
 import os
 import re
 import shutil
-import sys
 import tarfile
 import tempfile
 from pathlib import Path
@@ -819,7 +818,7 @@ def conda_convert(
         else:
             for c_extension in imports:
                 print(c_extension)
-        sys.exit()
+        return
 
     if not show_imports and len(platforms) == 0:
         raise CondaBuildUserError(

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -61,8 +61,7 @@ def test_show_imports(base_platform, package, capfd):
     download(f, fn)
 
     for platform in platforms:
-        with pytest.raises(SystemExit):
-            api.convert(fn, platforms=platform, show_imports=True)
+        api.convert(fn, platforms=platform, show_imports=True)
 
         output, error = capfd.readouterr()
 
@@ -81,8 +80,7 @@ def test_no_imports_found(base_platform, package, capfd):
     fn = f"{package_name}-py36_0.tar.bz2"
     download(f, fn)
 
-    with pytest.raises(SystemExit):
-        api.convert(fn, platforms=None, show_imports=True)
+    api.convert(fn, platforms=None, show_imports=True)
 
     output, error = capfd.readouterr()
     assert "No imports found." in output

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -121,13 +121,12 @@ def test_c_extension_error(base_platform, package):
     download(f, fn)
 
     for platform in platforms:
-        with pytest.raises(CondaBuildUserError) as e:
+        with pytest.raises(
+            CondaBuildUserError,
+            match=f"WARNING: Package {fn} contains C extensions; skipping conversion. "
+            "Use -f to force conversion.",
+        ):
             api.convert(fn, platforms=platform)
-
-    assert (
-        f"WARNING: Package {fn} contains C extensions; skipping conversion. "
-        "Use -f to force conversion."
-    ) in str(e.value)
 
 
 @pytest.mark.parametrize("base_platform", ["linux", "win", "osx"])

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -10,6 +10,7 @@ import pytest
 from conda.gateways.connection.download import download
 
 from conda_build import api
+from conda_build.exceptions import CondaBuildUserError
 from conda_build.utils import on_win, package_has_file
 
 from .utils import assert_package_consistency, metadata_dir
@@ -96,12 +97,11 @@ def test_no_platform(base_platform, package):
     fn = f"{package_name}-py36_0.tar.bz2"
     download(f, fn)
 
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(
+        CondaBuildUserError,
+        match="Error: --platform option required for conda package conversion.",
+    ):
         api.convert(fn, platforms=None)
-
-    assert "Error: --platform option required for conda package conversion." in str(
-        e.value
-    )
 
 
 @pytest.mark.parametrize("base_platform", ["linux", "win", "osx"])
@@ -121,7 +121,7 @@ def test_c_extension_error(base_platform, package):
     download(f, fn)
 
     for platform in platforms:
-        with pytest.raises(SystemExit) as e:
+        with pytest.raises(CondaBuildUserError) as e:
             api.convert(fn, platforms=platform)
 
     assert (


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Replacing `sys.exit` calls in `conda_build/convert.py` with the new `CondaBuildUserError` exception for better error handling + updating corresponding unit tests.

The changes in this PR are separated out from work previously done by @kenodegard in #5255
Xref #4209 


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~
