### PR TITLE
Add check to prevent duplicate rpaths on macos

### DIFF
--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -506,6 +506,17 @@ def mk_relative_osx(path, host_prefix, m, files, rpaths=("lib",)):
                 "@loader_path", relpath(join(host_prefix, rpath), dirname(path)), ""
             ).replace("/./", "/")
             macho.add_rpath(path, rpath_new, build_prefix=prefix, verbose=True)
+
+        # Check if there are duplicate rpaths and remove if any
+        seen_rpaths = set()
+        for rpath in macho.get_rpaths(path, build_prefix=prefix):
+            normalized = normpath(rpath)
+            if normalized in seen_rpaths:
+                macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
+                log = utils.get_logger(__name__)
+                log.info(f"Removing duplicate rpath from {path}: {rpath}")
+            else:
+                seen_rpaths.add(normalized)
     if s:
         # Skip for stub files, which have to use binary_has_prefix_files to be
         # made relocatable.

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -514,7 +514,7 @@ def mk_relative_osx(path, host_prefix, m, files, rpaths=("lib",)):
             if normalized in seen_rpaths:
                 macho.delete_rpath(path, rpath, build_prefix=prefix, verbose=True)
                 log = utils.get_logger(__name__)
-                log.info(f"Removing duplicate rpath from {path}: {rpath}")
+                log.info("Removing duplicate rpath from %s: %s", path, rpath)
             else:
                 seen_rpaths.add(normalized)
     if s:

--- a/news/5987-fix-duplicate-rpaths-macos.md
+++ b/news/5987-fix-duplicate-rpaths-macos.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Add a check to prevent duplicate rpaths on macos. (#5671) via (#5987)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test-recipes/metadata/_rpath_macos/build.sh
+++ b/tests/test-recipes/metadata/_rpath_macos/build.sh
@@ -10,7 +10,7 @@ if [[ "${target_platform:-}" == "osx-arm64" ]]; then
 else
   subdir="osx-64"
   pkg="libopenblas-0.3.33-pthreads_h705a207_0.conda"
-
+fi
 curl -L --fail \
   -o "$workdir/$pkg" \
   "https://conda.anaconda.org/conda-forge/${subdir}/${pkg}"

--- a/tests/test-recipes/metadata/_rpath_macos/build.sh
+++ b/tests/test-recipes/metadata/_rpath_macos/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+workdir="${SRC_DIR:-$PWD}/work"
+mkdir -p "$workdir" "$PREFIX/lib" "$PREFIX/share/$PKG_NAME"
+
+if [[ "${target_platform:-}" == "osx-arm64" ]]; then
+  subdir="osx-arm64"
+  pkg="libopenblas-0.3.33-pthreads_hddb8425_0.conda"
+else
+  subdir="osx-64"
+  pkg="libopenblas-0.3.33-pthreads_h705a207_0.conda"
+
+curl -L --fail \
+  -o "$workdir/$pkg" \
+  "https://conda.anaconda.org/conda-forge/${subdir}/${pkg}"
+
+unzip -o "$workdir/$pkg" -d "$workdir" >/dev/null
+
+pkg_archive="$(find "$workdir" -maxdepth 1 -name 'pkg-*.tar.zst' -print -quit)"
+test -n "$pkg_archive"
+
+tar --use-compress-program=unzstd \
+  -xf "$pkg_archive" \
+  -C "$workdir"
+
+install "$workdir/lib/libopenblas.0.dylib" \
+  "$PREFIX/lib/libopenblas.0.dylib"

--- a/tests/test-recipes/metadata/_rpath_macos/build.sh
+++ b/tests/test-recipes/metadata/_rpath_macos/build.sh
@@ -7,21 +7,23 @@ mkdir -p "$workdir" "$PREFIX/lib" "$PREFIX/share/$PKG_NAME"
 if [[ "${target_platform:-}" == "osx-arm64" ]]; then
   subdir="osx-arm64"
   pkg="libopenblas-0.3.33-pthreads_hddb8425_0.conda"
+  sha256="e1ec1db8ab19f1eddab1d99aba0e30d573e6f33c568fda7cab46390cb0f9bd5a"
 else
   subdir="osx-64"
   pkg="libopenblas-0.3.33-pthreads_h705a207_0.conda"
+  sha256="3654cdf68d4c9f2d89638310f336a60ecd5121a1"
 fi
+
 curl -L --fail \
   -o "$workdir/$pkg" \
   "https://conda.anaconda.org/conda-forge/${subdir}/${pkg}"
 
+echo "${sha256}  $workdir/$pkg" | shasum -a 256 -c -
+
 unzip -o "$workdir/$pkg" -d "$workdir" >/dev/null
 
-pkg_archive="$(find "$workdir" -maxdepth 1 -name 'pkg-*.tar.zst' -print -quit)"
-test -n "$pkg_archive"
-
-tar --use-compress-program=unzstd \
-  -xf "$pkg_archive" \
+tar --use-compress-program=unzstd -xf \
+  "$workdir"/pkg-*.tar.zst \
   -C "$workdir"
 
 install "$workdir/lib/libopenblas.0.dylib" \

--- a/tests/test-recipes/metadata/_rpath_macos/build.sh
+++ b/tests/test-recipes/metadata/_rpath_macos/build.sh
@@ -2,25 +2,17 @@
 set -euo pipefail
 
 workdir="${SRC_DIR:-$PWD}/work"
+
 mkdir -p "$workdir" "$PREFIX/lib" "$PREFIX/share/$PKG_NAME"
 
 if [[ "${target_platform:-}" == "osx-arm64" ]]; then
-  subdir="osx-arm64"
   pkg="libopenblas-0.3.33-pthreads_hddb8425_0.conda"
-  sha256="e1ec1db8ab19f1eddab1d99aba0e30d573e6f33c568fda7cab46390cb0f9bd5a"
 else
-  subdir="osx-64"
   pkg="libopenblas-0.3.33-pthreads_h705a207_0.conda"
-  sha256="3654cdf68d4c9f2d89638310f336a60ecd5121a1"
 fi
 
-curl -L --fail \
-  -o "$workdir/$pkg" \
-  "https://conda.anaconda.org/conda-forge/${subdir}/${pkg}"
 
-echo "${sha256}  $workdir/$pkg" | shasum -a 256 -c -
-
-unzip -o "$workdir/$pkg" -d "$workdir" >/dev/null
+unzip -o "$pkg" -d "$workdir" >/dev/null
 
 tar --use-compress-program=unzstd -xf \
   "$workdir"/pkg-*.tar.zst \

--- a/tests/test-recipes/metadata/_rpath_macos/meta.yaml
+++ b/tests/test-recipes/metadata/_rpath_macos/meta.yaml
@@ -2,6 +2,14 @@ package:
   name: install-broken-libopenblas
   version: "1.0.0"
 
+source:
+  - url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-pthreads_hddb8425_0.conda # [osx-arm64]
+    sha256: e1ec1db8ab19f1eddab1d99aba0e30d573e6f33c568fda7cab46390cb0f9bd5a # [osx-arm64]
+    target_directory: source  # [osx-arm64]
+  - url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-pthreads_h705a207_0.conda # [osx-64]
+    sha256: 15f5cf916c8fb749741dd49ac39e73b50ede76a9fc63bcce736517f409b2d0ee # [osx-64]
+    target_directory: source  # [osx-64]
+
 build:
   number: 0
   skip: true  # [not osx]

--- a/tests/test-recipes/metadata/_rpath_macos/meta.yaml
+++ b/tests/test-recipes/metadata/_rpath_macos/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: install-broken-libopenblas
+  version: "1.0.0"
+
+build:
+  number: 0
+  skip: true  # [not osx]

--- a/tests/test-recipes/metadata/_rpath_macos/meta.yaml
+++ b/tests/test-recipes/metadata/_rpath_macos/meta.yaml
@@ -3,12 +3,12 @@ package:
   version: "1.0.0"
 
 source:
-  - url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-pthreads_hddb8425_0.conda # [osx-arm64]
-    sha256: e1ec1db8ab19f1eddab1d99aba0e30d573e6f33c568fda7cab46390cb0f9bd5a # [osx-arm64]
-    target_directory: source  # [osx-arm64]
-  - url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-pthreads_h705a207_0.conda # [osx-64]
-    sha256: 15f5cf916c8fb749741dd49ac39e73b50ede76a9fc63bcce736517f409b2d0ee # [osx-64]
-    target_directory: source  # [osx-64]
+  - url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-pthreads_hddb8425_0.conda # [osx and arm64]
+    sha256: e1ec1db8ab19f1eddab1d99aba0e30d573e6f33c568fda7cab46390cb0f9bd5a # [osx and arm64]
+    target_directory: source  # [osx and arm64]
+  - url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.33-pthreads_h705a207_0.conda # [osx and x86_64]
+    sha256: 15f5cf916c8fb749741dd49ac39e73b50ede76a9fc63bcce736517f409b2d0ee # [osx and x86_64]
+    target_directory: source  # [osx and x86_64]
 
 build:
   number: 0

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from conda.base.context import context
 
 import conda_build.utils
 from conda_build import api, post
@@ -278,6 +279,22 @@ def test_rpath_symlink(mocker, testing_config):
     )
     # Should only be called on the actual binary, not its symlinks. (once per variant)
     assert mk_relative.call_count == 2
