### PR TITLE
revert host_deps to be  empty list

### DIFF
--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -561,7 +561,7 @@ def add_upstream_pins(
                 + extra_run_specs_from_build.get("strong_constrains", [])
             )
     else:
-        host_deps = set(utils.ensure_list(requirements.get("host")))
+        host_deps = []
         host_unsat = []
         if m.noarch or m.noarch_python:
             if m.build_is_host:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
The change from `host_deps=[]` to `host_deps = set(utils.ensure_list(requirements.get("host")))` in the non-cross else branch [caused existing host requirements to be overwritten and deduped](https://github.com/conda/conda-build/pull/6014/changes#diff-f242dc79ac6d542395fb22c0d9442f0b614eddce6eaf035893bf08c8b0ad7291R605). 
Fix: revert host_deps back to `[]`. 


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
