### PR TITLE
Support `--variants` when using `--output`

### DIFF
--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     import os
     from argparse import ArgumentParser, Namespace
     from collections.abc import Sequence
+    from typing import Any
 
     from ..config import Config
 
@@ -526,16 +527,17 @@ def check_recipe(path_list):
             )
 
 
-def output_action(recipe: os.PathLike, config: Config):
+def output_action(recipe: os.PathLike, config: Config, variants: dict[str, Any] | None):
     """Output the conda package filename which would have been created
 
     :param recipe: Path to recipe or recipe folder
     :param config: Config object used for various options
+    :param variants: Variants to use for the output
     """
     with LoggingContext(logging.CRITICAL + 1):
         config.verbose = False
         config.debug = False
-        paths = api.get_output_file_paths(recipe, config=config)
+        paths = api.get_output_file_paths(recipe, config=config, variants=variants)
         print("\n".join(sorted(paths)))
 
 
@@ -605,7 +607,7 @@ def execute(args: Sequence[str] | None = None) -> int:
         config.quiet = True
         config.debug = False
         for recipe in parsed.recipe:
-            output_action(recipe, config)
+            output_action(recipe, config, parsed.variants)
         return 0
 
     if parsed.test:

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -241,7 +241,9 @@ def execute(args: Sequence[str] | None = None) -> int:
 
     if parsed.output:
         with LoggingContext(logging.CRITICAL + 1):
-            paths = api.get_output_file_paths(metadata_tuples, config=config)
+            paths = api.get_output_file_paths(
+                metadata_tuples, config=config, variants=parsed.variants
+            )
             print("\n".join(sorted(paths)))
         if parsed.file:
             m = metadata_tuples[-1][0]

