### PR TITLE
Wrap native win-arm64 scripts with a `start /machine` launcher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,8 +69,7 @@ jobs:
   linux:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     defaults:
@@ -218,8 +217,7 @@ jobs:
   linux-benchmarks:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    #needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     defaults:
@@ -293,29 +291,25 @@ jobs:
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on && matrix.runs-on || 'windows-2022' }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # # test lower version (w/ stable conda)
-          # - python-version: '3.10'
-          #   conda-version: release
-          #   test-type: serial
-          #   runs-on: windows-2022
-          # - python-version: '3.10'
-          #   conda-version: release
-          #   test-type: parallel
-          #   runs-on: windows-2022
-          # # upper version (w/ canary conda)
-          # - python-version: '3.14'
-          #   conda-version: canary
-          #   test-type: serial
-          #   runs-on: windows-2022
-          # - python-version: '3.14'
-          #   conda-version: canary
-          #   test-type: parallel
-          #   runs-on: windows-2022
+          # test lower version (w/ stable conda)
+          - python-version: '3.10'
+            conda-version: release
+            test-type: serial
+          - python-version: '3.10'
+            conda-version: release
+            test-type: parallel
+          # upper version (w/ canary conda)
+          - python-version: '3.14'
+            conda-version: canary
+            test-type: serial
+          - python-version: '3.14'
+            conda-version: canary
+            test-type: parallel
           - python-version: '3.14'
             conda-version: release
             test-type: custom
@@ -420,8 +414,7 @@ jobs:
   macos:
     # only run test suite if there are code changes
     needs: changes
-    if: false
-    # github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
     runs-on: ${{ matrix.runs-on }}
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -356,7 +356,10 @@ jobs:
           run-post: false  # skip post cleanup
           pkgs-dirs: ${{ runner.arch == 'ARM64' && 'C' || 'D'}}:\conda_pkgs_dir
           installation-dir: ${{ runner.arch == 'ARM64' && 'C' || 'D'}}:\conda
-          architecture: x64  # force x64 even on ARM64 to test emulation
+          # force x64 even on ARM64 to test emulation
+          architecture: x64
+        env:
+          CONDA_SUBDIR: win-64
 
       - name: Choco Install
         if: runner.arch != 'ARM64'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,7 +319,7 @@ jobs:
           - python-version: '3.14'
             conda-version: release
             test-type: custom
-            pytest-expression: 'test_build_command_win_arm64_wrapper or test_win_arm64_build_on_emulated_win_64'
+            pytest-expression: test_build_command_win_arm64_wrapper or test_win_arm64_build_on_emulated_win_64
             runs-on: windows-11-arm
     env:
       ErrorActionPreference: Stop  # powershell exit on first error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -291,7 +291,7 @@ jobs:
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -300,21 +300,30 @@ jobs:
           - python-version: '3.10'
             conda-version: release
             test-type: serial
+            runs-on: windows-2022
           - python-version: '3.10'
             conda-version: release
             test-type: parallel
+            runs-on: windows-2022
           # upper version (w/ canary conda)
           - python-version: '3.14'
             conda-version: canary
             test-type: serial
+            runs-on: windows-2022
           - python-version: '3.14'
             conda-version: canary
             test-type: parallel
+            runs-on: windows-2022
+          - python-version: '3.14'
+            conda-version: release
+            test-type: custom
+            pytest-expression: 'test_build_command_win_arm64_wrapper or test_win_arm64_build_on_emulated_win_64'
+            runs-on: windows-11-arm
     env:
       ErrorActionPreference: Stop  # powershell exit on first error
       CONDA_CHANNEL_LABEL: ${{ matrix.conda-version == 'canary' && 'conda-canary/label/dev' || 'defaults' }}
       # Exclude benchmark and slow tests from Windows parallel runs
-      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial and not benchmark' || 'not serial and not slow and not benchmark' }}
+      PYTEST_MARKER: ${{ matrix.test-type == 'serial' && 'serial and not benchmark' || (matrix.test-type == 'parallel' && 'not serial and not slow and not benchmark' || '') }}
 
     steps:
       - name: Checkout Source
@@ -343,10 +352,12 @@ jobs:
         with:
           condarc-file: .github\condarc
           run-post: false  # skip post cleanup
-          pkgs-dirs: D:\conda_pkgs_dir
-          installation-dir: D:\conda
+          pkgs-dirs: ${{ runner.arch == 'ARM64' && 'C' || 'D'}}:\conda_pkgs_dir
+          installation-dir: ${{ runner.arch == 'ARM64' && 'C' || 'D'}}:\conda
+          architecture: x64  # force x64 even on ARM64 to test emulation
 
       - name: Choco Install
+        if: runner.arch != 'ARM64'
         # We may need the complete tooling so that cmake tests pass on windows
         run: choco install visualstudio2017-workload-vctools
 
@@ -380,7 +391,8 @@ jobs:
           --basetemp=${{ runner.temp }}
           --durations-path=durations\${{ runner.os }}.json
           -n auto
-          -m "${{ env.PYTEST_MARKER }}"
+          ${{ env.PYTEST_MARKER && '-m "' || ''}}${{ env.PYTEST_MARKER }}${{ env.PYTEST_MARKER && '"' || ''}}
+          ${{ matrix.pytest-expression && '-k "' || ''}}${{ matrix.pytest-expression }}${{ matrix.pytest-expression && '"' || ''}}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,8 @@ jobs:
   linux:
     # only run test suite if there are code changes
     needs: changes
-    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+    if: false
+    # github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     defaults:
@@ -217,7 +218,8 @@ jobs:
   linux-benchmarks:
     # only run test suite if there are code changes
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: false
+    #needs.changes.outputs.code == 'true'
 
     runs-on: ubuntu-latest
     defaults:
