### PR TITLE
Add support for generating v1 recipes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,7 @@ jobs:
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev::' || '' }}
       CONDA_VERSION: ${{ contains('canary|release', matrix.conda-version) && 'conda' || format('conda={0}', matrix.conda-version) }}
       PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial' || 'not serial' }}
+      REQUIREMENTS_V1_RECIPE_FORMAT: ${{ matrix.python-version != '3.10' && '--file tests/requirements-v1-recipe-format.txt' || ''}}
 
     steps:
       - name: Free Disk Space
@@ -165,6 +166,7 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
+          ${{ env.REQUIREMENTS_V1_RECIPE_FORMAT }}
           python=${{ matrix.python-version }}
           ${{ env.CONDA_CHANNEL_LABEL }}${{ env.CONDA_VERSION }}
 
@@ -296,6 +298,7 @@ jobs:
       ErrorActionPreference: Stop  # powershell exit on first error
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'defaults' }}
       PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial' || 'not serial and not slow' }}
+      REQUIREMENTS_V1_RECIPE_FORMAT: ${{ matrix.python-version != '3.10' && '--file tests/requirements-v1-recipe-format.txt' || ''}}
 
     steps:
       - name: Checkout Source
@@ -334,6 +337,7 @@ jobs:
           --file tests\requirements.txt
           --file tests\requirements-${{ runner.os }}.txt
           --file tests\requirements-ci.txt
+          ${{ env.REQUIREMENTS_V1_RECIPE_FORMAT }}
           python=${{ matrix.python-version }}
           ${{ env.CONDA_CHANNEL_LABEL }}::conda
 
@@ -405,6 +409,7 @@ jobs:
       # Use conda-forge for release tests since conda 25.11+ is not in defaults for osx-64
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'conda-forge' }}
       PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial' || 'not serial' }}
+      REQUIREMENTS_V1_RECIPE_FORMAT: ${{ matrix.python-version != '3.10' && '--file tests/requirements-v1-recipe-format.txt' || ''}}
 
     steps:
       - name: Checkout Source
@@ -454,6 +459,7 @@ jobs:
           --file tests/requirements.txt
           --file tests/requirements-${{ runner.os }}.txt
           --file tests/requirements-ci.txt
+          ${{ env.REQUIREMENTS_V1_RECIPE_FORMAT }}
           python=${{ matrix.python-version }}
           ${{ env.CONDA_CHANNEL_LABEL }}::conda
 

--- a/news/5919-v1-recipe-generation.md
+++ b/news/5919-v1-recipe-generation.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add support for generating v1 recipes using `conda-recipe-manager` (#5919).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_skeleton.py
+++ b/tests/cli/test_main_skeleton.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import os
+import sys
 
 import pytest
 
@@ -57,3 +58,16 @@ def test_skeleton_pypi_arguments_work(testing_workdir):
     metadata = api.render("photutils")[0][0]
     assert "--offline" in metadata.meta["build"]["script"]
     assert metadata.version() == "1.10.0"
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="requires python3.11 or higher")
+def test_v1_recipe_generation(testing_workdir):
+    """
+    Test v1 recipe generation
+    """
+    args = ["--output-format=v1", "pypi", "botocore"]
+    main_skeleton.execute(args)
+    assert os.path.isfile("botocore/recipe.yaml")
+    with open(os.path.join("botocore", "recipe.yaml")) as f:
+        assert "botocore" in f.read()

--- a/tests/requirements-v1-recipe-format.txt
+++ b/tests/requirements-v1-recipe-format.txt
@@ -1,0 +1,1 @@
+conda-recipe-manager


### PR DESCRIPTION
This PR adds support for generating v1 recipes using `conda-recipe-manager` to convert recipes generated with `conda-skeleton` to the newer format.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