--- a/news/6072-support-variants-flag-for-output.md
+++ b/news/6072-support-variants-flag-for-output.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Support `--variants` when using `--output`. (#6072)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -124,19 +124,18 @@ def test_build_output_build_path_variants(testing_config, capfd):
     testing_config.debug = False
 
     # Test that without passing --variants, we get all variants
-    args = ["--output", os.path.join(variants_dir, "12_variant_versions")]
+    args = ["--output", os.path.join(variants_dir, "11_variant_output_names")]
     main_build.execute(args)
+
+    names = [
+        "some_output_using_abc_ghi-1.0-hd82c8f6_0.conda",
+        "some_output_using_abc_jkl-1.0-h64b44fd_0.conda",
+        "some_output_using_def_ghi-1.0-h95087dd_0.conda",
+        "some_output_using_def_jkl-1.0-h085f5b8_0.conda",
+    ]
     test_paths = [
-        os.path.join(
-            testing_config.croot,
-            testing_config.host_subdir,
-            "my_package-470.470-h65f20af_0.conda",
-        ),
-        os.path.join(
-            testing_config.croot,
-            testing_config.host_subdir,
-            "my_package-480.480-h1f30878_0.conda",
-        ),
+        os.path.join(testing_config.croot, testing_config.host_subdir, name)
+        for name in names
     ]
     output, error = capfd.readouterr()
     assert "\n".join(test_paths) == output.rstrip(), error
@@ -145,18 +144,22 @@ def test_build_output_build_path_variants(testing_config, capfd):
     # Test that passing --variants, we get the specified variants
     args = [
         "--output",
-        os.path.join(variants_dir, "12_variant_versions"),
+        os.path.join(variants_dir, "11_variant_output_names"),
         "--variants",
-        "my_version=470",
+        "something: abc",
     ]
     main_build.execute(args)
-    test_path = os.path.join(
-        testing_config.croot,
-        testing_config.host_subdir,
-        "my_package-470.470-h65f20af_0.conda",
-    )
+
+    names = [
+        "some_output_using_abc_ghi-1.0-hd82c8f6_0.conda",
+        "some_output_using_abc_jkl-1.0-h64b44fd_0.conda",
+    ]
+    test_paths = [
+        os.path.join(testing_config.croot, testing_config.host_subdir, name)
+        for name in names
+    ]
     output, error = capfd.readouterr()
-    assert test_path == output.rstrip(), error
+    assert "\n".join(test_paths) == output.rstrip(), error
     assert error == ""
 
 

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -23,7 +23,7 @@ from conda_build.exceptions import CondaBuildUserError, DependencyNeedsBuildingE
 from conda_build.os_utils.external import find_executable
 from conda_build.utils import get_build_folders, on_win, package_has_file
 
-from ..utils import metadata_dir
+from ..utils import metadata_dir, variants_dir
 from ..utils import reset_config as _reset_config
 
 if TYPE_CHECKING:
@@ -113,6 +113,47 @@ def test_build_output_build_path(
         testing_config.croot,
         testing_config.host_subdir,
         "test_build_output_build_path-1.0-1.conda",
+    )
+    output, error = capfd.readouterr()
+    assert test_path == output.rstrip(), error
+    assert error == ""
+
+
+def test_build_output_build_path_variants(testing_config, capfd):
+    testing_config.verbose = False
+    testing_config.debug = False
+
+    # Test that without passing --variants, we get all variants
+    args = ["--output", os.path.join(variants_dir, "12_variant_versions")]
+    main_build.execute(args)
+    test_paths = [
+        os.path.join(
+            testing_config.croot,
+            testing_config.host_subdir,
+            "my_package-470.470-h65f20af_0.conda",
+        ),
+        os.path.join(
+            testing_config.croot,
+            testing_config.host_subdir,
+            "my_package-480.480-h1f30878_0.conda",
+        ),
+    ]
+    output, error = capfd.readouterr()
+    assert "\n".join(test_paths) == output.rstrip(), error
+    assert error == ""
+
+    # Test that passing --variants, we get the specified variants
+    args = [
+        "--output",
+        os.path.join(variants_dir, "12_variant_versions"),
+        "--variants",
+        "my_version=470",
+    ]
+    main_build.execute(args)
+    test_path = os.path.join(
+        testing_config.croot,
+        testing_config.host_subdir,
+        "my_package-470.470-h65f20af_0.conda",
     )
     output, error = capfd.readouterr()
     assert test_path == output.rstrip(), error

--- a/tests/cli/test_main_build.py
+++ b/tests/cli/test_main_build.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import fnmatch
 import os
 import re
 from pathlib import Path
@@ -127,18 +128,22 @@ def test_build_output_build_path_variants(testing_config, capfd):
     args = ["--output", os.path.join(variants_dir, "11_variant_output_names")]
     main_build.execute(args)
 
-    names = [
-        "some_output_using_abc_ghi-1.0-hd82c8f6_0.conda",
-        "some_output_using_abc_jkl-1.0-h64b44fd_0.conda",
-        "some_output_using_def_ghi-1.0-h95087dd_0.conda",
-        "some_output_using_def_jkl-1.0-h085f5b8_0.conda",
-    ]
-    test_paths = [
-        os.path.join(testing_config.croot, testing_config.host_subdir, name)
-        for name in names
+    # Build hash (h...) is not stable between local and CUI builds.
+    # So rely on the build string without the content hash.
+    patterns = [
+        "some_output_using_abc_ghi-1.0-*.conda",
+        "some_output_using_abc_jkl-1.0-*.conda",
+        "some_output_using_def_ghi-1.0-*.conda",
+        "some_output_using_def_jkl-1.0-*.conda",
     ]
     output, error = capfd.readouterr()
-    assert "\n".join(test_paths) == output.rstrip(), error
+    names = [os.path.basename(path) for path in output.rstrip().splitlines()]
+    assert len(names) == len(patterns), (
+        f"Expected {len(patterns)} packages, got {len(names)}"
+    )
+    assert all(
+        fnmatch.fnmatch(name, pattern) for name, pattern in zip(names, patterns)
+    ), error or output
     assert error == ""
 
     # Test that passing --variants, we get the specified variants
@@ -150,16 +155,18 @@ def test_build_output_build_path_variants(testing_config, capfd):
     ]
     main_build.execute(args)
 
-    names = [
-        "some_output_using_abc_ghi-1.0-hd82c8f6_0.conda",
-        "some_output_using_abc_jkl-1.0-h64b44fd_0.conda",
-    ]
-    test_paths = [
-        os.path.join(testing_config.croot, testing_config.host_subdir, name)
-        for name in names
+    patterns = [
+        "some_output_using_abc_ghi-1.0-*.conda",
+        "some_output_using_abc_jkl-1.0-*.conda",
     ]
     output, error = capfd.readouterr()
-    assert "\n".join(test_paths) == output.rstrip(), error
+    names = [os.path.basename(path) for path in output.rstrip().splitlines()]
+    assert len(names) == len(patterns), (
+        f"Expected {len(patterns)} packages, got {len(names)}"
+    )
+    assert all(
+        fnmatch.fnmatch(name, pattern) for name, pattern in zip(names, patterns)
+    ), error or output
     assert error == ""
 
 


### PR DESCRIPTION
### Description

Honor `--variants` when `conda-build --output` calculates package paths. The option was accepted by the CLI but was not forwarded to `get_output_file_paths()`, so `--output` always returned the full variant matrix.

The regression test covers both the full matrix and a matrix restricted with `--variants "something: abc"`.

### Checklist

- [x] Added a news entry.
- [x] Added regression coverage.
- [x] No documentation changes are needed.