### PR TITLE
Update wording and formatting to avoid implying a config command that doesn't exist

### DIFF
--- a/docs/source/concepts/recipe.rst
+++ b/docs/source/concepts/recipe.rst
@@ -105,9 +105,9 @@ Templates
 When you build a conda package, conda-build renders the package
 by reading a template in the ``meta.yaml``. See :ref:`jinja-templates`.
 
-Templates are filled in using your ``conda build config``,
+Templates are filled in using your conda-build configuration,
 which shows the matrix of things to build against. The
-``conda build config`` determines how many builds it has to do.
+conda-build configuration determines how many builds it has to do.
 For example, defining a ``conda_build_config.yaml`` of the form
 and filling it defines a matrix of 4 packages to build::
 
@@ -119,7 +119,7 @@ and filling it defines a matrix of 4 packages to build::
      - 1.4.0
 
 After this, conda-build determines what the outputs will be.
-For example, if your ``conda build config`` indicates that you
+For example, if your conda-build configuration indicates that you
 want 2 different versions of Python, conda-build will show
 you the rendering for each Python version.
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

It was pointed out to me that `conda build config` on the recipes page made it seem like `config` is a conda-build command, which is not the case. I removed the formatting and changed "config" to "configuration" to avoid confusion.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- ~[ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- ~[ ] Add / update necessary tests?~
- ~[ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
