### PR TITLE
fix: allow incomplete specs during intermediate parsing stages

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1591,32 +1591,27 @@ class MetaData:
                 ]
             )
 
-        def _parse_spec(spec, raise_errors=False):
+        specs = OrderedDict()
+        for spec in ensure_list(self.get_value("requirements/" + typ, [])):
+            if not spec:
+                continue
+
             try:
-                return MatchSpec(spec)
+                ms = MatchSpec(spec)
             except AssertionError:
-                if raise_errors:
+                if len(self.undefined_jinja_vars) == 0:
                     raise RuntimeError(f"Invalid package specification: {spec!r}")
                 else:
-                    return None
+                    continue
             except (AttributeError, ValueError) as e:
-                if raise_errors:
+                if len(self.undefined_jinja_vars) == 0:
                     raise RuntimeError(
                         "Received dictionary as spec.  Note that pip requirements are "
                         "not supported in conda-build meta.yaml.  Error message: "
                         + str(e)
                     )
                 else:
-                    return None
-
-        specs = OrderedDict()
-        for spec in ensure_list(self.get_value("requirements/" + typ, [])):
-            if not spec:
-                continue
-
-            ms = _parse_spec(spec, raise_errors=len(self.undefined_jinja_vars) == 0)
-            if ms is None:
-                continue
+                    continue
 
             if ms.name == self.name() and not (
                 typ == "build" and self.config.host_subdir != self.config.build_subdir

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1641,9 +1641,7 @@ class MetaData:
                         f"dependency '{ms.name}'"
                     )
                     if len(parts) >= 3:
-                        msg += (
-                            f"\nPerhaps you meant '{ms.name} {parts[1]}{parts[2]}'"
-                        )
+                        msg += f"\nPerhaps you meant '{ms.name} {parts[1]}{parts[2]}'"
                     sys.exit(msg)
             specs[spec] = ms
         return list(specs.values())

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1590,12 +1590,10 @@ class MetaData:
                     ("r-base", self.config.variant["r_base"]),
                 ]
             )
-
         specs = OrderedDict()
         for spec in ensure_list(self.get_value("requirements/" + typ, [])):
             if not spec:
                 continue
-
             try:
                 ms = MatchSpec(spec)
             except AssertionError:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1592,16 +1592,13 @@ class MetaData:
             )
 
         def _parse_spec(spec, raise_errors=False):
-            # parsing of specs may fail due to undefined jinja2
-            # so we do not raise in that case and try to handle it
-            # by parsing just the name
             try:
                 return MatchSpec(spec)
             except AssertionError:
                 if raise_errors:
                     raise RuntimeError(f"Invalid package specification: {spec!r}")
                 else:
-                    return _parse_spec(spec.split()[0], raise_errors=True)
+                    return None
             except (AttributeError, ValueError) as e:
                 if raise_errors:
                     raise RuntimeError(
@@ -1610,7 +1607,7 @@ class MetaData:
                         + str(e)
                     )
                 else:
-                    return _parse_spec(spec.split()[0], raise_errors=True)
+                    return None
 
         specs = OrderedDict()
         for spec in ensure_list(self.get_value("requirements/" + typ, [])):
@@ -1618,39 +1615,41 @@ class MetaData:
                 continue
 
             ms = _parse_spec(spec, raise_errors=len(self.undefined_jinja_vars) == 0)
+            if ms is None:
+                continue
 
             if ms.name == self.name() and not (
                 typ == "build" and self.config.host_subdir != self.config.build_subdir
             ):
                 raise RuntimeError(f"{self.name()} cannot depend on itself")
 
-            # IDK what this does since AFAIK the inner continue applies only
+            # TODO: IDK what this does since AFAIK the inner continue applies only
             # to the inner loop
             for name, ver in name_ver_list:
                 if ms.name == name:
                     if self.noarch:
                         continue
 
