### PR TITLE
Bump conda and conda-libmamba-solver minimum versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,10 +86,10 @@ jobs:
         include:
           # minimum Python/conda combo
           - python-version: '3.10'
-            conda-version: 24.11.0
+            conda-version: 25.11.0
             test-type: serial
           - python-version: '3.10'
-            conda-version: 24.11.0
+            conda-version: 25.11.0
             test-type: parallel
           # maximum Python/conda combo
           - python-version: '3.13'
@@ -402,7 +402,8 @@ jobs:
             conda-version: canary
             test-type: parallel
     env:
-      CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'defaults' }}
+      # Use conda-forge for release tests since conda 25.11+ is not in defaults for osx-64
+      CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'conda-forge' }}
       PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial' || 'not serial' }}
 
     steps:

--- a/news/bump-conda-requirement.md
+++ b/news/bump-conda-requirement.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Bump minimum `conda` version to 25.11.0 and `conda-libmamba-solver` to 25.11.0. Remove obsolete `CondaSolver` deprecation warning filters. (#xxxx)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Use `conda-forge` channel for macOS Intel (osx-64) CI tests since conda 25.11+ is not available in `defaults` channel for that platform. (#xxxx)

--- a/news/remove-restore-free-channel-filter.md
+++ b/news/remove-restore-free-channel-filter.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Remove obsolete `restore_free_channel` deprecation warning filter. This property was removed in conda 25.9.0. (#xxxx)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
   "beautifulsoup4",
   "chardet",
-  "conda >=24.11.0",
+  "conda >=25.11.0",
   # Disabled due to conda-index not being available on PyPI
   # "conda-index >=0.4.0",
   "conda-package-handling >=2.2.0",
@@ -128,9 +128,6 @@ filterwarnings = [
   "ignore:conda.core.index._supplement_index_with_system is pending deprecation:PendingDeprecationWarning:conda",
   # ignore tarfile Python 3.14 warning
   "ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning",
-  # TEMPORARY: Remove once CLS is released with https://github.com/conda/conda-libmamba-solver/pull/691
-  "ignore:conda.plugins.CondaSolver:PendingDeprecationWarning",
-  "ignore:conda.plugins.CondaSolver:DeprecationWarning",
   # ignore conda prefix data deprecation
   "ignore:conda.core.prefix_data:DeprecationWarning",
   # ignore conda prefix data pending deprecation (including pip_interop_enabled)
@@ -143,10 +140,10 @@ filterwarnings = [
   # ignore conda link PrefixActions deprecation
   "ignore:conda.core.link.PrefixActions is deprecated and will be removed in 26.3:DeprecationWarning",
   "ignore:conda.core.link.PrefixActions is pending deprecation and will be removed in 26.3:PendingDeprecationWarning",
-  # ignore conda context restore_free_channel deprecation
-  "ignore:conda.base.context.Context.restore_free_channel is deprecated:DeprecationWarning",
   # ignore conda PathType -> PathEnum rename deprecation
   "ignore:conda.models.enums.PathType is pending deprecation:PendingDeprecationWarning",
+  # ignore conda CONDA_PACKAGE_EXTENSIONS deprecation (use plugin_manager.get_package_extractors() instead)
+  "ignore:conda.base.constants.CONDA_PACKAGE_EXTENSIONS is pending deprecation:PendingDeprecationWarning",
 ]
 markers = [
   "serial: execute test serially (to avoid race conditions)",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,8 @@
 beautifulsoup4
 chardet
-conda >=24.11.0
+conda >=25.11.0
 conda-index >=0.4.0
-conda-libmamba-solver >=25.4.0  # ensure we use libmamba
+conda-libmamba-solver >=25.11.0  # includes fix for CondaSolver deprecation warnings
 conda-package-handling >=2.2.0
 editables
 evalidate >=2,<3.0a0


### PR DESCRIPTION
## Summary

- Bump minimum `conda` version from 24.11.0 to 25.11.0
- Bump minimum `conda-libmamba-solver` from 25.4.0 to 25.11.0
- Remove obsolete deprecation warning filters
- Use `conda-forge` channel for macOS Intel CI tests

## Background

### Removed Filters

| Filter | Reason |
|--------|--------|
| `CondaSolver` deprecation | Fixed in [CLS PR #691](https://github.com/conda/conda-libmamba-solver/pull/691), included in CLS 25.11.0 |
| `restore_free_channel` | Property removed in conda 25.9.0 |

### CI Changes

macOS Intel (osx-64) tests now use `conda-forge` channel instead of `defaults` because conda 25.11+ is not available in the `defaults` channel for osx-64 (only up to 25.7.0).

### Remaining Filters (Cannot Be Fixed in conda-build)

The remaining deprecation warning filters suppress warnings from **conda's internal code**, not from conda-build's direct usage:

| Filter | Source | Why It Can't Be Fixed |
|--------|--------|----------------------|
| `_supplement_index_with_system` | Deprecated function | conda-build doesn't call this - triggered by conda internals |
| `conda.core.prefix_data` | Internal deprecated methods | conda-build uses `PrefixData` class (not deprecated), but internal methods trigger warnings |
| `conda.trust` | Entire module deprecated | conda-build never imports this - triggered by conda internals |
| `PrefixActions` | Internal to `UnlinkLinkTransaction` | conda-build uses `UnlinkLinkTransaction` (not deprecated), internal usage triggers warning |
| `PathType` | Renamed to `PathEnum` | Already has forward-compatible import with try/except |

These filters will become unnecessary when conda 26.3 releases and removes these deprecated internal APIs.

## Checklist

- [x] News files added
- [x] Updated `pyproject.toml` (runtime dependency)
- [x] Updated `tests/requirements.txt` (test dependency)
- [x] Removed obsolete warning filters from pytest config
- [x] Updated macOS CI to use conda-forge channel