### PR TITLE
Use `start /machine` in multi-output's `script_interpreter`

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1803,18 +1803,6 @@ def bundle_conda(
         if activate_script:
             _write_activation_text(dest_file, metadata)
 
-        if not dest_file.endswith((".sh", ".bat", ".ps1")):
-            # Check whether the interpreter comes from BUILD_PREFIX or not
-            executable = shutil.which(args[0])
-            if executable is not None and not executable.startswith(
-                metadata.config.build_prefix
-            ):
-                log.warning(
-                    "If the output script (%s) is not .sh, .bat or .ps1, "
-                    "its script_interpreter field must be set to a tool installed in BUILD_PREFIX.",
-                    output["script"],
-                )
-
         args_to_run = [*args, dest_file]
         if on_win and dest_file.endswith((".bat", ".ps1")):
             from .windows import _running_subdir, wrap_script_with_machine

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1803,10 +1803,22 @@ def bundle_conda(
         if activate_script:
             _write_activation_text(dest_file, metadata)
 
+        args_to_run = [*args, dest_file]
+        if on_win:
+            from .windows import _running_subdir, wrap_script_with_machine
+
+            if metadata.config.build_subdir != _running_subdir():
+                # Support native build platform on emulated Python interpreter
+                # Need to ensure subprocess runs on the adequate architecture
+                # See conda_build.windows._build_arch for more info.
+                args_to_run = [
+                    *INTERPRETER_BAT, wrap_script_with_machine(dest_file, " ".join(args))
+                ]
+
         bundle_stats = {}
         try:
             utils.check_call_env(
-                [*args, dest_file],
+                args_to_run,
                 cwd=metadata.config.work_dir,
                 env=env_output,
                 stats=bundle_stats,

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1813,7 +1813,7 @@ def bundle_conda(
                 # See conda_build.windows._build_arch for more info.
                 args_to_run = [
                     *INTERPRETER_BAT,
-                    wrap_script_with_machine(dest_file, " ".join(args)),
+                    wrap_script_with_machine(metadata, dest_file, " ".join(args)),
                 ]
 
         bundle_stats = {}

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1803,8 +1803,20 @@ def bundle_conda(
         if activate_script:
             _write_activation_text(dest_file, metadata)
 
+        if not dest_file.endswith((".sh", ".bat", ".ps1")):
+            # Check whether the interpreter comes from BUILD_PREFIX or not
+            executable = shutil.which(args[0])
+            if executable is not None and not executable.startswith(
+                metadata.config.build_prefix
+            ):
+                log.warning(
+                    "If the output script (%s) is not .sh, .bat or .ps1, "
+                    "its script_interpreter field must be set to a tool installed in BUILD_PREFIX.",
+                    output[script],
+                )
+
         args_to_run = [*args, dest_file]
-        if on_win:
+        if on_win and dest_file.endswith((".bat", ".ps1")):
             from .windows import _running_subdir, wrap_script_with_machine
 
             if metadata.config.build_subdir != _running_subdir():

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1810,10 +1810,10 @@ def bundle_conda(
             if metadata.config.build_subdir != _running_subdir():
                 # Support native build platform on emulated Python interpreter
                 # Need to ensure subprocess runs on the adequate architecture
-                # See conda_build.windows._build_arch for more info.
+                # See conda_build.windows. wrap_script_with_machine for more info.
                 args_to_run = [
                     *INTERPRETER_BAT,
-                    wrap_script_with_machine(metadata, dest_file, " ".join(args)),
+                    wrap_script_with_machine(metadata, dest_file, tuple(args)),
                 ]
 
         bundle_stats = {}

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1812,7 +1812,8 @@ def bundle_conda(
                 # Need to ensure subprocess runs on the adequate architecture
                 # See conda_build.windows._build_arch for more info.
                 args_to_run = [
-                    *INTERPRETER_BAT, wrap_script_with_machine(dest_file, " ".join(args))
+                    *INTERPRETER_BAT,
+                    wrap_script_with_machine(dest_file, " ".join(args)),
                 ]
 
         bundle_stats = {}

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -1812,7 +1812,7 @@ def bundle_conda(
                 log.warning(
                     "If the output script (%s) is not .sh, .bat or .ps1, "
                     "its script_interpreter field must be set to a tool installed in BUILD_PREFIX.",
-                    output[script],
+                    output["script"],
                 )
 
         args_to_run = [*args, dest_file]

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -10,6 +10,7 @@ import sysconfig
 from functools import cache
 from itertools import product
 from os.path import dirname, isdir, isfile, join
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -31,6 +32,7 @@ except:
     pass
 
 from . import environ
+from .build import INTERPRETER_BAT
 from .utils import (
     check_call_env,
     copy_into,
@@ -431,16 +433,24 @@ def _running_subdir():
 
 def build_command_arguments(m, script: str) -> list[str]:
     if m.config.build_subdir != _running_subdir():
-        # See docstring of _cmd_machine_flag()
-        wrapper = os.path.join(os.path.dirname(script), "_conda_build_wrapper.bat")
-        with open(wrapper, "w") as f:
-            f.write(
-                "@echo off\r\n"
-                f'start /b /wait /machine {_build_arch(m)} cmd.exe /d /c "{script}"\r\n'
-                "exit /b %ERRORLEVEL%\r\n"
-            )
-        return ["cmd.exe", "/d", "/c", os.path.basename(wrapper)]
-    return ["cmd.exe", "/d", "/c", os.path.basename(script)]
+        wrapper = wrap_script_with_machine(script)
+        return [*INTERPRETER_BAT, os.path.basename(wrapper)]
+    return [*INTERPRETER_BAT, os.path.basename(script)]
+
+
+def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str:
+    # See docstring of _cmd_machine_flag()
+    script = Path(script)
+    wrapper = script.parent / script.stem + ".wrapped" + script.suffix
+    if script.suffix.lower().endswith((".bat", ".cmd")):
+        pre_script = " ".join(INTERPRETER_BAT)
+    with open(wrapper, "w") as f:
+        f.write(
+            "@echo off\r\n"
+            f'start /b /wait /machine {_build_arch(m)} {pre_script} "{script}"\r\n'
+            "exit /b %ERRORLEVEL%\r\n"
+        )
+    return str(wrapper)
 
 
 def build(m, bld_bat, stats, provision_only=False):

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -399,13 +399,7 @@ def write_build_scripts(m, env, bld_bat):
 
 
 def _build_arch(m) -> Literal["AMD64", "ARM64", "x86"]:
-    """
-    If conda-build is run from e.g. a win-64 environment on a win-arm64 machine
-    users may want to build natively by setting build_platform="win-arm64".
-    In those cases, we need to ensure that the CMD process is native ARM64
-    via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
-    This gives you the adequate /machine flag value for `start`.
-    """
+    # See docstring of wrap_script_with_machine()
     build_arch = m.config.build_subdir.split("-")[1].upper()
     return {"64": "AMD64", "32": "x86"}.get(build_arch, build_arch)
 
@@ -440,12 +434,18 @@ def build_command_arguments(m, script: str) -> list[str]:
 
 
 def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str:
+    """
+    If conda-build is run from e.g. a win-64 environment on a win-arm64 machine
+    users may want to build natively by setting build_platform="win-arm64".
+    In those cases, we need to ensure that the CMD process is native ARM64
+    via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
+    This wraps the script with adequate `start /machine xxx` call.
+    """
     from .build import INTERPRETER_BAT
 
-    # See docstring of _cmd_machine_flag()
     script = Path(script)
-    wrapper = script.parent / (script.stem + ".wrapper" + script.suffix)
-    if script.suffix.lower().endswith((".bat", ".cmd")):
+    wrapper = script.parent / (script.stem + ".wrapper.bat")
+    if not pre_script and script.suffix.lower().endswith((".bat", ".cmd")):
         pre_script = " ".join(INTERPRETER_BAT)
     with open(wrapper, "w") as f:
         f.write(

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -441,7 +441,9 @@ def build_command_arguments(m, script: str) -> list[str]:
 
 
 def wrap_script_with_machine(
-    m, script: str | Path, pre_script: tuple[str] | str = ()
+    m,
+    script: str | Path,
+    pre_script: tuple[str, ...] | str = (),
 ) -> str:
     """
     If conda-build is run from e.g. a win-64 environment on a win-arm64 machine
@@ -460,9 +462,9 @@ def wrap_script_with_machine(
         pre_script = guess_interpreter(script.name)
     if not isinstance(pre_script, str):
         pre_script = list2cmdline(pre_script)
-    # CMD breaks with Unix line endings; force \r\n on those even if not on Windows
-    newline_policy = "\r\n" if script.suffix.lower() in (".bat", ".cmd") else None
-    with open(wrapper, "w", newline=newline_policy) as f:
+    # Wrapper is always a .bat; CMD breaks with Unix line endings, so force CRLF
+    # even when conda-build itself is not running on Windows (e.g. unit tests).
+    with open(wrapper, "w", newline="\r\n") as f:
         f.write(
             "@echo off\n"
             f'start "" /b /wait /machine {_build_arch(m)} {pre_script} "{script}"\n'

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -460,7 +460,9 @@ def wrap_script_with_machine(
         pre_script = guess_interpreter(script.name)
     if not isinstance(pre_script, str):
         pre_script = list2cmdline(pre_script)
-    with open(wrapper, "w") as f:
+    # CMD breaks with Unix line endings; force \r\n on those even if not on Windows
+    newline_policy = "\r\n" if script.suffix.lower() in (".bat", ".cmd") else None
+    with open(wrapper, "w", newline=newline_policy) as f:
         f.write(
             "@echo off\n"
             f'start "" /b /wait /machine {_build_arch(m)} {pre_script} "{script}"\n'

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -425,6 +425,12 @@ def _running_subdir():
 
 
 def build_command_arguments(m, script: str) -> list[str]:
+    """
+    Return list of arguments of the form: ["cmd", "/d", "/c", script].
+
+    Script may be the original one, or a wrapper to choose specific architectures,
+    depending on the configuration set in `m` (metadata object).
+    """
     from .build import INTERPRETER_BAT
 
     if m.config.build_subdir != _running_subdir():
@@ -440,6 +446,8 @@ def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str
     In those cases, we need to ensure that the CMD process is native ARM64
     via this `start` wrapper. Otherwise Windows picks the AMD64 slice!
     This wraps the script with adequate `start /machine xxx` call.
+
+    Returns full path to wrapped script
     """
     from .build import INTERPRETER_BAT
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -11,6 +11,7 @@ from functools import cache
 from itertools import product
 from os.path import dirname, isdir, isfile, join
 from pathlib import Path
+from subprocess import list2cmdline
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -461,9 +462,9 @@ def wrap_script_with_machine(
         pre_script = list2cmdline(pre_script)
     with open(wrapper, "w") as f:
         f.write(
-            "@echo off\r\n"
-            f'start /b /wait /machine {_build_arch(m)} {pre_script} "{script}"\r\n'
-            "exit /b %ERRORLEVEL%\r\n"
+            "@echo off\n"
+            f'start "" /b /wait /machine {_build_arch(m)} {pre_script} "{script}"\n'
+            "exit /b %ERRORLEVEL%\n"
         )
     return str(wrapper)
 

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -32,7 +32,6 @@ except:
     pass
 
 from . import environ
-from .build import INTERPRETER_BAT
 from .utils import (
     check_call_env,
     copy_into,
@@ -432,6 +431,8 @@ def _running_subdir():
 
 
 def build_command_arguments(m, script: str) -> list[str]:
+    from .build import INTERPRETER_BAT
+
     if m.config.build_subdir != _running_subdir():
         wrapper = wrap_script_with_machine(script)
         return [*INTERPRETER_BAT, os.path.basename(wrapper)]
@@ -439,6 +440,8 @@ def build_command_arguments(m, script: str) -> list[str]:
 
 
 def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str:
+    from .build import INTERPRETER_BAT
+
     # See docstring of _cmd_machine_flag()
     script = Path(script)
     wrapper = script.parent / script.stem + ".wrapped" + script.suffix

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -434,7 +434,7 @@ def build_command_arguments(m, script: str) -> list[str]:
     from .build import INTERPRETER_BAT
 
     if m.config.build_subdir != _running_subdir():
-        wrapper = wrap_script_with_machine(script)
+        wrapper = wrap_script_with_machine(m, script)
         return [*INTERPRETER_BAT, os.path.basename(wrapper)]
     return [*INTERPRETER_BAT, os.path.basename(script)]
 
@@ -444,7 +444,7 @@ def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str
 
     # See docstring of _cmd_machine_flag()
     script = Path(script)
-    wrapper = script.parent / script.stem + ".wrapped" + script.suffix
+    wrapper = script.parent / (script.stem + ".wrapper" + script.suffix)
     if script.suffix.lower().endswith((".bat", ".cmd")):
         pre_script = " ".join(INTERPRETER_BAT)
     with open(wrapper, "w") as f:

--- a/conda_build/windows.py
+++ b/conda_build/windows.py
@@ -439,7 +439,9 @@ def build_command_arguments(m, script: str) -> list[str]:
     return [*INTERPRETER_BAT, os.path.basename(script)]
 
 
-def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str:
+def wrap_script_with_machine(
+    m, script: str | Path, pre_script: tuple[str] | str = ()
+) -> str:
     """
     If conda-build is run from e.g. a win-64 environment on a win-arm64 machine
     users may want to build natively by setting build_platform="win-arm64".
@@ -449,12 +451,14 @@ def wrap_script_with_machine(m, script: str | Path, pre_script: str = "") -> str
 
     Returns full path to wrapped script
     """
-    from .build import INTERPRETER_BAT
+    from .build import guess_interpreter
 
     script = Path(script)
-    wrapper = script.parent / (script.stem + ".wrapper.bat")
-    if not pre_script and script.suffix.lower().endswith((".bat", ".cmd")):
-        pre_script = " ".join(INTERPRETER_BAT)
+    wrapper = script.parent / (script.name + ".wrapper.bat")
+    if not pre_script:
+        pre_script = guess_interpreter(script.name)
+    if not isinstance(pre_script, str):
+        pre_script = list2cmdline(pre_script)
     with open(wrapper, "w") as f:
         f.write(
             "@echo off\r\n"

--- a/news/6080.md
+++ b/news/6080.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Make multi-output script subprocesses match `build_platform` architecture when running emulated Python processes too. Previous fix only dealt with top-level build scripts. (#6080)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -463,7 +463,7 @@ def test_build_command_win_arm64_wrapper(
 
     work_script = tmp_path / "conda_build.bat"
     work_script.write_text("@echo off\r\n")
-    wrapper = tmp_path / "conda_build.wrapper.bat"
+    wrapper = tmp_path / "conda_build.bat.wrapper.bat"
 
     cmd = windows.build_command_arguments(testing_metadata, str(work_script))
 
@@ -472,7 +472,7 @@ def test_build_command_win_arm64_wrapper(
         assert not wrapper.exists()
         return
 
-    assert cmd == [*INTERPRETER_BAT, "conda_build.wrapper.bat"]
+    assert cmd == [*INTERPRETER_BAT, "conda_build.bat.wrapper.bat"]
 
     contents = wrapper.read_text()
     contents_bytes = wrapper.read_bytes()
@@ -484,6 +484,7 @@ def test_build_command_win_arm64_wrapper(
     assert str(work_script) in contents
     # batch files must be CRLF; a bare LF breaks cmd.exe
     assert contents_bytes.count(b"\n") == contents_bytes.count(b"\r\n")
+    assert b"\r\r\n" not in contents_bytes
 
 
 @pytest.mark.skipif(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -21,6 +21,7 @@ import pytest
 from conda.common.compat import on_win
 
 from conda_build import api, build, windows
+from conda_build.build import INTERPRETER_BAT
 from conda_build.exceptions import CondaBuildUserError
 from conda_build.metadata import MetaData
 from conda_build.variants import get_default_variant
@@ -467,11 +468,11 @@ def test_build_command_win_arm64_wrapper(
     cmd = windows.build_command_arguments(testing_metadata, str(work_script))
 
     if not wrapped:
-        assert cmd == ["cmd.exe", "/d", "/c", "conda_build.bat"]
+        assert cmd == [*INTERPRETER_BAT, "conda_build.bat"]
         assert not wrapper.exists()
         return
 
-    assert cmd == ["cmd.exe", "/d", "/c", "conda_build.wrapper.bat"]
+    assert cmd == [*INTERPRETER_BAT, "conda_build.wrapper.bat"]
 
     contents = wrapper.read_text()
     contents_bytes = wrapper.read_bytes()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -517,3 +517,139 @@ def test_win_arm64_build_on_emulated_win_64(
     print(*sorted(os.listdir(testing_metadata.config.work_dir)), sep="\n")
     assert "PROCESSOR_ARCHITECTURE=ARM64" in out
     assert "ProcessArchitecture=Arm64" in out
+
+
+@pytest.mark.parametrize(
+    "script,pre_script,expected_command",
+    [
+        pytest.param("bld.bat", "", " ".join(INTERPRETER_BAT), id="bat-default"),
+        pytest.param(
+            "install.ps1",
+            "powershell -ExecutionPolicy ByPass -File",
+            "powershell -ExecutionPolicy ByPass -File",
+            id="ps1-explicit",
+        ),
+    ],
+)
+def test_wrap_script_with_machine(
+    testing_metadata: MetaData,
+    tmp_path: Path,
+    script: str,
+    pre_script: str,
+    expected_command: str,
+) -> None:
+    """The wrapper launches ``script`` through ``start /machine <build arch>``."""
+    testing_metadata.config.platform = "win"
+    testing_metadata.config.arch = "arm64"
+    testing_metadata.config.variant["target_platform"] = "win-arm64"
+
+    (source := tmp_path / script).write_text("@echo off\r\n")
+
+    wrapper = Path(
+        windows.wrap_script_with_machine(testing_metadata, source, pre_script)
+    )
+
+    # written next to the wrapped script, always a .bat regardless of the input
+    assert wrapper == tmp_path / f"{source.name}.wrapper.bat"
+
+    contents = wrapper.read_text()
+    assert 'start "" /b /wait /machine ARM64' in contents
+    assert expected_command in contents
+    assert str(source) in contents
+    # the child's exit code must reach conda-build
+    assert "exit /b %ERRORLEVEL%" in contents
+
+    if script == "bld.bat":
+        # batch files must be CRLF; a bare LF breaks cmd.exe and a stray CR
+        # (from newline translation) makes `goto`/`exit` targets unparseable
+        raw = wrapper.read_bytes()
+        assert raw.count(b"\n") == raw.count(b"\r\n")
+        assert b"\r\r\n" not in raw
+
+
+@pytest.mark.parametrize(
+    "script,build_subdir,running_subdir,wrapped",
+    [
+        pytest.param("install.bat", "win-arm64", "win-64", True, id="bat-arm64-on-64"),
+        pytest.param("install.bat", "win-64", "win-arm64", True, id="bat-64-on-arm64"),
+        pytest.param("install.ps1", "win-arm64", "win-64", True, id="ps1-arm64-on-64"),
+        pytest.param("install.bat", "win-arm64", "win-arm64", False, id="bat-native"),
+        pytest.param("install.sh", "win-arm64", "win-64", False, id="sh-never-wrapped"),
+    ],
+)
+def test_bundle_conda_win_arm64_wrapper(
+    testing_metadata: MetaData,
+    mocker: MockerFixture,
+    tmp_path: Path,
+    script: str,
+    build_subdir: str,
+    running_subdir: str,
+    wrapped: bool,
+) -> None:
+    """Output scripts are launched with the build_platform architecture.
+
+    Companion to ``test_build_command_win_arm64_wrapper``, which covers the
+    top-level build script. Here the script comes from an output definition and
+    is dispatched by ``bundle_conda``.
+    """
+    platform, arch = build_subdir.split("-")
+    testing_metadata.config.platform = platform
+    testing_metadata.config.arch = arch
+    testing_metadata.config.variant["target_platform"] = build_subdir
+
+    # the recipe (and its script) live in tmp_path
+    testing_metadata.path = str(tmp_path)
+    (tmp_path / script).write_text("@echo off\r\n")
+
+    mocker.patch.object(build, "on_win", True)
+    mocker.patch.object(windows, "_running_subdir", return_value=running_subdir)
+
+    # the interpreter is normally resolved out of BUILD_PREFIX; pin it so the
+    # assertions below do not depend on what is installed on the test machine
+    (interpreter := tmp_path / "interpreter.exe").touch()
+    mocker.patch(
+        "conda_build.os_utils.external.find_executable",
+        return_value=str(interpreter),
+    )
+
+    class _ScriptWouldHaveRun(Exception):
+        pass
+
+    check_call_env = mocker.patch(
+        "conda_build.utils.check_call_env",
+        side_effect=_ScriptWouldHaveRun,
+    )
+
+    with pytest.raises(_ScriptWouldHaveRun):
+        build.bundle_conda(
+            output={"script": script},
+            metadata=testing_metadata,
+            env={},
+            stats={},
+        )
+
+    work_dir = Path(testing_metadata.config.work_dir)
+    dest_file = work_dir / script
+    wrapper = work_dir / f"{dest_file.name}.wrapper.bat"
+    command = check_call_env.call_args.args[0]
+
+    if not wrapped:
+        assert command[0] == str(interpreter)
+        assert command[-1] == str(dest_file)
+        assert not wrapper.exists()
+        return
+
+    assert command == [*INTERPRETER_BAT, str(wrapper)]
+
+    contents = wrapper.read_text()
+    machine = "AMD64" if build_subdir == "win-64" else "ARM64"
+    assert f'start "" /b /wait /machine {machine}' in contents
+    # the real interpreter must be invoked *inside* the re-architected process
+    assert str(interpreter) in contents
+    assert str(dest_file) in contents
+    assert "exit /b %ERRORLEVEL%" in contents
+
+    raw = wrapper.read_bytes()
+    if script == "install.bat":
+        assert raw.count(b"\n") == raw.count(b"\r\n")
+        assert b"\r\r\n" not in raw

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -559,12 +559,11 @@ def test_wrap_script_with_machine(
     # the child's exit code must reach conda-build
     assert "exit /b %ERRORLEVEL%" in contents
 
-    if script == "bld.bat":
-        # batch files must be CRLF; a bare LF breaks cmd.exe and a stray CR
-        # (from newline translation) makes `goto`/`exit` targets unparseable
-        raw = wrapper.read_bytes()
-        assert raw.count(b"\n") == raw.count(b"\r\n")
-        assert b"\r\r\n" not in raw
+    # wrapper is always .bat; bare LF breaks cmd.exe and a stray CR
+    # (from newline translation) makes `goto`/`exit` targets unparseable
+    raw = wrapper.read_bytes()
+    assert raw.count(b"\n") == raw.count(b"\r\n")
+    assert b"\r\r\n" not in raw
 
 
 @pytest.mark.parametrize(
@@ -650,6 +649,5 @@ def test_bundle_conda_win_arm64_wrapper(
     assert "exit /b %ERRORLEVEL%" in contents
 
     raw = wrapper.read_bytes()
-    if script == "install.bat":
-        assert raw.count(b"\n") == raw.count(b"\r\n")
-        assert b"\r\r\n" not in raw
+    assert raw.count(b"\n") == raw.count(b"\r\n")
+    assert b"\r\r\n" not in raw

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -462,7 +462,7 @@ def test_build_command_win_arm64_wrapper(
 
     work_script = tmp_path / "conda_build.bat"
     work_script.write_text("@echo off\r\n")
-    wrapper = tmp_path / "_conda_build_wrapper.bat"
+    wrapper = tmp_path / "conda_build.wrapper.bat"
 
     cmd = windows.build_command_arguments(testing_metadata, str(work_script))
 
@@ -471,7 +471,7 @@ def test_build_command_win_arm64_wrapper(
         assert not wrapper.exists()
         return
 
-    assert cmd == ["cmd.exe", "/d", "/c", "_conda_build_wrapper.bat"]
+    assert cmd == ["cmd.exe", "/d", "/c", "conda_build.wrapper.bat"]
 
     contents = wrapper.read_text()
     contents_bytes = wrapper.read_bytes()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Follow up for #6047

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
