### PR TITLE
Wrap environment activation bat file paths with double quotes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -260,7 +260,7 @@ jobs:
           - python-version: '3.13'
             conda-version: canary
             test-type: parallel
-            basetemp: 'pytest with spaces'
+            basetemp: pytest with spaces
     env:
       ErrorActionPreference: Stop  # powershell exit on first error
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'defaults' }}
@@ -323,10 +323,9 @@ jobs:
         run: >
           pytest
           --cov=conda_build
-          --basetemp=${{ runner.temp }}
+          --basetemp=${{ runner.temp }}\${{ matrix.basetemp }}
           -n auto
           -m "${{ env.PYTEST_MARKER }}"
-          --basetemp ${env:TEMP}\${{ matrix.basetemp }}
         shell: pwsh
 
       - name: Upload Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -323,7 +323,7 @@ jobs:
         run: >
           pytest
           --cov=conda_build
-          --basetemp=${{ runner.temp }}\${{ matrix.basetemp }}
+          --basetemp="${{ runner.temp }}\${{ matrix.basetemp }}"
           -n auto
           -m "${{ env.PYTEST_MARKER }}"
         shell: pwsh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,7 +248,7 @@ jobs:
         python-version: ['3.9']
         conda-version: [release]
         test-type: [serial, parallel]
-        basetemp: pytest
+        basetemp: [pytest]
         include:
           - python-version: '3.13'
             conda-version: canary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,6 +248,7 @@ jobs:
         python-version: ['3.9']
         conda-version: [release]
         test-type: [serial, parallel]
+        basetemp: pytest
         include:
           - python-version: '3.13'
             conda-version: canary
@@ -255,6 +256,11 @@ jobs:
           - python-version: '3.13'
             conda-version: canary
             test-type: parallel
+            basetemp: pytest
+          - python-version: '3.13'
+            conda-version: canary
+            test-type: parallel
+            basetemp: 'pytest with spaces'
     env:
       ErrorActionPreference: Stop  # powershell exit on first error
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'defaults' }}
@@ -281,6 +287,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
         with:
+          activate-environment: ${{ matrix.activate-environment }}
           condarc-file: .github\condarc
           run-post: false  # skip post cleanup
           pkgs-dirs: D:\conda_pkgs_dir
@@ -319,6 +326,8 @@ jobs:
           --basetemp=${{ runner.temp }}
           -n auto
           -m "${{ env.PYTEST_MARKER }}"
+          --basetemp ${env:TEMP}\${{ matrix.basetemp }}
+        shell: pwsh
 
       - name: Upload Coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -3198,7 +3198,7 @@ def write_test_scripts(
             if utils.on_win:
                 tf.write(
                     'set "CONDA_SHLVL=" '
-                    "&& @CALL {}\\condabin\\conda_hook.bat {}"
+                    '&& @CALL "{}\\condabin\\conda_hook.bat" {}'
                     "&& set CONDA_EXE={python_exe}"
                     "&& set CONDA_PYTHON_EXE={python_exe}"
                     "&& set _CE_I={}"

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -277,7 +277,7 @@ def write_build_scripts(m, env, bld_bat):
             data = fi.read()
         with codecs.getwriter("utf-8")(open(work_script, "wb")) as fo:
             fo.write('IF "%CONDA_BUILD%" == "" (\n')
-            fo.write(f"    call {env_script}\n")
+            fo.write(f'    call "{env_script}"\n')
             fo.write(")\n")
             fo.write("REM ===== end generated header =====\n")
             fo.write(data)

--- a/news/5739-win-quote-paths
+++ b/news/5739-win-quote-paths
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Wrap environment activation bat file paths with double quotes to accommodate paths with spaces. (#5737 via #5739)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Activating build and test environments may fail on Windows if the path contains spaces, which is the case for example if the user name is `<first name> <last name>`. 

The cause of this error is some unwrapped paths in the activation files. The build environment only fails when a `bld.bat` is present in the recipe directory. In my observation, the test environment calls never appear to be fatal, i.e., the build succeeds even though there is an error in stderr.

Closes #5737 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?