### PR TITLE
python_version_independent: ignore python from other packages too

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -413,6 +413,8 @@ def get_upstream_pins(m: MetaData, precs, env):
     if m.python_version_independent and not m.noarch:
         ignore_pkgs_list.append("python")
     ignore_list = utils.ensure_list(m.get_value("build/ignore_run_exports"))
+    if m.python_version_independent and not m.noarch:
+        ignore_list.append("python")
     additional_specs = {}
     for prec in precs:
         if any((prec.name == req.split(" ")[0]) for req in ignore_pkgs_list):

--- a/news/gh5654.rst
+++ b/news/gh5654.rst
@@ -1,0 +1,20 @@
+### Enhancements
+
+* Ignore run_exports of python from other packages when building with
+  ``python_version_independent: true`` (#5654).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/metadata/_python_version_independent/meta.yaml
+++ b/tests/test-recipes/metadata/_python_version_independent/meta.yaml
@@ -13,6 +13,7 @@ build:
 
 requirements:
   build:
+    - cross-python_{{ target_platform }}   # [build_platform != target_platform]
   host:
     - python 3.11.*
     - setuptools


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
       
We were doing
```
ignore_run_exports_from:
- python
```
but we should have been doing both
```
ignore_run_exports_from:
- python
ignore_run_exports:
- python
```