### PR TITLE
Tests: pull `rattler-build` from the main channel, fix some issues with test recipes

### DIFF
--- a/tests/cli/test_main_skeleton.py
+++ b/tests/cli/test_main_skeleton.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import os
+import re
+from pathlib import Path
 
 import pytest
 
@@ -13,6 +15,17 @@ def test_skeleton_pypi(testing_workdir, testing_config):
     args = ["pypi", "peppercorn"]
     main_skeleton.execute(args)
     assert os.path.isdir("peppercorn")
+
+    # add setuptools to host dependencies
+    path = Path("peppercorn/meta.yaml")
+    path.write_text(
+        re.sub(
+            r"(  host:\n(?:    - .*\n)*?)(  run:\n)",
+            r"\1    - setuptools\n\2",
+            path.read_text(),
+            count=1,
+        )
+    )
 
     # ensure that recipe generated is buildable
     main_build.execute(("peppercorn",))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
 beautifulsoup4
 chardet
 conda >=25.11.0
-conda-forge::rattler-build
 conda-index >=0.4.0
 conda-libmamba-solver >=25.11.0  # includes fix for CondaSolver deprecation warnings
 conda-package-handling >=2.2.0
@@ -22,6 +21,7 @@ pytest-rerunfailures  # for handling flaky tests
 python >=3.10
 python-libarchive-c
 pyyaml
+rattler-build
 requests
 ripgrep  # for faster grep
 setuptools

--- a/tests/test-recipes/metadata/_script_win_creates_exe/meta.yaml
+++ b/tests/test-recipes/metadata/_script_win_creates_exe/meta.yaml
@@ -11,3 +11,4 @@ build:
 requirements:
   build:
     - python
+    - setuptools

--- a/tests/test-recipes/metadata/_script_win_creates_exe_garbled/meta.yaml
+++ b/tests/test-recipes/metadata/_script_win_creates_exe_garbled/meta.yaml
@@ -11,3 +11,4 @@ build:
 requirements:
   build:
     - python
+    - setuptools

--- a/tests/test-recipes/metadata/jinja_load_yaml/meta.yaml
+++ b/tests/test-recipes/metadata/jinja_load_yaml/meta.yaml
@@ -12,6 +12,7 @@ requirements:
   build:
     - {{ deps[0].replace("=", " =") }}
     - pip
+    - setuptools
 
   run:
   {% for dep in deps -%}

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1916,7 +1916,7 @@ def test_warning_on_file_clobbering(
         config=testing_config,
     )
     # The clobber warning here is raised when creating the test environment for b
-    if Version(conda_version) >= Version("24.9.0"):
+    if Version("24.9.0") <= Version(conda_version) <= Version("26.3.2"):
         # conda >=24.9.0
         clobber_warning_found = False
         for record in caplog.records:

--- a/tests/test_published_examples.py
+++ b/tests/test_published_examples.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -20,6 +21,18 @@ def test_skeleton_pypi():
 
     # 8.1.7 is the last version with 'setup.py', which is required
     check_call_env([conda_path, "skeleton", "pypi", "click", "--version", "8.1.7"])
+
+    # add setuptools to host dependencies
+    path = Path("click/meta.yaml")
+    path.write_text(
+        re.sub(
+            r"(  host:\n(?:    - .*\n)*?)(  run:\n)",
+            r"\1    - setuptools\n\2",
+            path.read_text(),
+            count=1,
+        )
+    )
+
     check_call_env([conda_path, "build", "click"])
 
 


### PR DESCRIPTION
rattler-build is available on https://repo.anaconda.com/pkgs/main/ so there is no need to use the conda-forge channel

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