@@ -296,24 +298,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # test lower version (w/ stable conda)
-          - python-version: '3.10'
-            conda-version: release
-            test-type: serial
-            runs-on: windows-2022
-          - python-version: '3.10'
-            conda-version: release
-            test-type: parallel
-            runs-on: windows-2022
-          # upper version (w/ canary conda)
-          - python-version: '3.14'
-            conda-version: canary
-            test-type: serial
-            runs-on: windows-2022
-          - python-version: '3.14'
-            conda-version: canary
-            test-type: parallel
-            runs-on: windows-2022
+          # # test lower version (w/ stable conda)
+          # - python-version: '3.10'
+          #   conda-version: release
+          #   test-type: serial
+          #   runs-on: windows-2022
+          # - python-version: '3.10'
+          #   conda-version: release
+          #   test-type: parallel
+          #   runs-on: windows-2022
+          # # upper version (w/ canary conda)
+          # - python-version: '3.14'
+          #   conda-version: canary
+          #   test-type: serial
+          #   runs-on: windows-2022
+          # - python-version: '3.14'
+          #   conda-version: canary
+          #   test-type: parallel
+          #   runs-on: windows-2022
           - python-version: '3.14'
             conda-version: release
             test-type: custom
@@ -415,7 +417,8 @@ jobs:
   macos:
     # only run test suite if there are code changes
     needs: changes
-    if: github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
+    if: false
+    # github.event_name == 'schedule' || needs.changes.outputs.code == 'true'
 
     runs-on: ${{ matrix.runs-on }}
     defaults:

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -439,8 +439,8 @@ def run_rattler(
         for variant in config_files:
             variant_config = variant_config.merge(VariantConfig.from_file(variant))
 
-    def get_config_value(name):
-        value = variant_config.get(name, config.subdir)
+    def get_config_value(name, fallback=None):
+        value = variant_config.get(name, fallback)
 
         if isinstance(value, list):
             if len(value) != 1:
@@ -450,9 +450,9 @@ def run_rattler(
             return value[0]
         return value
 
-    build_platform = get_config_value("build_platform")
-    host_platform = get_config_value("host_platform")
-    target_platform = get_config_value("target_platform")
+    build_platform = config.build_subdir  # Overridable via CONDA_SUBDIR env var
+    host_platform = config.host_subdir
+    target_platform = get_config_value("target_platform", config.target_subdir)
     noarch_build_platform = get_config_value("noarch_build_platform")
 
     # common tool / platform / render configuration

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -451,7 +451,7 @@ def run_rattler(
         return value
 
     build_platform = config.build_subdir  # Overridable via CONDA_SUBDIR env var
-    host_platform = config.host_subdir
+    host_platform = get_config_value("target_platform", config.host_subdir)
     target_platform = get_config_value("target_platform", config.target_subdir)
     noarch_build_platform = get_config_value("noarch_build_platform")
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import pprint
 import sys
 import sysconfig
@@ -85,14 +86,20 @@ def fix_staged_scripts(scripts_dir, config):
 
 
 @cache
-def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "X86"] | None:
+def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "x86"] | str | None:
     """
-    Queries the Windows registry to determine the native machine architecture.
-    This works reliably even if the Python process is running under emulation
-    (e.g. win-64 environment on a Windows ARM laptop).
+    Python 3.12+ `platform.machine()` on Windows reports the actual machine,
+    not the running interpreter. So we can just use that.
+
+    For prior versions, query the registry.
+
+    Returns None if it value cannot be obtained.
     """
     if sys.platform != "win32":
         raise OSError("This function is only supported on Windows.")
+
+    if sys.version_info >= (3, 12):
+        return platform.machine() or None
 
     import winreg
 
@@ -106,7 +113,7 @@ def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "X86"] | None
             return native_arch.upper()
     except Exception as e:
         log = get_logger(__name__)
-        log.debug("Could not detect native architecture via Registry", exc_info=e)
+        log.debug("Could not detect native architecture via registry", exc_info=e)
         return None
 
 
@@ -331,7 +338,7 @@ def write_build_scripts(m, env, bld_bat):
 
     if m.config.build_subdir != _running_subdir():
         # Can't trust the parent environment under these conditions
-        build_arch = _build_arch_from_metadata(m)
+        build_arch = _build_arch(m)
         env["PROCESSOR_ARCHITECTURE"] = build_arch
         if build_arch == get_native_windows_architecture():
             env.pop("PROCESSOR_ARCHITEW6432", None)
@@ -390,23 +397,24 @@ def write_build_scripts(m, env, bld_bat):
     return work_script, env_script
 
 
-def _build_arch_from_metadata(m) -> Literal["AMD64", "ARM64", "X86"]:
+def _build_arch(m) -> Literal["AMD64", "ARM64", "x86"]:
     """
-    If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
+    If conda-build is run from e.g. a win-64 environment on a win-arm64 machine
     users may want to build natively by setting build_platform="win-arm64".
     In those cases, we need to ensure that the CMD process is native ARM64
     via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
     This gives you the adequate /machine flag value for `start`.
     """
-    build_arch = m.config.build_subdir.split("-")[1]
-    return {"64": "AMD64", "32": "X86"}.get(build_arch, build_arch).upper()
+    build_arch = m.config.build_subdir.split("-")[1].upper()
+    return {"64": "AMD64", "32": "x86"}.get(build_arch, build_arch)
 
 
 def _running_subdir():
     """
-    Python platform.machine() (on which conda.base.context._native_subdir() relies)
-    reports ARM64 even when running from a win-64 installation.
-    This is different from what one can observe on macOS/Rosetta, where it reports x86_64.
+    On Python 3.12+, `platform.machine()` (on which conda.base.context._native_subdir() relies)
+    may report ARM64 even when running from a win-64 installation.
+    This is different from what one can observe on macOS/Rosetta, where an emulated osx-64 Python
+    on Apple Silicon reports x86_64.
 
     More context at https://github.com/python/cpython/issues/98962.
 
@@ -414,7 +422,9 @@ def _running_subdir():
     it was not overridden. `sysconfig.get_platform()` seems to be accurate enough.
     """
     if os.name == "nt":
-        arch = sysconfig.get_platform().lower()
+        arch = (
+            sysconfig.get_platform().lower()
+        )  # -> Literal['win-amd64', 'win-arm64', 'win32']
         return {"win-amd64": "win-64", "win32": "win-32"}.get(arch, arch)
     return context._native_subdir()
 
