### PR TITLE
fix: allow tuples, lists and dicts in selectors

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -289,7 +289,7 @@ def parseNameNotFound(error) -> str:
 @cache
 def evalidate_model():
     model = base_eval_model.clone()
-    model.nodes.extend(["Call", "Attribute"])
+    model.nodes.extend(["Call", "Attribute", "Tuple", "List", "Dict"])
     model.allowed_functions += [
         "int",
         "str",

--- a/news/5690-selector-lists.rst
+++ b/news/5690-selector-lists.rst
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fixed bug where selectors with lists, tuples, or dicts could not be processed. (#5690)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -83,11 +83,14 @@ def test_select_lines():
             "test {{ JINJA_VAR[:2] }} # stuff yes [abc]",
             "test {{ JINJA_VAR[:2] }} # [abc] stuff yes",
             '{{ environ["test"] }}  # [abc]',
+            '{{ environ["test"] }}  # [d in ("a", "b")]',
+            '{{ environ["test"] }}  # [d in ["a", "b"]]',
+            '{{ environ["test"] }}  # [d in {"a": 1, "b": 2}]',
             "",  # preserve trailing newline
         )
     )
 
-    assert select_lines(lines, {"abc": True}, variants_in_place=True) == "\n".join(
+    assert select_lines(lines, {"abc": True, "d": "b"}, variants_in_place=True) == "\n".join(
         (
             "",  # preserve leading newline
             "test",
@@ -106,10 +109,13 @@ def test_select_lines():
             "test {{ JINJA_VAR[:2] }}",
             "test {{ JINJA_VAR[:2] }}",
             '{{ environ["test"] }}',
+            '{{ environ["test"] }}',
+            '{{ environ["test"] }}',
+            '{{ environ["test"] }}',
             "",  # preserve trailing newline
         )
     )
-    assert select_lines(lines, {"abc": False}, variants_in_place=True) == "\n".join(
+    assert select_lines(lines, {"abc": False, "d": "c"}, variants_in_place=True) == "\n".join(
         (
             "",  # preserve leading newline
             "test",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import textwrap
 from contextlib import nullcontext
 from itertools import product
 from typing import TYPE_CHECKING
@@ -61,6 +62,20 @@ def test_uses_vcs_in_metadata(testing_workdir, testing_metadata):
         f.write("HG_WEEEEE")
     assert testing_metadata.uses_vcs_in_meta
     assert not testing_metadata.uses_vcs_in_build
+
+
+def test_select_lines_complicated_smoke():
+    # this snippet is from the conda-forge pinnings file
+    cfpinning = textwrap.dedent(
+        """
+        docker_image:                                       # [os.environ.get("BUILD_PLATFORM", "").startswith("linux-")]
+        # non-CUDA-enabled builds on AlmaLinux 8
+        - quay.io/condaforge/linux-anvil-x86_64:alma8     # [os.environ.get("BUILD_PLATFORM") == "linux-64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") in ("alma8", "ubi8")]
+        - quay.io/condaforge/linux-anvil-aarch64:alma8    # [os.environ.get("BUILD_PLATFORM") == "linux-aarch64" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") in ("alma8", "ubi8")]
+        - quay.io/condaforge/linux-anvil-ppc64le:alma8    # [os.environ.get("BUILD_PLATFORM") == "linux-ppc64le" and os.environ.get("DEFAULT_LINUX_VERSION", "alma9") in ("alma8", "ubi8")]
+        """  # noqa: E501
+    )
+    select_lines(cfpinning, {"os": OSModuleSubset}, variants_in_place=True)
 
 
 def test_select_lines():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -83,9 +83,9 @@ def test_select_lines():
             "test {{ JINJA_VAR[:2] }} # stuff yes [abc]",
             "test {{ JINJA_VAR[:2] }} # [abc] stuff yes",
             '{{ environ["test"] }}  # [abc]',
-            '{{ environ["test"] }}  # [d in ("a", "b")]',
-            '{{ environ["test"] }}  # [d in ["a", "b"]]',
-            '{{ environ["test"] }}  # [d in {"a": 1, "b": 2}]',
+            '{{ environ["test-tuple"] }}  # [d in ("a", "b")]',
+            '{{ environ["test-list"] }}  # [d in list(("a", "b"))]',
+            '{{ environ["test-dict"] }}  # [d in {"a": 1, "b": 2}]',
             "",  # preserve trailing newline
         )
     )
@@ -111,9 +111,9 @@ def test_select_lines():
             "test {{ JINJA_VAR[:2] }}",
             "test {{ JINJA_VAR[:2] }}",
             '{{ environ["test"] }}',
-            '{{ environ["test"] }}',
-            '{{ environ["test"] }}',
-            '{{ environ["test"] }}',
+            '{{ environ["test-tuple"] }}',
+            '{{ environ["test-list"] }}',
+            '{{ environ["test-dict"] }}',
             "",  # preserve trailing newline
         )
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -90,7 +90,9 @@ def test_select_lines():
         )
     )
 
-    assert select_lines(lines, {"abc": True, "d": "b"}, variants_in_place=True) == "\n".join(
+    assert select_lines(
+        lines, {"abc": True, "d": "b"}, variants_in_place=True
+    ) == "\n".join(
         (
             "",  # preserve leading newline
             "test",
@@ -115,7 +117,9 @@ def test_select_lines():
             "",  # preserve trailing newline
         )
     )
-    assert select_lines(lines, {"abc": False, "d": "c"}, variants_in_place=True) == "\n".join(
+    assert select_lines(
+        lines, {"abc": False, "d": "c"}, variants_in_place=True
+    ) == "\n".join(
         (
             "",  # preserve leading newline
             "test",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR allows tuples, lists and dicts in selectors as nodes in addition to allowing the creation functions. This let's folks use literals like `("a", "b")` in a selector.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->


closes #5689 