### PR TITLE
Fix test_strong_run_exports_from_build_applies_to_host

### DIFF
--- a/tests/test-recipes/split-packages/_strong_run_exports_applies_from_build_to_host/build.sh
+++ b/tests/test-recipes/split-packages/_strong_run_exports_applies_from_build_to_host/build.sh
@@ -1,1 +1,1 @@
-stat $PREFIX/lib/libc++.dylib
+stat $PREFIX/lib/libc++.*dylib


### PR DESCRIPTION
The test is failing due to the hardcoded check for `libc++.dylib`, however libcxx19 package contains only versioned libraries, so update the check to detect both versioned and unversioned library files

Closes: https://github.com/conda/conda-build/issues/5791

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
