### PR TITLE
fix: add float, len, and os.sep to evalidate model + jinja2

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -292,6 +292,7 @@ def evalidate_model():
     model.nodes.extend(["Call", "Attribute", "Tuple", "List", "Dict"])
     model.allowed_functions += [
         "int",
+        "float",
         "str",
         "list",
         "dict",

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -298,6 +298,7 @@ def evalidate_model():
         "list",
         "dict",
         "tuple",
+        "len",
     ]
     model.attributes += [
         # string methods

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -139,6 +139,7 @@ class OSModuleSubset:
 
     environ = os.environ
     getenv = os.getenv
+    sep = os.sep
 
 
 def get_selectors(config: Config) -> dict[str, bool]:
@@ -316,6 +317,7 @@ def evalidate_model():
         # for legacy os.environ and os.getenv
         "environ",
         "getenv",
+        "sep",
     ]
     return model
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -310,6 +310,8 @@ def evalidate_model():
         "startswith",
         "strip",
         "upper",
+        "join",
+        "replace",
         # dict methods
         "get",
         "items",

--- a/news/5693-float-selectors.rst
+++ b/news/5693-float-selectors.rst
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fixed bug where the `float` function was not allowed in selectors. (#5693)

--- a/news/5693-float-selectors.rst
+++ b/news/5693-float-selectors.rst
@@ -1,3 +1,4 @@
 ### Bug fixes
 
-* Fixed bug where the `float` function was not allowed in selectors. (#5693)
+* Fixed bug where the `float` and `len` functions were not allowed in selectors. (#5693)
+* Add `os.sep` to allowed attributes in the `os` module for Jinja and selectors. (#5693)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -103,6 +103,8 @@ def test_select_lines():
             '{{ environ["test-dict"] }}  # [d in {"a": 1, "b": 2}]',
             '{{ environ["test-float"] }}  # [int(float(vc)) == 10]',
             '{{ environ["test-sep"] }}  # [len(os.sep) == 1]',
+            '{{ environ["test-join"] }}  # ["/".join("a", "b") == "a/b"]',
+            '{{ environ["test-replace"] }}  # ["acb".replace("c", "/") == "a/b"]',
             "",  # preserve trailing newline
         )
     )
@@ -133,6 +135,8 @@ def test_select_lines():
             '{{ environ["test-dict"] }}',
             '{{ environ["test-float"] }}',
             '{{ environ["test-sep"] }}',
+            '{{ environ["test-join"] }}',
+            '{{ environ["test-replace"] }}',
             "",  # preserve trailing newline
         )
     )
@@ -150,6 +154,8 @@ def test_select_lines():
             "",  # preserve comment line (but not the comment)
             "test {{ JINJA_VAR[:2] }}",
             '{{ environ["test-sep"] }}',
+            '{{ environ["test-join"] }}',
+            '{{ environ["test-replace"] }}',
             "",  # preserve trailing newline
         )
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -149,7 +149,7 @@ def test_select_lines():
             "",  # preserve newline
             "",  # preserve comment line (but not the comment)
             "test {{ JINJA_VAR[:2] }}",
-            "{{ environ["test-sep"] }}",
+            '{{ environ["test-sep"] }}',
             "",  # preserve trailing newline
         )
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -101,12 +101,13 @@ def test_select_lines():
             '{{ environ["test-tuple"] }}  # [d in ("a", "b")]',
             '{{ environ["test-list"] }}  # [d in list(("a", "b"))]',
             '{{ environ["test-dict"] }}  # [d in {"a": 1, "b": 2}]',
+            '{{ environ["test-float"] }}  # [int(float(vc)) == 10]',
             "",  # preserve trailing newline
         )
     )
 
     assert select_lines(
-        lines, {"abc": True, "d": "b"}, variants_in_place=True
+        lines, {"abc": True, "d": "b", "vc": "10.4"}, variants_in_place=True
     ) == "\n".join(
         (
             "",  # preserve leading newline
@@ -129,11 +130,12 @@ def test_select_lines():
             '{{ environ["test-tuple"] }}',
             '{{ environ["test-list"] }}',
             '{{ environ["test-dict"] }}',
+            '{{ environ["test-float"] }}',
             "",  # preserve trailing newline
         )
     )
     assert select_lines(
-        lines, {"abc": False, "d": "c"}, variants_in_place=True
+        lines, {"abc": False, "d": "c", "vc": "11.4"}, variants_in_place=True
     ) == "\n".join(
         (
             "",  # preserve leading newline

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -149,8 +149,7 @@ def test_select_lines():
             "",  # preserve newline
             "",  # preserve comment line (but not the comment)
             "test {{ JINJA_VAR[:2] }}",
-            '{{ environ["test-sep"] }}'
-            "",  # preserve trailing newline
+            '{{ environ["test-sep"] }}',  # preserve trailing newline
         )
     )
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -149,7 +149,8 @@ def test_select_lines():
             "",  # preserve newline
             "",  # preserve comment line (but not the comment)
             "test {{ JINJA_VAR[:2] }}",
-            '{{ environ["test-sep"] }}',  # preserve trailing newline
+            "{{ environ["test-sep"] }}",
+            "",  # preserve trailing newline
         )
     )
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -102,6 +102,7 @@ def test_select_lines():
             '{{ environ["test-list"] }}  # [d in list(("a", "b"))]',
             '{{ environ["test-dict"] }}  # [d in {"a": 1, "b": 2}]',
             '{{ environ["test-float"] }}  # [int(float(vc)) == 10]',
+            '{{ environ["test-sep"] }}  # [len(os.sep) == 1]',
             "",  # preserve trailing newline
         )
     )
@@ -131,6 +132,7 @@ def test_select_lines():
             '{{ environ["test-list"] }}',
             '{{ environ["test-dict"] }}',
             '{{ environ["test-float"] }}',
+            '{{ environ["test-sep"] }}',
             "",  # preserve trailing newline
         )
     )
@@ -147,6 +149,7 @@ def test_select_lines():
             "",  # preserve newline
             "",  # preserve comment line (but not the comment)
             "test {{ JINJA_VAR[:2] }}",
+            '{{ environ["test-sep"] }}'
             "",  # preserve trailing newline
         )
     )


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR enables the `float` function for selectors. There are a few instances of this in the wild and it should be safe.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->

closes #5694 
