### PR TITLE
lint: update Ruff target version to Python 3.10

### DIFF
--- a/conda_build/deprecations.py
+++ b/conda_build/deprecations.py
@@ -13,7 +13,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
-    from typing import Any, Callable, ParamSpec, Self, TypeVar
+    from collections.abc import Callable
+    from typing import Any, ParamSpec, Self, TypeVar
 
     from packaging.version import Version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ testpaths = ["tests"]
 
 [tool.ruff]
 show-fixes = true
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 flake8-type-checking = {exempt-modules = [], strict = true}

--- a/tests/os_utils/test_codefile.py
+++ b/tests/os_utils/test_codefile.py
@@ -12,7 +12,7 @@ from conda_build.os_utils.pyldd import DLLfile, EXEfile, elffile, machofile
 from conda_build.os_utils.pyldd import codefile_class as pyldd_codefile_class
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
 LDD = Path(__file__).parent.parent / "data" / "ldd"
 


### PR DESCRIPTION
Closes #5835.

Update Ruff's target-version from Python 3.9 to Python 3.10 to match the project's supported Python versions. Applied the Ruff fixes required by the new target version.

Add a file to the news directory
No, Seemed like a minor change, would be happy to add a newsfragement if needed

Add / update necessary tests?
No, just updated pyproject.toml

Add / update outdated documentation?
No.