### PR TITLE
Fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,3 +99,9 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.3
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,9 +99,3 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.3
-    hooks:
-      - id: codespell
-        additional_dependencies:
-          - tomli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1023,7 +1023,7 @@
 * Relax `script_env` error in outputs when variable referenced in `script_env` is not defined.
   This unifies current behavior with the top-level build. (#5105)
 * Add support for Python 3.12. (#4997 via #4998)
-* Adopt calender versioning (CalVer) per CEP-8 for consistency with conda. (#4975)
+* Adopt calendar versioning (CalVer) per CEP-8 for consistency with conda. (#4975)
 * Adopt expedited CEP-9 deprecation policy. (#5064)
 
 ### Deprecations
@@ -2630,7 +2630,7 @@ In the upcoming January 2024 release of conda-build, significant changes are und
 
 ### Bug fixes
 
-* omit LIEF depedency on Windows until it is better tested #3288
+* omit LIEF dependency on Windows until it is better tested #3288
 * activate host environment #3288
 * allow calls to nm to fail #3290
 
@@ -3135,7 +3135,7 @@ In the upcoming January 2024 release of conda-build, significant changes are und
 * add creative commons as a license family (used to be classified OTHER)  #2893
 * handle empty packages in checks for duplicated files across subpackages  #2894
 * set PYTHON and other language path vars based on presence in build/host reqs, rather than binary file in either env.  Allows usage of PYTHON and friends in meta.yaml vars.  #2895
-* fix entry points incorrecty pointing at build prefix (instead of host), leading to prefix replacement failing  #2895
+* fix entry points incorrectly pointing at build prefix (instead of host), leading to prefix replacement failing  #2895
 * fix `merge_build_host` functionality.  Adding an empty host section now forces build and host to be split.  #2896
 
 ### Contributors
@@ -4214,7 +4214,7 @@ https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#host
 
 ### Enhancements
 
-* store test files specifed by `test/source_files` directly in packages.  This allows testing of packages that do not include recipes.  Recommendation: make subpackages for large data files.  #2232
+* store test files specified by `test/source_files` directly in packages.  This allows testing of packages that do not include recipes.  Recommendation: make subpackages for large data files.  #2232
 * add new syntax to `get_value` for accessing list items, such as multiple sources  #2247
 * add independently configurable source cache path (--cache-dir)  #2249
 * add `PKG_HASH` env var, available in meta.yaml.  Use this to put the package hash where you want it in your custom build/string field in meta.yaml.  #2250
@@ -4321,7 +4321,7 @@ https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#host
 * remove logging output showing up with --output option #2174
 * Fix `CONDA_*` variables without .  #2176
 * pass croot to extraction (file path length issue on win)  #2178
-* fix uncorrect unpacking of tuples with --skip-existing  #2179
+* fix incorrect unpacking of tuples with --skip-existing  #2179
 * Fix priority of setup.cfg over setup.py  #2180
 * Remove overly aggressive removal of test prefix at end of test phase  #2182
 * Fix upper bound increment to account for pre-release versions (alpha, beta, rc, etc.)  #2183
@@ -5854,7 +5854,7 @@ This release includes all current (1.21.14) changes made to the 1.21.x series.
 * Warn users on failed git repo info failure, rather than crash #1108
 * Remove killing MSBuild.exe at end of win build.  Remove psutil dependency.  #1109
 * Prepend PATH before creating env, to ensure post-link script success.  #1115, #1118
-* Make Python tests drop out on failure appropiately on win  #1122
+* Make Python tests drop out on failure appropriately on win  #1122
 * Make hyphenation consistent with `include_recipe` in meta.yaml  #1124
 * Use full path of test env when activating #1125
 
@@ -5984,7 +5984,7 @@ Contributors:
 * Fix unix-style paths returned from git on Windows preventing relative paths from providing Jinja2 metadata #995
 * improve logic handling "dirty" downloading.  Always download when not dirty.  #995
 * Fix post-build variables when no build section existed in original meta.yaml #999
-* Activate `_build` and `_test` environments approriately, rather than manipulating PATH directly #1002
+* Activate `_build` and `_test` environments appropriately, rather than manipulating PATH directly #1002
 * Don't clone git submodules until after first checkout #1025
 * Move `check_install` over from conda.install #1027
 
@@ -6106,7 +6106,7 @@ Contributors:
 
 * fix source/path and `GIT_*` issues, #801
 * fix invalid assertion, #855
-* environ.py refactor/clenup, #856
+* environ.py refactor/cleanup, #856
 * Better messaging for yaml parsing errors, #862
 * fix typo, #863
 * make `CONDA_PY` and `CONDA_NPY` available in build.sh, #837

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -265,7 +265,7 @@ def regex_files_rg(
         os.path.join(pu, f.replace("/", os.sep).encode("utf-8")) for f in files
     ]
     args_len = len(b" ".join(args_base))
-    # chunk them to avoid too long comand lines:
+    # chunk them to avoid too long command lines:
     file_lists = chunks(prefix_files, MAX_CHUNK_SIZE - args_len)
     for file_list in file_lists:
         args = args_base[:] + file_list
@@ -1136,7 +1136,7 @@ def get_files_with_prefix(m, replacements, files_in, prefix):
     print(
         "INFO :: Time taken to mark (prefix){}\n"
         "        {} replacements in {} files was {:.2f} seconds".format(
-            f" and mark+peform ({replacement_tags})" if replacement_tags else "",
+            f" and mark+perform ({replacement_tags})" if replacement_tags else "",
             total_replacements,
             len(all_matches),
             end - start,
@@ -1345,7 +1345,7 @@ def write_about_json(m):
 def write_info_json(m: MetaData):
     info_index = m.info_index()
     if m.pin_depends:
-        # Wtih 'strict' depends, we will have pinned run deps during rendering
+        # With 'strict' depends, we will have pinned run deps during rendering
         if m.pin_depends == "strict":
             runtime_deps = m.get_value("requirements/run", [])
             info_index["depends"] = runtime_deps
@@ -2505,7 +2505,7 @@ def build(
             del m_copy
 
         # get_dir here might be just work, or it might be one level deeper,
-        #    dependening on the source.
+        #    depending on the source.
         src_dir = m.config.work_dir
         if isdir(src_dir):
             if m.config.verbose:

--- a/conda_build/convert.py
+++ b/conda_build/convert.py
@@ -332,7 +332,7 @@ def update_executable_path(temp_dir, file_path, target_platform):
             renamed_executable_path = f"{renamed_path}-script.py"
 
     elif target_platform == "unix":
-        renamed_path = re.sub(r"\AScripts", "bin", file_path)
+        renamed_path = re.sub(r"\AScripts", "bin", file_path)  # codespell:ignore
         renamed_executable_path = renamed_path.replace("-script.py", "")
 
     return renamed_executable_path

--- a/conda_build/develop.py
+++ b/conda_build/develop.py
@@ -51,7 +51,7 @@ def relink_sharedobjects(pkg_path, build_prefix):
 def write_to_conda_pth(sp_dir, pkg_path):
     """
     Append pkg_path to conda.pth in site-packages directory for current
-    environment. Only add path if it doens't already exist.
+    environment. Only add path if it doesn't already exist.
 
     :param sp_dir: path to site-packages/. directory
     :param pkg_path: the package path to append to site-packes/. dir.

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -740,7 +740,7 @@ def linux_vars(m, get_default, prefix):
     # unless run through linux32. Issue a warning when we detect this.
     if build_arch == "x86_64" and platform_architecture[0] == "32bit":
         print("Warning: You are running 32-bit Python on a 64-bit linux installation")
-        print("         but have not launched it via linux32. Various qeuries *will*")
+        print("         but have not launched it via linux32. Various queries *will*")
         print("         give unexpected results (uname -m, platform.machine() etc)")
         build_arch = "i686"
     # the GNU triplet is powerpc, not ppc. This matters.
@@ -1090,7 +1090,7 @@ def create_env(
     is_conda: bool = False,
 ) -> None:
     """
-    Create a conda envrionment for the given prefix and specs.
+    Create a conda environment for the given prefix and specs.
 
     If config.test_env_template is set to a valid environment path, this function
     will first try to clone from that template environment for faster creation,

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -853,7 +853,7 @@ def build_string_from_metadata(metadata):
         build_pkg_names = [ms.name for ms in metadata.ms_depends(build_or_host)]
         build_deps = metadata.meta.get("requirements", {}).get(build_or_host, [])
         # TODO: this is the bit that puts in strings like py27np111 in the filename.  It would be
-        #    nice to get rid of this, since the hash supercedes that functionally, but not clear
+        #    nice to get rid of this, since the hash supersedes that functionally, but not clear
         #    whether anyone's tools depend on this file naming right now.
         for s, names, places in (
             ("np", "numpy", 2),
@@ -1310,7 +1310,7 @@ class MetaData:
                 time is used.
 
         permit_undefined_jinja: If True, *any* use of undefined jinja variables will
-                                evaluate to an emtpy string, without emitting an error.
+                                evaluate to an empty string, without emitting an error.
         """
         assert not self.final, "modifying metadata after finalization"
 
@@ -2016,7 +2016,7 @@ class MetaData:
         before standard conda macro processors.
 
         permit_undefined_jinja: If True, *any* use of undefined jinja variables will
-                                evaluate to an emtpy string, without emitting an error.
+                                evaluate to an empty string, without emitting an error.
         """
         from .jinja_context import (
             FilteredLoader,

--- a/conda_build/noarch_python.py
+++ b/conda_build/noarch_python.py
@@ -17,7 +17,7 @@ from .utils import bin_dirname, on_win, rm_rf
 def rewrite_script(fn: str, prefix: str | os.PathLike) -> str:
     """Take a file from the bin directory and rewrite it into the python-scripts
     directory with the same permissions after it passes some sanity checks for
-    noarch pacakges"""
+    noarch packages"""
 
     # Load and check the source file for not being a binary
     src = Path(prefix, bin_dirname, fn)
@@ -119,7 +119,7 @@ def transform(m, files, prefix):
     name = m.name()
 
     # Create *nix prelink script
-    # Note: it's important to use LF newlines or it wont work if we build on Win
+    # Note: it's important to use LF newlines or it won't work if we build on Win
     with open(join(bin_dir, f".{name}-pre-link.sh"), "wb") as fo:
         fo.write(
             b"""\

--- a/conda_build/os_utils/pyldd.py
+++ b/conda_build/os_utils/pyldd.py
@@ -89,7 +89,7 @@ Usage: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctool
     -L print shared libraries used
     -D print shared library id name
     -t print the text section (disassemble with -v)
-    -p <routine name>  start dissassemble from routine name
+    -p <routine name>  start disassemble from routine name
     -s <segname> <sectname> print contents of section
     -d print the data section
     -o print the Objective-C segment

--- a/conda_build/post.py
+++ b/conda_build/post.py
@@ -322,7 +322,7 @@ def compile_missing_pyc(files, cwd, python_exe, skip_compile_pyc=()):
             print("compiling .pyc files...")
             args = [python_exe, "-Wi", "-m", "py_compile"]
             args_len = len(" ".join(args)) + 1
-            # chunk them to avoid too long comand lines:
+            # chunk them to avoid too long command lines:
             groups = chunks(compile_files, MAX_CHUNK_SIZE - args_len)
             for group in groups:
                 call(args + group, cwd=cwd)
@@ -1513,7 +1513,7 @@ def check_overlinking_impl(
                         ]
                         replaced = install_names[0][1:]
                         if replaced.endswith("'"):
-                            # Some SDKs have install name surrounded by single qoutes
+                            # Some SDKs have install name surrounded by single quotes
                             replaced = replaced[1:-1]
                 sysroot_files.append(replaced)
             diffs = set(orig_sysroot_files) - set(sysroot_files)

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -1555,7 +1555,7 @@ def skeletonize(
                         continue
                     if name == "R":
                         # Put R first
-                        # Regarless of build or run, and whether this is a
+                        # Regardless of build or run, and whether this is a
                         # recommended package or not, it can only depend on
                         # r_interp since anything else can and will cause
                         # cycles in the dependency graph. The cran metadata
@@ -1746,7 +1746,7 @@ def get_license_info(license_text, allowed_license_families):
     license file shipped with R base. The template files are more complicated
     because they would need to be combined with the license information provided
     by the package authors. In this case, the template file and the license
-    information file are both packaged. All optional ('|' seperated) licenses
+    information file are both packaged. All optional ('|' separated) licenses
     are included, if they are matching.
 
     This function returns the path to the license file for the unambiguous

--- a/conda_build/skeletons/pypi.py
+++ b/conda_build/skeletons/pypi.py
@@ -515,7 +515,7 @@ def add_parser(repos):
     pypi.add_argument(
         "--version",
         help="""Version to use. Applies to all packages. If not specified the
-              lastest visible version on PyPI is used.""",
+              latest visible version on PyPI is used.""",
     )
     pypi.add_argument(
         "--all-urls",
@@ -729,7 +729,7 @@ def version_compare(package, versions):
         # Comparing normalized versions, displaying non normalized ones
         new_versions = versions[: norm_versions.index(local_version)]
         if len(new_versions) > 0:
-            print(f"Following new versions of {package} are avaliable")
+            print(f"Following new versions of {package} are available")
             for ver in new_versions:
                 print(ver)
         else:

--- a/conda_build/templates/npm.yaml
+++ b/conda_build/templates/npm.yaml
@@ -1,4 +1,4 @@
-#Automaticly generating npm conda package
+#Automatically generating npm conda package
 {% set data = load_npm()%}
 {% block body -%}
 {% block package -%}

--- a/conda_build/utils.py
+++ b/conda_build/utils.py
@@ -481,7 +481,7 @@ def try_acquire_locks(locks, timeout):
     """Try to acquire all locks.
 
     If any lock can't be immediately acquired, free all locks.
-    If the timeout is reached withou acquiring all locks, free all locks and raise.
+    If the timeout is reached without acquiring all locks, free all locks and raise.
 
     http://stackoverflow.com/questions/9814008/multiple-mutex-locking-strategies-and-why-libraries-dont-use-address-comparison
     """
@@ -1077,7 +1077,7 @@ def iter_entry_points(items):
     for item in items:
         m = entry_pat.match(item)
         if m is None:
-            sys.exit(f"Error cound not match entry point: {item!r}")
+            sys.exit(f"Error could not match entry point: {item!r}")
         yield m.groups()
 
 

--- a/docs/source/concepts/recipe.rst
+++ b/docs/source/concepts/recipe.rst
@@ -74,7 +74,7 @@ Conda-build performs the following steps:
 
 #. Tests the new conda package — if the recipe includes tests — by doing the following:
 
-   * Deletes the build environment and source directory to ensure that the new conda package does not inadvertantly depend on artifacts not included in the package.
+   * Deletes the build environment and source directory to ensure that the new conda package does not inadvertently depend on artifacts not included in the package.
 
    * Creates a test environment with the package and its dependencies.
 

--- a/docs/source/resources/add-win-start-menu-items.rst
+++ b/docs/source/resources/add-win-start-menu-items.rst
@@ -13,7 +13,7 @@ The easiest way to ensure that a package made with
 `conda constructor <https://github.com/conda/constructor>`_ does
 not install any menu shortcuts is to remove menuinst from
 the list of conda packages included. To do this, add the
-following to the ``constuct.yaml`` file:
+following to the ``construct.yaml`` file:
 
 .. code-block:: yaml
 

--- a/docs/source/resources/compiler-tools.rst
+++ b/docs/source/resources/compiler-tools.rst
@@ -469,7 +469,7 @@ tarballs, for example). In this case, there is a gotcha.
 
 Even if Anaconda compilers are used from outside of ``conda-build``, the GCC
 specs are customized so that, when linking an executable or a shared library,
-an RPATH pointing to ``lib/`` inside the current enviroment prefix directory
+an RPATH pointing to ``lib/`` inside the current environment prefix directory
 (``$CONDA_PREFIX/lib``) is added. This is done by changing the
 ``link_libgcc:`` section inside GCC ``specs`` file, and this change is done
 so that ``LD_LIBRARY_PATH`` isn't required for basic libraries.

--- a/docs/source/resources/link-scripts.rst
+++ b/docs/source/resources/link-scripts.rst
@@ -14,7 +14,7 @@ as the meta.yaml file. The following scripts can be added:
 * ``pre-unlink``---Executed before the package is removed. An error is
   indicated by a nonzero exit and causes the removal to fail.
 
-In addition to being co-located with the meta.yaml file, they must be named simply ``post-link.sh`` or ``post-link.bat``. Conda-build will rename them to .<name>-<action>.sh (or .bat) where ``<name>`` is the package name and ``<action>`` is one of the preceeding actions.
+In addition to being co-located with the meta.yaml file, they must be named simply ``post-link.sh`` or ``post-link.bat``. Conda-build will rename them to .<name>-<action>.sh (or .bat) where ``<name>`` is the package name and ``<action>`` is one of the proceeding actions.
 
 These scripts are executed in a subprocess by
 conda, using ``%COMSPEC% /c <script>`` on Windows and

--- a/docs/source/user-guide/v1-recipes.rst
+++ b/docs/source/user-guide/v1-recipes.rst
@@ -115,7 +115,7 @@ Migrating recipes
 =================
 
 Migrating recipes to v1 format can be beneficial because it provides faster
-rendering and buiding, standardized schema with autocomplete support,
+rendering and building, standardized schema with autocomplete support,
 and pure YAML syntax, which guarantees easier updates in the future.
 
 To migrate a recipe from v0 to v1 format, use the `conda-recipe-manager <https://github.com/conda/conda-recipe-manager>`__ tool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ changelog = "https://github.com/conda/conda-build/blob/main/CHANGELOG.md"
 documentation = "https://docs.conda.io/projects/conda-build/en/stable/"
 repository = "https://github.com/conda/conda-build"
 
+[tool.codespell]
+ignore-words-list = ["lief", "rever", "fo", "uptodate", "astroid", "wee", "adament"]
+skip = "*/commands/*.rst,*.patch"
+
 [tool.coverage.report]
 exclude_lines = [
   "if TYPE_CHECKING:",  # ignoring type checking imports

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,7 +223,7 @@ def variants_conda_build_sysroot(monkeypatch, request):
     if not on_mac:
         return {}
 
-    # if we do not speciy a custom sysroot, we get what the
+    # if we do not specify a custom sysroot, we get what the
     # current SDK has
     if "CONDA_BUILD_SYSROOT" not in os.environ:
         monkeypatch.setenv(

--- a/tests/test-recipes/metadata/_blas_pins/meta.yaml
+++ b/tests/test-recipes/metadata/_blas_pins/meta.yaml
@@ -205,7 +205,7 @@ outputs:
         - test -f $PREFIX/lib/liblapacke.so                         # [linux]
         - test -f $PREFIX/lib/liblapacke.so.{{ version_major }}     # [linux]
 
-  # For compatiblity
+  # For compatibility
   - name: blas
     version: "{{ blas_major }}.{{ blas_minor }}"
     # script: test_blas.sh   # [unix]

--- a/tests/test-recipes/metadata/_pytorch_cpu/meta.yaml
+++ b/tests/test-recipes/metadata/_pytorch_cpu/meta.yaml
@@ -82,7 +82,7 @@ requirements:
     - libuv                     # [win]
     - cmake
     - ninja
-    # Keep libprotobuf here so that a compatibile version
+    # Keep libprotobuf here so that a compatible version
     # of protobuf is installed between build and host
     - libprotobuf
     - protobuf
@@ -195,7 +195,7 @@ outputs:
         - intel-openmp {{ mkl }}  # [win]
         - cmake
         - ninja
-        # Keep libprotobuf here so that a compatibile version
+        # Keep libprotobuf here so that a compatible version
         # of protobuf is installed between build and host
         - libprotobuf
         - protobuf

--- a/tests/test-recipes/metadata/numpy_run/run_test.sh
+++ b/tests/test-recipes/metadata/numpy_run/run_test.sh
@@ -1,3 +1,3 @@
 conda list -p $PREFIX --canonical
-# Test the build string. Should contian NumPy, but not the version
+# Test the build string. Should contain NumPy, but not the version
 conda list -p $PREFIX --canonical | grep "conda-build-test-numpy-run-1\.0-0"

--- a/tests/test-recipes/split-packages/_build_string_with_variant/meta.yaml
+++ b/tests/test-recipes/split-packages/_build_string_with_variant/meta.yaml
@@ -47,7 +47,7 @@ outputs:
   #
   # Non-default variants track the "non_default_clang" feature.
   # This is used to weigh down non-default variants of the package, allowing
-  # the default variant to take precedence unless required explicitely.
+  # the default variant to take precedence unless required explicitly.
   - name: clang_variant
     version: 1.0
     build:

--- a/tests/test_api_convert.py
+++ b/tests/test_api_convert.py
@@ -335,7 +335,7 @@ def test_renaming_executables(base_platform, package):
     When converting the bin/ directory to Scripts/, only scripts
     need to be changed. Sometimes the /bin directory contains other
     files that are not Python scripts such as post-link.sh scripts.
-    This test converts a packaege that contains a post-link.sh script
+    This test converts a package that contains a post-link.sh script
     in the bin/ directory and checks to see that its filename remains
     the same.
     """

--- a/tests/test_api_debug.py
+++ b/tests/test_api_debug.py
@@ -81,7 +81,7 @@ def test_debug(
             output_id=output_id,
         )
 
-    # if we expected an error there wont be anything else to test
+    # if we expected an error there won't be anything else to test
     if has_error:
         return
 


### PR DESCRIPTION
This fixes a few typos identified and corrected with codespell. A configuration is added, as this tool has been run at least once before.

A pre-commit hook is suggested in this PR, although it can be perhaps commented-out if too time consuming (my local run take 0.18s, which is similar to some other longer-running hooks).

Please review for false-positive changes.