### PR TITLE
ci: limit vs2017-workload-vctools install to parallel jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -352,8 +352,8 @@ jobs:
           CONDA_SUBDIR: win-64
 
       - name: Choco Install
-        if: runner.arch != 'ARM64'
-        # We may need the complete tooling so that cmake tests pass on windows
+        if: runner.arch != 'ARM64' && matrix.test-type == 'parallel'
+        # The parallel tests compile binaries with the Visual Studio 2017 toolchain
         run: choco install visualstudio2017-workload-vctools
 
       - name: Conda Install

--- a/news/ci-limit-vs2017-choco.md
+++ b/news/ci-limit-vs2017-choco.md
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Install the Visual Studio 2017 Build Tools only for Windows test jobs that
+  exercise the compiler toolchain.


### PR DESCRIPTION
### Description

Stacked on top of #5964.

The Windows workflow installs the Visual Studio 2017 Build Tools in every x64 matrix job. The step takes about 280 seconds. Several parallel tests compile binaries with that toolchain, while the serial test selection does not exercise it.

This PR keeps the Chocolatey installation in x64 parallel jobs and skips it in x64 serial jobs. ARM64 jobs remain unchanged.

This preserves the existing compiler and overlinking coverage while removing the install cost from half of the x64 Windows matrix.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests? — workflow-only change
- [x] Add / update outdated documentation? — no user-facing documentation affected