### PR TITLE
fix: validate package existence in conda build --test

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -3306,7 +3306,8 @@ def test(
         and not metadata.config.test_run_post
     ):
         print("Nothing to test for:", test_package_name)
-        return True
+        # return False or raise an exception
+        raise CondaBuildUserError(f"No tests found for package: {test_package_name}")
 
     if metadata.config.remove_work_dir:
         for name, prefix in (

--- a/news/5614-test-package-validation.rst
+++ b/news/5614-test-package-validation.rst
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixes non-existent package validation in conda build --test issue #5612. (#5614)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

This PR changes the behavior when no tests are found for a package during conda build. Previously, the code would silently succeed by returning True when no tests were found. This could mask issues where tests were accidentally omitted or misconfigured.

Now, it will raise a CondaBuildUserError with a clear message indicating that no tests were found for the package. This makes the behavior more explicit and helps users identify when they may have accidentally omitted test configurations.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
