### PR TITLE
Remove osx-64 (macos-15-intel) from canary build matrix

### DIFF
--- a/.github/workflows/builds-review.yaml
+++ b/.github/workflows/builds-review.yaml
@@ -19,8 +19,6 @@ jobs:
             subdir: linux-64
           - runner: macos-latest
             subdir: osx-arm64
-          - runner: macos-15-intel  # FUTURE: Deprecated in Fall 2027
-            subdir: osx-64
           - runner: windows-latest
             subdir: win-64
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -567,8 +567,6 @@ jobs:
         include:
           - runner: ubuntu-latest
             subdir: linux-64
-          - runner: macos-15-intel # FUTURE: Deprecated in Fall 2027
-            subdir: osx-64
           - runner: macos-latest
             subdir: osx-arm64
           - runner: windows-latest


### PR DESCRIPTION
## Description

Remove the `macos-15-intel` / `osx-64` runner from the canary build matrix. This runner is failing on the `26.3.x` release branch and blocking the canary release builds.

Xref #5931