### PR TITLE
ci: add workflow concurrency limits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,10 @@ on:
       - .github/workflows/docs.yml
       - docs/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     if: '!github.event.repository.fork'


### PR DESCRIPTION
### Description

Cancel obsolete documentation workflow runs when a pull request or branch is updated.

Part of conda/infrastructure#706

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist - did you ...

- [x] ~~Add a file to the news directory for the next release notes?~~
- [x] ~~Add / update necessary tests?~~
- [x] ~~Add / update outdated documentation?~~