### PR TITLE
fix: use event to get tag for releases

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -1121,7 +1121,7 @@
   alternate_emails:
   - becker.mr@gmail.com
   - beckermr@users.noreply.github.com
-  num_commits: 32
+  num_commits: 31
   first_commit: 2019-10-17 23:05:16
   github: beckermr
 - name: Jinzhe Zeng

--- a/.authors.yml
+++ b/.authors.yml
@@ -1225,7 +1225,7 @@
   first_commit: 2020-11-19 10:46:41
 - name: Jannis Leidel
   email: jannis@leidel.info
-  num_commits: 36
+  num_commits: 37
   github: jezdez
   first_commit: 2020-11-19 10:46:41
 - name: Christof Kaufmann

--- a/.authors.yml
+++ b/.authors.yml
@@ -1121,7 +1121,7 @@
   alternate_emails:
   - becker.mr@gmail.com
   - beckermr@users.noreply.github.com
-  num_commits: 31
+  num_commits: 33
   first_commit: 2019-10-17 23:05:16
   github: beckermr
 - name: Jinzhe Zeng

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -11,7 +11,7 @@ concurrency:
   # concurrency group while a previous build is running it will be canceled.
   # Repeated pushes to a PR will cancel all previous builds, while multiple
   # merges to main will not cancel.
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.event.release.tag_name || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -11,7 +11,7 @@ concurrency:
   # concurrency group while a previous build is running it will be canceled.
   # Repeated pushes to a PR will cancel all previous builds, while multiple
   # merges to main will not cancel.
-  group: ${{ github.workflow }}-${{ github.ref_name || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -24,7 +24,7 @@ jobs:
     if: '!github.event.repository.fork'
     runs-on: ubuntu-latest
     env:
-      ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.ref_name }}
+      ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
     steps:
       - name: Checkout Source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -50,6 +50,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >
           gh release upload
-          --clobber "${{ github.ref_name }}"
+          --clobber "${{ github.event.release.tag_name }}"
           --repo "${{ github.repository }}"
           release/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Fix `get_conda_operation_locks` call to use correct arguments. (#4215 via #5259)
 * Use `conda_build.utils.tar_xf` everywhere to avoid blind usage of `tar.extractall` in `conda render` and `conda convert`.
+* Changed release upload workflow to use github event tag names. (#5686)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * Fix `get_conda_operation_locks` call to use correct arguments. (#4215 via #5259)
 * Use `conda_build.utils.tar_xf` everywhere to avoid blind usage of `tar.extractall` in `conda render` and `conda convert`.
-* Changed release upload workflow to use github event tag names. (#5686)
+* Fix release upload workflow to use GitHub event tag names. (#5686)
 
 ### Docs
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR uses the event to get the tag for releases in order to fix uploads. Thanks to @jezdez for figuring this out!

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
