### PR TITLE
Update v1 recipe test logic; fix flaky v1 test recipe

### DIFF
--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -110,6 +110,7 @@ def check_arguments_rattler(
             "zstd_compression_level",
             "channel",
             "override_channels",
+            "build_only",
         },
         "render": {
             "recipe",
@@ -212,15 +213,6 @@ def process_recipe(
         built_packages = list(build_result.packages)
 
         for pkg_path in built_packages:
-            if parsed_args.notest:
-                result.outputs.append(
-                    OutputResult(
-                        name=output_name,
-                        success=True,
-                    )
-                )
-                continue
-
             try:
                 pkg = Package.from_file(pkg_path)
             except RattlerBuildError as e:
@@ -233,36 +225,37 @@ def process_recipe(
                 )
                 continue
 
-            try:
-                # tests are ran in a different directory than build, so we need to add the build
-                # directory manually as a file:// channel
-                test_channels = [Path(output_dir).resolve().as_uri(), *channels]
+            if not (parsed_args.notest or parsed_args.build_only):
+                try:
+                    # tests are run in a different directory than build, so we need to add the build
+                    # directory manually as a file:// channel
+                    test_channels = [Path(output_dir).resolve().as_uri(), *channels]
 
-                test_results = pkg.run_tests(
-                    progress_callback=CondaProgressCallback(show_logs=show_logs),
-                    channel=test_channels,
-                )
-            except RattlerBuildError as e:
-                result.outputs.append(
-                    OutputResult(
-                        name=output_name,
-                        success=False,
-                        error=str(e),
+                    test_results = pkg.run_tests(
+                        progress_callback=CondaProgressCallback(show_logs=show_logs),
+                        channel=test_channels,
                     )
-                )
-                continue
-
-            test_failed = [r for r in test_results if not r.success]
-
-            if test_failed:
-                result.outputs.append(
-                    OutputResult(
-                        name=output_name,
-                        success=False,
-                        error="Package tests failed",
+                except RattlerBuildError as e:
+                    result.outputs.append(
+                        OutputResult(
+                            name=output_name,
+                            success=False,
+                            error=str(e),
+                        )
                     )
-                )
-                continue
+                    continue
+
+                test_failed = [r for r in test_results if not r.success]
+
+                if test_failed:
+                    result.outputs.append(
+                        OutputResult(
+                            name=output_name,
+                            success=False,
+                            error="Package tests failed",
+                        )
+                    )
+                    continue
 
             result.outputs.append(
                 OutputResult(

--- a/news/5973-update-v1-tests.md
+++ b/news/5973-update-v1-tests.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Update v1 recipe test logic and fix a flaky v1 test recipe (#5973)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_v1_recipes.py
+++ b/tests/test_v1_recipes.py
@@ -82,15 +82,15 @@ source:
 
 build:
   noarch: python
-  script: python -m pip install . -vv
+  script: python -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python 3.12.1.*
-    - pip 23.3.2.*
-    - setuptools 68.*
+    - python 3.10.*
+    - pip
+    - setuptools
   run:
-    - python >=3.11
+    - python >=3.10
 
 about:
   homepage: https://github.com/uiri/toml
@@ -116,10 +116,10 @@ extra:
     package = Package.from_file(build_result.packages[0])
 
     assert "site-packages/toml-0.10.2.dist-info/INSTALLER" in package.files
-    assert "site-packages/toml-0.10.2.dist-info/LICENSE" in package.files
+    assert "site-packages/toml-0.10.2.dist-info/licenses/LICENSE" in package.files
 
     assert "python" in package.depends
-    assert "python >=3.11" in package.depends
+    assert "python >=3.10" in package.depends
 
 
 def test_noarch_variant():


### PR DESCRIPTION
This PR fixes an intermittent failure in `tests/test_v1_recipes::test_python_noarch`  that would sometimes fail on windows canary builds with a cryptic `PyRattlerBuildError: Script failed to execute` error. I wasn't able to determine the exact cause of failure (it could be due to dependency version specifiers), but updating the `toml` test recipe to be more similar to [toml-feedstock](https://github.com/conda-forge/toml-feedstock) seems to resolve this.


While at it, update the test logic slightly as we can remove the redundant output return before running package tests.

Additionally, add support for the `--build-only` CLI argument. It implies building the package without running tests or uploading to anaconda.org. The upload part will be handled in https://github.com/conda/conda-build/pull/5955.



### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
