### PR TITLE
fix: raise ValueError for negative build numbers in metadata

### DIFF
--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1603,11 +1603,16 @@ class MetaData:
             return 0
 
         try:
-            return int(number)
+            n = int(number)
         except (ValueError, TypeError):
             raise ValueError(
                 f"Build number was invalid value '{number}'. Must be an integer."
             )
+        if n < 0:
+            raise ValueError(
+                f"Build number must be a non-negative integer, got '{number}'."
+            )
+        return n
 
     def get_depends_top_and_out(self, typ):
         meta_requirements = ensure_list(self.get_value("requirements/" + typ, []))[:]

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -321,11 +321,11 @@ Build number and string
 -----------------------
 
 The build number should be incremented for new builds of the same
-version. The number defaults to ``0``. The build string cannot
-contain "-". The string defaults to the default conda-build
-string plus the build number. When redefining the default string,
-we strongly recommend following the convention of adding the build
-number at the end of the string, with a preceding underscore.
+version. The number must be a non-negative integer and defaults to ``0``.
+The build string cannot contain "-". The string defaults to the default
+conda-build string plus the build number. When redefining the default
+string, we strongly recommend following the convention of adding the
+build number at the end of the string, with a preceding underscore.
 
 .. code-block:: yaml
 

--- a/news/5997-negative-build-number.md
+++ b/news/5997-negative-build-number.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Raise `ValueError` for negative build numbers in `meta.yaml` at metadata validation time, before any build scripts run. (#5332, #5997)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Clarify that `build/number` must be a non-negative integer. (#5997)
+
+### Other
+
+* <news item>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -276,6 +276,12 @@ def test_disallow_leading_period_in_version(testing_metadata):
         testing_metadata.version()
 
 
+def test_disallow_negative_build_number(testing_metadata):
+    testing_metadata.meta["build"]["number"] = -1
+    with pytest.raises(ValueError, match="non-negative"):
+        testing_metadata.build_number()
+
+
 def test_disallow_dash_in_features(testing_metadata):
     testing_metadata.meta["build"]["features"] = ["abc"]
     testing_metadata.parse_again()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->

## Summary

Negative build numbers (e.g. `number: -1`) were silently accepted by `build_number()` in `metadata.py`. The invalid value would propagate into the package filename (e.g. `pkg-1.0--1.tar.bz2`).

## Changes

- **`conda_build/metadata.py`**: Added a non-negative check in `build_number()` after the `int()` conversion. A `ValueError` is now raised at metadata validation time, before any build scripts run.
- **`tests/test_metadata.py`**: Added `test_disallow_negative_build_number` to verify the error is raised.

## Fixes

Closes #5332 