@@ -422,11 +432,11 @@ def _running_subdir():
 def build_command_arguments(m, script: str) -> list[str]:
     if m.config.build_subdir != _running_subdir():
         # See docstring of _cmd_machine_flag()
-        wrapper = os.path.join(os.path.dirname(script), "_win_native_wrapper.bat")
+        wrapper = os.path.join(os.path.dirname(script), "_conda_build_wrapper.bat")
         with open(wrapper, "w") as f:
             f.write(
                 "@echo off\r\n"
-                f'start /b /wait /machine {_build_arch_from_metadata(m)} cmd.exe /d /c "{script}"\r\n'
+                f'start /b /wait /machine {_build_arch(m)} cmd.exe /d /c "{script}"\r\n'
                 "exit /b %ERRORLEVEL%\r\n"
             )
         return ["cmd.exe", "/d", "/c", os.path.basename(wrapper)]

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -383,18 +383,22 @@ def write_build_scripts(m, env, bld_bat):
 
 
 def build_command_arguments(m, script: str) -> list[str]:
-    if m.config.build_subdir != context._native_subdir():
+    machine = m.config.build_subdir.split("-")[1]
+    machine = {"64": "AMD64", "32": "x86"}.get(machine, machine).upper()
+    if (
+        machine == get_native_windows_architecture()
+        and m.config.build_subdir != context._native_subdir()
+    ):
         # If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
         # users may want to build natively by setting build_platform="win-arm64".
         # In those cases, we need to ensure that the CMD process is native ARM64
         # via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
         wrapper = os.path.join(os.path.dirname(script), "_win_native_wrapper.bat")
-        machine = m.config.build_subdir.split("-")[1]
-        if machine == "64":
-            machine = "amd64"
         with open(wrapper, "w") as f:
             f.write(
                 "@echo off\r\n"
+                f'set "PROCESSOR_ARCHITECTURE={machine}"\r\n'
+                f'set "PROCESSOR_ARCHITEW6432="\r\n'
                 f'start /b /wait /machine {machine} cmd.exe /d /c "{script}"\r\n'
                 "exit /b %ERRORLEVEL%\r\n"
             )

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -84,7 +84,7 @@ def fix_staged_scripts(scripts_dir, config):
 
 
 @cache
