### PR TITLE
Remove `xdoctest` & ignore `libgcc` for overlinking/overdepending checks

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -1325,7 +1325,11 @@ def check_overlinking_impl(
     precs.append(pkg_vendored_dist)
     ignore_list = utils.ensure_list(ignore_run_exports)
     if subdir.startswith("linux"):
+        # libgcc-ng is the defaults & old conda-forge package name
         ignore_list.append("libgcc-ng")
+        # conda-forge::libgcc-ng was renamed 08/27/2024
+        # see https://github.com/conda-forge/ctng-compilers-feedstock/pull/148
+        ignore_list.append("libgcc")
 
     package_nature = {prec: library_nature(prec, run_prefix) for prec in precs}
     lib_packages = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,6 @@ addopts = [
   # "--store-durations",  # not available yet
   "--strict-markers",
   "--tb=native",
-  "--xdoctest-modules",
-  "--xdoctest-style=google",
   "-vv",
 ]
 doctest_optionflags = [

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -1,5 +1,4 @@
 anaconda-client
-conda-forge::xdoctest
 conda-verify
 contextlib2
 coverage

--- a/tests/test-recipes/metadata/_sysroot_detection/meta.yaml
+++ b/tests/test-recipes/metadata/_sysroot_detection/meta.yaml
@@ -9,8 +9,6 @@ source:
 
 build:
   number: 0
-  ignore_run_exports_from:
-    - {{ compiler('c') }}
 
 requirements:
   build:

--- a/tests/test-recipes/metadata/_sysroot_detection/meta.yaml
+++ b/tests/test-recipes/metadata/_sysroot_detection/meta.yaml
@@ -9,6 +9,8 @@ source:
 
 build:
   number: 0
+  ignore_run_exports_from:
+    - {{ compiler('c') }}
 
 requirements:
   build:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Found that while we were passing `--xdoctest-modules` we haven't actually been running any docstring example codes anyhow since `pytest` only crawls the `tests` directory by default.

Correcting this (and/or switching to use `doctests` instead) is out of scope and relegated to a future effort.

Also ignoring over depending checks for `libgcc` on linux as was previously done for `libgcc-ng` since conda-forge recently renamed `libgcc-ng` to `libgcc`.

Closes #5470 
Closes #5469 
Closes #5468 
Closes #5475 
Closes #5476 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
