### PR TITLE
fix: catch `CondaBuildUserError` w/ `SystemExit`

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -2579,7 +2579,7 @@ class MetaData:
                     ref_metadata.parse_until_resolved(
                         allow_no_other_outputs=True, bypass_env_check=True
                     )
-                except SystemExit:
+                except (SystemExit, CondaBuildUserError):
                     pass
                 outputs = get_output_dicts_from_metadata(ref_metadata)
 
@@ -2611,7 +2611,7 @@ class MetaData:
                         ref_metadata.other_outputs = out_metadata.other_outputs = (
                             all_output_metadata
                         )
-                except SystemExit:
+                except (SystemExit, CondaBuildUserError):
                     if not permit_undefined_jinja:
                         raise
                     output_tuples = []

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -34,7 +34,7 @@ from conda.models.version import VersionOrder
 
 from . import environ, exceptions, source, utils
 from .config import CondaPkgFormat
-from .exceptions import DependencyNeedsBuildingError
+from .exceptions import CondaBuildUserError, DependencyNeedsBuildingError
 from .index import get_build_index
 from .metadata import MetaData, MetaDataTuple, combine_top_level_metadata_with_output
 from .utils import (
@@ -894,7 +894,7 @@ def distribute_variants(
                 allow_no_other_outputs=allow_no_other_outputs,
                 bypass_env_check=bypass_env_check,
             )
-        except SystemExit:
+        except (SystemExit, CondaBuildUserError):
             pass
         need_source_download = not mv.needs_source_for_render or not mv.source_provided
 

--- a/news/5538-sysexit-vs-cdusererror
+++ b/news/5538-sysexit-vs-cdusererror
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed a bug where some ``CondaBuildUserError`` exceptions that were formally ``SystemExit`` exceptions
+  were not being caught properly. (#5538)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR catches `CondaBuildUserError` with `SystemExit` in internal routines in the code. What is going on is that as we've slowly been moving `sys.exit` calls to raising a `CondaBuildUserError`, we've inadvertently started raising exceptions in places where we should not be. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