-def get_native_windows_architecture() -> Literal['AMD64', 'ARM64', 'x86'] | None:
+def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "x86"] | None:
     """
     Queries the Windows registry to determine the native machine architecture.
     This works reliably even if the Python process is running under emulation
@@ -98,7 +98,9 @@ def get_native_windows_architecture() -> Literal['AMD64', 'ARM64', 'x86'] | None
     registry_path = r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
 
     try:
-        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, registry_path, 0, winreg.KEY_READ) as key:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, registry_path, 0, winreg.KEY_READ
+        ) as key:
             native_arch, _ = winreg.QueryValueEx(key, "PROCESSOR_ARCHITECTURE")
             return native_arch
     except Exception as e:

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -7,6 +7,7 @@ from os.path import dirname, isdir, isfile, join
 
 # importing setuptools patches distutils so that it knows how to find VC for python 2.7
 import setuptools  # noqa
+from conda.base.context import context
 
 # Leverage the hard work done by setuptools/distutils to find vcvarsall using
 # either the registry or the VS**COMNTOOLS environment variable
@@ -390,7 +391,22 @@ def build(m, bld_bat, stats, provision_only=False):
     work_script, env_script = write_build_scripts(m, env, bld_bat)
 
     if not provision_only and os.path.isfile(work_script):
-        cmd = ["cmd.exe", "/d", "/c", os.path.basename(work_script)]
+        if m.config.build_subdir == "win-arm64" and context._native_subdir == "win-64":
+            # If conda-build is run from a win-64 environment on a win-arm64 machine
+            # users may want to build natively by setting build_platform="win-arm64".
+            # In those cases, we need to ensure that the CMD process is native ARM64
+            # via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
+            wrap = os.path.join(
+                os.path.dirname(work_script), "_win_arm64_native_wrapper.bat"
+            )
+            with open(wrap, "w") as f:
+                f.write(
+                    "@echo off\r\n"
+                    f'start /b /wait /machine arm64 cmd.exe /d /c "{work_script}"\r\n'
+                )
+            cmd = ["cmd.exe", "/d", "/c", os.path.basename(wrap)]
+        else:
+            cmd = ["cmd.exe", "/d", "/c", os.path.basename(work_script)]
         # rewrite long paths in stdout back to their env variables
         if m.config.debug or m.config.no_rewrite_stdout_env:
             rewrite_env = None

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -328,6 +328,11 @@ def write_build_scripts(m, env, bld_bat):
         env["PYTHONDONTWRITEBYTECODE"] = True
     import codecs
 
+    if _is_native_build_platform_on_emulated_interpreter(m):
+        # Can't trust the parent environment under these conditions
+        env["PROCESSOR_ARCHITECTURE"] = get_native_windows_architecture()
+        env.pop("PROCESSOR_ARCHITEW6432", None)
+
     with codecs.getwriter("utf-8")(open(env_script, "wb")) as fo:
         # more debuggable with echo on
         fo.write("@echo on\n")
@@ -382,23 +387,28 @@ def write_build_scripts(m, env, bld_bat):
     return work_script, env_script
 
 
-def build_command_arguments(m, script: str) -> list[str]:
+def _is_native_build_platform_on_emulated_interpreter(m) -> bool:
+    """
+    If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
+    users may want to build natively by setting build_platform="win-arm64".
+    In those cases, we need to ensure that the CMD process is native ARM64
+    via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
+    """
     machine = m.config.build_subdir.split("-")[1]
     machine = {"64": "AMD64", "32": "x86"}.get(machine, machine).upper()
-    if (
+    return (
         machine == get_native_windows_architecture()
         and m.config.build_subdir != context._native_subdir()
-    ):
-        # If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
-        # users may want to build natively by setting build_platform="win-arm64".
-        # In those cases, we need to ensure that the CMD process is native ARM64
-        # via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
+    )
+
+
+def build_command_arguments(m, script: str) -> list[str]:
+    if _is_native_build_platform_on_emulated_interpreter(m):
         wrapper = os.path.join(os.path.dirname(script), "_win_native_wrapper.bat")
+        machine = get_native_windows_architecture()
         with open(wrapper, "w") as f:
             f.write(
                 "@echo off\r\n"
-                f'set "PROCESSOR_ARCHITECTURE={machine}"\r\n'
-                f'set "PROCESSOR_ARCHITEW6432="\r\n'
                 f'start /b /wait /machine {machine} cmd.exe /d /c "{script}"\r\n'
                 "exit /b %ERRORLEVEL%\r\n"
             )

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -348,6 +348,26 @@ def write_build_scripts(m, env, bld_bat):
     return work_script, env_script
 
 
+def build_command_arguments(m, script: str) -> list[str]:
+    if m.config.build_subdir != context._native_subdir():
+        # If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
+        # users may want to build natively by setting build_platform="win-arm64".
+        # In those cases, we need to ensure that the CMD process is native ARM64
+        # via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
+        wrapper = os.path.join(os.path.dirname(script), "_win_native_wrapper.bat")
+        machine = m.config.build_subdir.split("-")[1]
+        if machine == "64":
+            machine = "amd64"
+        with open(wrapper, "w") as f:
+            f.write(
+                "@echo off\r\n"
+                f'start /b /wait /machine {machine} cmd.exe /d /c "{script}"\r\n'
+                "exit /b %ERRORLEVEL%\r\n"
+            )
+        return ["cmd.exe", "/d", "/c", os.path.basename(wrapper)]
+    return ["cmd.exe", "/d", "/c", os.path.basename(script)]
+
+
 def build(m, bld_bat, stats, provision_only=False):
     # TODO: Prepending the prefixes here should probably be guarded by
     #         if not m.activate_build_script:
@@ -391,22 +411,7 @@ def build(m, bld_bat, stats, provision_only=False):
     work_script, env_script = write_build_scripts(m, env, bld_bat)
 
     if not provision_only and os.path.isfile(work_script):
-        if m.config.build_subdir == "win-arm64" and context._native_subdir == "win-64":
-            # If conda-build is run from a win-64 environment on a win-arm64 machine
-            # users may want to build natively by setting build_platform="win-arm64".
-            # In those cases, we need to ensure that the CMD process is native ARM64
-            # via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
-            wrap = os.path.join(
-                os.path.dirname(work_script), "_win_arm64_native_wrapper.bat"
-            )
-            with open(wrap, "w") as f:
-                f.write(
-                    "@echo off\r\n"
-                    f'start /b /wait /machine arm64 cmd.exe /d /c "{work_script}"\r\n'
-                )
-            cmd = ["cmd.exe", "/d", "/c", os.path.basename(wrap)]
-        else:
-            cmd = ["cmd.exe", "/d", "/c", os.path.basename(work_script)]
+        cmd = build_command_arguments(m, work_script)
         # rewrite long paths in stdout back to their env variables
         if m.config.debug or m.config.no_rewrite_stdout_env:
             rewrite_env = None

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -1,9 +1,17 @@
 # Copyright (C) 2014 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
 import os
 import pprint
+import sys
+from functools import cache
 from itertools import product
 from os.path import dirname, isdir, isfile, join
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 # importing setuptools patches distutils so that it knows how to find VC for python 2.7
 import setuptools  # noqa
@@ -73,6 +81,30 @@ def fix_staged_scripts(scripts_dir, config):
 
         # remove the original script
         os.remove(join(scripts_dir, fn))
+
+
+@cache
+def get_native_windows_architecture() -> Literal['AMD64', 'ARM64', 'x86'] | None:
+    """
+    Queries the Windows registry to determine the native machine architecture.
+    This works reliably even if the Python process is running under emulation
+    (e.g. win-64 environment on a Windows ARM laptop).
+    """
+    if sys.platform != "win32":
+        raise OSError("This function is only supported on Windows.")
+
+    import winreg
+
+    registry_path = r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+
+    try:
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, registry_path, 0, winreg.KEY_READ) as key:
+            native_arch, _ = winreg.QueryValueEx(key, "PROCESSOR_ARCHITECTURE")
+            return native_arch
+    except Exception as e:
+        log = get_logger(__name__)
+        log.debug("Could not detect native architecture via Registry", exc_info=e)
+        return None
 
 
 def build_vcvarsall_vs_path(version):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import os
-import platform
 import pprint
 import sys
+import sysconfig
 from functools import cache
 from itertools import product
 from os.path import dirname, isdir, isfile, join
@@ -411,12 +411,11 @@ def _running_subdir():
     More context at https://github.com/python/cpython/issues/98962.
 
     The most obvious way is to check %PROCESSOR_ARCHITECTURE%, if available, but we need to hope
-    it was not overridden.
+    it was not overridden. `sysconfig.get_platform()` seems to be accurate enough.
     """
     if os.name == "nt":
-        arch = os.environ.get("PROCESSOR_ARCHITECTURE", platform.machine()).upper()
-        arch = {"AMD64": "64", "X86": "32"}.get(arch, arch).lower()
-        return f"win-{arch}"
+        arch = sysconfig.get_platform().lower()
+        return {"win-amd64": "win-64", "win32": "win-32"}.get(arch, arch)
     return context._native_subdir()
 
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import pprint
 import sys
 from functools import cache
@@ -328,9 +329,9 @@ def write_build_scripts(m, env, bld_bat):
         env["PYTHONDONTWRITEBYTECODE"] = True
     import codecs
 
-    if m.config.build_subdir != context._native_subdir():
+    if m.config.build_subdir != _running_subdir():
         # Can't trust the parent environment under these conditions
-        build_arch = _cmd_machine_flag(m)
+        build_arch = _build_arch_from_metadata(m)
         env["PROCESSOR_ARCHITECTURE"] = build_arch
         if build_arch == get_native_windows_architecture():
             env.pop("PROCESSOR_ARCHITEW6432", None)
@@ -389,7 +390,7 @@ def write_build_scripts(m, env, bld_bat):
     return work_script, env_script
 
 
