### PR TITLE
Conditionally override version after cutting a release branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -560,20 +560,11 @@ jobs:
               # and not relative to the current release branch, if this is the case we need
               # to override the version with a derivative of the branch name
 
-              # drop x suffix
-              prefix = "${{ github.ref_name }}"[:-1]
-
               # override the version if `git describe --tag` does not start with the prefix
               last_release = check_output(["git", "describe", "--tag"])
-              if not last_release.startswith(prefix):
-                  # number of commits on this branch
-                  commits = check_output(["git", "rev-list", "--count", "HEAD", "^main"]).strip()
-
-                  # short hash for current commit
-                  short_hash = check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
-
+              if not last_release.startswith("${{ github.ref_name }}"[:-1]):
                   # override the version using the branch name, commit count, and short hash
-                  envs["VERSION_OVERRIDE"] = f"{prefix}0.{commits}_g{short_hash}"
+                  envs["VERSION_OVERRIDE"] = "${{ github.ref_name }}"
 
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -560,10 +560,10 @@ jobs:
               # and not relative to the current release branch, if this is the case we need
               # to override the version with a derivative of the branch name
 
-              # override the version if `git describe --tag` does not start with the prefix
+              # override the version if `git describe --tag` does not start with the branch version
               last_release = check_output(["git", "describe", "--tag"])
-              if not last_release.startswith("${{ github.ref_name }}"[:-1]):
-                  # override the version using the branch name, commit count, and short hash
+              prefix = "${{ github.ref_name }}"[:-1]  # without x suffix
+              if not last_release.startswith(prefix):
                   envs["VERSION_OVERRIDE"] = "${{ github.ref_name }}"
 
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -573,7 +573,7 @@ jobs:
                   short_hash = check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
 
                   # override the version using the branch name, commit count, and short hash
-                  envs["VERSION_OVERRIDE"] = f"{prefix}0.{commits}_g{hash_}"
+                  envs["VERSION_OVERRIDE"] = f"{prefix}0.{commits}_g{short_hash}"
 
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -566,7 +566,14 @@ jobs:
               # override the version if `git describe --tag` does not start with the prefix
               last_release = check_output(["git", "describe", "--tag"])
               if not last_release.startswith(prefix):
-                envs["VERSION_OVERRIDE"] = prefix + "0"
+                  # number of commits on this branch
+                  commits = check_output(["git", "rev-list", "--count", "HEAD", "^main"]).strip()
+
+                  # short hash for current commit
+                  short_hash = check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
+
+                  # override the version using the branch name, commit count, and short hash
+                  envs["VERSION_OVERRIDE"] = f"{prefix}0.{commits}_g{hash_}"
 
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -537,23 +537,38 @@ jobs:
       - name: Detect Label
         shell: python
         run: |
+          import re
           from pathlib import Path
-          from re import match
           from os import environ
+          from subprocess import check_output
 
-          if "${{ github.ref_name }}" == "main":
-              # main branch commits are uploaded to the dev label
-              label = "dev"
-          elif "${{ github.ref_name }}".startswith("feature/"):
+          # unless otherwise specified, commits are uploaded to the dev label
+          # e.g., `main` branch commits
+          envs = {"ANACONDA_ORG_LABEL": "dev"}
+
+          if "${{ github.ref_name }}".startswith("feature/"):
               # feature branch commits are uploaded to a custom label
-              label = "${{ github.ref_name }}"
-          else:
+              envs["ANACONDA_ORG_LABEL"] = "${{ github.ref_name }}"
+          elif re.match(r"\d+(\.\d+)+\.x", "${{ github.ref_name }}"):
               # release branch commits are added to the rc label
               # see https://github.com/conda/infrastructure/issues/760
               _, name = "${{ github.repository }}".split("/")
-              label = f"rc-{name}-${{ github.ref_name }}"
+              envs["ANACONDA_ORG_LABEL"] = f"rc-{name}-${{ github.ref_name }}"
 
-          Path(environ["GITHUB_ENV"]).write_text(f"ANACONDA_ORG_LABEL={label}")
+              # if no releases have occurred on this branch yet then `git describe --tag`
+              # will misleadingly produce a version number relative to the last release
+              # and not relative to the current release branch, if this is the case we need
+              # to override the version with a derivative of the branch name
+
+              # drop x suffix
+              prefix = "${{ github.ref_name }}"[:-1]
+
+              # override the version if `git describe --tag` does not start with the prefix
+              last_release = check_output(["git", "describe", "--tag"])
+              if not last_release.startswith(prefix):
+                envs["VERSION_OVERRIDE"] = prefix + "0"
+
+          Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
         uses: conda/actions/canary-release@976289d0cfd85139701b26ddd133abdd025a7b5f # v24.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda-build
   # VERSION_OVERRIDE is used by the canary release workflow
-  version: {{ os.getenv("VERSION_OVERRIDE") or GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version: {{ os.getenv("VERSION_OVERRIDE") or (GIT_DESCRIBE_TAG ~ "." ~ GIT_BUILD_STR) }}
 
 source:
   # git_url only captures committed code

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: conda-build
   # VERSION_OVERRIDE is used by the canary release workflow
-  version: {{ os.getenv("VERSION_OVERRIDE") or (GIT_DESCRIBE_TAG ~ "." ~ GIT_BUILD_STR) }}
+  version: {{ os.getenv("VERSION_OVERRIDE") or GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
 
 source:
   # git_url only captures committed code

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 package:
   name: conda-build
-  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  # VERSION_OVERRIDE is used by the canary release workflow
+  version: {{ os.getenv("VERSION_OVERRIDE") or GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
 
 source:
   # git_url only captures committed code


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

The first canary build created after cutting a release branch produces a misleading version/build string. Instead of deriving the version/build string from the upcoming release, it uses the version from the most recent release on `main`. This leads to a race condition with packages produced by the canary build workflow from the `main` branch.

The race condition occurs because both `main` and the release branch end up generating packages with the same version/build string. Even though we upload them to anaconda.org with different labels, only one package would "win." As a result, we occasionally see the package first appear under one label, only to disappear and reappear under the other label when the other canary build workflow finishes and uploads it's packages.

The proposed fix is to override the default behavior of `git describe --tag` when no releases have been made on the branch yet.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
