### PR TITLE
Fix ignore_run_exports_from_substr recipe and test

### DIFF
--- a/tests/test-recipes/metadata/ignore_run_exports_from_substr/meta.yaml
+++ b/tests/test-recipes/metadata/ignore_run_exports_from_substr/meta.yaml
@@ -9,6 +9,6 @@ build:
 
 requirements:
   host:
-    - conda-forge::python
+    - python
   run:
     - numpy

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -2153,9 +2153,12 @@ def test_api_build_inject_jinja2_vars_on_first_pass(testing_config):
     api.build(recipe_dir, config=testing_config)
 
 
-def test_ignore_run_exports_from_substr(monkeypatch, tmp_path, capsys):
+def test_ignore_run_exports_from_substr(monkeypatch, tmp_path, capsys, testing_config):
     monkeypatch.chdir(tmp_path)
-    api.build(str(metadata_path / "ignore_run_exports_from_substr"))
+    testing_config.channel_urls = ["conda-forge"]
+    api.build(
+        str(metadata_path / "ignore_run_exports_from_substr"), config=testing_config
+    )
     assert "- python_abi " in capsys.readouterr().out
 
 


### PR DESCRIPTION
The test recipe attempted to pull `python` from `conda-forge` channel by adding
a channel matchspec directly in the recipe. However, since
`conda-forge` is not passed to api.build() nor configured in Conda,
it's not guaranteed to work and caused the test to fail when using conda-rattler-solver. Update the test
recipe and pass the `conda-forge` channel in the test itself.

Closes: https://github.com/conda/conda-build/issues/5993

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