-def _cmd_machine_flag(m) -> Literal["AMD64", "ARM64", "X86"]:
+def _build_arch_from_metadata(m) -> Literal["AMD64", "ARM64", "X86"]:
     """
     If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
     users may want to build natively by setting build_platform="win-arm64".
@@ -401,14 +402,29 @@ def _cmd_machine_flag(m) -> Literal["AMD64", "ARM64", "X86"]:
     return {"64": "AMD64", "32": "X86"}.get(build_arch, build_arch).upper()
 
 
+def _running_subdir():
+    """
+    Python platform.machine() (on which conda.base.context._native_subdir() relies)
+    reports ARM64 even when running from a win-64 installation.
+    This is different from what one can observe on macOS/Rosetta, where it reports x86_64.
+    The most obvious way is to check %PROCESSOR_ARCHITECTURE%, if available, but we need to hope
+    it was not overridden.
+    """
+    if os.name == "nt":
+        arch = os.environ.get("PROCESSOR_ARCHITECTURE", platform.machine()).upper()
+        arch = {"AMD64": "64", "X86": "32"}.get(arch, arch).lower()
+        return f"win-{arch}"
+    return context._native_subdir()
+
+
 def build_command_arguments(m, script: str) -> list[str]:
-    if m.config.build_subdir != context._native_subdir():
+    if m.config.build_subdir != _running_subdir():
         # See docstring of _cmd_machine_flag()
         wrapper = os.path.join(os.path.dirname(script), "_win_native_wrapper.bat")
         with open(wrapper, "w") as f:
             f.write(
                 "@echo off\r\n"
-                f'start /b /wait /machine {_cmd_machine_flag(m)} cmd.exe /d /c "{script}"\r\n'
+                f'start /b /wait /machine {_build_arch_from_metadata(m)} cmd.exe /d /c "{script}"\r\n'
                 "exit /b %ERRORLEVEL%\r\n"
             )
         return ["cmd.exe", "/d", "/c", os.path.basename(wrapper)]

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -84,7 +84,7 @@ def fix_staged_scripts(scripts_dir, config):
 
 
 @cache
-def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "x86"] | None:
+def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "X86"] | None:
     """
     Queries the Windows registry to determine the native machine architecture.
     This works reliably even if the Python process is running under emulation
@@ -102,7 +102,7 @@ def get_native_windows_architecture() -> Literal["AMD64", "ARM64", "x86"] | None
             winreg.HKEY_LOCAL_MACHINE, registry_path, 0, winreg.KEY_READ
         ) as key:
             native_arch, _ = winreg.QueryValueEx(key, "PROCESSOR_ARCHITECTURE")
-            return native_arch
+            return native_arch.upper()
     except Exception as e:
         log = get_logger(__name__)
         log.debug("Could not detect native architecture via Registry", exc_info=e)
@@ -328,10 +328,12 @@ def write_build_scripts(m, env, bld_bat):
         env["PYTHONDONTWRITEBYTECODE"] = True
     import codecs
 
-    if _is_native_build_platform_on_emulated_interpreter(m):
+    if m.config.build_subdir != context._native_subdir():
         # Can't trust the parent environment under these conditions
-        env["PROCESSOR_ARCHITECTURE"] = get_native_windows_architecture()
-        env.pop("PROCESSOR_ARCHITEW6432", None)
+        build_arch = _cmd_machine_flag(m)
+        env["PROCESSOR_ARCHITECTURE"] = build_arch
+        if build_arch == get_native_windows_architecture():
+            env.pop("PROCESSOR_ARCHITEW6432", None)
 
     with codecs.getwriter("utf-8")(open(env_script, "wb")) as fo:
         # more debuggable with echo on
@@ -387,29 +389,26 @@ def write_build_scripts(m, env, bld_bat):
     return work_script, env_script
 
 
-def _is_native_build_platform_on_emulated_interpreter(m) -> bool:
+def _cmd_machine_flag(m) -> Literal["AMD64", "ARM64", "X86"]:
     """
     If conda-build is run from e.f. a win-64 environment on a win-arm64 machine
     users may want to build natively by setting build_platform="win-arm64".
     In those cases, we need to ensure that the CMD process is native ARM64
     via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
+    This gives you the adequate /machine flag value for `start`.
     """
-    machine = m.config.build_subdir.split("-")[1]
-    machine = {"64": "AMD64", "32": "x86"}.get(machine, machine).upper()
-    return (
-        machine == get_native_windows_architecture()
-        and m.config.build_subdir != context._native_subdir()
-    )
+    build_arch = m.config.build_subdir.split("-")[1]
+    return {"64": "AMD64", "32": "X86"}.get(build_arch, build_arch).upper()
 
 
 def build_command_arguments(m, script: str) -> list[str]:
-    if _is_native_build_platform_on_emulated_interpreter(m):
+    if m.config.build_subdir != context._native_subdir():
+        # See docstring of _cmd_machine_flag()
         wrapper = os.path.join(os.path.dirname(script), "_win_native_wrapper.bat")
-        machine = get_native_windows_architecture()
         with open(wrapper, "w") as f:
             f.write(
                 "@echo off\r\n"
-                f'start /b /wait /machine {machine} cmd.exe /d /c "{script}"\r\n'
+                f'start /b /wait /machine {_cmd_machine_flag(m)} cmd.exe /d /c "{script}"\r\n'
                 "exit /b %ERRORLEVEL%\r\n"
             )
         return ["cmd.exe", "/d", "/c", os.path.basename(wrapper)]

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -407,6 +407,9 @@ def _running_subdir():
     Python platform.machine() (on which conda.base.context._native_subdir() relies)
     reports ARM64 even when running from a win-64 installation.
     This is different from what one can observe on macOS/Rosetta, where it reports x86_64.
