### PR TITLE
Fix `find_used_variables_in_text()` to match variables without spaces

### DIFF
--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -776,7 +776,7 @@ def find_used_variables_in_text(variant, recipe_text, selectors_only=False):
         v_regex = re.escape(v)
         v_req_regex = "[-_]".join(map(re.escape, v.split("_")))
         variant_regex = (
-            rf"\{{\s*(?:pin_[a-z]+\(\s*?['\"])?{v_regex}[^_0-9a-zA-Z].*?\}}\}}"
+            rf"\{{\s*(?:pin_[a-z]+\(\s*?['\"])?{v_regex}(?:[^_0-9a-zA-Z].*?)?\}}\}}"
         )
         selector_regex = rf"^[^#\[]*?\#?\s\[[^\]]*?(?<![_\w\d]){v_regex}[=\s<>!\]]"
         # NOTE: why use a regex instead of the jinja2 parser/AST?

--- a/news/6036-fix-used-variables-without-spaces.md
+++ b/news/6036-fix-used-variables-without-spaces.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix finding used variables that do not feature spaces, e.g. `{{python_min}}`. (#6036)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -835,6 +835,11 @@ def test_get_vars():
             "{{ python_min }}",
             {"python_min"},
         ),
+        (
+            ("python", "python_min"),
+            "{{python_min}}",
+            {"python_min"},
+        ),
         # filters and other text
         (
             ("python", "python_min"),
@@ -854,6 +859,11 @@ def test_get_vars():
         (
             ("python", "python_min"),
             "{{ python_min|lower }}",
+            {"python_min"},
+        ),
+        (
+            ("python", "python_min"),
+            "{{python_min|lower}}",
             {"python_min"},
         ),
         # pin_* statements
@@ -878,6 +888,11 @@ def test_get_vars():
             {"python_min"},
         ),
         (
+            ("python", "python_min"),
+            "{{pin_compatible('python_min', max_pin='x.x')}}",
+            {"python_min"},
+        ),
+        (
             ("zlib", "ace"),
             "{% set p = zlib.replace('.', '') %}",
             {"zlib"},
@@ -885,6 +900,11 @@ def test_get_vars():
         (
             ("zlib", "xz", "ace"),
             "{% set p = azlib.replace('.', '') ~ xz ~ 'a' %}",
+            {"xz"},
+        ),
+        (
+            ("zlib", "xz", "ace"),
+            "{%set p = azlib.replace('.', '') ~ xz ~ 'a'%}",
             {"xz"},
         ),
     ],


### PR DESCRIPTION
### Description

Fix the regular expression used to find used variables in text to also match space-less variable references such as `{{python_min}}`.

This specific syntax used not to match because the regex expected the variable name to be followed by at least one character that wasn't a valid variable name; presumably to avoid matching a substring while allowing for all varieties of operators followed by anything.  Normally, this would match the space after the variable name.

However, given no space and no operator it caused the regex not to match at all.  To fix it, make that group optional; the regex will still reject substring matching, but it will accept variable name immediately followed by the closing braces.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~