### PR TITLE
ci: balance heavy tests across test matrix legs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,8 +103,8 @@ jobs:
     env:
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev::' || '' }}
       CONDA_VERSION: ${{ contains('canary|release', matrix.conda-version) && 'conda' || format('conda={0}', matrix.conda-version) }}
-      # Exclude benchmark tests from regular CI runs (they run separately in linux-benchmarks)
-      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial and not benchmark' || 'not serial and not benchmark' }}
+      # Split heavy tests into the other matrix leg to balance the xdist jobs
+      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && '(serial or heavy) and not benchmark' || 'not serial and not heavy and not benchmark' }}
 
     steps:
       # See https://github.com/conda/conda-build/pull/5866 — added to prevent the
@@ -314,8 +314,8 @@ jobs:
     env:
       ErrorActionPreference: Stop  # powershell exit on first error
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'defaults' }}
-      # Exclude benchmark and slow tests from Windows parallel runs
-      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial and not benchmark' || (matrix.test-type == 'parallel' && 'not serial and not slow and not benchmark' || '') }}
+      # Split heavy tests into the other matrix leg while preserving the Windows slow-test exclusion
+      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && '(serial or (heavy and not slow)) and not benchmark' || (matrix.test-type == 'parallel' && 'not serial and not heavy and not slow and not benchmark' || '') }}
 
     steps:
       - name: Checkout Source
@@ -446,8 +446,8 @@ jobs:
     env:
       # Use conda-forge for release tests since conda 25.11+ is not in defaults for osx-64
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'conda-forge' }}
-      # Exclude benchmark tests from regular CI runs
-      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial and not benchmark' || 'not serial and not benchmark' }}
+      # Split heavy tests into the other matrix leg to balance the xdist jobs
+      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && '(serial or heavy) and not benchmark' || 'not serial and not heavy and not benchmark' }}
 
     steps:
       - name: Checkout Source

--- a/news/ci-heavy-test-marker.md
+++ b/news/ci-heavy-test-marker.md
@@ -1,0 +1,21 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Introduce an `@pytest.mark.heavy` marker for five high-duration integration
+  tests. They now run in the CI matrix leg named `serial`, while both test legs
+  continue to use pytest-xdist, to distribute the workload more evenly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ filterwarnings = [
 markers = [
   "serial: execute test serially (to avoid race conditions)",
   "slow: execute the slow tests if active",
+  "heavy: long-running integration tests separated into one CI matrix leg to balance the xdist jobs",
   "sanity: execute the sanity tests",
   "no_default_testing_config: used internally to disable monkeypatching for testing_config",
   "benchmark: execute the benchmark tests",

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -327,6 +327,7 @@ def test_no_force_upload(
     call.assert_called_once_with([anaconda, "upload", "--force", *pkg])
 
 
+@pytest.mark.heavy
 @pytest.mark.slow
 def test_conda_py_no_period(testing_workdir, testing_metadata, monkeypatch):
     monkeypatch.setenv("CONDA_PY", "313")

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1831,6 +1831,7 @@ def test_overdepending_detection(testing_config, variants_conda_build_sysroot):
         api.build(recipe, config=testing_config, variants=variants_conda_build_sysroot)
 
 
+@pytest.mark.heavy
 @pytest.mark.skipif(not on_linux, reason="cannot compile for linux-ppc64le")
 def test_sysroots_detection(testing_config, variants_conda_build_sysroot):
     recipe = os.path.join(metadata_dir, "_sysroot_detection")
@@ -2086,6 +2087,7 @@ def test_rendered_is_reported(testing_config, capsys):
     assert "- base-outputs_overwrite_base_file >=1.0,<2.0a0" in captured.out
 
 
+@pytest.mark.heavy
 @pytest.mark.skipif(on_win, reason="Tests cross-compilation targeting Windows")
 def test_cross_unix_windows_mingw(testing_config):
     recipe = os.path.join(metadata_dir, "_cross_unix_windows_mingw")
@@ -2138,6 +2140,7 @@ def test_api_build_inject_jinja2_vars_on_first_pass(testing_config):
     api.build(recipe_dir, config=testing_config)
 
 
+@pytest.mark.heavy
 def test_ignore_run_exports_from_substr(monkeypatch, tmp_path, capsys, testing_config):
     monkeypatch.chdir(tmp_path)
     testing_config.channel_urls = ["conda-forge"]
@@ -2164,6 +2167,7 @@ def test_build_strings_glob_match(testing_config: Config) -> None:
         api.build(metadata_path / "_blas_pins", config=testing_config)
 
 
+@pytest.mark.heavy
 @pytest.mark.skipif(not on_linux, reason="needs __glibc virtual package")
 def test_api_build_grpc_issue5645(monkeypatch, tmp_path, testing_config):
     if Version(conda_version) < Version("25.1.0"):


### PR DESCRIPTION
### Description

Stacked on top of #5963.

This PR introduces an `@pytest.mark.heavy` marker and uses it to distribute five high-duration integration tests between the two xdist matrix legs.

The current `durations/Linux.json` records:

```
665.9s  test_api_build_grpc_issue5645
185.1s  test_conda_py_no_period
184.9s  test_sysroots_detection
126.0s  test_cross_unix_windows_mingw
124.5s  test_ignore_run_exports_from_substr
```

These stored call durations total about 1,286 seconds. They overlap when tests run under xdist, so they are useful for selecting expensive tests but are not a wall-time estimate.

Linux and macOS route heavy tests to the matrix leg named `serial`. Both matrix legs continue to run with `pytest -n auto`. On Windows, `heavy and slow` tests remain excluded, preserving the existing exclusion of `test_conda_py_no_period`.

The intended effect is to distribute long-running tests more evenly between concurrently scheduled CI jobs without changing their execution semantics.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests? — adds markers to five existing tests
- [x] Add / update outdated documentation? — no user-facing documentation affected
