### PR TITLE
Validate package names against CEP-26 naming conventions

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -824,6 +824,33 @@ def _str_version(package_meta):
     return package_meta
 
 
+_CEP26_NAME_RE: re.Pattern[str] = re.compile(
+    r"^(([a-z0-9])|([a-z0-9_](?!_)))[._-]?([a-z0-9]+(\.|-|_|$))*$"
+)
+_CEP26_VIRTUAL_NAME_RE: re.Pattern[str] = re.compile(
+    r"^__[a-z0-9][._-]?([a-z0-9]+(\.|-|_|$))*$"
+)
+
+
+def check_package_name(name: str) -> None:
+    """Validate a package name against CEP-26 naming conventions.
+
+    See https://conda.org/learn/ceps/cep-0026
+    """
+    if not name:
+        return
+    if not (_CEP26_NAME_RE.match(name) or _CEP26_VIRTUAL_NAME_RE.match(name)):
+        if invalid := re.findall(r"[^a-z0-9._-]", name):
+            raise CondaBuildUserError(
+                f"package/name contains invalid characters "
+                f"({''.join(dict.fromkeys(invalid))}): {name}"
+            )
+        raise CondaBuildUserError(
+            f"package/name does not follow CEP-26 naming conventions: {name}. "
+            f"See https://conda.org/learn/ceps/cep-0026"
+        )
+
+
 def check_bad_chrs(value: str, field: str) -> None:
     bad_chrs = set("=@#$%^&*:;\"'\\|<>?/ ")
     if field in ("package/version", "build/string"):
@@ -1580,7 +1607,7 @@ class MetaData:
         name = str(name)
         if name != name.lower():
             sys.exit(f"Error: package/name must be lowercase, got: {name!r}")
-        check_bad_chrs(name, "package/name")
+        check_package_name(name)
         return name
 
     def version(self) -> str:

--- a/news/5976-cep26-name-validation.md
+++ b/news/5976-cep26-name-validation.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Validate package names against CEP-26 naming conventions, rejecting names with invalid characters or structure. (#5976)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -26,6 +26,7 @@ from conda_build.metadata import (
     OSModuleSubset,
     _hash_dependencies,
     check_bad_chrs,
+    check_package_name,
     eval_selector,
     get_output_dicts_from_metadata,
     get_selectors,
@@ -729,6 +730,41 @@ def test_check_bad_chrs(value: str, field: str, invalid: str) -> None:
         else nullcontext()
     ):
         check_bad_chrs(value, field)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "numpy",
+        "my-package",
+        "my_package",
+        "my.package",
+        "r-base",
+        "python-dateutil",
+        "_openmp_mutex",
+        "_pkg",
+        "__glibc",
+        "__unix",
+    ],
+)
+def test_check_package_name_valid(name: str) -> None:
+    check_package_name(name)
+
+
+@pytest.mark.parametrize(
+    "name,match",
+    [
+        ("pack@ge", "invalid characters"),
+        ("pkg..name", "CEP-26"),
+        ("pkg--name", "CEP-26"),
+        (".pkg", "CEP-26"),
+        ("-pkg", "CEP-26"),
+        ("UPPER", "invalid characters"),
+    ],
+)
+def test_check_package_name_invalid(name: str, match: str) -> None:
+    with pytest.raises(CondaBuildUserError, match=match):
+        check_package_name(name)
 
 
 def test_parse_until_resolved(testing_metadata: MetaData, tmp_path: Path) -> None:


### PR DESCRIPTION
### Description

Validates `package/name` in recipes against [CEP-26](https://conda.org/learn/ceps/cep-0026) naming conventions, matching the validation recently added to conda's MatchSpec parser (conda/conda#16096).

Adds a `check_package_name()` function with the CEP-26 distributable and virtual package name regexes. This replaces the generic `check_bad_chrs()` call for `package/name` (which only checked a hardcoded set of special characters) with proper structural validation:

- Distributable names: must start with `[a-z0-9]` or single `_`, use only `[a-z0-9._-]`, no consecutive separators
- Virtual names: must start with `__`, followed by valid name characters

`check_bad_chrs()` continues to serve `package/version` and `build/string` fields unchanged.

Closes #5976.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] ~Add / update outdated documentation?~ (not applicable)