### PR TITLE
fix: load yaml with `SafeLoader`

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -143,7 +143,7 @@ def parse_config_file(path, config):
     with open(path) as f:
         contents = f.read()
     contents = select_lines(contents, get_selectors(config), variants_in_place=False)
-    content = yaml.load(contents, Loader=yaml.loader.BaseLoader) or {}
+    content = yaml.load(contents, Loader=yaml.loader.SafeLoader) or {}
     trim_empty_keys(content)
     return content
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

this function is used with `get_package_combined_spec` and is used to render config files in conda-smithy.

But, the `BaseLoader` parse bool `true` / `false` as str, which cause a inconsistent at render time and building time on the `build.skip` in rattler.build

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
