### PR TITLE
docs: document GIT_DESCRIBE_TAG_PEP440

### DIFF
--- a/docs/source/user-guide/environment-variables.rst
+++ b/docs/source/user-guide/environment-variables.rst
@@ -256,6 +256,9 @@ source either with git_url or path.
    * - GIT_DESCRIBE_TAG
      - String denoting the most recent tag from the current
        commit, based on the output of ``git describe --tags``.
+   * - GIT_DESCRIBE_TAG_PEP440
+     - PEP 440-compliant version derived from the output of
+       ``git describe --tags --long``.
    * - GIT_FULL_HASH
      - String with the full SHA1 of the current HEAD.
 

--- a/news/5991-document-git-describe-tag-pep440.md
+++ b/news/5991-document-git-describe-tag-pep440.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document the `GIT_DESCRIBE_TAG_PEP440` environment variable. (#5991)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

I added `GIT_DESCRIBE_TAG_PEP440` to the documented Git environment variables. `get_git_info()` already exposes this value, but the user guide did not mention it, which made the variable difficult for recipe authors to discover.

The description matches the current implementation: the value is a PEP 440-compliant version derived from `git describe --tags --long`.

Closes #5991

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] ~~Add / update necessary tests?~~ Documentation-only change; validated with a full Sphinx HTML build.
- [x] Add / update outdated documentation?
