### PR TITLE
ci: reduce test workflow overhead

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,10 @@ jobs:
       PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial and not benchmark' || 'not serial and not benchmark' }}
 
     steps:
+      # See https://github.com/conda/conda-build/pull/5866 — added to prevent the
+      # Post Cache step from running out of disk space. Trimmed to the entries
+      # that recover meaningful space; browser/editor/language-toolchain folders
+      # were removed as they contribute little to post-test disk pressure.
       - name: Free Disk Space
         uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1  # v3.2.2
         with:
@@ -118,25 +122,13 @@ jobs:
           remove_packages: >-
             azure-cli
             google-cloud-cli
-            microsoft-edge-stable
-            google-chrome-stable
-            firefox
             postgresql*
             temurin-*
             *llvm*
-            mysql*
             dotnet-sdk-*
           remove_packages_one_command: true
           remove_folders: >-
-            /usr/share/swift
-            /usr/share/az*
             /usr/local/lib/node_modules
-            /usr/local/share/chromium
-            /usr/local/share/powershell
-            /usr/local/julia
-            /usr/local/aws-cli
-            /usr/local/aws-sam-cli
-            /usr/share/gradle
           rm_cmd: rmz
           rmz_version: 3.1.1
           testing: false
@@ -191,6 +183,10 @@ jobs:
           pytest
           --cov=conda_build
           --durations-path=durations/${{ runner.os }}.json
+          --cov-append
+          --cov-branch
+          --cov-report=term
+          --cov-report=xml
           --reruns 1
           --reruns-delay 1
           -n auto
@@ -387,6 +383,10 @@ jobs:
         run: >
           pytest
           --cov=conda_build
+          --cov-append
+          --cov-branch
+          --cov-report=term
+          --cov-report=xml
           --basetemp=${{ runner.temp }}
           --durations-path=durations\${{ runner.os }}.json
           -n auto
@@ -526,6 +526,10 @@ jobs:
           pytest
           --cov=conda_build
           --durations-path=durations/${{ runner.os }}.json
+          --cov-append
+          --cov-branch
+          --cov-report=term
+          --cov-report=xml
           -n auto
           -m "${{ env.PYTEST_MARKER }}"
         env:

--- a/news/ci-test-speed-hygiene.md
+++ b/news/ci-test-speed-hygiene.md
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Reduce CI test overhead by moving coverage options out of the global pytest
+  configuration and into the test workflow and trimming the Linux disk-cleanup
+  list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,10 @@ local_scheme = "dirty-tag"
 [tool.pytest.ini_options]
 addopts = [
   "--color=yes",
-  # "--cov=conda_build",   # passed in test runner scripts instead (avoid debugger)
-  "--cov-append",
-  "--cov-branch",
-  "--cov-report=term",  # print summary table to screen
-  "--cov-report=xml",  # for codecov/codecov-action upload
+  # Coverage options are passed by CI (.github/workflows/tests.yml) so they
+  # don't interfere with local debugging. See the "Run Tests" steps there for
+  # the exact flags used: --cov=conda_build --cov-append --cov-branch
+  # --cov-report=term --cov-report=xml
   "--durations=16",  # show 16 slowest tests
   "--junitxml=junit.xml",
   # "--splitting-algorithm=least_duration",  # not used


### PR DESCRIPTION
### Description

First of three stacked PRs reducing CI test overhead.

This PR:

- moves the coverage options from global pytest configuration into the Linux, Windows, and macOS test steps
- keeps coverage enabled in CI while avoiding it for local pytest and benchmark runs
- trims the Linux disk-cleanup list to the entries that recover meaningful space

The test selection, xdist scheduling, and retry policy are unchanged. Test jobs continue to fetch full git history because hatch-vcs uses it to calculate the project version.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests? — workflow and test configuration only
- [x] Add / update outdated documentation? — no user-facing documentation affected
