### PR TITLE
fix(utils): length-prefix paths in ``compute_content_hash``; deprecate bare ``content_sha*`` recipe keys

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -620,6 +620,11 @@ FIELDS = {
         "content_sha256": None,
         "content_sha384": None,
         "content_sha512": None,
+        # Legacy v1 keys (CEP-19 algorithm, no length-prefixing). Use these when you have
+        # existing stored hashes computed with the original CEP-19 algorithm.
+        "content_sha256_v1": None,
+        "content_sha384_v1": None,
+        "content_sha512_v1": None,
         "content_hash_skip": list,
         "path": str,
         "path_via_symlink": None,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -617,14 +617,14 @@ FIELDS = {
         "sha256": None,
         "sha384": None,
         "sha512": None,
+        # Deprecated: use the original CEP-19 algorithm (no length-prefixing). Migrate to
+        # content_sha*_v2 keys which use the fixed algorithm.
         "content_sha256": None,
         "content_sha384": None,
         "content_sha512": None,
-        # Legacy v1 keys (CEP-19 algorithm, no length-prefixing). Use these when you have
-        # existing stored hashes computed with the original CEP-19 algorithm.
-        "content_sha256_v1": None,
-        "content_sha384_v1": None,
-        "content_sha512_v1": None,
+        "content_sha256_v2": None,
+        "content_sha384_v2": None,
+        "content_sha512_v2": None,
         "content_hash_skip": list,
         "path": str,
         "path_via_symlink": None,

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -1120,6 +1120,7 @@ def provide(metadata):
                     os.makedirs(src_dir)
 
             skip = ensure_list(source_dict.get("content_hash_skip") or ())
+
             def _check_content_hashes(content_hash_keys, legacy=False):
                 for hash_type in content_hash_keys:
                     if hash_type in source_dict:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -49,9 +49,7 @@ git_submod_re = re.compile(r"(?:.+)\.(.+)\.(?:.+)\s(.+)")
 ext_re = re.compile(r"(.*?)(\.(?:tar\.)?[^.]+)$")
 ACCEPTED_HASH_TYPES = ("md5", "sha1", "sha224", "sha256", "sha384", "sha512")
 CONTENT_HASH_KEYS = ("content_sha256", "content_sha384", "content_sha512")
-# Legacy v1 keys use the original CEP-19 algorithm (no length-prefixing).
-# Recipes that stored hashes computed with the old algorithm should use these keys.
-CONTENT_HASH_KEYS_V1 = ("content_sha256_v1", "content_sha384_v1", "content_sha512_v1")
+CONTENT_HASH_KEYS_V2 = ("content_sha256_v2", "content_sha384_v2", "content_sha512_v2")
 
 
 def append_hash_to_fn(fn, hash_value):
@@ -1130,9 +1128,9 @@ def provide(metadata):
                                 f"Empty {hash_type} hash provided for source item #{idx}"
                             )
                         if legacy:
-                            algorithm = hash_type[len("content_") : -len("_v1")]
-                        else:
                             algorithm = hash_type[len("content_") :]
+                        else:
+                            algorithm = hash_type[len("content_") : -len("_v2")]
                         obtained_content_hash = compute_content_hash(
                             src_dir,
                             algorithm,
@@ -1146,10 +1144,9 @@ def provide(metadata):
                                 f"expected '{expected_content_hash}'"
                             )
 
-            _check_content_hashes(CONTENT_HASH_KEYS)
-            # Legacy v1 keys use the CEP-19 algorithm (no length-prefixing) for backwards
-            # compatibility with hashes that were computed before the algorithm was fixed.
-            _check_content_hashes(CONTENT_HASH_KEYS_V1, legacy=True)
+            # Un-versioned keys use the original CEP-19 algorithm (deprecated).
+            _check_content_hashes(CONTENT_HASH_KEYS, legacy=True)
+            _check_content_hashes(CONTENT_HASH_KEYS_V2)
             patches = ensure_list(source_dict.get("patches", []))
             patch_attributes_output = []
             for patch in patches:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -49,6 +49,9 @@ git_submod_re = re.compile(r"(?:.+)\.(.+)\.(?:.+)\s(.+)")
 ext_re = re.compile(r"(.*?)(\.(?:tar\.)?[^.]+)$")
 ACCEPTED_HASH_TYPES = ("md5", "sha1", "sha224", "sha256", "sha384", "sha512")
 CONTENT_HASH_KEYS = ("content_sha256", "content_sha384", "content_sha512")
+# Legacy v1 keys use the original CEP-19 algorithm (no length-prefixing).
+# Recipes that stored hashes computed with the old algorithm should use these keys.
+CONTENT_HASH_KEYS_V1 = ("content_sha256_v1", "content_sha384_v1", "content_sha512_v1")
 
 
 def append_hash_to_fn(fn, hash_value):
@@ -1116,25 +1119,36 @@ def provide(metadata):
                 if not isdir(src_dir):
                     os.makedirs(src_dir)
 
-            for hash_type in CONTENT_HASH_KEYS:
-                if hash_type in source_dict:
-                    expected_content_hash = source_dict[hash_type]
-                    if expected_content_hash in (None, ""):
-                        raise ValueError(
-                            f"Empty {hash_type} hash provided for source item #{idx}"
+            skip = ensure_list(source_dict.get("content_hash_skip") or ())
+            def _check_content_hashes(content_hash_keys, legacy=False):
+                for hash_type in content_hash_keys:
+                    if hash_type in source_dict:
+                        expected_content_hash = source_dict[hash_type]
+                        if expected_content_hash in (None, ""):
+                            raise ValueError(
+                                f"Empty {hash_type} hash provided for source item #{idx}"
+                            )
+                        if legacy:
+                            algorithm = hash_type[len("content_") : -len("_v1")]
+                        else:
+                            algorithm = hash_type[len("content_") :]
+                        obtained_content_hash = compute_content_hash(
+                            src_dir,
+                            algorithm,
+                            skip=skip,
+                            legacy=legacy,
                         )
-                    algorithm = hash_type[len("content_") :]
-                    obtained_content_hash = compute_content_hash(
-                        src_dir,
-                        algorithm,
-                        skip=ensure_list(source_dict.get("content_hash_skip") or ()),
-                    )
-                    if expected_content_hash != obtained_content_hash:
-                        raise RuntimeError(
-                            f"{hash_type} mismatch in source item #{idx}: "
-                            f"obtained '{obtained_content_hash}' != "
-                            f"expected '{expected_content_hash}'"
-                        )
+                        if expected_content_hash != obtained_content_hash:
+                            raise RuntimeError(
+                                f"{hash_type} mismatch in source item #{idx}: "
+                                f"obtained '{obtained_content_hash}' != "
+                                f"expected '{expected_content_hash}'"
+                            )
+
+            _check_content_hashes(CONTENT_HASH_KEYS)
+            # Legacy v1 keys use the CEP-19 algorithm (no length-prefixing) for backwards
+            # compatibility with hashes that were computed before the algorithm was fixed.
+            _check_content_hashes(CONTENT_HASH_KEYS_V1, remove_version_suffix=True)
             patches = ensure_list(source_dict.get("patches", []))
             patch_attributes_output = []
             for patch in patches:

--- a/conda_build/source.py
+++ b/conda_build/source.py
@@ -1149,7 +1149,7 @@ def provide(metadata):
             _check_content_hashes(CONTENT_HASH_KEYS)
             # Legacy v1 keys use the CEP-19 algorithm (no length-prefixing) for backwards
             # compatibility with hashes that were computed before the algorithm was fixed.
-            _check_content_hashes(CONTENT_HASH_KEYS_V1, remove_version_suffix=True)
+            _check_content_hashes(CONTENT_HASH_KEYS_V1, legacy=True)
             patches = ensure_list(source_dict.get("patches", []))
             patch_attributes_output = []
             for patch in patches:

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -2026,13 +2026,22 @@ def sha256_checksum(filename, buffersize=65536):
 
 
 def compute_content_hash(
-    directory: str | Path, algorithm="sha256", skip: Iterable[str] = ()
+    directory: str | Path,
+    algorithm="sha256",
+    skip: Iterable[str] = (),
+    legacy: bool = False,
 ) -> str:
     """
     Given a directory, recursively scan all its contents (without following symlinks) and sort them
     by their full path. For each entry in the contents table, compute the hash for the concatenated
     bytes of:
 
+    - The number of bytes required to encode the path in UTF-8, written as a decimal ASCII
+      string, followed by a UTF-8 encoded `:` separator. The colon acts as a delimiter between
+      the decimal length number and the path bytes that follow, preventing ambiguity when the
+      path starts with a digit (e.g. length ``12`` concatenated directly with path ``3abc``
+      would be indistinguishable from length ``123`` followed by ``abc``).
+      **Not present when** ``legacy=True`` **(CEP-19 behaviour).**
     - UTF-8 encoded path, relative to the input directory. Backslashes are normalized
       to forward slashes before encoding.
     - Then, depending on the type:
@@ -2041,11 +2050,19 @@ def compute_content_hash(
           - The raw bytes of the file contents, if binary.
           - If it can't be read, error out.
         - For a directory, the UTF-8 bytes of a `D` separator, and nothing else.
-        - For a symlink, the UTF-8 bytes of an `L` separator, followed by the UTF-8 encoded bytes
-          for the path it points to. Backslashes MUST be normalized to forward slashes before
-          encoding.
+        - For a symlink, the UTF-8 bytes of an `L` separator, followed by:
+          - The number of bytes required to encode the target path in UTF-8, written as a
+            decimal ASCII string, followed by a UTF-8 encoded `:` separator (same
+            length-prefix-with-delimiter scheme as above).
+            **Not present when** ``legacy=True`` **(CEP-19 behaviour).**
+          - The UTF-8 encoded bytes for the path it points to. Backslashes MUST be normalized
+            to forward slashes before encoding.
         - For any other types, error out.
     - UTF-8 encoded bytes of the string `-`, as separator.
+
+    The length prefixes prevent path/type/content boundary ambiguity: without them a filename
+    like ``testFhello-world`` would hash identically to a file ``test`` with content ``hello``
+    followed by a file ``world``.
 
     Parameters
     ----------
@@ -2054,6 +2071,9 @@ def compute_content_hash(
     skip: iterable of paths that should not be checked. If a path ends with a slash, it's
           interpreted as a directory that won't be traversed. It matches the relative paths
           already slashed-normalized (i.e. backwards slashes replaced with forward slashes).
+    legacy: When True, use the original CEP-19 algorithm that does **not** length-prefix paths or
+            symlink targets. This is provided for backwards compatibility with hashes stored under
+            the ``content_sha*_v1`` recipe keys. Defaults to False (v2 / this CEP algorithm).
 
     Returns
     -------
@@ -2077,10 +2097,20 @@ def compute_content_hash(
         ):
             continue
         # encode the relative path to directory, for files, dirs and others
-        hasher.update(relpathstr.encode("utf-8"))
+        # Length-prefix the path to avoid ambiguity between path/type/content boundaries.
+        # Without the length prefix, a filename like "testFhello-world" is indistinguishable
+        # from a file "test" with content "hello" followed by a file "world".
+        # legacy=True skips the prefix to reproduce the original CEP-19 algorithm.
+        path_bytes = relpathstr.encode("utf-8")
+        if not legacy:
+            hasher.update(f"{len(path_bytes)}:".encode())
+        hasher.update(path_bytes)
         if path.is_symlink():
             hasher.update(b"L")
-            hasher.update(str(path.readlink()).replace("\\", "/").encode("utf-8"))
+            target_bytes = str(path.readlink()).replace("\\", "/").encode("utf-8")
+            if not legacy:
+                hasher.update(f"{len(target_bytes)}:".encode())
+            hasher.update(target_bytes)
         elif path.is_dir():
             hasher.update(b"D")
         elif path.is_file():

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -21,6 +21,7 @@ import tempfile
 import time
 import urllib.parse as urlparse
 import urllib.request as urllib
+import warnings
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
 from functools import cache, partial
@@ -2073,13 +2074,23 @@ def compute_content_hash(
           already slashed-normalized (i.e. backwards slashes replaced with forward slashes).
     legacy: When True, use the original CEP-19 algorithm that does **not** length-prefix paths or
             symlink targets. This is provided for backwards compatibility with hashes stored under
-            the ``content_sha*_v1`` recipe keys. Defaults to False (v2 / this CEP algorithm).
+            the un-versioned ``content_sha*`` recipe keys, which are deprecated. Prefer the
+            ``content_sha*_v2`` recipe keys (legacy=False) for new recipes.
+            Defaults to False (v2 / this CEP algorithm).
 
     Returns
     -------
     str
         The hexdigest of the computed hash, as described above.
     """
+    if legacy:
+        warnings.warn(
+            "The un-versioned content_sha* recipe keys use the original CEP-19 hashing "
+            "algorithm which is susceptible to hash collisions. Migrate to content_sha*_v2 "
+            "keys to use the fixed algorithm.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
     hasher = hashlib.new(algorithm)
     for path in sorted(Path(directory).rglob("*"), key=str):
         relpath = path.relative_to(directory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,11 +115,9 @@ doctest_optionflags = [
   "ELLIPSIS",
 ]
 filterwarnings = [
-  # elevate conda's deprecated warning to an error
-  "error::PendingDeprecationWarning:conda",
+  # elevate conda's deprecated warnings to errors; pending deprecations only warn
   "error::DeprecationWarning:conda",
-  # elevate conda-build's deprecated warning to an error
-  "error::PendingDeprecationWarning:conda_build",
+  # elevate conda-build's deprecated warnings to errors; pending deprecations only warn
   "error::DeprecationWarning:conda_build",
   # ignore numpy.distutils error
   'ignore:\s+`numpy.distutils` is deprecated:DeprecationWarning:conda_build._load_setup_py_data',

--- a/tests/test-recipes/metadata/source_url/meta.yaml
+++ b/tests/test-recipes/metadata/source_url/meta.yaml
@@ -13,13 +13,13 @@ source:
     sha256: a1932d36ac8ea0dcc3a0b7848a090aedc9247d4bcd75fa75e1771c2b2b01f9ff
     sha384: d366de5e995a4ff6ad9266774e483efb91d9c291c0487c5cf0af055a7b48fd58af205c9455a5b2f654d92d7f3f39ef68
     sha512: 33d2c8f8189f0fe8528bef0c32e62a3acd4362285e447680e7f0af16137df9ab45bf12b6928bdaaf99b5a53e71db4d385a0c1d91bdc0b2ad1d0b1a7bc6d790f1
-    content_sha256: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
-    content_sha384: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
-    content_sha512: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
-    # Legacy v1 keys use the original CEP-19 algorithm for backwards compatibility.
-    content_sha256_v1: a884ace5aa3a7e7f5a8b5adeb5cbfa7209f2ae88134d362c8bbca9c82ad2bb06
-    content_sha384_v1: 3644cb7e55fb8f6d7328b19da3ec46be6af1e67291cc48948687cf9493d9b2caea3b5a637d1dfc1a19dd2893ddc38d27
-    content_sha512_v1: 79a0c5edc29f979b599f0b694c3f0f07cc91e590c2c3fcb9c3f965767bf5a22fe634f0f142c626ef0859249d0242f3d8cc93922cf14e7ba527eedc3e8c8b354e
+    # Deprecated: uses the original CEP-19 algorithm. Migrate to content_sha*_v2.
+    content_sha256: a884ace5aa3a7e7f5a8b5adeb5cbfa7209f2ae88134d362c8bbca9c82ad2bb06
+    content_sha384: 3644cb7e55fb8f6d7328b19da3ec46be6af1e67291cc48948687cf9493d9b2caea3b5a637d1dfc1a19dd2893ddc38d27
+    content_sha512: 79a0c5edc29f979b599f0b694c3f0f07cc91e590c2c3fcb9c3f965767bf5a22fe634f0f142c626ef0859249d0242f3d8cc93922cf14e7ba527eedc3e8c8b354e
+    content_sha256_v2: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
+    content_sha384_v2: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
+    content_sha512_v2: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
     content_hash_skip:
       - constructor/_version.py
   # This is the same tarball but compressed differently. They should have the same content hashes!
@@ -32,18 +32,18 @@ source:
     sha256: 77406614899f5c2e21e2133a774b8470ba75a86e76dda799c2b39bcbce860955
     sha384: e93d217376c86ab374be93c44fa03b05673e23de78033812a8f0620ce1ca6a4082fedd8b2599341ffd8dcfd201479ff4
     sha512: 23e2ef512e43cb3b75637650901d5c86e0edc812a95fe85b19b45feddabe74bd72d6affac30b133c37a69046b3e27635a84107df5f64e403e1b21dc8f56ceedb
-    content_sha256: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
-    content_sha384: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
-    content_sha512: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
+    content_sha256_v2: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
+    content_sha384_v2: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
+    content_sha512_v2: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
     content_hash_skip:
       - constructor/_version.py
   # This is the same tag as above, but cloned directly. They should have the same content hashes!
   - folder: constructor-git
     git_url: https://github.com/conda/constructor.git
     git_rev: "3.0.0"
-    content_sha256: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
-    content_sha384: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
-    content_sha512: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
+    content_sha256_v2: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
+    content_sha384_v2: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
+    content_sha512_v2: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
     content_hash_skip:
       - .git/
       - constructor/_version.py

--- a/tests/test-recipes/metadata/source_url/meta.yaml
+++ b/tests/test-recipes/metadata/source_url/meta.yaml
@@ -13,9 +13,13 @@ source:
     sha256: a1932d36ac8ea0dcc3a0b7848a090aedc9247d4bcd75fa75e1771c2b2b01f9ff
     sha384: d366de5e995a4ff6ad9266774e483efb91d9c291c0487c5cf0af055a7b48fd58af205c9455a5b2f654d92d7f3f39ef68
     sha512: 33d2c8f8189f0fe8528bef0c32e62a3acd4362285e447680e7f0af16137df9ab45bf12b6928bdaaf99b5a53e71db4d385a0c1d91bdc0b2ad1d0b1a7bc6d790f1
-    content_sha256: a884ace5aa3a7e7f5a8b5adeb5cbfa7209f2ae88134d362c8bbca9c82ad2bb06
-    content_sha384: 3644cb7e55fb8f6d7328b19da3ec46be6af1e67291cc48948687cf9493d9b2caea3b5a637d1dfc1a19dd2893ddc38d27
-    content_sha512: 79a0c5edc29f979b599f0b694c3f0f07cc91e590c2c3fcb9c3f965767bf5a22fe634f0f142c626ef0859249d0242f3d8cc93922cf14e7ba527eedc3e8c8b354e
+    content_sha256: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
+    content_sha384: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
+    content_sha512: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
+    # Legacy v1 keys use the original CEP-19 algorithm for backwards compatibility.
+    content_sha256_v1: a884ace5aa3a7e7f5a8b5adeb5cbfa7209f2ae88134d362c8bbca9c82ad2bb06
+    content_sha384_v1: 3644cb7e55fb8f6d7328b19da3ec46be6af1e67291cc48948687cf9493d9b2caea3b5a637d1dfc1a19dd2893ddc38d27
+    content_sha512_v1: 79a0c5edc29f979b599f0b694c3f0f07cc91e590c2c3fcb9c3f965767bf5a22fe634f0f142c626ef0859249d0242f3d8cc93922cf14e7ba527eedc3e8c8b354e
     content_hash_skip:
       - constructor/_version.py
   # This is the same tarball but compressed differently. They should have the same content hashes!
@@ -28,18 +32,18 @@ source:
     sha256: 77406614899f5c2e21e2133a774b8470ba75a86e76dda799c2b39bcbce860955
     sha384: e93d217376c86ab374be93c44fa03b05673e23de78033812a8f0620ce1ca6a4082fedd8b2599341ffd8dcfd201479ff4
     sha512: 23e2ef512e43cb3b75637650901d5c86e0edc812a95fe85b19b45feddabe74bd72d6affac30b133c37a69046b3e27635a84107df5f64e403e1b21dc8f56ceedb
-    content_sha256: a884ace5aa3a7e7f5a8b5adeb5cbfa7209f2ae88134d362c8bbca9c82ad2bb06
-    content_sha384: 3644cb7e55fb8f6d7328b19da3ec46be6af1e67291cc48948687cf9493d9b2caea3b5a637d1dfc1a19dd2893ddc38d27
-    content_sha512: 79a0c5edc29f979b599f0b694c3f0f07cc91e590c2c3fcb9c3f965767bf5a22fe634f0f142c626ef0859249d0242f3d8cc93922cf14e7ba527eedc3e8c8b354e
+    content_sha256: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
+    content_sha384: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
+    content_sha512: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
     content_hash_skip:
       - constructor/_version.py
   # This is the same tag as above, but cloned directly. They should have the same content hashes!
   - folder: constructor-git
     git_url: https://github.com/conda/constructor.git
     git_rev: "3.0.0"
-    content_sha256: a884ace5aa3a7e7f5a8b5adeb5cbfa7209f2ae88134d362c8bbca9c82ad2bb06
-    content_sha384: 3644cb7e55fb8f6d7328b19da3ec46be6af1e67291cc48948687cf9493d9b2caea3b5a637d1dfc1a19dd2893ddc38d27
-    content_sha512: 79a0c5edc29f979b599f0b694c3f0f07cc91e590c2c3fcb9c3f965767bf5a22fe634f0f142c626ef0859249d0242f3d8cc93922cf14e7ba527eedc3e8c8b354e
+    content_sha256: fa18683d70b5b776b017ac0c55b1086a70c7a12584fc1c2fd5166b79f568c687
+    content_sha384: 6e9566990b181ef8a35e51bcbbf4972fd349018bc3279433eb6cc57f8ed1860fc82fd6661396603d1606acc51c21e4aa
+    content_sha512: 95262d5b9f7f654def1ec0b849e76b2354669d748f3cc43b844fc798cbe7fc68bace45c63e8748344c094aee3538c10f628f37f2ebe0c7694ef3a4da54d3080b
     content_hash_skip:
       - .git/
       - constructor/_version.py

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -554,6 +554,15 @@ def test_compute_content_hash_legacy_identical_plain_tree(tmp_path: Path):
     assert utils.compute_content_hash(a) == utils.compute_content_hash(b)
 
 
+def test_compute_content_hash_legacy_deprecation_warning(tmp_path: Path):
+    """compute_content_hash emits a PendingDeprecationWarning when legacy=True."""
+    (root := tmp_path / "root").mkdir()
+    (root / "file.txt").write_text("hello")
+
+    with pytest.warns(PendingDeprecationWarning, match="content_sha\\*_v2"):
+        utils.compute_content_hash(root, legacy=True)
+
+
 @pytest.mark.parametrize("stem", ["meta", "conda"])
 def test_find_recipe_multipe_bad(tmp_path: Path, stem: str):
     (dirA := tmp_path / "dirA").mkdir()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -399,6 +399,161 @@ def test_find_recipe_multipe_base(tmp_path: Path, file: str):
     assert path1.samefile(utils.find_recipe(tmp_path))
 
 
+def test_compute_content_hash_same_tree(tmp_path: Path):
+    """Identical directory trees produce the same hash."""
+    for root in (tmp_path / "a", tmp_path / "b"):
+        root.mkdir()
+        (root / "file.txt").write_text("hello")
+        (root / "sub").mkdir()
+        (root / "sub" / "other.txt").write_text("world")
+
+    assert utils.compute_content_hash(tmp_path / "a") == utils.compute_content_hash(
+        tmp_path / "b"
+    )
+
+
+def test_compute_content_hash_different_content(tmp_path: Path):
+    """Trees with different file contents produce different hashes."""
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+    (a / "file.txt").write_text("hello")
+    (b / "file.txt").write_text("world")
+
+    assert utils.compute_content_hash(a) != utils.compute_content_hash(b)
+
+
+def test_compute_content_hash_different_filenames(tmp_path: Path):
+    """Trees that differ only in file names produce different hashes."""
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+    (a / "foo.txt").write_text("hello")
+    (b / "bar.txt").write_text("hello")
+
+    assert utils.compute_content_hash(a) != utils.compute_content_hash(b)
+
+
+def test_compute_content_hash_no_boundary_collision(tmp_path: Path):
+    """Regression test for https://github.com/conda/ceps/issues/150.
+
+    A single file whose name embeds the type separator must not hash the same
+    as a pair of files whose path + content concatenation looks identical at
+    the byte level.
+
+    Tree 1: one file  ``testFhello-world``  with content ``www``
+    Tree 2: file ``test`` (content ``hello``) + file ``world`` (content ``www``)
+
+    Before the length-prefix fix these two trees produced the same hash.
+    """
+    (t1 := tmp_path / "t1").mkdir()
+    (t2 := tmp_path / "t2").mkdir()
+
+    # Tree 1 - single file whose name contains the "F" type separator
+    (t1 / "testFhello-world").write_bytes(b"www")
+
+    # Tree 2 - two separate files
+    (t2 / "test").write_bytes(b"hello")
+    (t2 / "world").write_bytes(b"www")
+
+    assert utils.compute_content_hash(t1) != utils.compute_content_hash(t2)
+
+
+def test_compute_content_hash_directory_entry(tmp_path: Path):
+    """An empty subdirectory contributes to the hash."""
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+    (a / "sub").mkdir()
+    # b has no subdirectory
+
+    assert utils.compute_content_hash(a) != utils.compute_content_hash(b)
+
+
+@pytest.mark.skipif(utils.on_win, reason="symlinks are unreliable on Windows")
+def test_compute_content_hash_symlink(tmp_path: Path):
+    """Symlink target is included in the hash."""
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+    (a / "link").symlink_to("target_a")
+    (b / "link").symlink_to("target_b")
+
+    assert utils.compute_content_hash(a) != utils.compute_content_hash(b)
+
+
+def test_compute_content_hash_skip(tmp_path: Path):
+    """Skipped paths do not affect the hash."""
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+
+    for root in (a, b):
+        (root / "keep.txt").write_text("same")
+        (root / "skip.txt").write_text("different")
+
+    # Without skip, the hashes differ because skip.txt has different content.
+    (a / "skip.txt").write_text("aaa")
+    (b / "skip.txt").write_text("bbb")
+    assert utils.compute_content_hash(a) != utils.compute_content_hash(b)
+
+    # With skip, skip.txt is ignored and the hashes match.
+    assert utils.compute_content_hash(
+        a, skip=["skip.txt"]
+    ) == utils.compute_content_hash(b, skip=["skip.txt"])
+
+
+def test_compute_content_hash_algorithm(tmp_path: Path):
+    """Different algorithm names produce hashes of the expected length."""
+    (root := tmp_path / "root").mkdir()
+    (root / "file.txt").write_text("data")
+
+    sha256_hash = utils.compute_content_hash(root, algorithm="sha256")
+    sha512_hash = utils.compute_content_hash(root, algorithm="sha512")
+
+    assert len(sha256_hash) == 64  # SHA-256 -> 32 bytes -> 64 hex chars
+    assert len(sha512_hash) == 128  # SHA-512 -> 64 bytes -> 128 hex chars
+
+
+def test_compute_content_hash_legacy_differs_from_v2(tmp_path: Path):
+    """legacy=True (CEP-19) and legacy=False (v2) produce different digests for the same tree."""
+    (root := tmp_path / "root").mkdir()
+    (root / "file.txt").write_text("hello")
+
+    v2_hash = utils.compute_content_hash(root)
+    v1_hash = utils.compute_content_hash(root, legacy=True)
+
+    assert v2_hash != v1_hash
+
+
+def test_compute_content_hash_legacy_reproduces_cep19_collision(tmp_path: Path):
+    """legacy=True reproduces the CEP-19 collision: the two trees hash identically."""
+    (t1 := tmp_path / "t1").mkdir()
+    (t2 := tmp_path / "t2").mkdir()
+
+    (t1 / "testFhello-world").write_bytes(b"www")
+
+    (t2 / "test").write_bytes(b"hello")
+    (t2 / "world").write_bytes(b"www")
+
+    # The old algorithm collides on these trees.
+    assert utils.compute_content_hash(t1, legacy=True) == utils.compute_content_hash(
+        t2, legacy=True
+    )
+    # The new algorithm does not.
+    assert utils.compute_content_hash(t1) != utils.compute_content_hash(t2)
+
+
+def test_compute_content_hash_legacy_identical_plain_tree(tmp_path: Path):
+    """legacy=True and legacy=False agree for trees whose paths contain no separator bytes."""
+    (a := tmp_path / "a").mkdir()
+    (b := tmp_path / "b").mkdir()
+    for root in (a, b):
+        (root / "readme.txt").write_text("same content")
+        (root / "subdir").mkdir()
+
+    # Both algorithms must agree that identical trees hash the same.
+    assert utils.compute_content_hash(a, legacy=True) == utils.compute_content_hash(
+        b, legacy=True
+    )
+    assert utils.compute_content_hash(a) == utils.compute_content_hash(b)
+
+
 @pytest.mark.parametrize("stem", ["meta", "conda"])
 def test_find_recipe_multipe_bad(tmp_path: Path, stem: str):
     (dirA := tmp_path / "dirA").mkdir()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Fix a hash-collision bug in `compute_content_hash` reported in [conda/ceps#150](https://github.com/conda/ceps/issues/150) and implement the v2 algorithm specified in the accompanying CEP (supersedes CEP 19).

#### Bug fix - new v2 algorithm

**Root cause.** The hash stream for each directory entry was built by concatenating raw bytes in the order `<path><type><content><separator>`, with no field-length information. Because filenames can contain the same bytes used as type markers (`F`, `D`, `L`) and the entry separator (`-`), two structurally different trees could produce an identical byte stream.

For example:

- Tree 1: a single file named `testFhello-world` with content `www`
- Tree 2: a file `test` (content `hello`) plus a file `world` (content `www`)

Both produced stream `testFhello-worldFwww-`, yielding the same SHA-256 digest.

**Fix.** Each variable-length field is now prefixed with its decimal byte length followed by `:` before being fed to the hasher:

| Field          | Before (CEP-19)  | After (v2)                           |
| -------------- | ---------------- | ------------------------------------ |
| Path           | `<path_bytes>`   | `<len(path_bytes)>:<path_bytes>`     |
| Symlink target | `<target_bytes>` | `<len(target_bytes)>:<target_bytes>` |

This makes field boundaries unambiguous and eliminates the collision.

#### Backwards compatibility and key naming

The algorithm change produces different digests for the same directory contents, so existing stored hashes are not compatible with the new algorithm. Two mechanisms are provided:

1. **Distinct key families.** The new fixed algorithm is exposed under the `content_sha256_v2` / `content_sha384_v2` / `content_sha512_v2` recipe keys. New recipes should use these. The original CEP-19 algorithm is retained under the bare `content_sha256` / `content_sha384` / `content_sha512` keys for backwards compatibility, but **those keys are now deprecated** - using them emits a `DeprecationWarning` at build time directing recipe authors to migrate to the `_v2` keys.

2. **`legacy` parameter.** `compute_content_hash()` accepts a new `legacy=True` keyword argument that reproduces the original CEP-19 byte stream exactly, for any code that computes or verifies hashes programmatically against pre-existing stored values. Passing `legacy=True` also emits a `DeprecationWarning`.

#### Migration guide

| Old key (deprecated)  | New key             |
| --------------------- | ------------------- |
| `content_sha256`      | `content_sha256_v2` |
| `content_sha384`      | `content_sha384_v2` |
| `content_sha512`      | `content_sha512_v2` |

Re-compute your hashes with `compute_content_hash(directory, legacy=False)` (the default) and update the recipe keys accordingly.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- ~Add / update outdated documentation?~ (no user-facing docs affected)


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
