### PR TITLE
Fix SP_DIR resolving to wrong path for free-threading Python builds

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -96,7 +96,10 @@ def get_py_ver(config):
     py = config.variant.get("python", get_default_variant(config)["python"])
     if not hasattr(py, "split"):
         py = py[0]
-    return ".".join(py.split(".")[:2])
+    ver = ".".join(py.split(".")[:2])
+    if config.variant.get("is_freethreading", False) and not ver.endswith("t"):
+        ver += "t"
+    return ver
 
 
 def get_r_ver(config):

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -997,12 +997,16 @@ def get_stdlib_dir(prefix, py_ver):
         lib_dir = os.path.join(prefix, "Lib")
     else:
         lib_dir = os.path.join(prefix, "lib")
-        python_folder = glob(os.path.join(lib_dir, "python?.*"), recursive=True)
-        python_folder = sorted(filterfalse(islink, python_folder))
-        if python_folder:
-            lib_dir = os.path.join(lib_dir, python_folder[0])
+        exact = os.path.join(lib_dir, f"python{py_ver}")
+        if os.path.isdir(exact):
+            lib_dir = exact
         else:
-            lib_dir = os.path.join(lib_dir, f"python{py_ver}")
+            python_folder = glob(os.path.join(lib_dir, "python?.*"), recursive=True)
+            python_folder = sorted(filterfalse(islink, python_folder))
+            if python_folder:
+                lib_dir = os.path.join(lib_dir, python_folder[0])
+            else:
+                lib_dir = os.path.join(lib_dir, f"python{py_ver}")
     return lib_dir
 
 

--- a/news/5990-fix-sp-dir-freethreading.md
+++ b/news/5990-fix-sp-dir-freethreading.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix SP_DIR resolving to wrong path for free-threading Python builds. (#5563) via (#5990)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -5,7 +5,8 @@ import platform
 
 import pytest
 
-from conda_build.environ import create_env, os_vars
+from conda_build.config import Config
+from conda_build.environ import create_env, get_py_ver, os_vars
 
 on_linux = platform.system() == "Linux"
 
@@ -50,3 +51,22 @@ def test_build_variable_defaults_to_architecture_based_distro(testing_metadata):
 
     # Verify BUILD uses default cos6 or cos7 (not a custom cdt_name)
     assert "conda_cos6" in env_vars["BUILD"] or "conda_cos7" in env_vars["BUILD"]
+
+
+def test_get_py_ver_normal():
+    config = Config(variant={"python": "3.13"})
+    ver = get_py_ver(config)
+    assert ver == "3.13"
+    assert not ver.endswith("t")
+
+
+def test_get_py_ver_freethreading():
+    config = Config(variant={"python": "3.13", "is_freethreading": True})
+    ver = get_py_ver(config)
+    assert ver == "3.13t"
+
+
+def test_get_py_ver_freethreading_no_double_t():
+    config = Config(variant={"python": "3.13t", "is_freethreading": True})
+    ver = get_py_ver(config)
+    assert ver == "3.13t"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,27 @@ from conda_build.exceptions import BuildLockError
 
 
 @pytest.mark.skipif(
+    utils.on_win, reason="unix-specific path logic"
+)
+def test_get_stdlib_dir_exact_match(testing_workdir):
+    lib_dir = os.path.join(testing_workdir, "lib")
+    for name in ("python3.13t", "python3.13"):
+        (Path(lib_dir) / name).mkdir(parents=True)
+    result = utils.get_stdlib_dir(testing_workdir, "3.13t")
+    assert result == os.path.join(lib_dir, "python3.13t")
+
+
+@pytest.mark.skipif(
+    utils.on_win, reason="unix-specific path logic"
+)
+def test_get_stdlib_dir_fallback(testing_workdir):
+    lib_dir = os.path.join(testing_workdir, "lib")
+    os.makedirs(lib_dir)
+    result = utils.get_stdlib_dir(testing_workdir, "3.13t")
+    assert result == os.path.join(lib_dir, "python3.13t")
+
+
+@pytest.mark.skipif(
     utils.on_win, reason="only unix has python version in site-packages path"
 )
 def test_get_site_packages():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,9 +14,7 @@ import conda_build.utils as utils
 from conda_build.exceptions import BuildLockError
 
 
-@pytest.mark.skipif(
-    utils.on_win, reason="unix-specific path logic"
-)
+@pytest.mark.skipif(utils.on_win, reason="unix-specific path logic")
 def test_get_stdlib_dir_exact_match(testing_workdir):
     lib_dir = os.path.join(testing_workdir, "lib")
     for name in ("python3.13t", "python3.13"):
@@ -25,9 +23,7 @@ def test_get_stdlib_dir_exact_match(testing_workdir):
     assert result == os.path.join(lib_dir, "python3.13t")
 
 
-@pytest.mark.skipif(
-    utils.on_win, reason="unix-specific path logic"
-)
+@pytest.mark.skipif(utils.on_win, reason="unix-specific path logic")
 def test_get_stdlib_dir_fallback(testing_workdir):
     lib_dir = os.path.join(testing_workdir, "lib")
     os.makedirs(lib_dir)


### PR DESCRIPTION
- Prefer exact python{py_ver} directory match in get_stdlib_dir() before falling back to the glob pattern, so that python3.13t/ is correctly selected when py_ver is "3.13t"
- Honor is_freethreading variant key in get_py_ver() by appending the "t" suffix to the Python version string when the key is set

Closes #5563
