### PR TITLE
Add note about build string value

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -324,7 +324,7 @@ The build number should be incremented for new builds of the same
 version. The number defaults to ``0``. The build string cannot
 contain "-". The string defaults to the default conda-build
 string plus the build number. When redefining the default string,
-we strongly recommend following the convention of adding the build 
+we strongly recommend following the convention of adding the build
 number at the end of the string, with a preceding underscore.
 
 .. code-block:: yaml

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -323,7 +323,9 @@ Build number and string
 The build number should be incremented for new builds of the same
 version. The number defaults to ``0``. The build string cannot
 contain "-". The string defaults to the default conda-build
-string plus the build number.
+string plus the build number. When redefining the default string,
+we strongly recommend following the convention of adding the build 
+number at the end of the string, with a preceding underscore.
 
 .. code-block:: yaml
 

--- a/news/5676-add-note-about-build-string
+++ b/news/5676-add-note-about-build-string
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+*
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Add recommendation to append build number to build string when overwriting build string. (#5676)
+
+### Other
+
+* <news item>


### PR DESCRIPTION

### Description

Add recommendation about changing build string value.  When conda is building it's change report it can classify a changed package as an upgrade, downgrade, revised or superseded. For example:
* Change in version: update or downgrade, accordingly.
* Same version, but change in build number: upgrade or downgrade, accordingly.
* Same version and build number, but different build string: changed/adjusted/revised.
* Different channel: superseded.

ref: https://github.com/conda/conda/pull/14727


### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
