### PR TITLE
Use inclusive language: rename whitelist to allowlist

### DIFF
--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -179,7 +179,7 @@ def _get_default_settings():
         #    (GNU ld: -as-needed, Apple ld64: -dead_strip_dylibs -no_implicit_dylibs)
         # 2. A missing package in reqs/run (maybe that package is missing run_exports?)
         # 3. A missing (or broken) CDT package in reqs/build or (on systems without CDTs)
-        # 4. .. a missing value in the hard-coded but metadata-augmentable library whitelist
+        # 4. .. a missing value in the hard-coded but metadata-augmentable library allowlist
         # It is important that packages do not suffer from 2 because uninstalling that missing
         # package leads to an inability to run this package.
         #

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -694,6 +694,9 @@ FIELDS = {
         "post-link": str,
         "pre-unlink": str,
         "missing_dso_whitelist": None,
+        "missing_dso_allowlist": None,  # preferred alias for missing_dso_whitelist
+        "runpath_whitelist": None,
+        "runpath_allowlist": None,  # preferred alias for runpath_whitelist
         "error_overdepending": None,
         "error_overlinking": None,
         "overlinking_ignore_patterns": [],

--- a/conda_build/skeletons/rpm.py
+++ b/conda_build/skeletons/rpm.py
@@ -45,7 +45,7 @@ source:
 build:
   number: 2
   noarch: generic
-  missing_dso_whitelist:
+  missing_dso_allowlist:
     - '*'
 
 {depends}

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -995,10 +995,10 @@ Use this sparingly, as the overlinking checks generally do prevent you from maki
      - "bin/*"
 
 
-Whitelisting shared libraries
+Allowlisting shared libraries
 -----------------------------
 
-The ``missing_dso_whitelist`` build key is a list of globs for
+The ``missing_dso_allowlist`` build key is a list of globs for
 dynamic shared object (DSO) files that should be ignored when
 examining linkage information.
 
@@ -1011,12 +1011,12 @@ or error ``--error-overlinking`` will result.
 .. code-block:: yaml
 
  build:
-   missing_dso_whitelist:
+   missing_dso_allowlist:
 
 
 These keys allow additions to the list of allowed libraries.
 
-The ``runpath_whitelist`` build key is a list of globs for paths
+The ``runpath_allowlist`` build key is a list of globs for paths
 which are allowed to appear as runpaths in the package's shared
 libraries. All other runpaths will cause a warning message to be
 printed during the build.
@@ -1024,7 +1024,12 @@ printed during the build.
 .. code-block:: yaml
 
  build:
-   runpath_whitelist:
+   runpath_allowlist:
+
+.. note::
+
+   The previous key names ``missing_dso_whitelist`` and ``runpath_whitelist``
+   are still supported for backward compatibility.
 
 
 .. _requirements:

--- a/news/5902-inclusive-language.md
+++ b/news/5902-inclusive-language.md
@@ -1,0 +1,22 @@
+### Enhancements
+
+* Add ``missing_dso_allowlist`` and ``runpath_allowlist`` as preferred recipe keys. (#5902)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Deprecate ``build/missing_dso_whitelist`` recipe key in favor of ``build/missing_dso_allowlist``. (#5902)
+* Deprecate ``build/runpath_whitelist`` recipe key in favor of ``build/runpath_allowlist``. (#5902)
+* Deprecate ``DEFAULT_MAC_WHITELIST`` constant in favor of ``DEFAULT_MAC_ALLOWLIST``. (#5902)
+* Deprecate ``DEFAULT_WIN_WHITELIST`` constant in favor of ``DEFAULT_WIN_ALLOWLIST``. (#5902)
+
+### Docs
+
+* Update documentation to use inclusive language (allowlist instead of whitelist). (#5902)
+
+### Other
+
+* Replace internal uses of ``whitelist`` with ``allowlist`` for more inclusive language. (#5902)

--- a/news/5902-inclusive-language.md
+++ b/news/5902-inclusive-language.md
@@ -8,10 +8,12 @@
 
 ### Deprecations
 
-* Deprecate ``build/missing_dso_whitelist`` recipe key in favor of ``build/missing_dso_allowlist``. (#5902)
-* Deprecate ``build/runpath_whitelist`` recipe key in favor of ``build/runpath_allowlist``. (#5902)
-* Deprecate ``DEFAULT_MAC_WHITELIST`` constant in favor of ``DEFAULT_MAC_ALLOWLIST``. (#5902)
-* Deprecate ``DEFAULT_WIN_WHITELIST`` constant in favor of ``DEFAULT_WIN_ALLOWLIST``. (#5902)
+* Deprecate ``build/missing_dso_whitelist`` recipe key in favor of ``build/missing_dso_allowlist`` (pending in 26.9, removal in 27.3). (#5902)
+* Deprecate ``build/runpath_whitelist`` recipe key in favor of ``build/runpath_allowlist`` (pending in 26.9, removal in 27.3). (#5902)
+* Deprecate ``conda_build.post.check_overlinking_impl``'s ``missing_dso_whitelist`` keyword argument in favor of ``missing_dso_allowlist`` (pending in 26.9, removal in 27.3). (#5902)
+* Deprecate ``conda_build.post.check_overlinking_impl``'s ``runpath_whitelist`` keyword argument in favor of ``runpath_allowlist`` (pending in 26.9, removal in 27.3). (#5902)
+* Deprecate ``conda_build.post.DEFAULT_MAC_WHITELIST`` constant in favor of ``DEFAULT_MAC_ALLOWLIST`` (pending in 26.9, removal in 27.3). (#5902)
+* Deprecate ``conda_build.post.DEFAULT_WIN_WHITELIST`` constant in favor of ``DEFAULT_WIN_ALLOWLIST`` (pending in 26.9, removal in 27.3). (#5902)
 
 ### Docs
 

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -222,99 +222,76 @@ def test_rpath_symlink(mocker, testing_config):
     assert mk_relative.call_count == 2
 
 
-# -------------------------------------------------------------------------
-# Deprecation tests for the legacy `whitelist` spellings (see PR #5902 and
-# conda_build.deprecations for the deprecation policy).
-# -------------------------------------------------------------------------
-
-
-class TestWhitelistDeprecations:
-    """Verify legacy ``*_whitelist`` names still work and emit warnings.
-
-    The new ``*_allowlist`` names are the preferred spelling; the legacy
-    names are scheduled for removal in 27.3 (deprecated in 26.9).
-    """
-
-    def test_default_mac_whitelist_constant_is_deprecated(self):
-        """``post.DEFAULT_MAC_WHITELIST`` aliases ``DEFAULT_MAC_ALLOWLIST``."""
-        with pytest.warns(
-            (PendingDeprecationWarning, DeprecationWarning),
-            match="DEFAULT_MAC_WHITELIST",
-        ):
-            assert post.DEFAULT_MAC_WHITELIST is post.DEFAULT_MAC_ALLOWLIST
-
-    def test_default_win_whitelist_constant_is_deprecated(self):
-        """``post.DEFAULT_WIN_WHITELIST`` aliases ``DEFAULT_WIN_ALLOWLIST``."""
-        with pytest.warns(
-            (PendingDeprecationWarning, DeprecationWarning),
-            match="DEFAULT_WIN_WHITELIST",
-        ):
-            assert post.DEFAULT_WIN_WHITELIST is post.DEFAULT_WIN_ALLOWLIST
-
-    def test_missing_dso_whitelist_kwarg_is_deprecated(self):
-        """``missing_dso_whitelist=`` is renamed to ``missing_dso_allowlist=``.
-
-        Call ``check_overlinking_impl`` with only the deprecated kwarg: the
-        ``@deprecated.argument`` decorator emits the warning before the wrapped
-        function runs, then the wrapped function raises ``TypeError`` because
-        its other required positional arguments are missing. We assert both.
-        """
-        with pytest.warns(
-            (PendingDeprecationWarning, DeprecationWarning),
-            match="missing_dso_whitelist",
-        ):
-            with pytest.raises(TypeError):
-                post.check_overlinking_impl(missing_dso_whitelist=["libfoo.so"])
-
-    def test_runpath_whitelist_kwarg_is_deprecated(self):
-        """``runpath_whitelist=`` is renamed to ``runpath_allowlist=``."""
-        with pytest.warns(
-            (PendingDeprecationWarning, DeprecationWarning),
-            match="runpath_whitelist",
-        ):
-            with pytest.raises(TypeError):
-                post.check_overlinking_impl(runpath_whitelist=["/opt/foo"])
-
-    @pytest.mark.parametrize(
-        "key",
-        ["build/missing_dso_whitelist", "build/runpath_whitelist"],
-    )
-    def test_recipe_key_whitelist_is_deprecated(self, key, mocker):
-        """Using the legacy ``build/*_whitelist`` recipe keys emits a warning."""
-        # Build the minimum MetaData-shaped mock that check_overlinking reads.
-        stored = {
-            "build/overlinking_ignore_patterns": [],
-            key: ["libfoo.so"] if "missing_dso" in key else ["/opt/foo"],
-        }
-        m = mocker.Mock()
-        m.get_value.side_effect = lambda k, default=None: stored.get(k, default)
-        # Bypass the real check_overlinking_impl entirely for this test.
-        mocker.patch.object(post, "check_overlinking_impl", return_value=None)
-
-        with pytest.warns((PendingDeprecationWarning, DeprecationWarning), match=key):
-            post.check_overlinking(m, files=[])
-
-    @pytest.mark.parametrize(
-        "legacy,preferred",
-        [
-            ("build/missing_dso_whitelist", "build/missing_dso_allowlist"),
-            ("build/runpath_whitelist", "build/runpath_allowlist"),
-        ],
-    )
-    def test_allowlist_takes_precedence_over_whitelist(
-        self, legacy, preferred, mocker, recwarn
+@pytest.mark.parametrize(
+    "legacy_constant, allowlist_constant",
+    [
+        ("DEFAULT_MAC_WHITELIST", "DEFAULT_MAC_ALLOWLIST"),
+        ("DEFAULT_WIN_WHITELIST", "DEFAULT_WIN_ALLOWLIST"),
+    ],
+)
+def test_default_whitelist_constant_is_deprecated(legacy_constant, allowlist_constant):
+    with pytest.warns(
+        (PendingDeprecationWarning, DeprecationWarning), match=legacy_constant
     ):
-        """When both keys are set the new key wins and no warning fires."""
-        stored = {
-            "build/overlinking_ignore_patterns": [],
-            legacy: ["legacy"],
-            preferred: ["preferred"],
-        }
-        m = mocker.Mock()
-        m.get_value.side_effect = lambda k, default=None: stored.get(k, default)
-        mocker.patch.object(post, "check_overlinking_impl", return_value=None)
+        assert getattr(post, legacy_constant) is getattr(post, allowlist_constant)
 
-        post.check_overlinking(m, files=[])
 
-        # No whitelist-specific deprecation warning when the new key is set.
-        assert not [w for w in recwarn.list if legacy.split("/")[-1] in str(w.message)]
+@pytest.mark.parametrize(
+    "kwarg, value",
+    [
+        ("missing_dso_whitelist", ["libfoo.so"]),
+        ("runpath_whitelist", ["/opt/foo"]),
+    ],
+)
+def test_check_overlinking_impl_whitelist_kwarg_is_deprecated(kwarg, value):
+    with pytest.warns((PendingDeprecationWarning, DeprecationWarning), match=kwarg):
+        with pytest.raises(TypeError):
+            post.check_overlinking_impl(**{kwarg: value})
+
+
+@pytest.fixture
+def bypass_check_overlinking_impl(monkeypatch):
+    monkeypatch.setattr(post, "check_overlinking_impl", lambda **kwargs: None)
+
+
+@pytest.mark.parametrize(
+    "legacy_key, value",
+    [
+        ("missing_dso_whitelist", ["libfoo.so"]),
+        ("runpath_whitelist", ["/opt/foo"]),
+    ],
+)
+def test_check_overlinking_whitelist_recipe_key_is_deprecated(
+    testing_metadata, bypass_check_overlinking_impl, legacy_key, value
+):
+    testing_metadata.meta.setdefault("build", {})[legacy_key] = value
+    with pytest.warns(
+        (PendingDeprecationWarning, DeprecationWarning),
+        match=f"build/{legacy_key}",
+    ):
+        post.check_overlinking(testing_metadata, files=[])
+
+
+@pytest.mark.parametrize(
+    "legacy_key, preferred_key, legacy_value, preferred_value",
+    [
+        ("missing_dso_whitelist", "missing_dso_allowlist", ["legacy"], ["preferred"]),
+        ("runpath_whitelist", "runpath_allowlist", ["/legacy"], ["/preferred"]),
+    ],
+)
+def test_check_overlinking_allowlist_takes_precedence(
+    testing_metadata,
+    bypass_check_overlinking_impl,
+    recwarn,
+    legacy_key,
+    preferred_key,
+    legacy_value,
+    preferred_value,
+):
+    build = testing_metadata.meta.setdefault("build", {})
+    build[legacy_key] = legacy_value
+    build[preferred_key] = preferred_value
+
+    post.check_overlinking(testing_metadata, files=[])
+
+    assert not [w for w in recwarn.list if legacy_key in str(w.message)]

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -220,3 +220,101 @@ def test_rpath_symlink(mocker, testing_config):
     )
     # Should only be called on the actual binary, not its symlinks. (once per variant)
     assert mk_relative.call_count == 2
+
+
+# -------------------------------------------------------------------------
+# Deprecation tests for the legacy `whitelist` spellings (see PR #5902 and
+# conda_build.deprecations for the deprecation policy).
+# -------------------------------------------------------------------------
+
+
+class TestWhitelistDeprecations:
+    """Verify legacy ``*_whitelist`` names still work and emit warnings.
+
+    The new ``*_allowlist`` names are the preferred spelling; the legacy
+    names are scheduled for removal in 27.3 (deprecated in 26.9).
+    """
+
+    def test_default_mac_whitelist_constant_is_deprecated(self):
+        """``post.DEFAULT_MAC_WHITELIST`` aliases ``DEFAULT_MAC_ALLOWLIST``."""
+        with pytest.warns(
+            (PendingDeprecationWarning, DeprecationWarning),
+            match="DEFAULT_MAC_WHITELIST",
+        ):
+            assert post.DEFAULT_MAC_WHITELIST is post.DEFAULT_MAC_ALLOWLIST
+
+    def test_default_win_whitelist_constant_is_deprecated(self):
+        """``post.DEFAULT_WIN_WHITELIST`` aliases ``DEFAULT_WIN_ALLOWLIST``."""
+        with pytest.warns(
+            (PendingDeprecationWarning, DeprecationWarning),
+            match="DEFAULT_WIN_WHITELIST",
+        ):
+            assert post.DEFAULT_WIN_WHITELIST is post.DEFAULT_WIN_ALLOWLIST
+
+    def test_missing_dso_whitelist_kwarg_is_deprecated(self):
+        """``missing_dso_whitelist=`` is renamed to ``missing_dso_allowlist=``.
+
+        Call ``check_overlinking_impl`` with only the deprecated kwarg: the
+        ``@deprecated.argument`` decorator emits the warning before the wrapped
+        function runs, then the wrapped function raises ``TypeError`` because
+        its other required positional arguments are missing. We assert both.
+        """
+        with pytest.warns(
+            (PendingDeprecationWarning, DeprecationWarning),
+            match="missing_dso_whitelist",
+        ):
+            with pytest.raises(TypeError):
+                post.check_overlinking_impl(missing_dso_whitelist=["libfoo.so"])
+
+    def test_runpath_whitelist_kwarg_is_deprecated(self):
+        """``runpath_whitelist=`` is renamed to ``runpath_allowlist=``."""
+        with pytest.warns(
+            (PendingDeprecationWarning, DeprecationWarning),
+            match="runpath_whitelist",
+        ):
+            with pytest.raises(TypeError):
+                post.check_overlinking_impl(runpath_whitelist=["/opt/foo"])
+
+    @pytest.mark.parametrize(
+        "key",
+        ["build/missing_dso_whitelist", "build/runpath_whitelist"],
+    )
+    def test_recipe_key_whitelist_is_deprecated(self, key, mocker):
+        """Using the legacy ``build/*_whitelist`` recipe keys emits a warning."""
+        # Build the minimum MetaData-shaped mock that check_overlinking reads.
+        stored = {
+            "build/overlinking_ignore_patterns": [],
+            key: ["libfoo.so"] if "missing_dso" in key else ["/opt/foo"],
+        }
+        m = mocker.Mock()
+        m.get_value.side_effect = lambda k, default=None: stored.get(k, default)
+        # Bypass the real check_overlinking_impl entirely for this test.
+        mocker.patch.object(post, "check_overlinking_impl", return_value=None)
+
+        with pytest.warns((PendingDeprecationWarning, DeprecationWarning), match=key):
+            post.check_overlinking(m, files=[])
+
+    @pytest.mark.parametrize(
+        "legacy,preferred",
+        [
+            ("build/missing_dso_whitelist", "build/missing_dso_allowlist"),
+            ("build/runpath_whitelist", "build/runpath_allowlist"),
+        ],
+    )
+    def test_allowlist_takes_precedence_over_whitelist(
+        self, legacy, preferred, mocker, recwarn
+    ):
+        """When both keys are set the new key wins and no warning fires."""
+        stored = {
+            "build/overlinking_ignore_patterns": [],
+            legacy: ["legacy"],
+            preferred: ["preferred"],
+        }
+        m = mocker.Mock()
+        m.get_value.side_effect = lambda k, default=None: stored.get(k, default)
+        mocker.patch.object(post, "check_overlinking_impl", return_value=None)
+
+        post.check_overlinking(m, files=[])
+
+        # No whitelist-specific deprecation warning when the new key is set.
+        assert not [w for w in recwarn.list if legacy.split("/")[-1] in str(w.message)]


### PR DESCRIPTION
## Summary

This PR updates the codebase to use more inclusive language by renaming `whitelist` to `allowlist`.

- Add `missing_dso_allowlist` and `runpath_allowlist` as preferred recipe keys
- Old keys (`missing_dso_whitelist`, `runpath_whitelist`) remain fully supported for backward compatibility
- Rename internal variables and constants
- Update documentation with backward compatibility note

## Backward Compatibility

- Both old and new recipe keys are validated and work
- New keys take precedence when both are specified  
- Existing recipes continue to work unchanged
- Test recipes using old keys verified to still work

Supersedes #5301
Partially resolves #4540