### PR TITLE
Improve build number and string example

### DIFF
--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -331,7 +331,7 @@ number at the end of the string, with a preceding underscore.
 
    build:
      number: 1
-     string: abc
+     string: abc_1_
 
 A hash will appear when the package is affected by one or more variables from
 the conda_build_config.yaml file. The hash is made up from the "used" variables

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -331,7 +331,7 @@ number at the end of the string, with a preceding underscore.
 
    build:
      number: 1
-     string: abc_1_
+     string: abc_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
 
 A hash will appear when the package is affected by one or more variables from
 the conda_build_config.yaml file. The hash is made up from the "used" variables


### PR DESCRIPTION
### Description

The paragraph above says:

> When redefining the default string,
we strongly recommend following the convention of adding the build number at the end of the string, with a preceding underscore.

We should add the recommendation to the example.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] ~~Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?~~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] ~~Add / update necessary tests?~~
- [X] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
