### PR TITLE
Remove dependency on rattler-build

### DIFF
--- a/news/5986-remove-rattler-build-dependency.md
+++ b/news/5986-remove-rattler-build-dependency.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Remove redundant dependency on rattler-build. (#5986)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,6 @@ requirements:
     - python
     - python-libarchive-c
     - pyyaml
-    - rattler-build
     - requests
     - tomli                        # [py<311]
     - tqdm

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -22,7 +22,6 @@ pytest-rerunfailures  # for handling flaky tests
 python >=3.10
 python-libarchive-c
 pyyaml
-rattler-build
 requests
 ripgrep  # for faster grep
 setuptools


### PR DESCRIPTION
We are not using rattler-build CLI anymore in the code so we can drop the unneded dependency.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
