### PR TITLE
Port v1 recipe support to py-rattler-build

### DIFF
--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -70,13 +70,6 @@ def check_arguments_rattler(
             "channel",
             "override_channels",
         },
-        "debug": {
-            "recipe",
-            "output_id",
-            "variant_config_files",
-            "exclusive_config_files",
-            "override_channels",
-        },
     }
 
     # check for unsupported CLI arguments
@@ -106,7 +99,6 @@ def process_recipes(
     no_build_id: bool,
     package_format: str,
     no_include_recipe: bool,
-    debug: bool,
     target_platform: str,
     build_platform: str,
     host_platform: str,
@@ -191,7 +183,6 @@ def process_recipes(
                     no_build_id=no_build_id,
                     package_format=package_format,
                     no_include_recipe=no_include_recipe,
-                    debug=debug,
                 )
             except RattlerBuildError as e:
                 err = CondaBuildUserError(
@@ -226,7 +217,7 @@ def process_recipes(
 
 def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -> int:
     """Run rattler-build for v1 recipes"""
-    if command not in ("build", "render", "debug"):
+    if command not in ("build", "render"):
         raise ValueError(f"Unrecognized subcommand: {command}")
 
     # Initialize configuration defaults
@@ -239,7 +230,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     no_build_id: bool = False
     experimental: bool = False
     package_format: str | None = None
-    debug: bool = command == "debug"
     channels: list[str] = []
     extra_context: dict[str] = {}
     show_logs: bool = getattr(parsed_args, "quiet", False) is False
@@ -279,9 +269,10 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     else:
         channel_priority = "disabled"
 
-    if command in ("build", "render", "debug"):
+    if command in ("build", "render"):
         # TODO: --ignore-recipe-variants only available via deprecated
         # rattler_build.cli_api:build_recipes()
+        # xref https://github.com/prefix-dev/rattler-build/issues/2334
         # cmd.append("--ignore-recipe-variants")
 
         from ..variants import find_config_files
@@ -335,8 +326,8 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         else:
             package_format = ".tar.bz2"
 
-    if command in ("build", "render", "debug"):
-        if command in ("render", "debug"):
+    if command in ("build", "render"):
+        if command in ("render"):
             recipe_path = join(parsed_args.recipe, "recipe.yaml")
             recipes = [recipe_path]
         else:
@@ -345,6 +336,8 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             ]
 
         # configure variant
+        # TODO: implement support for multiple config files
+        # xref https://github.com/prefix-dev/rattler-build/issues/2336
         if config_files:
             for variant in config_files:
                 variant_config = VariantConfig.from_file(variant)
@@ -359,7 +352,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             no_build_id=no_build_id,
             package_format=package_format,
             no_include_recipe=no_include_recipe,
-            debug=debug,
             target_platform=target_platform,
             build_platform=build_platform,
             host_platform=host_platform,

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -126,7 +126,7 @@ def process_recipe(
     tool_config: ToolConfiguration,
     render_config: RenderConfig,
     parsed_args: argparse.Namespace,
-) -> tuple[bool, str | None, str | None]:
+) -> tuple[bool, str | None]:
     """
     Function to parse, render and optionally build or test a conda packlage recipe using the py-rattler-build API.
 
@@ -143,19 +143,19 @@ def process_recipe(
         err = CondaBuildUserError(
             f"Failed to process recipe file {recipe_path}: {str(e)}"
         )
-        return False, str(err), None
+        return False, str(err)
 
     try:
         rendered = recipe.render(variant_config, render_config)
     except RattlerBuildError as e:
         err = CondaBuildUserError(f"Failed to render recipe {recipe_path}: {str(e)}")
-        return False, str(err), None
+        return False, str(err)
 
     if command == "render":
         for item in rendered:
             data = item.recipe.to_dict()
             print(yaml.safe_dump(data, indent=2, sort_keys=False))
-        return True, None, None
+        return True, None
 
     for i, variant in enumerate(rendered, 1):
         print(
@@ -174,26 +174,15 @@ def process_recipe(
             )
         except RattlerBuildError as e:
             err = CondaBuildUserError(f"Failed to build recipe {recipe_path}: {str(e)}")
-            return False, str(err), None
+            return False, str(err)
 
         if not parsed_args.notest:
             built_package_path = build_result.packages[0]
             pkg = Package.from_file(built_package_path)
 
-            test_results = pkg.run_tests(
-                progress_callback=CondaProgressCallback(show_logs=show_logs)
-            )
+            pkg.run_tests(progress_callback=CondaProgressCallback(show_logs=show_logs))
 
-            test_failed = [r for r in test_results if not r.success]
-            if test_failed:
-                test_log = "\n\n".join("".join(r.output) for r in test_failed)
-                return (
-                    False,
-                    (f"Failed tests: {len(test_failed)} test(s) failed"),
-                    test_log,
-                )
-
-    return True, None, None
+    return True, None
 
 
 def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -> int:
@@ -325,10 +314,9 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
 
         succeeded: list[str] = []
         failed: dict[str, str] = {}
-        failed_logs: dict[str, str] = {}
 
         for recipe_path in recipes:
-            ok, err, test_log = process_recipe(
+            ok, err = process_recipe(
                 recipe_path=recipe_path,
                 variant_config=variant_config,
                 command=command,
@@ -346,8 +334,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
                 succeeded.append(recipe_path)
             else:
                 failed[recipe_path] = err or f"Failed recipe {recipe_path}"
-                if test_log:
-                    failed_logs[recipe_path] = test_log
 
         # summary
         print("\n=== Build summary ===")
@@ -362,12 +348,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             print("\nFailed:")
             for p, e in failed.items():
                 print(f"  - {Path(p).resolve()}")
-
-            if failed_logs and not show_logs:
-                print("\n=== Test logs ===")
-                for p, log in failed_logs.items():
-                    print(f"\n--- {Path(p).resolve()} ---")
-                    print(log, end="" if log.endswith("\n") else "\n")
 
             msg = "Recipe build failures:\n" + "\n".join(
                 f"  - {Path(p).absolute()}: {e}" for p, e in failed.items()

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import argparse
 from os.path import join
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from conda.base.context import context
@@ -13,15 +13,22 @@ from rattler_build import (
     RattlerBuildError,
     RecipeParseError,
 )
-from rattler_build.progress import LogEvent, SimpleProgressCallback
+from rattler_build.progress import SimpleProgressCallback
 from rattler_build.render import RenderConfig
 from rattler_build.stage0 import Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 from rattler_build.variant_config import VariantConfig
 
-from ..config import CondaPkgFormat, Config
+from ..config import CondaPkgFormat
 from ..exceptions import CondaBuildUserError
 from ..utils import get_logger
+
+if TYPE_CHECKING:
+    import argparse
+
+    from rattler_build.progress import LogEvent
+
+    from ..config import Config
 
 CONFIG_FILES = {"conda_build_config.yaml", "variants.yaml"}
 
@@ -173,10 +180,7 @@ def process_recipe(
                 test_log = "\n\n".join("".join(r.output) for r in test_failed)
                 return (
                     False,
-                    (
-                        f"Failed tests: "
-                        f"{len(test_failed)} test(s) failed"
-                    ),
+                    (f"Failed tests: {len(test_failed)} test(s) failed"),
                     test_log,
                 )
 

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -250,11 +250,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         channel_priority = "disabled"
 
     if command in ("build", "render"):
-        # TODO: --ignore-recipe-variants only available via deprecated
-        # rattler_build.cli_api:build_recipes()
-        # xref https://github.com/prefix-dev/rattler-build/issues/2334
-        # cmd.append("--ignore-recipe-variants")
-
         from ..variants import find_config_files
 
         if len(parsed_args.recipe) > 1:

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -4,9 +4,13 @@ import argparse
 from os.path import join
 from pathlib import Path
 
-from conda import CondaError
+import yaml
 from conda.base.context import context
-from rattler_build import RattlerBuildError
+from conda.exceptions import CondaError
+from rattler_build import (
+    RattlerBuildError,
+    RecipeParseError,
+)
 from rattler_build.progress import RichProgressCallback
 from rattler_build.render import RenderConfig
 from rattler_build.stage0 import MultiOutputRecipe, Stage0Recipe
@@ -57,6 +61,7 @@ def check_arguments_rattler(
             "conda_pkg_format",
             "zstd_compression_level",
             "channel",
+            "override_channels",
         },
         "render": {
             "recipe",
@@ -64,12 +69,14 @@ def check_arguments_rattler(
             "verbose",
             "exclusive_config_files",
             "channel",
+            "override_channels",
         },
         "debug": {
             "recipe",
             "output_id",
             "variant_config_files",
             "exclusive_config_files",
+            "override_channels",
         },
     }
 
@@ -111,92 +118,91 @@ def process_recipes(
     noarch_build_platform: str,
     channel_priority: str,
 ) -> int:
-    import yaml
 
     succeeded: list[str] = []
     failed: dict[str, str] = {}
+    errors: list[Exception] = []
 
     for recipe_path in recipes:
         recipe_path_str = str(recipe_path)
+
+        # load the recipe file
         try:
-            # load the recipe file
-            try:
-                recipe = Stage0Recipe.from_file(Path(recipe_path))
-            except RattlerBuildError as e:
-                raise CondaBuildUserError(
-                    f"Failed to process recipe {recipe_path}: {str(e)}"
-                )
-
-            if isinstance(recipe, MultiOutputRecipe):
-                for idx, output in enumerate(recipe.outputs, 1):
-                    output_dict = output.to_dict()
-                    if "staging" in output_dict:
-                        experimental = True
-
-            # common tool / platform / render configuration
-            tool_config = ToolConfiguration(
-                test_strategy=test_strategy,
-                skip_existing=skip_existing,
-                noarch_build_platform=noarch_build_platform,
-                channel_priority=channel_priority,
+            recipe = Stage0Recipe.from_file(Path(recipe_path))
+        except RecipeParseError as e:
+            err = CondaBuildUserError(
+                f"Failed to process recipe {recipe_path}: {str(e)}"
             )
-
-            platform_config = PlatformConfig(
-                target_platform=target_platform,
-                build_platform=build_platform,
-                host_platform=host_platform,
-                experimental=experimental,
-            )
-
-            render_config = RenderConfig(
-                platform=platform_config,
-                extra_context=extra_context,
-            )
-
-            # render the recipe
-            try:
-                rendered = recipe.render(variant_config, render_config)
-            except Exception as e:
-                raise CondaBuildUserError(
-                    f"Failed to render recipe {recipe_path}: {str(e)}"
-                )
-
-            if command == "render":
-                for item in rendered:
-                    data = item.recipe.to_dict()
-                    print(yaml.safe_dump(data, indent=2, sort_keys=False))
-                succeeded.append(recipe_path_str)
-                continue
-
-            # build all rendered variants
-            for i, variant in enumerate(rendered, 1):
-                print(
-                    f"\n🔨 Building variant {i}/{len(rendered)} "
-                    f"for recipe {recipe_path}"
-                )
-
-                try:
-                    with RichProgressCallback(show_logs=show_logs) as progress_callback:
-                        variant.run_build(
-                            tool_config=tool_config,
-                            output_dir=output_dir,
-                            channels=channels,
-                            progress_callback=progress_callback,
-                            no_build_id=no_build_id,
-                            package_format=package_format,
-                            no_include_recipe=no_include_recipe,
-                            debug=debug,
-                        )
-                except RattlerBuildError as e:
-                    raise CondaError(f"Build failed for recipe {recipe_path}: {str(e)}")
-
-            # if all variants built without raising, mark recipe as succeeded
-            succeeded.append(recipe_path_str)
-
-        except Exception as e:
-            # catch any failure for this recipe and continue with the next
+            errors.append(err)
             failed[recipe_path_str] = str(e)
-            print(f"Skipping remaining work for recipe {recipe_path}.")
+            continue
+
+        if isinstance(recipe, MultiOutputRecipe):
+            for output in recipe.outputs:
+                output_dict = output.to_dict()
+                print(output_dict)
+                if "staging" in output_dict:
+                    experimental = True
+
+        # common tool / platform / render configuration
+        tool_config = ToolConfiguration(
+            test_strategy=test_strategy,
+            skip_existing=skip_existing,
+            noarch_build_platform=noarch_build_platform,
+            channel_priority=channel_priority,
+        )
+
+        platform_config = PlatformConfig(
+            target_platform=target_platform,
+            build_platform=build_platform,
+            host_platform=host_platform,
+            experimental=experimental,
+        )
+
+        render_config = RenderConfig(
+            platform=platform_config,
+            extra_context=extra_context,
+        )
+
+        # render the recipe
+        try:
+            rendered = recipe.render(variant_config, render_config)
+        except RattlerBuildError as e:
+            err = CondaBuildUserError(
+                f"Failed to render recipe {recipe_path}: {str(e)}"
+            )
+            errors.append(err)
+            failed[recipe_path_str] = str(e)
+            continue
+
+        if command == "render":
+            for item in rendered:
+                data = item.recipe.to_dict()
+                print(yaml.safe_dump(data, indent=2, sort_keys=False))
+            succeeded.append(recipe_path_str)
+            continue
+
+        # build all rendered variants
+        for i, variant in enumerate(rendered, 1):
+            print(f"\n🔨 Building variant {i}/{len(rendered)} for recipe {recipe_path}")
+
+            try:
+                with RichProgressCallback(show_logs=show_logs) as progress_callback:
+                    variant.run_build(
+                        tool_config=tool_config,
+                        output_dir=output_dir,
+                        channels=channels,
+                        progress_callback=progress_callback,
+                        no_build_id=no_build_id,
+                        package_format=package_format,
+                        no_include_recipe=no_include_recipe,
+                        debug=debug,
+                    )
+            except RattlerBuildError as e:
+                err = CondaError(f"Build failed for recipe {recipe_path}: {str(e)}")
+
+        # if all variants built without raising, mark recipe as succeeded
+        succeeded.append(recipe_path_str)
 
     # summary
     print("\n=== Build summary ===")
@@ -213,6 +219,9 @@ def process_recipes(
             print(f"  - {path}: {error}")
     else:
         print("\nFailed: none")
+
+    if errors:
+        raise CondaBuildUserError(errors)
 
     return 1 if failed else 0
 
@@ -232,7 +241,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     no_build_id: bool = False
     experimental: bool = False
     package_format: str | None = None
-    debug: bool = False
+    debug: bool = command == "debug"
     channels: list[str] = []
     extra_context: dict[str] = {}
     show_logs: bool = getattr(parsed_args, "quiet", False) is False
@@ -246,24 +255,33 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
 
     # TODO: investigate why is config.channel_urls
     # does not pick up condarc settings, need to use context.channels
-    channels = list(context.channels)
-    if config.channel_urls:
-        for url in config.channel_urls:
-            # TODO: fix -c local
-            # TypeError: argument 'channels': 'Channel' object cannot be cast as 'str'
-            if url in context.custom_multichannels:
-                channels.extend(
-                    [local_url for local_url in context.custom_multichannels[url]]
-                )
-            else:
-                channels.append(url)
+    if parsed_args.override_channels:
+        if not parsed_args.channel:
+            raise CondaBuildUserError(
+                "Channels must be specified using -c/--channel argument when --override-channels is used."
+            )
+        channels = list(parsed_args.channel)
+    else:
+        channels = list(context.channels)
+        if config.channel_urls:
+            for url in config.channel_urls:
+                # TODO: fix -c local
+                # TypeError: argument 'channels': 'Channel' object cannot be cast as 'str'
+                if url in context.custom_multichannels:
+                    channels.extend(
+                        [local_url for local_url in context.custom_multichannels[url]]
+                    )
+                else:
+                    channels.append(url)
+
+    channels = list(dict.fromkeys(channels))
 
     if context.channel_priority == "strict":
         channel_priority = "strict"
     else:
         channel_priority = "disabled"
 
-    if command in ("build", "render"):
+    if command in ("build", "render", "debug"):
         # TODO: --ignore-recipe-variants only available via deprecated
         # rattler_build.cli_api:build_recipes()
         # cmd.append("--ignore-recipe-variants")
@@ -299,7 +317,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         # TODO: find this option in py-rattler-build
         # cmd.append("--verbose")
 
-    # if command == "debug":
     # TODO: output_name does not exist in python bindings
     # if parsed_args.output_id:
     # cmd.extend(["--output-name", parsed_args.output_id])
@@ -309,7 +326,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         if parsed_args.output_folder:
             output_dir = parsed_args.output_folder
         no_build_id = not parsed_args.set_build_id
-        debug = parsed_args.debug
         test_strategy = "skip" if parsed_args.notest else "native"
         # if parsed_args.quiet:
         # TODO: quiet does not exist in py-rattler-build
@@ -321,8 +337,8 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         else:
             package_format = ".tar.bz2"
 
-    if command in ("build", "render"):
-        if command == "render":
+    if command in ("build", "render", "debug"):
+        if command in ("render", "debug"):
             recipe_path = join(parsed_args.recipe, "recipe.yaml")
             recipes = [recipe_path]
         else:

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-from os.path import join
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -33,6 +33,30 @@ if TYPE_CHECKING:
 CONFIG_FILES = {"conda_build_config.yaml", "variants.yaml"}
 
 log = get_logger(__name__)
+
+
+@dataclass(kw_only=True)
+class OutputResult:
+    name: str
+    success: bool
+    error: str | None = None
+
+
+@dataclass(kw_only=True)
+class RecipeResult:
+    recipe_path: str
+    outputs: list[OutputResult] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def failed(self) -> bool:
+        return self.error is not None or any(
+            not output.success for output in self.outputs
+        )
+
+    @property
+    def success(self) -> bool:
+        return bool(self.outputs) and not self.failed
 
 
 class CondaProgressCallback(SimpleProgressCallback):
@@ -121,12 +145,12 @@ def process_recipe(
     channels: list[str],
     show_logs: bool,
     no_build_id: bool,
-    package_format: str,
+    package_format: str | None,
     no_include_recipe: bool,
     tool_config: ToolConfiguration,
     render_config: RenderConfig,
     parsed_args: argparse.Namespace,
-) -> tuple[bool, str | None]:
+) -> RecipeResult:
     """
     Function to parse, render and optionally build or test a conda packlage recipe using the py-rattler-build API.
 
@@ -136,31 +160,34 @@ def process_recipe(
         - Build each rendered variant using `variant.run_build()`
         - If testing is enabled, run tests on the built package with `Package.run_tests()`
     """
+    result = RecipeResult(recipe_path=recipe_path)
 
     try:
         recipe = Stage0Recipe.from_file(Path(recipe_path))
     except RecipeParseError as e:
-        err = CondaBuildUserError(
-            f"Failed to process recipe file {recipe_path}: {str(e)}"
-        )
-        return False, str(err)
+        result.error = f"Failed to process recipe file {recipe_path}: {e}"
+        return result
 
     try:
         rendered = recipe.render(variant_config, render_config)
     except RattlerBuildError as e:
-        err = CondaBuildUserError(f"Failed to render recipe {recipe_path}: {str(e)}")
-        return False, str(err)
+        result.error = f"Failed to render recipe {recipe_path}: {e}"
+        return result
 
     if command == "render":
         for item in rendered:
             data = item.recipe.to_dict()
             print(yaml.safe_dump(data, indent=2, sort_keys=False))
-        return True, None
+        return result
 
     for i, variant in enumerate(rendered, 1):
         print(
-            f"\nBuilding variant {i}/{len(rendered)} for recipe {Path(recipe_path).absolute()}"
+            f"\nBuilding variant {i}/{len(rendered)} for recipe {Path(recipe_path).resolve()}"
         )
+
+        recipe_dict = variant.recipe.to_dict()
+        package_section = recipe_dict.get("package", {})
+        output_name = package_section.get("name")
 
         try:
             build_result = variant.run_build(
@@ -173,16 +200,73 @@ def process_recipe(
                 no_include_recipe=no_include_recipe,
             )
         except RattlerBuildError as e:
-            err = CondaBuildUserError(f"Failed to build recipe {recipe_path}: {str(e)}")
-            return False, str(err)
+            result.outputs.append(
+                OutputResult(
+                    name=output_name,
+                    success=False,
+                    error=str(e),
+                )
+            )
+            continue
 
-        if not parsed_args.notest:
-            built_package_path = build_result.packages[0]
-            pkg = Package.from_file(built_package_path)
+        built_packages = list(build_result.packages)
 
-            pkg.run_tests(progress_callback=CondaProgressCallback(show_logs=show_logs))
+        for pkg_path in built_packages:
+            if parsed_args.notest:
+                result.outputs.append(
+                    OutputResult(
+                        name=output_name,
+                        success=True,
+                    )
+                )
+                continue
 
-    return True, None
+            try:
+                pkg = Package.from_file(pkg_path)
+            except RattlerBuildError as e:
+                result.outputs.append(
+                    OutputResult(
+                        name=output_name,
+                        success=False,
+                        error=str(e),
+                    )
+                )
+                continue
+
+            try:
+                test_results = pkg.run_tests(
+                    progress_callback=CondaProgressCallback(show_logs=show_logs)
+                )
+            except RattlerBuildError as e:
+                result.outputs.append(
+                    OutputResult(
+                        name=output_name,
+                        success=False,
+                        error=str(e),
+                    )
+                )
+                continue
+
+            test_failed = [r for r in test_results if not r.success]
+
+            if test_failed:
+                result.outputs.append(
+                    OutputResult(
+                        name=output_name,
+                        success=False,
+                        error="Package tests failed",
+                    )
+                )
+                continue
+
+            result.outputs.append(
+                OutputResult(
+                    name=output_name,
+                    success=True,
+                )
+            )
+
+    return result
 
 
 def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -> int:
@@ -192,14 +276,13 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
 
     # Initialize configuration defaults
     skip_existing: bool | None = None
-    noarch_build_platform: str | None = None
     channel_priority: str | None = None
     output_dir: str = config.croot
     no_include_recipe: bool = False
     no_build_id: bool = False
     package_format: str | None = None
     channels: list[str] = []
-    extra_context: dict[str] = {}
+    extra_context: dict[str, str] = {}
     show_logs: bool = getattr(parsed_args, "quiet", False) is False
     target_platform: str = config.variant.get("host_platform", config.subdir)
     build_platform: str = config.variant.get("build_platform", config.subdir)
@@ -254,11 +337,11 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
                     f"Recipe configuration files detected but multiple recipes were passed: {recipes_with_cfg}"
                 )
             else:
+                # single-recipe case: include recipe config files if any exist
                 config_files = find_config_files(
                     None, config, recipe_config_filenames=None
                 )
         else:
-            # single-recipe case: include recipe config files if any exist
             config_files = find_config_files(
                 Path(parsed_args.recipe[0]),
                 config,
@@ -299,12 +382,12 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     )
 
     if command in ("build", "render"):
-        if command in ("render"):
-            recipe_path = join(parsed_args.recipe, "recipe.yaml")
-            recipes = [recipe_path]
+        if command == "render":
+            recipes = [str(Path(parsed_args.recipe) / "recipe.yaml")]
         else:
             recipes = [
-                join(recipe_dir, "recipe.yaml") for recipe_dir in parsed_args.recipe
+                str(Path(recipe_dir) / "recipe.yaml")
+                for recipe_dir in parsed_args.recipe
             ]
 
         # configure variant
@@ -313,52 +396,85 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             for variant in config_files:
                 variant_config = variant_config.merge(VariantConfig.from_file(variant))
 
-        succeeded: list[str] = []
-        failed: dict[str, str] = {}
+        recipe_results: list[RecipeResult] = []
 
         for recipe_path in recipes:
-            ok, err = process_recipe(
-                recipe_path=recipe_path,
-                variant_config=variant_config,
-                command=command,
-                output_dir=output_dir,
-                channels=channels,
-                show_logs=show_logs,
-                no_build_id=no_build_id,
-                package_format=package_format,
-                no_include_recipe=no_include_recipe,
-                tool_config=tool_config,
-                render_config=render_config,
-                parsed_args=parsed_args,
+            recipe_results.append(
+                process_recipe(
+                    recipe_path=recipe_path,
+                    variant_config=variant_config,
+                    command=command,
+                    output_dir=output_dir,
+                    channels=channels,
+                    show_logs=show_logs,
+                    no_build_id=no_build_id,
+                    package_format=package_format,
+                    no_include_recipe=no_include_recipe,
+                    tool_config=tool_config,
+                    render_config=render_config,
+                    parsed_args=parsed_args,
+                )
             )
-            if ok:
-                succeeded.append(recipe_path)
-            else:
-                failed[recipe_path] = err or f"Failed recipe {recipe_path}"
 
-        # summary
+        if command == "render":
+            failed = [r for r in recipe_results if r.failed]
+            if failed:
+                msg = "\n".join(
+                    [
+                        "Recipe render failures",
+                        *[
+                            f"  - {Path(r.recipe_path).resolve()}: {r.error or 'Unknown error'}"
+                            for r in failed
+                        ],
+                    ]
+                )
+                raise CondaBuildUserError(msg)
+            return 0
+
+        recipe_count = len(recipe_results)
+        total_outputs = sum(len(r.outputs) for r in recipe_results)
+        succeeded_outputs = sum(
+            1 for r in recipe_results for output in r.outputs if output.success
+        )
+        failed_outputs = total_outputs - succeeded_outputs
+
         print("\n=== Build summary ===")
-        if succeeded:
-            print("Succeeded:")
-            for path in succeeded:
-                print(f"  - {path}")
-        else:
-            print("Succeeded: none")
+        print(
+            f"Tried to build {recipe_count} recipe file{'s' if recipe_count != 1 else ''}, "
+            f"resulting in {total_outputs} output{'s' if total_outputs != 1 else ''}."
+        )
+        print(f"{succeeded_outputs} succeeded, {failed_outputs} failed.\n")
+        print("Details:")
 
+        for recipe in recipe_results:
+            recipe_icon = "❌" if recipe.failed else "✅"
+            print(f"- {recipe_icon} {Path(recipe.recipe_path).resolve()}")
+
+            if recipe.outputs:
+                for output in recipe.outputs:
+                    if output.success:
+                        print(f"  - ✅ {output.name}: Succeeded")
+                    else:
+                        print(f"  - ❌ {output.name}: {output.error}")
+            elif recipe.error:
+                print(f"  - ❌ recipe: {recipe.error}")
+
+        failed = [r for r in recipe_results if r.failed]
         if failed:
-            print("\nFailed:")
-            for p, e in failed.items():
-                print(f"  - {Path(p).resolve()}")
+            msg_lines = ["Recipe build failures:"]
+            for recipe in failed:
+                msg_lines.append(f"  - {Path(recipe.recipe_path).resolve()}")
+                if recipe.outputs:
+                    for output in recipe.outputs:
+                        if not output.success:
+                            reason = output.error
+                            msg_lines.append(f"      - {output.name}: {reason}")
+                elif recipe.error:
+                    msg_lines.append(f"      - recipe: {recipe.error}")
 
-            msg = "\n".join(
-                [
-                    "Recipe build failures",
-                    *[f"  - {Path(p).absolute()}: {e}" for p, e in failed.items()],
-                ]
-            )
+            print(end="\n")
+            raise CondaBuildUserError("\n".join(msg_lines))
 
-            raise CondaBuildUserError(msg)
-        else:
-            print("\nFailed: none")
+        return 0
 
-        return 1 if failed else 0
+    return 1 if failed else 0

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -297,8 +297,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     )
     variant_config: VariantConfig = VariantConfig()
 
-    # TODO: investigate why is config.channel_urls
-    # does not pick up condarc settings, need to use context.channels
     if parsed_args.override_channels:
         if not parsed_args.channel:
             raise CondaBuildUserError(
@@ -307,18 +305,9 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         channels = list(parsed_args.channel)
     else:
         channels = list(context.channels)
-        if config.channel_urls:
-            for url in config.channel_urls:
-                # TODO: fix -c local
-                # TypeError: argument 'channels': 'Channel' object cannot be cast as 'str'
-                if url in context.custom_multichannels:
-                    channels.extend(
-                        [local_url for local_url in context.custom_multichannels[url]]
-                    )
-                else:
-                    channels.append(url)
 
-    channels = list(dict.fromkeys(channels))
+    # Local and multichannel not supported yet, xref https://github.com/conda/rattler/issues/1327
+    channels = list(dict.fromkeys(c for c in channels if c != "local"))
 
     if context.channel_priority == "strict":
         channel_priority = "strict"

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -426,7 +426,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             if failed:
                 msg = "\n".join(
                     [
-                        "Recipe render failures",
+                        "Recipe render failures:",
                         *[
                             f"  - {Path(r.recipe_path).resolve()}: {r.error or 'Unknown error'}"
                             for r in failed
@@ -477,9 +477,9 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
                 elif recipe.error:
                     msg_lines.append(f"      - recipe: {recipe.error}")
 
-            print(end="\n")
-            raise CondaBuildUserError("\n".join(msg_lines))
+            if parsed_args.debug:
+                raise CondaBuildUserError("\n".join(msg_lines))
+            else:
+                return 1
 
         return 0
-
-    return 1 if failed else 0

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -174,7 +174,7 @@ def process_recipe(
                 return (
                     False,
                     (
-                        f"Failed tests for recipe {Path(recipe_path).absolute()}: "
+                        f"Failed tests: "
                         f"{len(test_failed)} test(s) failed"
                     ),
                     test_log,
@@ -263,9 +263,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
                 recipe_config_filenames=CONFIG_FILES,
             )
 
-    # TODO: output_name does not exist in python bindings
-    # if parsed_args.output_id:
-    # cmd.extend(["--output-name", parsed_args.output_id])
     if command == "build":
         if parsed_args.extra_meta:
             extra_context.update(parsed_args.extra_meta)

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import yaml
 from conda.base.context import context
-from conda.exceptions import CondaError
 from rattler_build import (
     RattlerBuildError,
     RecipeParseError,
@@ -121,7 +120,6 @@ def process_recipes(
 
     succeeded: list[str] = []
     failed: dict[str, str] = {}
-    errors: list[Exception] = []
 
     for recipe_path in recipes:
         recipe_path_str = str(recipe_path)
@@ -131,10 +129,9 @@ def process_recipes(
             recipe = Stage0Recipe.from_file(Path(recipe_path))
         except RecipeParseError as e:
             err = CondaBuildUserError(
-                f"Failed to process recipe {recipe_path}: {str(e)}"
+                f"Failed to process recipe file {recipe_path}: {str(e)}"
             )
-            errors.append(err)
-            failed[recipe_path_str] = str(e)
+            failed[recipe_path_str] = str(err)
             continue
 
         if isinstance(recipe, MultiOutputRecipe):
@@ -171,8 +168,7 @@ def process_recipes(
             err = CondaBuildUserError(
                 f"Failed to render recipe {recipe_path}: {str(e)}"
             )
-            errors.append(err)
-            failed[recipe_path_str] = str(e)
+            failed[recipe_path_str] = str(err)
             continue
 
         if command == "render":
@@ -198,8 +194,10 @@ def process_recipes(
                     debug=debug,
                 )
             except RattlerBuildError as e:
-                err = CondaError(f"Build failed for recipe {recipe_path}: {str(e)}")
-                failed[recipe_path_str] = str(e)
+                err = CondaBuildUserError(
+                    f"Failed to build recipe {recipe_path}: {str(e)}"
+                )
+                failed[recipe_path_str] = str(err)
                 continue
 
         # if all variants built without raising, mark recipe as succeeded
@@ -216,13 +214,12 @@ def process_recipes(
 
     if failed:
         print("\nFailed:")
-        for path, error in failed.items():
-            print(f"  - {path}: {error}")
+        msg = "Recipe build failures:\n" + "\n".join(
+            f"  - {p}: {e}" for p, e in failed.items()
+        )
+        raise CondaBuildUserError(msg)
     else:
         print("\nFailed: none")
-
-    if errors:
-        raise CondaBuildUserError(errors)
 
     return 1 if failed else 0
 

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -10,7 +10,7 @@ from rattler_build import (
     RattlerBuildError,
     RecipeParseError,
 )
-from rattler_build.progress import SimpleProgressCallback
+from rattler_build.progress import LogEvent, SimpleProgressCallback
 from rattler_build.render import RenderConfig
 from rattler_build.stage0 import Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
@@ -18,8 +18,24 @@ from rattler_build.variant_config import VariantConfig
 
 from ..config import CondaPkgFormat, Config
 from ..exceptions import CondaBuildUserError
+from ..utils import get_logger
 
 CONFIG_FILES = {"conda_build_config.yaml", "variants.yaml"}
+
+log = get_logger(__name__)
+
+
+class CondaProgressCallback(SimpleProgressCallback):
+    def __init__(self, show_logs: bool = True):
+        super().__init__()
+        self.show_logs = show_logs
+
+    def on_log(self, event: LogEvent) -> None:
+        if not self.show_logs:
+            return
+
+        level_name = {"error": "error", "warn": "warning"}.get(event.level, "info")
+        getattr(log, level_name)(event.message)
 
 
 def check_arguments_rattler(
@@ -139,14 +155,14 @@ def process_recipes(
 
         # build all rendered variants
         for i, variant in enumerate(rendered, 1):
-            print(f"\n🔨 Building variant {i}/{len(rendered)} for recipe {recipe_path}")
+            print(f"\nBuilding variant {i}/{len(rendered)} for recipe {recipe_path}")
 
             try:
                 variant.run_build(
                     tool_config=tool_config,
                     output_dir=output_dir,
                     channels=channels,
-                    progress_callback=SimpleProgressCallback(),
+                    progress_callback=CondaProgressCallback(show_logs=show_logs),
                     no_build_id=no_build_id,
                     package_format=package_format,
                     no_include_recipe=no_include_recipe,

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -4,10 +4,12 @@ import argparse
 from os.path import join
 from pathlib import Path
 
+from conda import CondaError
 from conda.base.context import context
+from rattler_build import RattlerBuildError
 from rattler_build.progress import RichProgressCallback
 from rattler_build.render import RenderConfig
-from rattler_build.stage0 import Stage0Recipe
+from rattler_build.stage0 import MultiOutputRecipe, Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 from rattler_build.variant_config import VariantConfig
 
@@ -91,8 +93,6 @@ def check_arguments_rattler(
 def process_recipes(
     recipes: list[str],
     variant_config: VariantConfig,
-    render_config: RenderConfig,
-    tool_config: ToolConfiguration,
     command: str,
     output_dir: str,
     channels: list[str],
@@ -101,6 +101,15 @@ def process_recipes(
     package_format: str,
     no_include_recipe: bool,
     debug: bool,
+    target_platform: str,
+    build_platform: str,
+    host_platform: str,
+    experimental: bool,
+    extra_context: dict[str],
+    test_strategy: str,
+    skip_existing: bool,
+    noarch_build_platform: str,
+    channel_priority: str,
 ) -> int:
     import yaml
 
@@ -113,10 +122,36 @@ def process_recipes(
             # load the recipe file
             try:
                 recipe = Stage0Recipe.from_file(Path(recipe_path))
-            except Exception as e:
+            except RattlerBuildError as e:
                 raise CondaBuildUserError(
                     f"Failed to process recipe {recipe_path}: {str(e)}"
                 )
+
+            if isinstance(recipe, MultiOutputRecipe):
+                for idx, output in enumerate(recipe.outputs, 1):
+                    output_dict = output.to_dict()
+                    if "staging" in output_dict:
+                        experimental = True
+
+            # common tool / platform / render configuration
+            tool_config = ToolConfiguration(
+                test_strategy=test_strategy,
+                skip_existing=skip_existing,
+                noarch_build_platform=noarch_build_platform,
+                channel_priority=channel_priority,
+            )
+
+            platform_config = PlatformConfig(
+                target_platform=target_platform,
+                build_platform=build_platform,
+                host_platform=host_platform,
+                experimental=experimental,
+            )
+
+            render_config = RenderConfig(
+                platform=platform_config,
+                extra_context=extra_context,
+            )
 
             # render the recipe
             try:
@@ -127,8 +162,9 @@ def process_recipes(
                 )
 
             if command == "render":
-                data = rendered[0].recipe.to_dict()
-                print(yaml.safe_dump(data, indent=2, sort_keys=False))
+                for item in rendered:
+                    data = item.recipe.to_dict()
+                    print(yaml.safe_dump(data, indent=2, sort_keys=False))
                 succeeded.append(recipe_path_str)
                 continue
 
@@ -151,9 +187,8 @@ def process_recipes(
                             no_include_recipe=no_include_recipe,
                             debug=debug,
                         )
-                except Exception as e:
-                    print(f"Build failed for recipe {recipe_path}: {str(e)}")
-                    raise
+                except RattlerBuildError as e:
+                    raise CondaError(f"Build failed for recipe {recipe_path}: {str(e)}")
 
             # if all variants built without raising, mark recipe as succeeded
             succeeded.append(recipe_path_str)
@@ -195,6 +230,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     output_dir: str = config.croot
     no_include_recipe: bool = False
     no_build_id: bool = False
+    experimental: bool = False
     package_format: str | None = None
     debug: bool = False
     channels: list[str] = []
@@ -206,6 +242,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     noarch_build_platform: str = config.variant.get(
         "noarch_build_platform", config.subdir
     )
+    variant_config: VariantConfig = VariantConfig()
 
     # TODO: investigate why is config.channel_urls
     # does not pick up condarc settings, need to use context.channels
@@ -293,36 +330,14 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
                 join(recipe_dir, "recipe.yaml") for recipe_dir in parsed_args.recipe
             ]
 
-        from ..variants import find_config_files
-
         # configure variant
-        for variant in config_files:
-            variant_config = VariantConfig.from_file(variant)
-
-        # common tool / platform / render configuration
-        tool_config = ToolConfiguration(
-            test_strategy=test_strategy,
-            skip_existing=skip_existing,
-            noarch_build_platform=noarch_build_platform,
-            channel_priority=channel_priority,
-        )
-
-        platform_config = PlatformConfig(
-            target_platform=target_platform,
-            build_platform=build_platform,
-            host_platform=host_platform,
-        )
-
-        render_config = RenderConfig(
-            platform=platform_config,
-            extra_context=extra_context,
-        )
+        if config_files:
+            for variant in config_files:
+                variant_config = VariantConfig.from_file(variant)
 
         return process_recipes(
             recipes=recipes,
             variant_config=variant_config,
-            render_config=render_config,
-            tool_config=tool_config,
             command=command,
             output_dir=output_dir,
             channels=channels,
@@ -331,4 +346,13 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             package_format=package_format,
             no_include_recipe=no_include_recipe,
             debug=debug,
+            target_platform=target_platform,
+            build_platform=build_platform,
+            host_platform=host_platform,
+            experimental=experimental,
+            extra_context=extra_context,
+            test_strategy=test_strategy,
+            skip_existing=skip_existing,
+            noarch_build_platform=noarch_build_platform,
+            channel_priority=channel_priority,
         )

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -11,7 +11,7 @@ from rattler_build import (
     RattlerBuildError,
     RecipeParseError,
 )
-from rattler_build.progress import RichProgressCallback
+from rattler_build.progress import SimpleProgressCallback
 from rattler_build.render import RenderConfig
 from rattler_build.stage0 import MultiOutputRecipe, Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
@@ -187,19 +187,20 @@ def process_recipes(
             print(f"\n🔨 Building variant {i}/{len(rendered)} for recipe {recipe_path}")
 
             try:
-                with RichProgressCallback(show_logs=show_logs) as progress_callback:
-                    variant.run_build(
-                        tool_config=tool_config,
-                        output_dir=output_dir,
-                        channels=channels,
-                        progress_callback=progress_callback,
-                        no_build_id=no_build_id,
-                        package_format=package_format,
-                        no_include_recipe=no_include_recipe,
-                        debug=debug,
-                    )
+                variant.run_build(
+                    tool_config=tool_config,
+                    output_dir=output_dir,
+                    channels=channels,
+                    progress_callback=SimpleProgressCallback(),
+                    no_build_id=no_build_id,
+                    package_format=package_format,
+                    no_include_recipe=no_include_recipe,
+                    debug=debug,
+                )
             except RattlerBuildError as e:
                 err = CondaError(f"Build failed for recipe {recipe_path}: {str(e)}")
+                failed[recipe_path_str] = str(e)
+                continue
 
         # if all variants built without raising, mark recipe as succeeded
         succeeded.append(recipe_path_str)

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -234,8 +234,13 @@ def process_recipe(
                 continue
 
             try:
+                # tests are ran in a different directory than build, so we need to add the build
+                # directory manually as a file:// channel
+                test_channels = [Path(output_dir).resolve().as_uri(), *channels]
+
                 test_results = pkg.run_tests(
-                    progress_callback=CondaProgressCallback(show_logs=show_logs)
+                    progress_callback=CondaProgressCallback(show_logs=show_logs),
+                    channel=test_channels,
                 )
             except RattlerBuildError as e:
                 result.outputs.append(

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import argparse
 from os.path import join
 from pathlib import Path
@@ -7,6 +9,7 @@ from pathlib import Path
 import yaml
 from conda.base.context import context
 from rattler_build import (
+    Package,
     RattlerBuildError,
     RecipeParseError,
 )
@@ -103,8 +106,8 @@ def check_arguments_rattler(
         )
 
 
-def process_recipes(
-    recipes: list[str],
+def process_recipe(
+    recipe_path: str,
     variant_config: VariantConfig,
     command: str,
     output_dir: str,
@@ -114,86 +117,70 @@ def process_recipes(
     package_format: str,
     no_include_recipe: bool,
     tool_config: ToolConfiguration,
-    platform_config: PlatformConfig,
     render_config: RenderConfig,
-) -> int:
+    parsed_args: argparse.Namespace,
+) -> tuple[bool, str | None, str | None]:
 
-    succeeded: list[str] = []
-    failed: dict[str, str] = {}
-
-    for recipe_path in recipes:
-        recipe_path_str = str(recipe_path)
-
-        # load the recipe file
-        try:
-            recipe = Stage0Recipe.from_file(Path(recipe_path))
-        except RecipeParseError as e:
-            err = CondaBuildUserError(
-                f"Failed to process recipe file {recipe_path}: {str(e)}"
-            )
-            failed[recipe_path_str] = str(err)
-            continue
-
-        # render the recipe
-        try:
-            rendered = recipe.render(variant_config, render_config)
-        except RattlerBuildError as e:
-            err = CondaBuildUserError(
-                f"Failed to render recipe {recipe_path}: {str(e)}"
-            )
-            failed[recipe_path_str] = str(err)
-            continue
-
-        if command == "render":
-            for item in rendered:
-                data = item.recipe.to_dict()
-                print(yaml.safe_dump(data, indent=2, sort_keys=False))
-            succeeded.append(recipe_path_str)
-            continue
-
-        # build all rendered variants
-        for i, variant in enumerate(rendered, 1):
-            print(f"\nBuilding variant {i}/{len(rendered)} for recipe {recipe_path}")
-
-            try:
-                variant.run_build(
-                    tool_config=tool_config,
-                    output_dir=output_dir,
-                    channels=channels,
-                    progress_callback=CondaProgressCallback(show_logs=show_logs),
-                    no_build_id=no_build_id,
-                    package_format=package_format,
-                    no_include_recipe=no_include_recipe,
-                )
-            except RattlerBuildError as e:
-                err = CondaBuildUserError(
-                    f"Failed to build recipe {recipe_path}: {str(e)}"
-                )
-                failed[recipe_path_str] = str(err)
-                continue
-
-        # if all variants built without raising, mark recipe as succeeded
-        succeeded.append(recipe_path_str)
-
-    # summary
-    print("\n=== Build summary ===")
-    if succeeded:
-        print("Succeeded:")
-        for path in succeeded:
-            print(f"  - {path}")
-    else:
-        print("Succeeded: none")
-
-    if failed:
-        print("\nFailed:")
-        msg = "Recipe build failures:\n" + "\n".join(
-            f"  - {p}: {e}" for p, e in failed.items()
+    try:
+        recipe = Stage0Recipe.from_file(Path(recipe_path))
+    except RecipeParseError as e:
+        err = CondaBuildUserError(
+            f"Failed to process recipe file {recipe_path}: {str(e)}"
         )
-        raise CondaBuildUserError(msg)
-    else:
-        print("\nFailed: none")
+        return False, str(err), None
 
-    return 1 if failed else 0
+    try:
+        rendered = recipe.render(variant_config, render_config)
+    except RattlerBuildError as e:
+        err = CondaBuildUserError(f"Failed to render recipe {recipe_path}: {str(e)}")
+        return False, str(err), None
+
+    if command == "render":
+        for item in rendered:
+            data = item.recipe.to_dict()
+            print(yaml.safe_dump(data, indent=2, sort_keys=False))
+        return True, None, None
+
+    for i, variant in enumerate(rendered, 1):
+        print(
+            f"\nBuilding variant {i}/{len(rendered)} for recipe {Path(recipe_path).absolute()}"
+        )
+
+        try:
+            build_result = variant.run_build(
+                tool_config=tool_config,
+                output_dir=output_dir,
+                channels=channels,
+                progress_callback=CondaProgressCallback(show_logs=show_logs),
+                no_build_id=no_build_id,
+                package_format=package_format,
+                no_include_recipe=no_include_recipe,
+            )
+        except RattlerBuildError as e:
+            err = CondaBuildUserError(f"Failed to build recipe {recipe_path}: {str(e)}")
+            return False, str(err), None
+
+        if not parsed_args.notest:
+            built_package_path = build_result.packages[0]
+            pkg = Package.from_file(built_package_path)
+
+            test_results = pkg.run_tests(
+                progress_callback=CondaProgressCallback(show_logs=show_logs)
+            )
+
+            test_failed = [r for r in test_results if not r.success]
+            if test_failed:
+                test_log = "\n\n".join("".join(r.output) for r in test_failed)
+                return (
+                    False,
+                    (
+                        f"Failed tests for recipe {Path(recipe_path).absolute()}: "
+                        f"{len(test_failed)} test(s) failed"
+                    ),
+                    test_log,
+                )
+
+    return True, None, None
 
 
 def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -> int:
@@ -202,7 +189,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         raise ValueError(f"Unrecognized subcommand: {command}")
 
     # Initialize configuration defaults
-    test_strategy: str | None = None
     skip_existing: bool | None = None
     noarch_build_platform: str | None = None
     channel_priority: str | None = None
@@ -295,7 +281,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
 
     # common tool / platform / render configuration
     tool_config = ToolConfiguration(
-        test_strategy=test_strategy,
+        test_strategy=None,
         skip_existing=skip_existing,
         noarch_build_platform=noarch_build_platform,
         channel_priority=channel_priority,
@@ -327,17 +313,58 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             for variant in config_files:
                 variant_config = variant_config.merge(VariantConfig.from_file(variant))
 
-        return process_recipes(
-            recipes=recipes,
-            variant_config=variant_config,
-            command=command,
-            output_dir=output_dir,
-            channels=channels,
-            show_logs=show_logs,
-            no_build_id=no_build_id,
-            package_format=package_format,
-            no_include_recipe=no_include_recipe,
-            tool_config=tool_config,
-            platform_config=platform_config,
-            render_config=render_config,
-        )
+        succeeded: list[str] = []
+        failed: dict[str, str] = {}
+        failed_logs: dict[str, str] = {}
+
+        for recipe_path in recipes:
+            ok, err, test_log = process_recipe(
+                recipe_path=recipe_path,
+                variant_config=variant_config,
+                command=command,
+                output_dir=output_dir,
+                channels=channels,
+                show_logs=show_logs,
+                no_build_id=no_build_id,
+                package_format=package_format,
+                no_include_recipe=no_include_recipe,
+                tool_config=tool_config,
+                render_config=render_config,
+                parsed_args=parsed_args,
+            )
+            if ok:
+                succeeded.append(recipe_path)
+            else:
+                failed[recipe_path] = err or f"Failed recipe {recipe_path}"
+                if test_log:
+                    failed_logs[recipe_path] = test_log
+
+        # summary
+        print("\n=== Build summary ===")
+        if succeeded:
+            print("Succeeded:")
+            for path in succeeded:
+                print(f"  - {path}")
+        else:
+            print("Succeeded: none")
+
+        if failed:
+            print("\nFailed:")
+            for p, e in failed.items():
+                print(f"  - {Path(p).resolve()}")
+
+            if failed_logs and not show_logs:
+                print("\n=== Test logs ===")
+                for p, log in failed_logs.items():
+                    print(f"\n--- {Path(p).resolve()} ---")
+                    print(log, end="" if log.endswith("\n") else "\n")
+
+            msg = "Recipe build failures:\n" + "\n".join(
+                f"  - {Path(p).absolute()}: {e}" for p, e in failed.items()
+            )
+
+            raise CondaBuildUserError(msg)
+        else:
+            print("\nFailed: none")
+
+        return 1 if failed else 0

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -304,7 +304,9 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             )
         channels = list(parsed_args.channel)
     else:
-        channels = list(context.channels)
+        channels = [channel for channel in context.channels if channel != "defaults"]
+        if "defaults" in context.channels:
+            channels.extend(channel.base_url for channel in context.default_channels)
 
     # Local and multichannel not supported yet, xref https://github.com/conda/rattler/issues/1327
     channels = list(dict.fromkeys(c for c in channels if c != "local"))

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -350,8 +350,11 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             for p, e in failed.items():
                 print(f"  - {Path(p).resolve()}")
 
-            msg = "Recipe build failures:\n" + "\n".join(
-                f"  - {Path(p).absolute()}: {e}" for p, e in failed.items()
+            msg = "\n".join(
+                [
+                    "Recipe build failures",
+                    *[f"  - {Path(p).absolute()}: {e}" for p, e in failed.items()],
+                ]
             )
 
             raise CondaBuildUserError(msg)

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -337,11 +337,10 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             ]
 
         # configure variant
-        # TODO: implement support for multiple config files
-        # xref https://github.com/prefix-dev/rattler-build/issues/2336
+        # merge config files in the order they are stacked
         if config_files:
             for variant in config_files:
-                variant_config = VariantConfig.from_file(variant)
+                variant_config = variant_config.merge(VariantConfig.from_file(variant))
 
         return process_recipes(
             recipes=recipes,

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -12,7 +12,7 @@ from rattler_build import (
 )
 from rattler_build.progress import SimpleProgressCallback
 from rattler_build.render import RenderConfig
-from rattler_build.stage0 import MultiOutputRecipe, Stage0Recipe
+from rattler_build.stage0 import Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 from rattler_build.variant_config import VariantConfig
 
@@ -99,15 +99,9 @@ def process_recipes(
     no_build_id: bool,
     package_format: str,
     no_include_recipe: bool,
-    target_platform: str,
-    build_platform: str,
-    host_platform: str,
-    experimental: bool,
-    extra_context: dict[str],
-    test_strategy: str,
-    skip_existing: bool,
-    noarch_build_platform: str,
-    channel_priority: str,
+    tool_config: ToolConfiguration,
+    platform_config: PlatformConfig,
+    render_config: RenderConfig,
 ) -> int:
 
     succeeded: list[str] = []
@@ -125,33 +119,6 @@ def process_recipes(
             )
             failed[recipe_path_str] = str(err)
             continue
-
-        if isinstance(recipe, MultiOutputRecipe):
-            for output in recipe.outputs:
-                output_dict = output.to_dict()
-                print(output_dict)
-                if "staging" in output_dict:
-                    experimental = True
-
-        # common tool / platform / render configuration
-        tool_config = ToolConfiguration(
-            test_strategy=test_strategy,
-            skip_existing=skip_existing,
-            noarch_build_platform=noarch_build_platform,
-            channel_priority=channel_priority,
-        )
-
-        platform_config = PlatformConfig(
-            target_platform=target_platform,
-            build_platform=build_platform,
-            host_platform=host_platform,
-            experimental=experimental,
-        )
-
-        render_config = RenderConfig(
-            platform=platform_config,
-            extra_context=extra_context,
-        )
 
         # render the recipe
         try:
@@ -228,7 +195,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     output_dir: str = config.croot
     no_include_recipe: bool = False
     no_build_id: bool = False
-    experimental: bool = False
     package_format: str | None = None
     channels: list[str] = []
     extra_context: dict[str] = {}
@@ -326,6 +292,25 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         else:
             package_format = ".tar.bz2"
 
+    # common tool / platform / render configuration
+    tool_config = ToolConfiguration(
+        test_strategy=test_strategy,
+        skip_existing=skip_existing,
+        noarch_build_platform=noarch_build_platform,
+        channel_priority=channel_priority,
+    )
+
+    platform_config = PlatformConfig(
+        target_platform=target_platform,
+        build_platform=build_platform,
+        host_platform=host_platform,
+    )
+
+    render_config = RenderConfig(
+        platform=platform_config,
+        extra_context=extra_context,
+    )
+
     if command in ("build", "render"):
         if command in ("render"):
             recipe_path = join(parsed_args.recipe, "recipe.yaml")
@@ -352,13 +337,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
             no_build_id=no_build_id,
             package_format=package_format,
             no_include_recipe=no_include_recipe,
-            target_platform=target_platform,
-            build_platform=build_platform,
-            host_platform=host_platform,
-            experimental=experimental,
-            extra_context=extra_context,
-            test_strategy=test_strategy,
-            skip_existing=skip_existing,
-            noarch_build_platform=noarch_build_platform,
-            channel_priority=channel_priority,
+            tool_config=tool_config,
+            platform_config=platform_config,
+            render_config=render_config,
         )

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -152,7 +152,7 @@ def process_recipe(
     parsed_args: argparse.Namespace,
 ) -> RecipeResult:
     """
-    Function to parse, render and optionally build or test a conda packlage recipe using the py-rattler-build API.
+    Function to parse, render and optionally build or test a conda package recipe using the py-rattler-build API.
 
     Workflow:
         - Load and parse the recipe via `Stage0Recipe.from_file()`

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -297,19 +297,26 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
     )
     variant_config: VariantConfig = VariantConfig()
 
+    # select list of channels to iterate over:
+    #   a) select channels passed through the CLI if --override-channels
+    #   b) use all channels from Conda's context otherwise
     if parsed_args.override_channels:
         if not parsed_args.channel:
             raise CondaBuildUserError(
                 "Channels must be specified using -c/--channel argument when --override-channels is used."
             )
-        channels = list(parsed_args.channel)
+        source_channels = parsed_args.channel
     else:
-        channels = [channel for channel in context.channels if channel != "defaults"]
-        if "defaults" in context.channels:
-            channels.extend(channel.base_url for channel in context.default_channels)
+        source_channels = context.channels
 
-    # Local and multichannel not supported yet, xref https://github.com/conda/rattler/issues/1327
-    channels = list(dict.fromkeys(c for c in channels if c != "local"))
+    for channel in source_channels:
+        # handle multichannels ('defaults', 'local' and user defined multichannels)
+        if channel in context.custom_multichannels:
+            channels.extend(
+                str(subchannel) for subchannel in context.custom_multichannels[channel]
+            )
+        else:
+            channels.append(channel)
 
     if context.channel_priority == "strict":
         channel_priority = "strict"

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -280,6 +280,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
 
     # common tool / platform / render configuration
     tool_config = ToolConfiguration(
+        # test execution is handled manually in process_recipe()
         test_strategy=None,
         skip_existing=skip_existing,
         noarch_build_platform=noarch_build_platform,

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -63,7 +63,6 @@ def check_arguments_rattler(
         "build": {
             "recipe",
             "variant_config_files",
-            "verbose",
             "exclusive_config_files",
             "extra_meta",
             "output_folder",
@@ -81,7 +80,6 @@ def check_arguments_rattler(
         "render": {
             "recipe",
             "variant_config_files",
-            "verbose",
             "exclusive_config_files",
             "channel",
             "override_channels",
@@ -284,10 +282,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
                 recipe_config_filenames=CONFIG_FILES,
             )
 
-        # if config.verbose:
-        # TODO: find this option in py-rattler-build
-        # cmd.append("--verbose")
-
     # TODO: output_name does not exist in python bindings
     # if parsed_args.output_id:
     # cmd.extend(["--output-name", parsed_args.output_id])
@@ -297,10 +291,6 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
         if parsed_args.output_folder:
             output_dir = parsed_args.output_folder
         no_build_id = not parsed_args.set_build_id
-        test_strategy = "skip" if parsed_args.notest else "native"
-        # if parsed_args.quiet:
-        # TODO: quiet does not exist in py-rattler-build
-        # cmd.append("-q")
         skip_existing = parsed_args.skip_existing or "none"
         no_include_recipe = not parsed_args.include_recipe
         if parsed_args.conda_pkg_format == CondaPkgFormat.V2:

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -311,6 +311,7 @@ def run_rattler(command: str, parsed_args: argparse.Namespace, config: Config) -
 
     for channel in source_channels:
         # handle multichannels ('defaults', 'local' and user defined multichannels)
+        # TODO: fix multichannel priority
         if channel in context.custom_multichannels:
             channels.extend(
                 str(subchannel) for subchannel in context.custom_multichannels[channel]

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -127,6 +127,15 @@ def process_recipe(
     render_config: RenderConfig,
     parsed_args: argparse.Namespace,
 ) -> tuple[bool, str | None, str | None]:
+    """
+    Function to parse, render and optionally build or test a conda packlage recipe using the py-rattler-build API.
+
+    Workflow:
+        - Load and parse the recipe via `Stage0Recipe.from_file()`
+        - Render the recipe variants according to the provided variant and render configuration objects
+        - Build each rendered variant using `variant.run_build()`
+        - If testing is enabled, run tests on the built package with `Package.run_tests()`
+    """
 
     try:
         recipe = Stage0Recipe.from_file(Path(recipe_path))

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -105,7 +105,8 @@ def execute(args: Sequence[str] | None = None) -> int:
         parsed_only_recipe = parser.parse_args([parsed.recipe_or_package_file_path])
         check_arguments_rattler(parser.prog.split()[-1], parsed, parsed_only_recipe)
         parsed.recipe = parsed.recipe_or_package_file_path
-        return run_rattler(parsed, config)
+        command = parser.prog.split()[-1]
+        return run_rattler(command, parsed, config)
 
     try:
         activation_string = api.debug(

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -9,9 +9,7 @@ from typing import TYPE_CHECKING
 from conda.base.context import context
 
 from .. import api
-from .._rattler_build.compat import check_arguments_rattler, run_rattler
-from ..config import get_or_merge_config
-from ..utils import is_v1_recipe, on_win
+from ..utils import on_win
 from . import validators as valid
 from .main_render import get_render_parser
 
@@ -99,14 +97,6 @@ def execute(args: Sequence[str] | None = None) -> int:
     parser = get_parser()
     parsed = parser.parse_args(args)
     context.__init__(argparse_args=parsed)
-
-    if is_v1_recipe(parsed.recipe_or_package_file_path):
-        config = get_or_merge_config(None, **parsed.__dict__)
-        parsed_only_recipe = parser.parse_args([parsed.recipe_or_package_file_path])
-        check_arguments_rattler(parser.prog.split()[-1], parsed, parsed_only_recipe)
-        parsed.recipe = parsed.recipe_or_package_file_path
-        command = parser.prog.split()[-1]
-        return run_rattler(command, parsed, config)
 
     try:
         activation_string = api.debug(

--- a/news/5924-py-rattler.md
+++ b/news/5924-py-rattler.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Port v1 recipe support to py-rattler-build (#5924).
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - pkginfo
     - psutil
     - py-lief
-    - py-rattler-build >=0.61.1
+    - py-rattler-build >=0.61.4
     - python
     - python-libarchive-c
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - pkginfo
     - psutil
     - py-lief
-    - py-rattler-build >=0.58.0
+    - py-rattler-build >=0.58.2
     - python
     - python-libarchive-c
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - pkginfo
     - psutil
     - py-lief
+    - py-rattler-build >=0.58.0
     - python
     - python-libarchive-c
     - pyyaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - pkginfo
     - psutil
     - py-lief
-    - py-rattler-build >=0.58.2
+    - py-rattler-build >=0.61.1
     - python
     - python-libarchive-c
     - pyyaml

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -562,8 +562,15 @@ def test_build_with_empty_channel_fails(empty_channel: Path) -> None:
 def test_build_v1_recipe() -> None:
     """Test building a v1 recipe"""
     recipe = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
+    env_file = os.path.join(
+        metadata_dir, "..", "variants", "32_v1_recipe", "environment.yml"
+    )
 
     args = [recipe, "-c", "conda-forge", "--override-channels"]
+    assert main_build.execute(args) == 0
+
+    # Check if default channels will be handled properly
+    args = [recipe, "-c", "conda-forge", "-m", env_file]
     assert main_build.execute(args) == 0
 
 

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -586,3 +586,20 @@ def test_build_v1_recipe_multi_output(testing_workdir: str) -> None:
 
     conda_packages = list(out.rglob("*.conda"))
     assert len(conda_packages) == 2
+
+
+def test_build_v1_recipe_result_report(capsys) -> None:
+    """Test for checking build summary report when building multiple recipes"""
+    recipe1 = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
+    recipe2 = os.path.join(metadata_dir, "..", "variants", "33_v1_recipe_multi_output")
+
+    args = [recipe1, recipe2, "-c", "conda-forge", "--override-channels"]
+    assert main_build.execute(args) == 0
+
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+
+    assert "Tried to build 2 recipe files, resulting in 3 outputs." in output
+    assert "pytest: Succeeded" in output
+    assert "myproject-lib: Succeeded" in output
+    assert "myproject-tools: Succeeded" in output

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -566,38 +566,10 @@ def test_build_v1_recipe() -> None:
     args = [recipe, "-c", "conda-forge", "--override-channels"]
     assert main_build.execute(args) == 0
 
+    # check if 'defaults' multichannel will be handled properly
 
-def test_build_v1_with_multi_channel(capfd) -> None:
-    """Test building a v1 recipe with multichannels"""
-    recipe = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
-    env_file = os.path.join(
-        metadata_dir, "..", "variants", "32_v1_recipe", "environment.yml"
-    )
-
-    # Check if default channel will be handled properly
-    args = [
-        recipe,
-        "-m",
-        env_file,
-        "--override-channels",
-        "-c",
-        "defaults",
-        "-c",
-        "conda-forge",
-        "--no-test",
-    ]
+    args = [recipe, "-c", "conda-forge", "-c", "defaults", "--override-channels"]
     assert main_build.execute(args) == 0
-
-    out, err = capfd.readouterr()
-
-    expected_channels = [
-        "https://repo.anaconda.com/pkgs/main/",
-        "https://repo.anaconda.com/pkgs/r/",
-        "conda-forge",
-    ]
-
-    for channel in expected_channels:
-        assert channel in out
 
 
 def test_build_v1_recipe_multi_output(testing_workdir: str) -> None:

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -559,9 +559,23 @@ def test_build_with_empty_channel_fails(empty_channel: Path) -> None:
         )
 
 
-def test_build_with_v1_recipe() -> None:
+def test_build_v1_recipe() -> None:
     """Test building a v1 recipe"""
     recipe = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
 
-    args = [recipe]
+    args = [recipe, "-c", "conda-forge"]
     assert main_build.execute(args) == 0
+
+
+def test_build_v1_recipe_multi_output(testing_workdir: str) -> None:
+    """Test building a multi-output v1 recipe"""
+    recipe = os.path.join(metadata_dir, "..", "variants", "33_v1_recipe_multi_output")
+
+    out = Path(testing_workdir, "out")
+    out.mkdir(parents=True)
+
+    args = [recipe, "--output-folder", str(out), "-c", "conda-forge"]
+    assert main_build.execute(args) == 0
+
+    conda_packages = list(out.rglob("*.conda"))
+    assert len(conda_packages) == 2

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -562,16 +562,42 @@ def test_build_with_empty_channel_fails(empty_channel: Path) -> None:
 def test_build_v1_recipe() -> None:
     """Test building a v1 recipe"""
     recipe = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
-    env_file = os.path.join(
-        metadata_dir, "..", "variants", "32_v1_recipe", "environment.yml"
-    )
 
     args = [recipe, "-c", "conda-forge", "--override-channels"]
     assert main_build.execute(args) == 0
 
-    # Check if default channels will be handled properly
-    args = [recipe, "-c", "conda-forge", "-m", env_file]
+
+def test_build_v1_with_multi_channel(capfd) -> None:
+    """Test building a v1 recipe with multichannels"""
+    recipe = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
+    env_file = os.path.join(
+        metadata_dir, "..", "variants", "32_v1_recipe", "environment.yml"
+    )
+
+    # Check if default channel will be handled properly
+    args = [
+        recipe,
+        "-m",
+        env_file,
+        "--override-channels",
+        "-c",
+        "defaults",
+        "-c",
+        "conda-forge",
+        "--no-test",
+    ]
     assert main_build.execute(args) == 0
+
+    out, err = capfd.readouterr()
+
+    expected_channels = [
+        "https://repo.anaconda.com/pkgs/main/",
+        "https://repo.anaconda.com/pkgs/r/",
+        "conda-forge",
+    ]
+
+    for channel in expected_channels:
+        assert channel in out
 
 
 def test_build_v1_recipe_multi_output(testing_workdir: str) -> None:

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -563,7 +563,7 @@ def test_build_v1_recipe() -> None:
     """Test building a v1 recipe"""
     recipe = os.path.join(metadata_dir, "..", "variants", "32_v1_recipe")
 
-    args = [recipe, "-c", "conda-forge"]
+    args = [recipe, "-c", "conda-forge", "--override-channels"]
     assert main_build.execute(args) == 0
 
 
@@ -574,7 +574,14 @@ def test_build_v1_recipe_multi_output(testing_workdir: str) -> None:
     out = Path(testing_workdir, "out")
     out.mkdir(parents=True)
 
-    args = [recipe, "--output-folder", str(out), "-c", "conda-forge"]
+    args = [
+        recipe,
+        "--output-folder",
+        str(out),
+        "-c",
+        "conda-forge",
+        "--override-channels",
+    ]
     assert main_build.execute(args) == 0
 
     conda_packages = list(out.rglob("*.conda"))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,6 +17,7 @@ pip
 pkginfo
 psutil
 py-lief
+py-rattler-build
 pytest-rerunfailures  # for handling flaky tests
 python >=3.10
 python-libarchive-c

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,7 +17,7 @@ pip
 pkginfo
 psutil
 py-lief
-py-rattler-build
+py-rattler-build >=0.61.4 # v1 recipe support
 pytest-rerunfailures  # for handling flaky tests
 python >=3.10
 python-libarchive-c

--- a/tests/test-recipes/variants/32_v1_recipe/environment.yml
+++ b/tests/test-recipes/variants/32_v1_recipe/environment.yml
@@ -1,0 +1,2 @@
+channels:
+  - defaults

--- a/tests/test-recipes/variants/32_v1_recipe/environment.yml
+++ b/tests/test-recipes/variants/32_v1_recipe/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - defaults

--- a/tests/test-recipes/variants/32_v1_recipe/environment.yml
+++ b/tests/test-recipes/variants/32_v1_recipe/environment.yml
@@ -1,2 +1,3 @@
 channels:
+  - conda-forge
   - defaults

--- a/tests/test-recipes/variants/32_v1_recipe/recipe.yaml
+++ b/tests/test-recipes/variants/32_v1_recipe/recipe.yaml
@@ -1,47 +1,52 @@
+schema_version: 1
+
 context:
-  version: 9.0.2
+  version: 9.0.3
+  python_min: '3.10'
 
 package:
   name: pytest
   version: ${{ version }}
 
 source:
-- url: https://pypi.org/packages/source/p/pytest/pytest-${{ version }}.tar.gz
-  sha256: 75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11
+  url: https://pypi.org/packages/source/p/pytest/pytest-${{ version }}.tar.gz
+  sha256: b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
 
 build:
-  script: ${{ PYTHON }} -m pip install .
+  number: 1
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
   python:
     entry_points:
-    - py.test = pytest:console_main
-    - pytest = pytest:console_main
-  noarch: python
+      - pytest = pytest:console_main
+      - py.test = pytest:console_main
 
 requirements:
   host:
-  - python >=3.10
-  - setuptools>=77
-  - setuptools-scm>=6.2.3
-  - pip
+    - pip
+    - python ${{ python_min }}.*
+    - setuptools >=77
+    - setuptools_scm >=6.2.3
   run:
-  - python >=3.10
-  - colorama >=0.4 # sys_platform == "win32"
-  - exceptiongroup >=1 # python_version < "3.11"
-  - iniconfig >=1.0.1
-  - packaging >=22
-  - pluggy <2,>=1.5
-  - pygments >=2.7.2
-  - tomli >=1
-  - argcomplete  # extra == "dev"
-  - attrs >=19.2 # extra == "dev"
-  - hypothesis >=3.56 # extra == "dev"
-  - mock  # extra == "dev"
-  - requests  # extra == "dev"
-  - setuptools  # extra == "dev"
-  - xmlschema  # extra == "dev"
+    - colorama >=0.4
+    - pygments >=2.7.2
+    - python >=${{ python_min }}
+    - iniconfig >=1.0.1
+    - packaging >=22
+    - pluggy >=1.5,<2
+    - tomli >=1
+    - exceptiongroup >=1
+  run_constraints:
+    - pytest-faulthandler >=2
 
 tests:
-- python:
-    imports:
-    - pytest
-    pip_check: true
+  - python:
+      imports:
+        - pytest
+      python_version:
+        - ${{ python_min }}.*
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - pytest -h

--- a/tests/test-recipes/variants/33_v1_recipe_multi_output/recipe.yaml
+++ b/tests/test-recipes/variants/33_v1_recipe_multi_output/recipe.yaml
@@ -1,0 +1,51 @@
+schema_version: 1
+
+context:
+  name: myproject
+  version: "2.0.0"
+
+recipe:
+  version: ${{ version }}
+
+outputs:
+  # First output: The library
+  - package:
+      name: ${{ name }}-lib
+    build:
+      script:
+        interpreter: python
+        content: |
+          import os
+          from pathlib import Path
+
+          prefix = Path(os.environ["PREFIX"])
+          lib_dir = prefix / "lib" / "python"
+          lib_dir.mkdir(parents=True, exist_ok=True)
+
+          (lib_dir / "myproject_lib.py").write_text('VERSION = "2.0.0"')
+          print(f"Created library at {lib_dir}")
+    requirements:
+      build:
+        - python
+
+  # Second output: Uses the library as a host dependency
+  - package:
+      name: ${{ name }}-tools
+    build:
+      script:
+        interpreter: python
+        content: |
+          import os
+          from pathlib import Path
+
+          prefix = Path(os.environ["PREFIX"])
+
+          # Read and print the lib file (installed as host dependency)
+          lib_file = prefix / "lib" / "python" / "myproject_lib.py"
+          print(f"Reading library from: {lib_file}")
+          print(lib_file.read_text())
+    requirements:
+      build:
+        - python
+      host:
+        - ${{ name }}-lib

--- a/tests/test_v1_recipes.py
+++ b/tests/test_v1_recipes.py
@@ -1,0 +1,193 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+from rattler_build.package import Package
+from rattler_build.render import RenderConfig
+from rattler_build.stage0 import Stage0Recipe
+from rattler_build.tool_config import PlatformConfig
+from rattler_build.variant_config import VariantConfig
+
+
+def test_variants():
+    """
+    Test variants with multiple values for one key.
+    """
+
+    recipe_yaml = """
+package:
+  name: test-multi-variant
+  version: 1.0.0
+
+build:
+  string: np${{ numpy | replace(".", "") }}py${{ python | replace(".", "") }}h${{ hash }}_${{ build_number }}
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python }}.*
+    - numpy ${{ numpy }}.*
+  run:
+    - python ${{ python }}.*
+    - numpy ${{ numpy }}.*
+
+about:
+  summary: Test recipe for multiple variant values
+  """
+
+    variant_yaml = """
+python:
+  - 3.11
+  - 3.12
+
+numpy:
+  - 2.0
+  """
+
+    # load and render the recipe
+    recipe = Stage0Recipe.from_yaml(recipe_yaml)
+    variant_config = VariantConfig.from_yaml(variant_yaml)
+    rendered = recipe.render(variant_config, RenderConfig())
+
+    # we should have 2 variants
+    assert len(rendered) == 2
+
+    # check first output
+    assert "python 3.11.*" in rendered[0].recipe.requirements.host
+    assert "numpy 2.0.*" in rendered[0].recipe.requirements.host
+    assert rendered[0].recipe.used_variant["python"] == "3.11"
+    assert rendered[0].recipe.used_variant["numpy"] == "2.0"
+    assert "np20py311" in rendered[0].recipe.build.string
+
+    # check second output
+    assert "python 3.12.*" in rendered[1].recipe.requirements.host
+    assert "numpy 2.0.*" in rendered[1].recipe.requirements.host
+    assert rendered[1].recipe.used_variant["python"] == "3.12"
+    assert rendered[1].recipe.used_variant["numpy"] == "2.0"
+    assert "np20py312" in rendered[1].recipe.build.string
+
+
+def test_noarch_python():
+    recipe_yaml = """
+context:
+  name: toml
+  version: 0.10.2
+
+package:
+  name: "${{ name|lower }}"
+  version: "${{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
+
+build:
+  noarch: python
+  script: python -m pip install . -vv
+
+requirements:
+  host:
+    - python 3.12.1.*
+    - pip 23.3.2.*
+    - setuptools 68.*
+  run:
+    - python >=3.11
+
+about:
+  homepage: https://github.com/uiri/toml
+  license: MIT
+  license_file: LICENSE
+  summary: Python lib for TOML.
+
+extra:
+  recipe-maintainers:
+    - conda-forge/toml-feedstock
+  foobar: 123
+  tags:
+    - toml
+    - config
+    - parser
+    """
+
+    # load, render and build the recipe
+    recipe = Stage0Recipe.from_yaml(recipe_yaml)
+    rendered = recipe.render(VariantConfig(), RenderConfig())
+    build_result = rendered[0].run_build()
+
+    package = Package.from_file(build_result.packages[0])
+
+    assert "site-packages/toml-0.10.2.dist-info/INSTALLER" in package.files
+    assert "site-packages/toml-0.10.2.dist-info/LICENSE" in package.files
+
+    assert "python" in package.depends
+    assert "python >=3.11" in package.depends
+
+
+def test_noarch_variant():
+    recipe_yaml = """
+context:
+  name: rattler-build-demo
+  version: 1
+  build_variant: ${{ 'unix' if unix else 'win' }}
+  build_number: 0
+
+outputs:
+  - package:
+      name: ${{ name }}
+      version: ${{ version }}
+    build:
+      noarch: generic
+      number: ${{ build_number }}
+      string: ${{ build_variant }}_${{ hash }}_${{ build_number }}
+    requirements:
+      run:
+        - ${{ "__unix" if unix }}
+        - ${{ "__win >=11.0.123 foobar" if win }}
+
+  - package:
+      name: ${{ name }}-subpackage
+      version: ${{ version }}
+    build:
+      noarch: generic
+      number: ${{ build_number }}
+      string: ${{ build_variant }}_${{ hash }}_${{ build_number }}
+    requirements:
+      run:
+        - ${{ pin_subpackage('rattler-build-demo', exact=True) }}
+    """
+
+    recipe = Stage0Recipe.from_yaml(recipe_yaml)
+
+    platform_config = PlatformConfig(target_platform="linux-64")
+
+    render_config = RenderConfig(platform=platform_config)
+    rendered = recipe.render(VariantConfig(), render_config)
+
+    assert len(rendered) == 2
+
+    output1 = rendered[0].recipe.to_dict()
+    assert output1["requirements"]["run"] == ["__unix"]
+    assert output1["build"]["string"] == "unix_5600cae_0"
+
+    output2 = rendered[1].recipe.to_dict()
+    pin = {"pin_subpackage": {"name": "rattler-build-demo", "exact": True}}
+    assert output2["build"]["string"] == "unix_63d9094_0"
+    assert output2["build"]["noarch"] == "generic"
+    assert output2["requirements"]["run"] == [pin]
+
+    platform_config = PlatformConfig(target_platform="win-64")
+
+    render_config = RenderConfig(platform=platform_config)
+    rendered = recipe.render(VariantConfig(), render_config)
+
+    assert len(rendered) == 2
+    output1_win = rendered[0].recipe.to_dict()
+    assert output1_win["requirements"]["run"] == ["__win >=11.0.123 foobar"]
+    assert output1_win["build"]["string"] == "win_19aa286_0"
+    assert output1_win["build"]["noarch"] == "generic"
+
+    pin = {"pin_subpackage": {"name": "rattler-build-demo", "exact": True}}
+
+    output2_win = rendered[1].recipe.to_dict()
+    assert output2_win["build"]["string"] == "win_95d38b2_0"
+    assert output2_win["build"]["noarch"] == "generic"
+    assert output2_win["requirements"]["run"] == [pin]


### PR DESCRIPTION
Closes: https://github.com/conda/conda-build/issues/5891
Closes: https://github.com/conda/conda-build/issues/5892
Closes: https://github.com/conda/conda-build/issues/5893
Closes: https://github.com/conda/conda-build/issues/5897
Closes: https://github.com/conda/conda-build/issues/5895
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR continues the work started in https://github.com/conda/conda-build/pull/5880 replacing the `rattler-build` CLI subprocess calls with the new py-rattler API.

It currently supports rendering and building v1 packages. Support for `conda-debug` was removed due to issues with the debug API; which has since been refactored in py-rattler and will be integrated in a subsequent PR to reduce the complexity in this one.

Py-rattler API documentation is available [here](https://rattler-build.prefix.dev/latest/py-rattler-build/reference/), but this summary describes how the API is used within this PR for easier review:

- The logic for finding rattler-build binary has been removed as we are no longer using the CLI tool.
- Core functionality of the code is in `run_rattler()` and `process_recipe()` functions.
- `run_rattler()` initializes configuration variables based on the values stored in `argparse.Namespace` and `Config` objects. It delegates recipe processing to a separate function and handles the build summary reporting at the end.
- Configuration file discovery logic has remained largely unchanged from the previous version
- Most of the rattler-build general settings are now handled through [`ToolConfiguration`](https://rattler-build.prefix.dev/latest/py-rattler-build/reference/configuration/#rattler_build.ToolConfiguration), while [`PlatformConfig`](https://rattler-build.prefix.dev/latest/py-rattler-build/reference/configuration/#platformconfig) and [`RenderConfig`](https://rattler-build.prefix.dev/latest/py-rattler-build/reference/rendering/#renderconfig) define platform-specific settings and rendering behavior, respectively.
- Configuration files are loaded using `VariantConfig.from_file()` method, respecting the order in which they are stacked.

`process_recipes()` performs loading, rendering, build and testing the recipe. Recipes are loaded with `Stage0Recipe.from_file()`, rendered with `recipe.render()` and build with `variant.run_build()`. If enabled, testing runs after the build to follow v0 recipe behavior in `conda-build`. 
 

#### Progress reporting

Py-rattler uses the [`ProgressCallback`](https://rattler-build.prefix.dev/latest/py-rattler-build/reference/progress/#progress) protocol for progress reporting, with some built-in implementations and options to define custom callbacks. This PR integrates `SimpleProgressCallback` and forwards the event levels and messages to conda’s logging system. This implementation is minimal but additional UI improvements are expected to be added in future versions.

#### Build results and summary

Build results are stored in dataclasses that contain recipe and output info about build status and error messages. Each `process_recipe()` call returns a `RecipeResult` object containing all relevant build summary details. Short summary is displayed upon completion, displaying per-recipe and per-output build results along with any errors if present.



#### Limitations/features currently not implemented:
- As previously mentioned, no`conda-debug` support, will be added in a separate PR
- No multi-output with staging outputs recipe support. It is currently labeled as an experimental feature in rattler-build and depends on the draft CEP: https://github.com/conda/ceps/pull/102 
- ~~No multichannel support, depends on https://github.com/conda/rattler/issues/1327~~ **EDIT**: multichannels are taken care of with 5d34a0c9d841a9fa965c3dbaa53660498c2ddb60
- Package upload and networking-specific configuration are currently not supported, subsequent work is planned in https://github.com/conda/conda-build/issues/5894 and https://github.com/conda/conda-build/issues/5898
- User documentation will be added in a separate PR (https://github.com/conda/conda-build/issues/5896)

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
