### PR TITLE
`25.11.x` Fix conda.models.enums.PathType deprecation warning

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -33,7 +33,13 @@ from conda.core.prefix_data import PrefixData
 from conda.exceptions import CondaError, NoPackagesFoundError, UnsatisfiableError
 from conda.gateways.disk.create import TemporaryDirectory
 from conda.models.channel import Channel
-from conda.models.enums import FileMode, PathType
+from conda.models.enums import FileMode
+
+try:
+    from conda.models.enums import PathEnum as PathType
+except ImportError:
+    # FUTURE: remove for `conda>=26.9`
+    from conda.models.enums import PathType
 from conda.models.match_spec import MatchSpec
 from conda.utils import url_path
 

--- a/news/fix-pathtype-deprecation.md
+++ b/news/fix-pathtype-deprecation.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix `PendingDeprecationWarning` for `conda.models.enums.PathType` by using the new `PathEnum` name with backward compatibility. (#6004)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,8 @@ filterwarnings = [
   "ignore:conda.core.link.PrefixActions is pending deprecation and will be removed in 26.3:PendingDeprecationWarning",
   # ignore conda context restore_free_channel deprecation
   "ignore:conda.base.context.Context.restore_free_channel is deprecated:DeprecationWarning",
+  # ignore conda PathType -> PathEnum rename deprecation
+  "ignore:conda.models.enums.PathType is pending deprecation:PendingDeprecationWarning",
 ]
 markers = [
   "serial: execute test serially (to avoid race conditions)",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,15 +4,20 @@ import json
 from pathlib import Path
 
 import pytest
-from conda.models.enums import PathType
-
-from conda_build._link import pyc_f
 
 try:
     from conda.common.serialize.json import CondaJSONEncoder
 except ImportError:
     # FUTURE: remove for `conda>=25.9`
     from conda.auxlib.entity import EntityEncoder as CondaJSONEncoder
+
+try:
+    from conda.models.enums import PathEnum as PathType
+except ImportError:
+    # FUTURE: remove for `conda>=26.9`
+    from conda.models.enums import PathType
+
+from conda_build._link import pyc_f
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Fix the `PendingDeprecationWarning` for `conda.models.enums.PathType` that was causing canary test failures.

Conda renamed `PathType` to `PathEnum` to follow Python enum naming conventions. This PR:

1. Updates imports to use the new `PathEnum` name with backward compatibility for older conda versions
2. Adds a warning filter to `pyproject.toml` to prevent test failures from the deprecation warning

### Changes

- `conda_build/build.py`: Use `PathEnum as PathType` with fallback
- `tests/test_misc.py`: Use `PathEnum as PathType` with fallback  
- `pyproject.toml`: Add ignore filter for the PathType deprecation warning

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?