### PR TITLE
fix: pin pydata_sphinx_theme to get docs to build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ Sphinx==7.4.7
 conda-sphinx-theme==0.2.1
 linkify-it-py==2.0.2
 myst-parser==2.0.0
+pydata_sphinx_theme==0.15.4
 pylint==2.17.5
 requests==2.31.0
 ruamel.yaml==0.17.32


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR is attempting to fix the docs build. I diffed the logs and noticed a version change on `pydata_sphinx_theme`, so I am attempting to pin it.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
