### PR TITLE
fix: enable `float`, `replace`, `join`, `len`, and `os.sep` for jinja2 and selectors

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -293,6 +293,8 @@ def evalidate_model():
     model.nodes.extend(["Call", "Attribute", "Tuple", "List", "Dict"])
     model.allowed_functions += [
         "int",
+        "float",
+        "len",
         "str",
         "list",
         "dict",
@@ -308,6 +310,8 @@ def evalidate_model():
         "startswith",
         "strip",
         "upper",
+        "join",
+        "replace",
         # dict methods
         "get",
         "items",

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -139,6 +139,7 @@ class OSModuleSubset:
 
     environ = os.environ
     getenv = os.getenv
+    sep = os.sep
 
 
 def get_selectors(config: Config) -> dict[str, bool]:
@@ -312,9 +313,10 @@ def evalidate_model():
         "items",
         "keys",
         "values",
-        # for legacy os.environ and os.getenv
+        # for legacy os attributes
         "environ",
         "getenv",
+        "sep",
     ]
     return model
 

--- a/news/5695-os-sep-allowed.rst
+++ b/news/5695-os-sep-allowed.rst
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* Added `len`, `replace`, `float`, and `join` functions/methods for selectors. (#5695)
 * Added `os.sep` to allowed attributes for jinja2 and selectors. (#5695)
 
 ### Deprecations

--- a/news/5695-os-sep-allowed.rst
+++ b/news/5695-os-sep-allowed.rst
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Added `os.sep` to allowed attributes for jinja2 and selectors. (#5695)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -155,7 +155,7 @@ def test_select_lines():
             "test {{ JINJA_VAR[:2] }}",
             '{{ environ["test-sep"] }}',
             '{{ environ["test-join"] }}',
-            '{{ environ["test-replace"] }}',            
+            '{{ environ["test-replace"] }}',
             "",  # preserve trailing newline
         )
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -101,12 +101,16 @@ def test_select_lines():
             '{{ environ["test-tuple"] }}  # [d in ("a", "b")]',
             '{{ environ["test-list"] }}  # [d in list(("a", "b"))]',
             '{{ environ["test-dict"] }}  # [d in {"a": 1, "b": 2}]',
+            '{{ environ["test-float"] }}  # [int(float(vc)) == 10]',
+            '{{ environ["test-sep"] }}  # [len(os.sep) == 1]',
+            '{{ environ["test-join"] }}  # ["/".join("a", "b") == "a/b"]',
+            '{{ environ["test-replace"] }}  # ["acb".replace("c", "/") == "a/b"]',
             "",  # preserve trailing newline
         )
     )
 
     assert select_lines(
-        lines, {"abc": True, "d": "b"}, variants_in_place=True
+        lines, {"abc": True, "d": "b", "vc": "10.4"}, variants_in_place=True
     ) == "\n".join(
         (
             "",  # preserve leading newline
@@ -129,11 +133,15 @@ def test_select_lines():
             '{{ environ["test-tuple"] }}',
             '{{ environ["test-list"] }}',
             '{{ environ["test-dict"] }}',
+            '{{ environ["test-float"] }}',
+            '{{ environ["test-sep"] }}',
+            '{{ environ["test-join"] }}',
+            '{{ environ["test-replace"] }}',
             "",  # preserve trailing newline
         )
     )
     assert select_lines(
-        lines, {"abc": False, "d": "c"}, variants_in_place=True
+        lines, {"abc": False, "d": "c", "vc": "11.4"}, variants_in_place=True
     ) == "\n".join(
         (
             "",  # preserve leading newline
@@ -145,6 +153,9 @@ def test_select_lines():
             "",  # preserve newline
             "",  # preserve comment line (but not the comment)
             "test {{ JINJA_VAR[:2] }}",
+            '{{ environ["test-sep"] }}',
+            '{{ environ["test-join"] }}',
+            '{{ environ["test-replace"] }}',            
             "",  # preserve trailing newline
         )
     )

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -102,15 +102,17 @@ def test_select_lines():
             '{{ environ["test-list"] }}  # [d in list(("a", "b"))]',
             '{{ environ["test-dict"] }}  # [d in {"a": 1, "b": 2}]',
             '{{ environ["test-float"] }}  # [int(float(vc)) == 10]',
-            '{{ environ["test-sep"] }}  # [len(os.sep) == 1]',
-            '{{ environ["test-join"] }}  # ["/".join("a", "b") == "a/b"]',
+            '{{ environ["test-sep"] }}  # [os.sep in ("/", "\\\\") and len(os.sep) == 1]',
+            '{{ environ["test-join"] }}  # ["/".join(("a", "b")) == "a/b"]',
             '{{ environ["test-replace"] }}  # ["acb".replace("c", "/") == "a/b"]',
             "",  # preserve trailing newline
         )
     )
 
     assert select_lines(
-        lines, {"abc": True, "d": "b", "vc": "10.4"}, variants_in_place=True
+        lines,
+        {"abc": True, "d": "b", "vc": "10.4", "os": OSModuleSubset},
+        variants_in_place=True,
     ) == "\n".join(
         (
             "",  # preserve leading newline
@@ -141,7 +143,9 @@ def test_select_lines():
         )
     )
     assert select_lines(
-        lines, {"abc": False, "d": "c", "vc": "11.4"}, variants_in_place=True
+        lines,
+        {"abc": False, "d": "c", "vc": "11.4", "os": OSModuleSubset},
+        variants_in_place=True,
     ) == "\n".join(
         (
             "",  # preserve leading newline


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR does as it says.

closes #5694

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
