### PR TITLE
test: rerun all tests three times on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,6 +147,8 @@ jobs:
         run: >
           pytest
           --cov=conda_build
+          --reruns 3
+          --reruns-delay 1
           -n auto
           -m "${{ env.PYTEST_MARKER }}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,3 +276,14 @@ def empty_channel(tmp_path_factory: pytest.TempPathFactory) -> Path:
     channel = tmp_path_factory.mktemp("empty_channel", numbered=False)
     update_index(channel)
     return channel
+
+
+@pytest.fixture(autouse=True)
+def unique_package_cache():
+    import tempfile
+
+    import conda.base.context
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with conda.base.context.context._override("_pkgs_dirs", [str(tmpdir)]):
+            yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,14 +276,3 @@ def empty_channel(tmp_path_factory: pytest.TempPathFactory) -> Path:
     channel = tmp_path_factory.mktemp("empty_channel", numbered=False)
     update_index(channel)
     return channel
-
-
-@pytest.fixture(autouse=True)
-def unique_package_cache():
-    import tempfile
-
-    import conda.base.context
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with conda.base.context.context._override("_pkgs_dirs", [str(tmpdir)]):
-            yield


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The package cache corruption continues. Any locking mechanisms are failing. I am trying this change to the config to see how much slower things get.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