+
+    More context at https://github.com/python/cpython/issues/98962.
+
     The most obvious way is to check %PROCESSOR_ARCHITECTURE%, if available, but we need to hope
     it was not overridden.
     """

--- a/docs/source/resources/define-metadata.rst
+++ b/docs/source/resources/define-metadata.rst
@@ -2106,7 +2106,7 @@ variables are booleans.
      - The NumPy version as an integer such as ``111``. See the
        CONDA_NPY :ref:`environment variable <build-envs>`.
    * - build_platform
-     - The native subdir of the conda executable
+     - The native subdir of the conda executable. Override with ``CONDA_SUBDIR`` env var when calling ``conda-build``.
 
 The use of the Python version selectors, `py27`, `py34`, etc. is discouraged in
 favor of the more general comparison operators.  Additional selectors in this

--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -130,7 +130,7 @@ inherited from the shell environment in which you invoke
    * - STDLIB_DIR
      - Python standard library location.
    * - build_platform
-     - The native subdir of the conda executable
+     - The native subdir of the conda executable. Override with ``CONDA_SUBDIR`` env var when calling ``conda-build``.
 
 Unix-style packages on Windows, which are usually statically
 linked to executables, are built in a special ``Library``

--- a/news/6047-win-arm64-native.md
+++ b/news/6047-win-arm64-native.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Make CMD subprocesses match `build_platform` architecture when running emulated Python processes. (#6048 via #6047)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/6047-win-arm64-native.md
+++ b/news/6047-win-arm64-native.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * Make CMD subprocesses match `build_platform` architecture when running emulated Python processes. (#6048 via #6047)
+* `recipe.yaml` build/host platform handling now behaves in the same as it did in `meta.yaml`. Accidentally allowed `{build,host}_platform` settings in `conda_build_config.yaml` are no longer valid; instead, users can export `CONDA_SUBDIR` and define the `target_platform` setting, respectively. (#6047)
 
 ### Deprecations
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -503,7 +503,7 @@ def test_win_arm64_build_on_emulated_win_64(
         f"powershell -Command \"'ProcessArchitecture=' + {cmdlet}\"\r\n"
         f"exit /b 42\r\n"
     )
-    testing_metadata.config.arch = "arm64"
+    testing_metadata.config.arch = "arm64"  # this is for build_platform
     testing_metadata.config.variant["target_platform"] = "win-arm64"
     with pytest.raises(subprocess.CalledProcessError) as exc:
         windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -508,7 +508,7 @@ def test_win_arm64_build_on_emulated_win_64(
     cmdlet = "[System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture"
     (tmp_path / "bld.bat").write_text(
         f"echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n"
-        f'powershell -Command "echo ProcessArchitecture=({cmdlet})"\r\n'
+        f'powershell -Command "\'ProcessArchitecture=\' + {cmdlet}"\r\n'
     )
     testing_metadata.config.arch = "arm64"
     testing_metadata.config.variant["target_platform"] = "win-arm64"
@@ -528,4 +528,4 @@ def test_win_arm64_build_on_emulated_win_64(
     ).exists():
         print(wrapper.read_text())
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
-    assert "ProcessArchitecture=ARM64" in out
+    assert "ProcessArchitecture=Arm64" in out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -456,7 +456,8 @@ def test_build_command_win_arm64_wrapper(
 ):
     testing_metadata.config.arch = build_subdir.split("-")[1]
     monkeypatch.setattr(context, "_native_subdir", lambda: native_subdir)
-
+    patched_native = "AMD64" if native_subdir == "win-64" else "ARM64"
+    monkeypatch.setattr(windows.get_native_windows_architecture, lambda: patched_native)
     work_script = tmp_path / "conda_build.bat"
     work_script.write_text("@echo off\r\n")
     wrapper = tmp_path / "_win_native_wrapper.bat"
@@ -472,7 +473,7 @@ def test_build_command_win_arm64_wrapper(
 
     contents = wrapper.read_text()
     contents_bytes = wrapper.read_bytes()
-    machine = "amd64" if build_subdir == "win-64" else "arm64"
+    machine = "AMD64" if build_subdir == "win-64" else "ARM64"
     assert f"/machine {machine}" in contents
     assert "/b" in contents
     assert "/wait" in contents

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -496,8 +496,8 @@ def test_win_arm64_build_on_emulated_win_64(
     """
     cmdlet = "[System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture"
     (tmp_path / "bld.bat").write_text(
-        f'echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n"'
-        f'powershell -Command "echo ProcessArchitecture=({cmdlet})\r\n"'
+        f'echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n'
+        f'powershell -Command "echo ProcessArchitecture=({cmdlet})"\r\n'
     )
     testing_metadata.config.arch = "arm64"
     windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from conda.base.context import context
+from conda.base.context import context, reset_context
 from conda.common.compat import on_win
 
 from conda_build import api, build, windows
@@ -455,9 +455,13 @@ def test_build_command_win_arm64_wrapper(
     wrapped,
 ):
     testing_metadata.config.arch = build_subdir.split("-")[1]
+    testing_metadata.config.host_subdir = build_subdir
+    testing_metadata.config.target_subdir = build_subdir
     monkeypatch.setattr(context, "_native_subdir", lambda: native_subdir)
     patched_native = "AMD64" if native_subdir == "win-64" else "ARM64"
-    monkeypatch.setattr(windows.get_native_windows_architecture, lambda: patched_native)
+    monkeypatch.setattr(
+        windows, "get_native_windows_architecture", lambda: patched_native
+    )
     work_script = tmp_path / "conda_build.bat"
     work_script.write_text("@echo off\r\n")
     wrapper = tmp_path / "_win_native_wrapper.bat"
