### PR TITLE
Remove `sys.exit` from `develop.py`

### DIFF
--- a/conda_build/develop.py
+++ b/conda_build/develop.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import shutil
 import sys
 from os.path import abspath, exists, expanduser, isdir, join
+from pathlib import Path
+from typing import TYPE_CHECKING
 
+from .exceptions import CondaBuildUserError
 from .os_utils.external import find_executable
 from .post import mk_relative_osx
 from .utils import check_call_env, get_site_packages, on_mac, rec_glob
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def relink_sharedobjects(pkg_path, build_prefix):
@@ -56,13 +62,13 @@ def write_to_conda_pth(sp_dir, pkg_path):
             print("added " + pkg_path)
 
 
-def get_setup_py(path_):
-    """Return full path to setup.py or exit if not found"""
+def get_setup_py(path_: Path) -> Path:
+    """Return full path to setup.py or raise error if not found"""
     # build path points to source dir, builds are placed in the
     setup_py = join(path_, "setup.py")
 
     if not exists(setup_py):
-        sys.exit(f"No setup.py found in {path_}. Exiting.")
+        raise CondaBuildUserError(f"No setup.py found in {path_}.")
 
     return setup_py
 
@@ -136,12 +142,11 @@ def execute(
     uninstall: bool = False,
 ) -> None:
     if not isdir(prefix):
-        sys.exit(
-            f"""\
-Error: environment does not exist: {prefix}
-#
-# Use 'conda create' to create the environment first.
-#"""
+        raise CondaBuildUserError(
+            f"""Error: environment does not exist: {prefix}
+            \n
+            Use 'conda create' to create the environment first.
+            """
         )
 
     assert find_executable("python", prefix=prefix)

--- a/conda_build/develop.py
+++ b/conda_build/develop.py
@@ -143,10 +143,9 @@ def execute(
 ) -> None:
     if not isdir(prefix):
         raise CondaBuildUserError(
-            f"""Error: environment does not exist: {prefix}
-            \n
-            Use 'conda create' to create the environment first.
-            """
+            f"Error: environment does not exist: {prefix}\n"
+            f"\n"
+            f"Use 'conda create' to create the environment first."
         )
 
     assert find_executable("python", prefix=prefix)

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -4,9 +4,7 @@
 Simple tests for testing functions in develop module - lower level than going through API.
 """
 
-from os.path import join
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Generator
 
 import pytest

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -104,13 +104,11 @@ def test_uninstall(site_packages: Path, conda_pth: Path):
         assert list(filter(None, conda_pth.read_text().split("\n"))) == develop_paths
 
 
-def test_get_setup_py(conda_pth: Path):
-    with TemporaryDirectory() as tmpdir:
-        conda_pth = Path(tmpdir)
-        setup_py_path = join(conda_pth, "setup.py")
-        open(setup_py_path, "x").close()
-        result = get_setup_py(str(conda_pth))
-        assert "setup.py" in result
+def test_get_setup_py(tmp_path: Path):
+    setup_py_path = tmp_path / "setup.py"
+    setup_py_path.touch()
+    result = get_setup_py(str(tmp_path))
+    assert "setup.py" in result
 
     with pytest.raises(CondaBuildUserError, match="No setup.py found in "):
         get_setup_py("/path/to/non-existent")

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -9,7 +9,8 @@ from typing import Generator
 
 import pytest
 
-from conda_build.develop import _uninstall, write_to_conda_pth
+from conda_build.develop import _uninstall, execute, get_setup_py, write_to_conda_pth
+from conda_build.exceptions import CondaBuildUserError
 from conda_build.utils import rm_rf
 
 from .utils import thisdir
@@ -99,3 +100,15 @@ def test_uninstall(site_packages: Path, conda_pth: Path):
         _uninstall(site_packages, path)
 
         assert list(filter(None, conda_pth.read_text().split("\n"))) == develop_paths
+
+
+def test_get_setup_py(conda_pth: Path):
+    with pytest.raises(CondaBuildUserError, match="No setup.py found in "):
+        get_setup_py("/path/to/non-existent")
+
+
+def test_execute_error_nonexistent_prefix():
+    with pytest.raises(
+        CondaBuildUserError, match="Error: environment does not exist: "
+    ):
+        execute("/path/to/non-existent/prefix", "python", "setup.py", "install")

--- a/tests/test_develop.py
+++ b/tests/test_develop.py
@@ -4,7 +4,9 @@
 Simple tests for testing functions in develop module - lower level than going through API.
 """
 
+from os.path import join
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Generator
 
 import pytest
@@ -103,6 +105,13 @@ def test_uninstall(site_packages: Path, conda_pth: Path):
 
 
 def test_get_setup_py(conda_pth: Path):
+    with TemporaryDirectory() as tmpdir:
+        conda_pth = Path(tmpdir)
+        setup_py_path = join(conda_pth, "setup.py")
+        open(setup_py_path, "x").close()
+        result = get_setup_py(str(conda_pth))
+        assert "setup.py" in result
+
     with pytest.raises(CondaBuildUserError, match="No setup.py found in "):
         get_setup_py("/path/to/non-existent")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Replacing `sys.exit` calls in `conda_build/develop.py` with the new `CondaBuildUserError` exception for better error handling + unit tests. 

The changes in this PR are separated out from work previously done by @kenodegard in #5255
Xref #4209 


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] ~~Add / update outdated documentation?~~

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
