### PR TITLE
Fix typo in install-conda-build.rst

### DIFF
--- a/docs/source/install-conda-build.rst
+++ b/docs/source/install-conda-build.rst
@@ -26,7 +26,7 @@ the general conda recommendation not to use the ``base`` env for normal work;
 see `Conda Managing Environments`_ for instance. However, conda-build is better
 viewed as part of the conda infrastructure, and not as a normal package. Hence,
 installing it in the ``base`` env makes more sense. More information:
-`Must conda-build be installed in the base envt?`_
+`Must conda-build be installed in the base env?`_
 
 Other considerations
 --------------------
@@ -78,4 +78,4 @@ page <https://github.com/conda/conda-build/releases>`_.
 
 .. _`Conda Managing Environments`:                      https://conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments
 .. _`conda-verfiy`:                                     https://github.com/conda/conda-verify
-.. _`Must conda-build be installed in the base envt?`:  https://github.com/conda/conda-build/issues/4995
+.. _`Must conda-build be installed in the base env?`:  https://github.com/conda/conda-build/issues/4995


### PR DESCRIPTION
s/envt/env - I'm guessing "env" is the expected word here.

### Description

Typo fix in documentation

### Checklist - did you ...

- [ ] ~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?~
- [ ] ~Add / update necessary tests?~
- [ ] ~Add / update outdated documentation?~