@@ -483,6 +487,12 @@ def test_build_command_win_arm64_wrapper(
     assert contents_bytes.count(b"\n") == contents_bytes.count(b"\r\n")
 
 
+@pytest.fixture
+def force_win_arm64(monkeypatch):
+    monkeypatch.setenv("CONDA_SUBDIR", "win-arm64")
+    reset_context()
+
+
 @pytest.mark.skipif(
     not (on_win and windows.get_native_windows_architecture() == "ARM64"),
     reason="Windows ARM only test",
@@ -497,10 +507,12 @@ def test_win_arm64_build_on_emulated_win_64(
     """
     cmdlet = "[System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture"
     (tmp_path / "bld.bat").write_text(
-        f'echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n'
+        f"echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n"
         f'powershell -Command "echo ProcessArchitecture=({cmdlet})"\r\n'
     )
     testing_metadata.config.arch = "arm64"
+    testing_metadata.config.host_subdir = "win-arm64"
+    testing_metadata.config.target_subdir = "win-arm64"
     windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
     out, err = capsys.readouterr()
     print(out)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -523,7 +523,9 @@ def test_win_arm64_build_on_emulated_win_64(
     print("---")
     print("conda_build.bat:")
     print(Path(testing_metadata.config.work_dir, "conda_build.bat").read_text())
-    if (wrapper := Path(testing_metadata.config.work_dir, "_win_native_wrapper.bat")).exists():
+    if (
+        wrapper := Path(testing_metadata.config.work_dir, "_win_native_wrapper.bat")
+    ).exists():
         print(wrapper.read_text())
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
     assert "ProcessArchitecture=ARM64" in out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -512,6 +512,6 @@ def test_win_arm64_build_on_emulated_win_64(
     print(out)
     print("---")
     print("Directory contents:")
-    print(*sorted(os.listdir(testing_metadata.config.work_dir), sep="\n"))
+    print(*sorted(os.listdir(testing_metadata.config.work_dir)), sep="\n")
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
     assert "ProcessArchitecture=Arm64" in out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -17,9 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from conda.base.context import context
 from conda.common.compat import on_win
 
-from conda_build import api, build
+from conda_build import api, build, windows
 from conda_build.exceptions import CondaBuildUserError
 from conda_build.metadata import MetaData
 from conda_build.variants import get_default_variant
@@ -434,3 +435,48 @@ def test_warn_implicit_numpy_variant(
     build._warn_implicit_numpy_variant(m)
     n_warn = sum(1 for r in caplog.records if r.levelno == logging.WARNING)
     assert n_warn == (1 if expected_warning else 0)
+
+
+@pytest.mark.parametrize(
+    "build_subdir,native_subdir,wrapped",
+    [
+        ("win-arm64", "win-64", True),
+        ("win-64", "win-arm64", True),
+        ("win-arm64", "win-arm64", False),
+        ("win-64", "win-64", False),
+    ],
+)
+def test_build_command_win_arm64_wrapper(
+    testing_metadata: MetaData,
+    monkeypatch,
+    tmp_path,
+    build_subdir,
+    native_subdir,
+    wrapped,
+):
+    testing_metadata.config.arch = build_subdir.split("-")[1]
+    monkeypatch.setattr(context, "_native_subdir", lambda: native_subdir)
+
+    work_script = tmp_path / "conda_build.bat"
+    work_script.write_text("@echo off\r\n")
+    wrapper = tmp_path / "_win_native_wrapper.bat"
+
+    cmd = windows.build_command_arguments(testing_metadata, str(work_script))
+
+    if not wrapped:
+        assert cmd == ["cmd.exe", "/d", "/c", "conda_build.bat"]
+        assert not wrapper.exists()
+        return
+
+    assert cmd == ["cmd.exe", "/d", "/c", "_win_native_wrapper.bat"]
+
+    contents = wrapper.read_text()
+    contents_bytes = wrapper.read_bytes()
+    machine = "amd64" if build_subdir == "win-64" else "arm64"
+    assert f"/machine {machine}" in contents
+    assert "/b" in contents
+    assert "/wait" in contents
+    assert "%ERRORLEVEL%" in contents
+    assert str(work_script) in contents
+    # batch files must be CRLF; a bare LF breaks cmd.exe
+    assert contents_bytes.count(b"\n") == contents_bytes.count(b"\r\n")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from conda.base.context import context, reset_context
+from conda.base.context import reset_context
 from conda.common.compat import on_win
 
 from conda_build import api, build, windows
@@ -506,7 +506,7 @@ def test_win_arm64_build_on_emulated_win_64(
     cmdlet = "[System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture"
     (tmp_path / "bld.bat").write_text(
         f"echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n"
-        f'powershell -Command "\'ProcessArchitecture=\' + {cmdlet}"\r\n'
+        f"powershell -Command \"'ProcessArchitecture=' + {cmdlet}\"\r\n"
     )
     testing_metadata.config.arch = "arm64"
     testing_metadata.config.variant["target_platform"] = "win-arm64"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -461,7 +461,7 @@ def test_build_command_win_arm64_wrapper(
 
     work_script = tmp_path / "conda_build.bat"
     work_script.write_text("@echo off\r\n")
-    wrapper = tmp_path / "_win_native_wrapper.bat"
+    wrapper = tmp_path / "_conda_build_wrapper.bat"
 
     cmd = windows.build_command_arguments(testing_metadata, str(work_script))
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -507,7 +507,7 @@ def test_win_arm64_build_on_emulated_win_64(
     testing_metadata.config.variant["target_platform"] = "win-arm64"
     with pytest.raises(subprocess.CalledProcessError) as exc:
         windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
-    assert exc.returncode == 42
+    assert exc.value.returncode == 42
     out, err = capsys.readouterr()
     print(out)
     print("---")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -438,7 +438,7 @@ def test_warn_implicit_numpy_variant(
 
 
 @pytest.mark.parametrize(
-    "build_subdir,native_subdir,wrapped",
+    "build_subdir,running_subdir,wrapped",
     [
         ("win-arm64", "win-64", True),
         ("win-64", "win-arm64", True),
@@ -451,17 +451,15 @@ def test_build_command_win_arm64_wrapper(
     monkeypatch,
     tmp_path,
     build_subdir,
-    native_subdir,
+    running_subdir,
     wrapped,
 ):
-    testing_metadata.config.arch = build_subdir.split("-")[1]
-    testing_metadata.config.host_subdir = build_subdir
-    testing_metadata.config.target_subdir = build_subdir
-    monkeypatch.setattr(context, "_native_subdir", lambda: native_subdir)
-    patched_native = "AMD64" if native_subdir == "win-64" else "ARM64"
-    monkeypatch.setattr(
-        windows, "get_native_windows_architecture", lambda: patched_native
-    )
+    platform, arch = build_subdir.split("-")
+    testing_metadata.config.platform = platform
+    testing_metadata.config.arch = arch
+    testing_metadata.config.variant["target_platform"] = build_subdir
+    monkeypatch.setattr(windows, "_running_subdir", lambda: running_subdir)
+
     work_script = tmp_path / "conda_build.bat"
     work_script.write_text("@echo off\r\n")
     wrapper = tmp_path / "_win_native_wrapper.bat"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -511,8 +511,7 @@ def test_win_arm64_build_on_emulated_win_64(
         f'powershell -Command "echo ProcessArchitecture=({cmdlet})"\r\n'
     )
     testing_metadata.config.arch = "arm64"
-    testing_metadata.config.host_subdir = "win-arm64"
-    testing_metadata.config.target_subdir = "win-arm64"
+    testing_metadata.config.variant["target_platform"] = "win-arm64"
     windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
     out, err = capsys.readouterr()
     print(out)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 import sys
 from collections import defaultdict
 from contextlib import nullcontext
@@ -500,10 +501,13 @@ def test_win_arm64_build_on_emulated_win_64(
     (tmp_path / "bld.bat").write_text(
         f"echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n"
         f"powershell -Command \"'ProcessArchitecture=' + {cmdlet}\"\r\n"
+        f"exit /b 42\r\n"
     )
     testing_metadata.config.arch = "arm64"
     testing_metadata.config.variant["target_platform"] = "win-arm64"
-    windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
+    assert exc.returncode == 42
     out, err = capsys.readouterr()
     print(out)
     print("---")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from conda.base.context import reset_context
 from conda.common.compat import on_win
 
 from conda_build import api, build, windows
@@ -471,7 +470,7 @@ def test_build_command_win_arm64_wrapper(
         assert not wrapper.exists()
         return
 
-    assert cmd == ["cmd.exe", "/d", "/c", "_win_native_wrapper.bat"]
+    assert cmd == ["cmd.exe", "/d", "/c", "_conda_build_wrapper.bat"]
 
     contents = wrapper.read_text()
     contents_bytes = wrapper.read_bytes()
@@ -483,12 +482,6 @@ def test_build_command_win_arm64_wrapper(
     assert str(work_script) in contents
     # batch files must be CRLF; a bare LF breaks cmd.exe
     assert contents_bytes.count(b"\n") == contents_bytes.count(b"\r\n")
-
-
-@pytest.fixture
-def force_win_arm64(monkeypatch):
-    monkeypatch.setenv("CONDA_SUBDIR", "win-arm64")
-    reset_context()
 
 
 @pytest.mark.skipif(
@@ -514,16 +507,7 @@ def test_win_arm64_build_on_emulated_win_64(
     out, err = capsys.readouterr()
     print(out)
     print("---")
-    print(*os.listdir(testing_metadata.config.work_dir), sep="\n")
-    print("---")
-    print("build_env_setup.bat:")
-    print(Path(testing_metadata.config.work_dir, "build_env_setup.bat").read_text())
-    print("---")
-    print("conda_build.bat:")
-    print(Path(testing_metadata.config.work_dir, "conda_build.bat").read_text())
-    if (
-        wrapper := Path(testing_metadata.config.work_dir, "_win_native_wrapper.bat")
-    ).exists():
-        print(wrapper.read_text())
+    print("Directory contents:")
+    print(*sorted(os.listdir(testing_metadata.config.work_dir), sep="\n"))
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
     assert "ProcessArchitecture=Arm64" in out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -515,5 +515,15 @@ def test_win_arm64_build_on_emulated_win_64(
     windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
     out, err = capsys.readouterr()
     print(out)
+    print("---")
+    print(*os.listdir(testing_metadata.config.work_dir), sep="\n")
+    print("---")
+    print("build_env_setup.bat:")
+    print(Path(testing_metadata.config.work_dir, "build_env_setup.bat").read_text())
+    print("---")
+    print("conda_build.bat:")
+    print(Path(testing_metadata.config.work_dir, "conda_build.bat").read_text())
+    if (wrapper := Path(testing_metadata.config.work_dir, "_win_native_wrapper.bat")).exists():
+        print(wrapper.read_text())
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
     assert "ProcessArchitecture=ARM64" in out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -480,3 +480,25 @@ def test_build_command_win_arm64_wrapper(
     assert str(work_script) in contents
     # batch files must be CRLF; a bare LF breaks cmd.exe
     assert contents_bytes.count(b"\n") == contents_bytes.count(b"\r\n")
+
+
+@pytest.mark.skipif(
+    not (on_win and windows.get_native_windows_architecture() == "ARM64"),
+    reason="Windows ARM only test",
+)
+def test_win_arm64_build_on_emulated_win_64(
+    testing_metadata: MetaData, tmp_path, capsys
+):
+    """
+    This test checks the architecture of the launched CMD on Windows ARM
+    machines that are running emulated x64 processes. Critical for bootstrapping
+    win-arm64 distributions from their win-64 counterparts via emulation.
+    """
+    (tmp_path / "bld.bat").write_text(
+        "echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%"
+    )
+    testing_metadata.config.arch = "arm64"
+    windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
+    out, err = capsys.readouterr()
+    print(out)
+    assert "PROCESSOR_ARCHITECTURE=ARM64" in out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -494,11 +494,14 @@ def test_win_arm64_build_on_emulated_win_64(
     machines that are running emulated x64 processes. Critical for bootstrapping
     win-arm64 distributions from their win-64 counterparts via emulation.
     """
+    cmdlet = "[System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture"
     (tmp_path / "bld.bat").write_text(
-        "echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%"
+        f'echo PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%\r\n"'
+        f'powershell -Command "echo ProcessArchitecture=({cmdlet})\r\n"'
     )
     testing_metadata.config.arch = "arm64"
     windows.build(testing_metadata, str(tmp_path / "bld.bat"), {})
     out, err = capsys.readouterr()
     print(out)
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
+    assert "ProcessArchitecture=ARM64" in out


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes https://github.com/conda/conda-build/issues/6048 by:

- Wrapping the CMD subprocesses with a `start /mahcine` launcher
- Adjusting `PROCESSOR_ARCHITECTURE` and friends so they are not blindly inherited and injected from the parent process

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