-            # only validate here if we have all jinja2 variables defined
-            if len(self.undefined_jinja_vars) == 0:
-                for c in "=!@#$%^&*:;\"'\\|<>?/":
-                    if c in ms.name:
-                        sys.exit(
-                            f"Error: bad character '{c}' in package name "
-                            f"dependency '{ms.name}'"
+            # TODO: the validation here appears to be a waste of time since MatchSpec
+            # appears to validate?
+            for c in "=!@#$%^&*:;\"'\\|<>?/":
+                if c in ms.name:
+                    sys.exit(
+                        f"Error: bad character '{c}' in package name "
+                        f"dependency '{ms.name}'"
+                    )
+            parts = spec.split()
+            if len(parts) >= 2:
+                if parts[1] in {">", ">=", "=", "==", "!=", "<", "<="}:
+                    msg = (
+                        f"Error: bad character '{parts[1]}' in package version "
+                        f"dependency '{ms.name}'"
+                    )
+                    if len(parts) >= 3:
+                        msg += (
+                            f"\nPerhaps you meant '{ms.name} {parts[1]}{parts[2]}'"
                         )
-                parts = spec.split()
-                if len(parts) >= 2:
-                    if parts[1] in {">", ">=", "=", "==", "!=", "<", "<="}:
-                        msg = (
-                            f"Error: bad character '{parts[1]}' in package version "
-                            f"dependency '{ms.name}'"
-                        )
-                        if len(parts) >= 3:
-                            msg += (
-                                f"\nPerhaps you meant '{ms.name} {parts[1]}{parts[2]}'"
-                            )
-                        sys.exit(msg)
+                    sys.exit(msg)
             specs[spec] = ms
         return list(specs.values())
 

--- a/news/5555-skip-bad-specs-while-still-parsing.rst
+++ b/news/5555-skip-bad-specs-while-still-parsing.rst
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed a bug where bad match specs from intermediate parsing results would cause parsing to fail. (#5555)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -2082,7 +2082,7 @@ def test_conda_build_script_errors_without_conda_info_handlers(tmp_path, recipe,
 
 def test_api_build_inject_jinja2_vars_on_first_pass(testing_config):
     recipe_dir = os.path.join(metadata_dir, "_inject_jinja2_vars_on_first_pass")
-    with pytest.raises(RuntimeError):
+    with pytest.raises((RuntimeError, CondaBuildUserError)):
         api.build(recipe_dir, config=testing_config)
 
     testing_config.variant = {"python_min": "3.12"}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -655,3 +655,56 @@ build:
         pytest.fail(
             "Undefined variable caused error, even though this build is skipped"
         )
+
+
+@pytest.mark.parametrize("have_variant", [True, False])
+def test_parse_until_resolved_missing_jinja_in_spec(
+    testing_metadata: MetaData,
+    tmp_path: Path,
+    have_variant: bool,
+) -> None:
+    (recipe := tmp_path / (name := "meta.yaml")).write_text(
+        """
+package:
+    name: dummy
+    version: 1.0.0
+
+build:
+    noarch: python
+    number: 0
+
+requirements:
+    host:
+        - python ={{ python_min }}
+    run:
+        - python >={{ python_min }}
+"""
+    )
+    (tmp_path / "conda_build_config.yaml").write_text(
+        """
+python_min:
+    - 3.6
+"""
+    )
+    testing_metadata._meta_path = recipe
+    testing_metadata._meta_name = name
+    if have_variant:
+        testing_metadata.config.variant = {"python_min": "3.6"}
+    else:
+        delattr(testing_metadata.config, "variant")
+        delattr(testing_metadata.config, "variant_config_files")
+        delattr(testing_metadata.config, "variants")
+
+    try:
+        testing_metadata.parse_until_resolved()
+        if not have_variant:
+            pytest.fail("Undefined variable did NOT cause spec parsing error!")
+        else:
+            print("parsed OK!")
+    except (Exception, SystemExit):
+        if have_variant:
+            pytest.fail(
+                "Undefined variable caused spec parsing error even if we have the variant!"
+            )
+        else:
+            print("did not parse OK!")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR allows incomplete specs if they do not parse by skipping them for intermediate parsing stages. This behavior has been in the code for a while if a spec was completely specified by eg jinja2 (eg a list element `- {{ mpi }}`). The PR extends this behavior to any soec that does not parse during intermediate stages. For the final parsing stage, specs that do not parse will raise. 

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