+
+
+@pytest.mark.skipif(not on_mac, reason="macOS-only test")
+def test_duplicate_rpath_macos(testing_config, caplog):
+    api.build(
+        os.path.join(metadata_dir, "_rpath_macos"),
+        config=testing_config,
+    )
+
+    captured_text = caplog.text
+    # On osx-64 the library has only one duplicate rpath,
+    # while on arm64 it has two
+    if context.subdir == "osx-64":
+        assert captured_text.count("Removing duplicate rpath") == 1
+    else:
+        assert captured_text.count("Removing duplicate rpath") == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from conda.base.context import context
 
 import conda_build.utils
 from conda_build import api, post
@@ -289,12 +288,8 @@ def test_duplicate_rpath_macos(testing_config, caplog):
     )
 
     captured_text = caplog.text
-    # On osx-64 the library has only one duplicate rpath,
-    # while on arm64 it has two
-    if context.subdir == "osx-64":
-        assert captured_text.count("Removing duplicate rpath") == 1
-    else:
-        assert captured_text.count("Removing duplicate rpath") == 2
+    # The library has only one duplicate rpath
+    assert captured_text.count("Removing duplicate rpath") == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
MacOS 15.4 introduced a breaking change where binaries with duplicate rhatps caused dlopen failures. Although this has since been addressed in cctools, conda-build is also adding rpaths during post processing so add a safeguard to detect and remove any duplicate rpaths.

Closes: https://github.com/conda/conda-build/issues/5671

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
