### PR TITLE
Improve licence metadata (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -44,7 +43,8 @@ dependencies = [
 ]
 description = "tools for building conda packages"
 dynamic = ["version"]
-license = {file = "LICENSE"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE", "AUTHORS.md"]
 name = "conda-build"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This improves the project's licence metadata, following [PEP 639](https://peps.python.org/pep-0639/):

- Change `licence` from a deprecated table structure, to a valid SPDX identifier: [`BSD-3-Clause`](https://spdx.org/licenses/BSD-3-Clause.html)
- Explicitly specify licence files, including AUTHORS.md
- Remove the licence classifier, which is deprecated
- The minimum version of hatchling is already above [v1.5.0](https://hatch.pypa.io/1.13/history/hatchling/#hatchling-v1.5.0) when final draft of PEP 639 was supported.