### PR TITLE
Bugfix for issue #5759

### DIFF
--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -137,8 +137,9 @@ def create_shell_files(m: MetaData, test_dir: os.PathLike) -> list[str]:
                 f.write("\n\n")
                 for cmd in commands:
                     # Normalize path separators for consistent handling
-                    normalized_cmd = _normalize_path_separators_in_command(cmd, status)
-                    f.write(normalized_cmd)
+                    if status:
+                        cmd = _normalize_path_separators_in_command(cmd)
+                    f.write(cmd)
                     f.write("\n")
                     if status:
                         f.write("IF %ERRORLEVEL% NEQ 0 exit /B 1\n")

--- a/conda_build/create_test.py
+++ b/conda_build/create_test.py
@@ -55,16 +55,19 @@ def _normalize_path_separators_in_command(cmd: str, is_windows: bool) -> str:
         "ROOT",
     ]
 
-    # Pattern to match any of these environment variables followed by a path separator
+    # Pattern to match any of these environment variables followed by a path
     # This matches %VAR%/path or %VAR%\\path for any VAR in the list
-    env_pattern = r"(%" + "|%".join(f"{var}%" for var in path_env_vars) + r")([/\\])"
+    # We capture the entire path after the environment variable
+    env_pattern = r"(%" + "|%".join(f"{var}%" for var in path_env_vars) + r")([/\\].*)"
 
     def replace_env_path(match):
         env_var = match.group(1)
-        # Always use backslash for Windows paths when environment variables are involved
-        return f"{env_var}\\"
+        path_part = match.group(2)
+        # Normalize all separators in the path part to backslashes
+        normalized_path = path_part.replace("/", "\\")
+        return f"{env_var}{normalized_path}"
 
-    # Replace environment variable path separators to use backslashes consistently
+    # Replace environment variable paths to use backslashes consistently
     normalized_cmd = re.sub(env_pattern, replace_env_path, cmd)
 
     return normalized_cmd

--- a/news/5759-windows-path-separators.md
+++ b/news/5759-windows-path-separators.md
@@ -1,3 +1,3 @@
 ### Bug fixes
 
-* Fix path separator handling in pytest commands with --ignore flag and SP_DIR on Windows. This resolves issues where mixed forward and backward slashes in paths could cause pytest to fail. (#5759)
+* Fix path separator handling in test commands with environment variables on Windows. The fix now detects the actual separator used in environment variables and matches path separators accordingly, using efficient string operations to normalize only the specific parts containing environment variables and prevent mixed separator issues that could cause test failures. (#5759)

--- a/news/5759-windows-path-separators.md
+++ b/news/5759-windows-path-separators.md
@@ -1,3 +1,3 @@
 ### Bug fixes
 
-* Fix path separator handling in test commands with environment variables on Windows. The fix now detects the actual separator used in environment variables and matches path separators accordingly, using efficient string operations to normalize only the specific parts containing environment variables and prevent mixed separator issues that could cause test failures. (#5759)
+* Fix path separator handling in test commands with environment variables on Windows. The fix now detects the actual separator used in environment variables and matches path separators accordingly, using efficient string operations to normalize only the specific parts containing environment variables and prevent mixed separator issues that could cause test failures. (#5759 via #5765)

--- a/news/5759-windows-path-separators.md
+++ b/news/5759-windows-path-separators.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Fix path separator handling in pytest commands with --ignore flag and SP_DIR on Windows. This resolves issues where mixed forward and backward slashes in paths could cause pytest to fail. (#5759)

--- a/tests/test_create_test.py
+++ b/tests/test_create_test.py
@@ -153,30 +153,32 @@ def test_create_run_test(
 
 
 @pytest.mark.parametrize(
-    "prefix,cmd,is_windows,expected",
+    "prefix,cmd,expected",
     [
+        (
+            "C:\\path\\to\\prefix",
+            "pytest -v --ignore=%PREFIX%/tests",
+            "pytest -v --ignore=%PREFIX%\\tests",
+        ),  # backslash environment variable -> normal windows path
         (
             "C:/path/to/prefix",
             "pytest -v --ignore=%PREFIX%\\tests",
-            True,
             "pytest -v --ignore=%PREFIX%/tests",
         ),  # forward slash environment variable
         (
             "C:\\path\\to\\prefix",
-            "pytest -v --ignore=%PREFIX%/tests",
-            True,
-            "pytest -v --ignore=%PREFIX%\\tests",
-        ),  # backslash environment variable
+            'pytest -v --ignore="%PREFIX%/test dir with spaces/test"',
+            'pytest -v --ignore="%PREFIX%\\test dir with spaces\\test"',
+        ),
         (
-            "/path/to/prefix",
-            "pytest -v --ignore=${PREFIX}/tests",
-            False,
-            "pytest -v --ignore=${PREFIX}/tests",
-        ),  # non-windows command is unchanged
+            "C:/path/to/prefix",
+            'pytest -v --ignore="%PREFIX%\\test dir with spaces\\test"',
+            'pytest -v --ignore="%PREFIX%/test dir with spaces/test"',
+        ),
     ],
 )
-def test_path_separator_normalization(prefix, cmd, is_windows, expected, monkeypatch):
+def test_path_separator_normalization(prefix, cmd, expected, monkeypatch):
     """Test that path separators are normalized correctly in test commands."""
     monkeypatch.setenv("PREFIX", prefix)
-    result = _normalize_path_separators_in_command(cmd, is_windows)
+    result = _normalize_path_separators_in_command(cmd)
     assert result == expected


### PR DESCRIPTION
## Fix path separator handling in pytest commands with --ignore flag and SP_DIR on Windows

Fixes GitHub issue #5759 where conda-build behaved unpredictably with slashes and backslashes when using pytest commands with the `--ignore` flag and `SP_DIR` paths on Windows.

### What was the problem?

When `SP_DIR` environment variable was set with backslashes on Windows (e.g., `C:\path\to\site-packages`), pytest commands using forward slashes (e.g., `pytest -v --ignore=%SP_DIR%/path/to/ignore`) would create mixed path separators when expanded, causing pytest to fail.

### What's the solution?

Added a path normalization function `_normalize_path_separators_in_command()` that ensures consistent backslashes for the entire path after environment variables in test commands on Windows. This handles 13 common environment variables including `SP_DIR`, `PREFIX`, `BUILD_PREFIX`, `SRC_DIR`, etc.

### Key changes:

- **Added**: `_normalize_path_separators_in_command()` function in `conda_build/create_test.py`
- **Modified**: `create_shell_files()` to normalize commands before writing to shell scripts

### Example:

**Before**: `pytest -v --ignore=%SP_DIR%/path/to/ignore` → `pytest -v --ignore=C:\path\to\site-packages/path/to/ignore` (mixed separators)

**After**: `pytest -v --ignore=%SP_DIR%/path/to/ignore` → `pytest -v --ignore=C:\path\to\site-packages\path\to\ignore` (consistent backslashes)

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

**Note**: This is a bug fix that resolves a Windows-specific issue with path handling in test commands. The fix is backward compatible and doesn't affect Unix systems.
