### PR TITLE
fix: do not use deprecated schannel attribute from conda

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -1356,6 +1356,8 @@ def _display_actions(prefix, precs):
     show_channel_urls = context.show_channel_urls
 
     def channel_str(rec):
+        if rec.get("channel_name"):
+            return rec["channel_name"]
         if rec.get("schannel"):
             return rec["schannel"]
         if rec.get("url"):

--- a/news/5722-schannel-dep.md
+++ b/news/5722-schannel-dep.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Removed usage of the `schannel` attribute which is deprecated in `conda`. (#5722)

--- a/news/XXXX-schannel-dep.md
+++ b/news/XXXX-schannel-dep.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Removed usage of the `schannel` attribute which is deprecated in `conda`. (#XXX)

--- a/news/XXXX-schannel-dep.md
+++ b/news/XXXX-schannel-dep.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-* Removed usage of the `schannel` attribute which is deprecated in `conda`. (#XXX)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ filterwarnings = [
   # ignore conda error
   "ignore:conda.plan is pending deprecation:PendingDeprecationWarning:conda",
   "ignore:conda.trust.* is pending deprecation:PendingDeprecationWarning: conda",
+  "ignore:conda.core.link.PrefixActions is pending deprecation:PendingDeprecationWarning: conda",
+  "ignore:conda.core.prefix_data.python_record_for_prefix is pending deprecation:PendingDeprecationWarning: conda",
   # ignore tarfile
   "ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ filterwarnings = [
   "ignore:conda.core.index._make_virtual_package is pending deprecation:PendingDeprecationWarning:conda",
   # ignore conda error
   "ignore:conda.plan is pending deprecation:PendingDeprecationWarning:conda",
+  "ignore:conda.trust.* is pending deprecation:PendingDeprecationWarning: conda",
   # ignore tarfile
   "ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
 ]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
