### PR TITLE
Numpy warning removal

### DIFF
--- a/conda_build/api.py
+++ b/conda_build/api.py
@@ -52,7 +52,10 @@ def render(
     """Given path to a recipe, return the MetaData object(s) representing that recipe, with jinja2
        templates evaluated.
 
-    Returns a list of (metadata, need_download, need_reparse in env) tuples"""
+    Returns a list of (metadata, need_download, need_reparse in env) tuples.
+
+    See :mod:`conda_build.render`.
+    """
     from .render import render_metadata_tuples, render_recipe
 
     config = get_or_merge_config(config, **kwargs)

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -93,9 +93,38 @@ from .utils import (
 )
 from .variants import (
     dict_of_lists_to_list_of_dicts,
+    get_default_variant,
     get_package_variants,
     set_language_env_vars,
 )
+
+
+def _warn_implicit_numpy_variant(m: MetaData) -> None:
+    """Log when build/host need numpy but the matrix numpy pin still matches conda-build's default.
+
+    If ``variant['numpy']`` differs from :func:`~conda_build.variants.get_default_variant`,
+    assume an intentional pin and stay quiet.
+
+    Matching the default can still mean it was set but this should be rare.
+    """
+
+    default_np = get_default_variant(m.config)["numpy"]
+    pinned = m.config.variant.get("numpy")
+    if pinned is not None and pinned != default_np:
+        return
+    if not any(
+        ms.name == "numpy"
+        for section in ("build", "host")
+        for ms in m.ms_depends(section)
+    ):
+        return
+    utils.get_logger(__name__).warning(
+        "numpy is required by this recipe under requirements build/host but the numpy "
+        "variant is still conda-build's default (%s). Prefer setting numpy in "
+        "conda_build_config.yaml (or equivalent) when you depend on numpy at build time.",
+        default_np,
+    )
+
 
 if on_win:
     from . import windows
@@ -2453,6 +2482,8 @@ def build(
                         r"|".join(rf"(?:^{exc}(?:\s|$|\Z))" for exc in excludes)
                     )
             add_upstream_pins(m, False, exclude_pattern, [])
+
+        _warn_implicit_numpy_variant(top_level_pkg)
 
         create_build_envs(top_level_pkg, notest)
 

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -9,11 +9,10 @@ import os
 import re
 import sys
 import time
-import warnings
 from collections import OrderedDict
 from functools import cache, lru_cache
 from os.path import isdir, isfile, join
-from typing import TYPE_CHECKING, NamedTuple, overload
+from typing import TYPE_CHECKING, Any, NamedTuple, overload
 
 import jinja2
 import yaml
@@ -56,6 +55,7 @@ from .variants import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
     from typing import Any, Literal, Self
 
     OutputDict = dict[str, Any]
@@ -143,22 +143,32 @@ class OSModuleSubset:
     sep = os.sep
 
 
-def get_selectors(config: Config) -> dict[str, bool]:
-    """Aggregates selectors for use in recipe templating.
-
-    Derives selectors from the config and variants to be injected
-    into the Jinja environment prior to templating.
+def build_selector_map(
+    *,
+    host_subdir: str,
+    build_subdir: str,
+    variant: Mapping[str, Any],
+    defaults: Mapping[str, Any],
+    feature_list: Iterable[tuple[str, bool]],
+    environ: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the mapping used for YAML line selectors and Jinja.
 
     Args:
-        config (Config): The config object
+        host_subdir: The host subdirectory (e.g. ``config.host_subdir``).
+        build_subdir: The build subdirectory (e.g. ``config.build_subdir``).
+        variant: The active variant slice (e.g. ``config.variant``).
+        defaults: The default variant values (e.g. from ``get_default_variant``).
+        feature_list: The feature list (e.g. from ``FEATURE_*`` environment toggles).
+        environ: The environment variables (e.g. from ``os.environ``).
 
     Returns:
-        dict[str, bool]: Dictionary of on/off selectors for Jinja
+        A mixed-type dict (booleans, ints, strings, …) for YAML ``# [...]`` line selectors
+        and Jinja, not only boolean flags.
     """
-    # Remember to update the docs of any of this changes
-    plat = config.host_subdir
+    plat = host_subdir
 
-    d = dict(
+    d: dict[str, Any] = dict(
         linux32=bool(plat == "linux-32"),
         linux64=bool(plat == "linux-64"),
         arm=plat.startswith("linux-arm"),
@@ -166,8 +176,7 @@ def get_selectors(config: Config) -> dict[str, bool]:
         win32=bool(plat == "win-32"),
         win64=bool(plat == "win-64"),
         os=OSModuleSubset,
-        environ=OSModuleSubset.environ,
-        nomkl=bool(int(os.environ.get("FEATURE_NOMKL", False))),
+        nomkl=bool(int(environ.get("FEATURE_NOMKL", False))),
     )
 
     # Add the current platform to the list of subdirs to enable conda-build
@@ -189,57 +198,53 @@ def get_selectors(config: Config) -> dict[str, bool]:
         if arch == "32":
             d["x86"] = plat.endswith(("-32", "-64"))
 
-    defaults = get_default_variant(config)
-    py = config.variant.get("python", defaults["python"])
+    py = variant.get("python", defaults["python"])
     # there are times when python comes in as a tuple
     if not hasattr(py, "split"):
         py = py[0]
     # go from "3.6 *_cython" -> "36"
     # or from "3.6.9" -> "36"
     py_major, py_minor, *_ = py.split(" ")[0].split(".")
-    py = int(f"{py_major}{py_minor}")
+    py_ver_int = int(f"{py_major}{py_minor}")
 
-    d["build_platform"] = config.build_subdir
+    d["build_platform"] = build_subdir
 
     d.update(
         dict(
-            py=py,
+            py=py_ver_int,
             py3k=bool(py_major == "3"),
             py2k=bool(py_major == "2"),
-            py26=bool(py == 26),
-            py27=bool(py == 27),
-            py33=bool(py == 33),
-            py34=bool(py == 34),
-            py35=bool(py == 35),
-            py36=bool(py == 36),
+            py26=bool(py_ver_int == 26),
+            py27=bool(py_ver_int == 27),
+            py33=bool(py_ver_int == 33),
+            py34=bool(py_ver_int == 34),
+            py35=bool(py_ver_int == 35),
+            py36=bool(py_ver_int == 36),
         )
     )
 
-    np = config.variant.get("numpy")
+    np = variant.get("numpy")
     if not np:
         np = defaults["numpy"]
-        if config.verbose:
-            utils.get_logger(__name__).warning(
-                "No numpy version specified in conda_build_config.yaml.  "
-                "Falling back to default numpy value of {}".format(defaults["numpy"])
-            )
     d["np"] = int("".join(np.split(".")[:2]))
 
-    pl = config.variant.get("perl", defaults["perl"])
+    pl = variant.get("perl", defaults["perl"])
     d["pl"] = pl
 
-    lua = config.variant.get("lua", defaults["lua"])
+    lua = variant.get("lua", defaults["lua"])
     d["lua"] = lua
     d["luajit"] = bool(lua[0] == "2")
 
     for feature, value in feature_list:
         d[feature] = value
-    d.update(os.environ)
+
+    d.update(environ)
+    d["environ"] = environ
 
     # here we try to do some type conversion for more intuitive usage.  Otherwise,
     #    values like 35 are strings by default, making relational operations confusing.
     # We also convert "True" and things like that to booleans.
-    for k, v in config.variant.items():
+    for k, v in variant.items():
         if k not in d:
             try:
                 d[k] = int(v)
@@ -250,13 +255,68 @@ def get_selectors(config: Config) -> dict[str, bool]:
     return d
 
 
-def ns_cfg(config: Config) -> dict[str, bool]:
-    warnings.warn(
-        "`conda_build.metadata.ns_cfg` is pending deprecation and will be removed in a "
-        "future release. Please use `conda_build.metadata.get_selectors` instead.",
-        PendingDeprecationWarning,
+def cbc_line_selectors(config: Config) -> dict[str, Any]:
+    """Namespace for preprocessing variant config files (e.g. ``conda_build_config.yaml``).
+
+    Special case for building the selector map for CBC files.  At this point in the change,
+    the variants have not been applied (unless the caller uses something like --numpy in the CLI).
+    Thus, the same selector checks that apply to recipes are not valid for the CBC case.
+
+    Args:
+        config: The build config (e.g. ``config.host_subdir``, ``config.build_subdir``, ``config.variant``).
+
+    Returns:
+        A dict of selector names and their values for the CBC file.
+    """
+    defaults = get_default_variant(config)
+    return build_selector_map(
+        host_subdir=config.host_subdir,
+        build_subdir=config.build_subdir,
+        variant=config.variant,
+        defaults=defaults,
+        feature_list=feature_list,
+        environ=os.environ,
     )
-    return get_selectors(config)
+
+
+def recipe_selectors(config: Config) -> dict[str, Any]:
+    """Namespace for recipe rendering: Jinja globals, :func:`select_lines` on rendered YAML, etc.
+
+    Map selectors for recipe rendering.  In this case, the variants have been applied so it is
+    an appropriate time to check for missing pins and emit warnings if necessary.
+
+    Args:
+        config: The build config (e.g. ``config.host_subdir``, ``config.build_subdir``, ``config.variant``).
+
+    Returns:
+        A dict of selector names and their values for the recipe rendering.
+    """
+    defaults = get_default_variant(config)
+    # NOTE: Numpy is the only special case but perhaps it should expand important
+    # missing pins as a warning as well.  Also, it could be expanded to check if numpy
+    # is even necessary for the build in the future.
+    if not config.variant.get("numpy") and config.verbose:
+        utils.get_logger(__name__).warning(
+            "No numpy version specified in conda_build_config.yaml.  "
+            "Falling back to default numpy value of {}".format(defaults["numpy"])
+        )
+    return build_selector_map(
+        host_subdir=config.host_subdir,
+        build_subdir=config.build_subdir,
+        variant=config.variant,
+        defaults=defaults,
+        feature_list=feature_list,
+        environ=os.environ,
+    )
+
+
+def get_selectors(config: Config) -> dict[str, Any]:
+    """Aggregates selectors for recipe templating and YAML line selection on ``meta.yaml``.
+
+    Equivalent to :func:`recipe_selectors` (historical name). Prefer the named entry points
+    when documenting CBC vs recipe behavior.
+    """
+    return recipe_selectors(config)
 
 
 # Selectors must be either:

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -55,7 +55,6 @@ from .variants import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
     from typing import Any, Literal, Self
 
     OutputDict = dict[str, Any]
@@ -143,30 +142,20 @@ class OSModuleSubset:
     sep = os.sep
 
 
-def build_selector_map(
-    *,
-    host_subdir: str,
-    build_subdir: str,
-    variant: Mapping[str, Any],
-    defaults: Mapping[str, Any],
-    feature_list: Iterable[tuple[str, bool]],
-    environ: Mapping[str, Any],
-) -> dict[str, Any]:
+def get_selectors(config: Config) -> dict[str, Any]:
     """Build the mapping used for YAML line selectors and Jinja.
 
+    Gather selectors from the config, variant, environment variables, and feature list for
+    use in YAML line selectors and Jinja.
+
     Args:
-        host_subdir: The host subdirectory (e.g. ``config.host_subdir``).
-        build_subdir: The build subdirectory (e.g. ``config.build_subdir``).
-        variant: The active variant slice (e.g. ``config.variant``).
-        defaults: The default variant values (e.g. from ``get_default_variant``).
-        feature_list: The feature list (e.g. from ``FEATURE_*`` environment toggles).
-        environ: The environment variables (e.g. from ``os.environ``).
+        config (Config): The build config object
 
     Returns:
         A mixed-type dict (booleans, ints, strings, …) for YAML ``# [...]`` line selectors
         and Jinja, not only boolean flags.
     """
-    plat = host_subdir
+    plat = config.host_subdir
 
     d: dict[str, Any] = dict(
         linux32=bool(plat == "linux-32"),
@@ -176,7 +165,8 @@ def build_selector_map(
         win32=bool(plat == "win-32"),
         win64=bool(plat == "win-64"),
         os=OSModuleSubset,
-        nomkl=bool(int(environ.get("FEATURE_NOMKL", False))),
+        environ=OSModuleSubset.environ,
+        nomkl=bool(int(os.environ.get("FEATURE_NOMKL", False))),
     )
 
     # Add the current platform to the list of subdirs to enable conda-build
@@ -198,7 +188,9 @@ def build_selector_map(
         if arch == "32":
             d["x86"] = plat.endswith(("-32", "-64"))
 
-    py = variant.get("python", defaults["python"])
+    defaults = get_default_variant(config)
+
+    py = config.variant.get("python", defaults["python"])
     # there are times when python comes in as a tuple
     if not hasattr(py, "split"):
         py = py[0]
@@ -207,7 +199,7 @@ def build_selector_map(
     py_major, py_minor, *_ = py.split(" ")[0].split(".")
     py_ver_int = int(f"{py_major}{py_minor}")
 
-    d["build_platform"] = build_subdir
+    d["build_platform"] = config.build_subdir
 
     d.update(
         dict(
@@ -223,28 +215,27 @@ def build_selector_map(
         )
     )
 
-    np = variant.get("numpy")
+    np = config.variant.get("numpy")
     if not np:
         np = defaults["numpy"]
     d["np"] = int("".join(np.split(".")[:2]))
 
-    pl = variant.get("perl", defaults["perl"])
+    pl = config.variant.get("perl", defaults["perl"])
     d["pl"] = pl
 
-    lua = variant.get("lua", defaults["lua"])
+    lua = config.variant.get("lua", defaults["lua"])
     d["lua"] = lua
     d["luajit"] = bool(lua[0] == "2")
 
     for feature, value in feature_list:
         d[feature] = value
 
-    d.update(environ)
-    d["environ"] = environ
+    d.update(OSModuleSubset.environ)
 
     # here we try to do some type conversion for more intuitive usage.  Otherwise,
     #    values like 35 are strings by default, making relational operations confusing.
     # We also convert "True" and things like that to booleans.
-    for k, v in variant.items():
+    for k, v in config.variant.items():
         if k not in d:
             try:
                 d[k] = int(v)
@@ -253,70 +244,6 @@ def build_selector_map(
                     v = v.lower() == "true"
                 d[k] = v
     return d
-
-
-def cbc_line_selectors(config: Config) -> dict[str, Any]:
-    """Namespace for preprocessing variant config files (e.g. ``conda_build_config.yaml``).
-
-    Special case for building the selector map for CBC files.  At this point in the change,
-    the variants have not been applied (unless the caller uses something like --numpy in the CLI).
-    Thus, the same selector checks that apply to recipes are not valid for the CBC case.
-
-    Args:
-        config: The build config (e.g. ``config.host_subdir``, ``config.build_subdir``, ``config.variant``).
-
-    Returns:
-        A dict of selector names and their values for the CBC file.
-    """
-    defaults = get_default_variant(config)
-    return build_selector_map(
-        host_subdir=config.host_subdir,
-        build_subdir=config.build_subdir,
-        variant=config.variant,
-        defaults=defaults,
-        feature_list=feature_list,
-        environ=os.environ,
-    )
-
-
-def recipe_selectors(config: Config) -> dict[str, Any]:
-    """Namespace for recipe rendering: Jinja globals, :func:`select_lines` on rendered YAML, etc.
-
-    Map selectors for recipe rendering.  In this case, the variants have been applied so it is
-    an appropriate time to check for missing pins and emit warnings if necessary.
-
-    Args:
-        config: The build config (e.g. ``config.host_subdir``, ``config.build_subdir``, ``config.variant``).
-
-    Returns:
-        A dict of selector names and their values for the recipe rendering.
-    """
-    defaults = get_default_variant(config)
-    # NOTE: Numpy is the only special case but perhaps it should expand important
-    # missing pins as a warning as well.  Also, it could be expanded to check if numpy
-    # is even necessary for the build in the future.
-    if not config.variant.get("numpy") and config.verbose:
-        utils.get_logger(__name__).warning(
-            "No numpy version specified in conda_build_config.yaml.  "
-            "Falling back to default numpy value of {}".format(defaults["numpy"])
-        )
-    return build_selector_map(
-        host_subdir=config.host_subdir,
-        build_subdir=config.build_subdir,
-        variant=config.variant,
-        defaults=defaults,
-        feature_list=feature_list,
-        environ=os.environ,
-    )
-
-
-def get_selectors(config: Config) -> dict[str, Any]:
-    """Aggregates selectors for recipe templating and YAML line selection on ``meta.yaml``.
-
-    Equivalent to :func:`recipe_selectors` (historical name). Prefer the named entry points
-    when documenting CBC vs recipe behavior.
-    """
-    return recipe_selectors(config)
 
 
 # Selectors must be either:

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -4,26 +4,34 @@
 
 **Pipeline**
 
-- Merge ``conda_build_config.yaml`` / variant specs (:mod:`conda_build.variants`) and expand the
-  matrix.
-- :func:`render_recipe` constructs :class:`~conda_build.metadata.MetaData`: Jinja
-  (:meth:`~conda_build.metadata.MetaData._get_contents`), then YAML
-  (:func:`~conda_build.metadata.parse`). :func:`~conda_build.metadata.get_selectors` runs on CBC
-  text and again on rendered ``meta.yaml`` (selectors + Jinja globals).
-- :func:`distribute_variants` and :func:`render_metadata_tuples` cover multiple variants and
-  subpackages.
+- **Variant discovery**
+  - Merge or stack ``conda_build_config.yaml`` and other variant inputs, then expand the build
+    matrix (see :mod:`conda_build.variants`).
+  - Line-filter CBC text before each file loads (``cbc_line_selectors`` in ``parse_config_file``,
+    then combined spec / ``get_package_variants``), before ``meta.yaml`` is rendered for a cell.
 
-**CLI** (the only user-facing commands that enter this module’s orchestration)
+- **Recipe render**
+  - ``render_recipe`` builds :class:`~conda_build.metadata.MetaData`.
+  - Jinja expands ``{{ ... }}`` in ``meta.yaml`` and includes (``MetaData._get_contents``). The
+    recipe selector map from ``get_selectors`` / ``recipe_selectors`` is available as Jinja
+    globals (and for line-filtering loaded snippets).
+  - ``parse`` runs after that: it applies YAML line selectors (``# [...]`` comments) to the
+    rendered text, then loads YAML, still using the same selector map (this is not another Jinja
+    step).
 
-- **conda build** — :mod:`conda_build.cli.main_build` → :func:`conda_build.api.build` →
-  :func:`conda_build.build.build_tree` → :func:`render_recipe`, then compile/test in
-  :mod:`conda_build.build`. Some helper paths call :func:`conda_build.api.render` directly.
-- **conda render** — :mod:`conda_build.cli.main_render` builds :class:`~conda_build.config.Config`
-  from argparse (channels, variants, ``--no-source``, …) → :func:`conda_build.api.render`, then
-  prints or writes the rendered recipe (see that module for flags such as ``--file``).
+- **Multi-variant / outputs:** ``distribute_variants`` and ``render_metadata_tuples`` for extra
+  variant columns and subpackages.
 
-**Programmatic:** :func:`conda_build.api.render`, :func:`conda_build.api.build`. **Paths:**
-:func:`bldpkg_path` and helpers below.
+**CLI** (user-facing entry points that use this module)
+
+- **conda build** — ``conda_build.cli.main_build`` → ``conda_build.api.build`` →
+  ``conda_build.build.build_tree`` → ``render_recipe``, then compile/test. Some paths call
+  ``conda_build.api.render`` only.
+- **conda render** — ``conda_build.cli.main_render`` builds ``Config``, then
+  ``conda_build.api.render`` (see that module for ``--file`` and other flags).
+
+**Programmatic:** ``conda_build.api.render``, ``conda_build.api.build``. **Paths:** ``bldpkg_path``
+and helpers in this file.
 """
 
 from __future__ import annotations

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -7,14 +7,13 @@
 - **Variant discovery**
   - Merge or stack ``conda_build_config.yaml`` and other variant inputs, then expand the build
     matrix (see :mod:`conda_build.variants`).
-  - Line-filter CBC text before each file loads (``cbc_line_selectors`` in ``parse_config_file``,
-    then combined spec / ``get_package_variants``), before ``meta.yaml`` is rendered for a cell.
+  - Line-filter CBC text before each file loads before ``meta.yaml`` is rendered for a cell.
 
 - **Recipe render**
   - ``render_recipe`` builds :class:`~conda_build.metadata.MetaData`.
   - Jinja expands ``{{ ... }}`` in ``meta.yaml`` and includes (``MetaData._get_contents``). The
-    recipe selector map from ``get_selectors`` / ``recipe_selectors`` is available as Jinja
-    globals (and for line-filtering loaded snippets).
+    recipe selector map from ``get_selectors`` is available as Jinja globals (and for
+    line-filtering loaded snippets).
   - ``parse`` runs after that: it applies YAML line selectors (``# [...]`` comments) to the
     rendered text, then loads YAML, still using the same selector map (this is not another Jinja
     step).
@@ -932,13 +931,14 @@ def distribute_variants(
     #     used mostly, and can be reduced
     metadata.config.input_variants = variants
 
+    metadata.config.variant = variants[0]
+
     recipe_requirements = metadata.extract_requirements_text()
     recipe_package_and_build_text = metadata.extract_package_and_build_text()
     recipe_text = recipe_package_and_build_text + recipe_requirements
     if hasattr(recipe_text, "decode"):
         recipe_text = recipe_text.decode()
 
-    metadata.config.variant = variants[0]
     used_variables = metadata.get_used_loop_vars(force_global=False)
     top_loop = metadata.get_reduced_variant_set(used_variables)
 

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -1,5 +1,31 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+"""Recipe on disk → finalized :class:`~conda_build.metadata.MetaData`.
+
+**Pipeline**
+
+- Merge ``conda_build_config.yaml`` / variant specs (:mod:`conda_build.variants`) and expand the
+  matrix.
+- :func:`render_recipe` constructs :class:`~conda_build.metadata.MetaData`: Jinja
+  (:meth:`~conda_build.metadata.MetaData._get_contents`), then YAML
+  (:func:`~conda_build.metadata.parse`). :func:`~conda_build.metadata.get_selectors` runs on CBC
+  text and again on rendered ``meta.yaml`` (selectors + Jinja globals).
+- :func:`distribute_variants` and :func:`render_metadata_tuples` cover multiple variants and
+  subpackages.
+
+**CLI** (the only user-facing commands that enter this module’s orchestration)
+
+- **conda build** — :mod:`conda_build.cli.main_build` → :func:`conda_build.api.build` →
+  :func:`conda_build.build.build_tree` → :func:`render_recipe`, then compile/test in
+  :mod:`conda_build.build`. Some helper paths call :func:`conda_build.api.render` directly.
+- **conda render** — :mod:`conda_build.cli.main_render` builds :class:`~conda_build.config.Config`
+  from argparse (channels, variants, ``--no-source``, …) → :func:`conda_build.api.render`, then
+  prints or writes the rendered recipe (see that module for flags such as ``--file``).
+
+**Programmatic:** :func:`conda_build.api.render`, :func:`conda_build.api.build`. **Paths:**
+:func:`bldpkg_path` and helpers below.
+"""
+
 from __future__ import annotations
 
 import functools

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
-"""This file handles the parsing of feature specifications from files,
-ending up with a configuration matrix"""
+"""Parse variant configuration files (e.g. ``conda_build_config.yaml``) into a build matrix.
+
+Each file is preprocessed with YAML line selectors in ``parse_config_file`` before load."""
 
 from __future__ import annotations
 

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -142,11 +142,13 @@ def get_default_variant(config):
 
 
 def parse_config_file(path, config, loader=yaml.loader.BaseLoader):
-    from .metadata import get_selectors, select_lines
+    from .metadata import cbc_line_selectors, select_lines
 
     with open(path) as f:
         contents = f.read()
-    contents = select_lines(contents, get_selectors(config), variants_in_place=False)
+    contents = select_lines(
+        contents, cbc_line_selectors(config), variants_in_place=False
+    )
     content = yaml.load(contents, Loader=loader) or {}
     trim_empty_keys(content)
     return content

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -142,13 +142,11 @@ def get_default_variant(config):
 
 
 def parse_config_file(path, config, loader=yaml.loader.BaseLoader):
-    from .metadata import cbc_line_selectors, select_lines
+    from .metadata import get_selectors, select_lines
 
     with open(path) as f:
         contents = f.read()
-    contents = select_lines(
-        contents, cbc_line_selectors(config), variants_in_place=False
-    )
+    contents = select_lines(contents, get_selectors(config), variants_in_place=False)
     content = yaml.load(contents, Loader=loader) or {}
     trim_empty_keys(content)
     return content

--- a/news/5962-numpy-warn-fix-for-config-files.md
+++ b/news/5962-numpy-warn-fix-for-config-files.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Stop the verbose "No numpy version specified in conda_build_config.yaml" warning when that warning does not apply to config files: parsing of `conda_build_config.yaml` now uses a dedicated selector path (`cbc_line_selectors`) that does not look up `numpy` from the (not-yet-merged) variant. The previous behavior on recipe and full metadata rendering is unchanged. (PR #5962)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,8 +8,10 @@ and is more unit-test oriented.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
+from collections import defaultdict
 from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,17 +21,15 @@ from conda.common.compat import on_win
 
 from conda_build import api, build
 from conda_build.exceptions import CondaBuildUserError
+from conda_build.metadata import MetaData
+from conda_build.variants import get_default_variant
 
 from .utils import get_noarch_python_meta, metadata_dir
-
-if TYPE_CHECKING:
-    from conda_build.config import Config
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from conda_build.config import Config
-    from conda_build.metadata import MetaData
 
 
 def test_build_preserves_PATH(testing_config):
@@ -389,3 +389,48 @@ def test_tests_failed(testing_metadata: MetaData, tmp_path: Path):
             broken_dir=tmp_path,
             config=testing_metadata.config,
         )
+
+
+@pytest.mark.parametrize(
+    "numpy_version, requires_numpy, expected_warning",
+    [
+        ("default", True, True),
+        ("2.1.0", True, False),
+        ("2.1.0", False, False),
+    ],
+    ids=[
+        "default_pin_with_numpy_dep",
+        "explicit_pin_with_numpy_dep",
+        "numpy_dep_absent",
+    ],
+)
+def test_warn_implicit_numpy_variant(
+    testing_config: Config,
+    caplog: pytest.LogCaptureFixture,
+    numpy_version: str,
+    requires_numpy: bool,
+    expected_warning: bool,
+) -> None:
+
+    def _minimal_meta_with_reqs(requirements: dict) -> defaultdict:
+        d = defaultdict(dict)
+        d["package"]["name"] = "implicit_numpy_warn_test_pkg"
+        d["package"]["version"] = "1.0"
+        d["build"]["number"] = "0"
+        d["requirements"] = dict(requirements)
+        return d
+
+    variant = dict(get_default_variant(testing_config))
+    if numpy_version != "default":
+        variant["numpy"] = numpy_version
+
+    testing_config.variant = variant
+    testing_config.variants = [variant]
+    m = MetaData.fromdict(
+        _minimal_meta_with_reqs({"host": ["numpy"] if requires_numpy else []}),
+        config=testing_config,
+    )
+    caplog.set_level(logging.WARNING)
+    build._warn_implicit_numpy_variant(m)
+    n_warn = sum(1 for r in caplog.records if r.levelno == logging.WARNING)
+    assert n_warn == (1 if expected_warning else 0)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import logging
 import os
 import subprocess
 import sys
@@ -26,12 +25,10 @@ from conda_build.metadata import (
     MetaData,
     OSModuleSubset,
     _hash_dependencies,
-    cbc_line_selectors,
     check_bad_chrs,
     eval_selector,
     get_output_dicts_from_metadata,
     get_selectors,
-    recipe_selectors,
     sanitize,
     select_lines,
     yamlize,
@@ -645,40 +642,6 @@ def test_get_selectors(
         # override with True values
         **{key: True for key in expected},
     }
-
-
-def test_cbc_line_selectors_matches_recipe_selectors(caplog) -> None:
-    config = Config(
-        host_subdir="linux-64",
-        variant={"numpy": "1.22", "python": "3.11.*"},
-    )
-    with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
-        cbc = cbc_line_selectors(config)
-        rcp = recipe_selectors(config)
-    assert cbc == rcp
-    assert "No numpy version specified" not in caplog.text
-
-
-def test_cbc_line_selectors_no_numpy_warning_verbose(caplog) -> None:
-    config = Config(host_subdir="linux-64", variant={})
-    config.verbose = True
-    with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
-        cbc_line_selectors(config)
-    assert "No numpy version specified" not in caplog.text
-
-
-def test_recipe_selectors_numpy_warning_verbose(caplog) -> None:
-    config = Config(host_subdir="linux-64", variant={})
-    config.verbose = True
-    utils.dedupe_filter.msgs.clear()
-    with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
-        recipe_selectors(config)
-    assert "No numpy version specified" in caplog.text
-
-
-def test_get_selectors_is_recipe_selectors() -> None:
-    config = Config(host_subdir="linux-64")
-    assert get_selectors(config) == recipe_selectors(config)
 
 
 def test_fromstring():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -17,7 +17,7 @@ from conda import __version__ as conda_version
 from conda.base.context import context
 from packaging.version import Version
 
-from conda_build import api
+from conda_build import api, utils
 from conda_build.config import Config
 from conda_build.exceptions import CondaBuildUserError
 from conda_build.metadata import (
@@ -670,6 +670,7 @@ def test_cbc_line_selectors_no_numpy_warning_verbose(caplog) -> None:
 def test_recipe_selectors_numpy_warning_verbose(caplog) -> None:
     config = Config(host_subdir="linux-64", variant={})
     config.verbose = True
+    utils.dedupe_filter.msgs.clear()
     with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
         recipe_selectors(config)
     assert "No numpy version specified" in caplog.text

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -25,10 +26,12 @@ from conda_build.metadata import (
     MetaData,
     OSModuleSubset,
     _hash_dependencies,
+    cbc_line_selectors,
     check_bad_chrs,
     eval_selector,
     get_output_dicts_from_metadata,
     get_selectors,
+    recipe_selectors,
     sanitize,
     select_lines,
     yamlize,
@@ -642,6 +645,39 @@ def test_get_selectors(
         # override with True values
         **{key: True for key in expected},
     }
+
+
+def test_cbc_line_selectors_matches_recipe_selectors(caplog) -> None:
+    config = Config(
+        host_subdir="linux-64",
+        variant={"numpy": "1.22", "python": "3.11.*"},
+    )
+    with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
+        cbc = cbc_line_selectors(config)
+        rcp = recipe_selectors(config)
+    assert cbc == rcp
+    assert "No numpy version specified" not in caplog.text
+
+
+def test_cbc_line_selectors_no_numpy_warning_verbose(caplog) -> None:
+    config = Config(host_subdir="linux-64", variant={})
+    config.verbose = True
+    with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
+        cbc_line_selectors(config)
+    assert "No numpy version specified" not in caplog.text
+
+
+def test_recipe_selectors_numpy_warning_verbose(caplog) -> None:
+    config = Config(host_subdir="linux-64", variant={})
+    config.verbose = True
+    with caplog.at_level(logging.WARNING, logger="conda_build.metadata"):
+        recipe_selectors(config)
+    assert "No numpy version specified" in caplog.text
+
+
+def test_get_selectors_is_recipe_selectors() -> None:
+    config = Config(host_subdir="linux-64")
+    assert get_selectors(config) == recipe_selectors(config)
 
 
 def test_fromstring():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -16,7 +16,7 @@ from conda import __version__ as conda_version
 from conda.base.context import context
 from packaging.version import Version
 
-from conda_build import api, utils
+from conda_build import api
 from conda_build.config import Config
 from conda_build.exceptions import CondaBuildUserError
 from conda_build.metadata import (

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 from typing import TYPE_CHECKING
@@ -148,3 +149,42 @@ def test_render_recipe(testing_config: Config) -> None:
         assert len(recipes) == 48
     else:
         assert len(recipes) == 16
+
+
+def test_distribute_variants_numpy_from_cbc_seen_by_selectors(
+    tmp_path: Path, testing_config: Config, caplog: pytest.LogCaptureFixture
+) -> None:
+    """config.variant must be set before extract_* helpers; they call get_selectors."""
+    recipe = tmp_path / "recipe"
+    recipe.mkdir()
+    (recipe / "meta.yaml").write_text(
+        """
+package:
+  name: test_cbc_numpy_warn
+  version: "1.0"
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - python
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (recipe / "conda_build_config.yaml").write_text(
+        """
+numpy:
+  - "1.26"
+python:
+  - "3.12"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    testing_config.verbose = True
+    testing_config.croot = tmp_path
+    caplog.set_level(logging.WARNING)
+
+    render_recipe(recipe, config=testing_config)
+
+    assert "No numpy version specified" not in caplog.text


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fixes #3170.

#### What went wrong
parse_config_file evaluated YAML line selectors with the same selector setup as the full recipe.  As the merged variant is being read at that moment the numpy key isn't available yet (unless --numpy was used in the cli call), so conda-build could emit the verbose “No numpy version specified in conda_build_config.yaml” warning at the very beginning every time.

#### What was changed

- Introduce build_selector_map with two entry points: 
   - cbc_line_selectors (used when reading conda_build_config.yaml)
   - recipe_selectors (used for Jinja + parse + get_recipe_text + FilteredLoader).
- get_selectors is a thin wrapper around recipe_selectors for backward compatibility
- The CBC path does not run the “numpy missing from variant” warning; the recipe path keeps the existing verbose warning when numpy is not in the variant.
- environ wiring: at the end of build_selector_map, apply d.update(environ) then set d["environ"] = environ so a rare env var named environ cannot overwrite the full mapping, while keeping prior behavior for normal keys.
- removal of ns_cfg function which has had a warning of PendingDeprecation for a few years now.

#### User-visible impact
Removes numpy warnings when processing conda_build_config.yaml chain (which is the reason most people would see that in the first line); no intentional change to recipe rendering semantics beyond that.

#### How tested
Selector-related tests in tests/test_metadata.py (and a full local run of the test suite) pass.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
