### PR TITLE
Remove pytest-codspeed install from personal fork

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,6 +209,7 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
+          --file tests/requirements-benchmarks.txt
           python=${{ matrix.python-version }}
 
       - name: Install CodSpeed

--- a/tests/requirements-benchmarks.txt
+++ b/tests/requirements-benchmarks.txt
@@ -1,0 +1,1 @@
+conda-forge::pytest-codspeed >=3.0.0


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

With the `pytest-codspeed 3.0.0` release (https://github.com/CodSpeedHQ/pytest-codspeed/releases/tag/v3.0.0) and conda-forge feedstock update (https://github.com/conda-forge/pytest-codspeed-feedstock/pull/2) we can discontinue depending on a personal fork of `pytest-codspeed`.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
