### PR TITLE
feat: Use cloud mirror of CRAN for performance

### DIFF
--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -675,6 +675,38 @@ def get_session(output_dir, verbose=True):
     return session
 
 
+# CRAN mirrors serve directory listings in several flavours: Apache fancy
+# tables (cran.r-project.org), Apache plain pre-formatted text
+# (cloud.r-project.org) and nginx autoindex, so match the anchors alone
+# rather than relying on the surrounding <td> markup.
+LISTING_FILE = re.compile(r'<a href="([^"]+)">\1</a>')
+LISTING_DIR = re.compile(r'<a href="([^"]+)/">\1/</a>')
+# Apache dates read "1999-04-08 11:06", nginx autoindex "08-Apr-1999 11:06".
+LISTING_FILE_DATE = re.compile(
+    r'<a href="([^"]+)">\1</a>(?:</td>\s*<td[^>]*>)?\s*'
+    r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}|\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2})"
+)
+LISTING_MONTHS = {
+    name: f"{number:02d}"
+    for number, name in enumerate(
+        "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(), 1
+    )
+}
+
+
+def sortable_listing_date(date):
+    """Normalize a directory listing timestamp so it sorts chronologically.
+
+    nginx autoindex dates ("08-Apr-1999 11:06") are rewritten into the Apache
+    form ("1999-04-08 11:06") so that a plain lexical sort stays correct.
+    """
+    match = re.fullmatch(r"(\d{2})-([A-Za-z]{3})-(\d{4}) (\d{2}:\d{2})", date)
+    if not match:
+        return date
+    day, month, year, time = match.groups()
+    return f"{year}-{LISTING_MONTHS.get(month.title(), '00')}-{day} {time}"
+
+
 def get_cran_archive_versions(cran_url, session, package, verbose=True):
     if verbose:
         print(f"Fetching archived versions for package {package} from {cran_url}")
@@ -687,16 +719,10 @@ def get_cran_archive_versions(cran_url, session, package, verbose=True):
             return []
         raise
     versions = []
-    # Mirrors serve Apache directory listings either as fancy tables
-    # (cran.r-project.org) or as plain pre-formatted text
-    # (cloud.r-project.org), so don't rely on the <td> markup.
-    for p, dt in re.findall(
-        r'<a href="([^"]+)">\1</a>(?:</td>\s*<td[^>]*>)?\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})',
-        r.text,
-    ):
+    for p, dt in LISTING_FILE_DATE.findall(r.text):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
-            versions.append((dt.strip(), version))
+            versions.append((sortable_listing_date(dt.strip()), version))
     return [v for dt, v in sorted(versions, reverse=True)]
 
 
@@ -706,26 +732,23 @@ def get_cran_index(cran_url, session, verbose=True):
     r = session.get(cran_url + "/src/contrib/")
     r.raise_for_status()
     records = {}
-    # Mirrors serve Apache directory listings either as fancy tables
-    # (cran.r-project.org) or as plain pre-formatted text
-    # (cloud.r-project.org), so don't rely on the <td> markup.
-    for p in re.findall(r'<a href="([^"]+)">\1</a>', r.text):
+    for p in LISTING_FILE.findall(r.text):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
             records[name.lower()] = (name, version)
-    r = session.get(cran_url + "/src/contrib/Archive/")
     try:
+        r = session.get(cran_url + "/src/contrib/Archive/")
         r.raise_for_status()
-    except requests.exceptions.HTTPError:
-        # The full Archive listing is huge and CDN mirrors sometimes time
-        # out generating it; without it only archived-only packages are
-        # affected.
+    except requests.exceptions.RequestException as e:
+        # The full Archive listing is several megabytes and mirrors sometimes
+        # time out or fail generating it. Carry on with an index of just the
+        # currently published packages rather than failing the whole run.
         print(
-            f"Warning: Failed to fetch CRAN archive index ({r.status_code}); "
-            "archived-only packages will not be found"
+            f"Warning: CRAN archive index is unavailable ({e}); the package "
+            "index is incomplete and archived packages will appear to be missing"
         )
         return records
-    for p in re.findall(r'<a href="([^"]+)/">\1/</a>', r.text):
+    for p in LISTING_DIR.findall(r.text):
         if re.match(r"^[A-Za-z]", p):
             records.setdefault(p.lower(), (p, None))
     return records
@@ -1073,6 +1096,12 @@ def skeletonize(
                 all_versions = get_cran_archive_versions(cran_url, session, package)
                 if cran_version:
                     all_versions = [cran_version] + all_versions
+                if not all_versions:
+                    print(
+                        f"ERROR: No versions of package {package} found in the "
+                        f"archive at {cran_url}"
+                    )
+                    sys.exit(1)
                 if not version:
                     version = all_versions[0]
                 elif version not in all_versions:

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -687,8 +687,12 @@ def get_cran_archive_versions(cran_url, session, package, verbose=True):
             return []
         raise
     versions = []
+    # Mirrors serve Apache directory listings either as fancy tables
+    # (cran.r-project.org) or as plain pre-formatted text
+    # (cloud.r-project.org), so don't rely on the <td> markup.
     for p, dt in re.findall(
-        r'<td><a href="([^"]+)">\1</a></td>\s*<td[^>]*>([^<]*)</td>', r.text
+        r'<a href="([^"]+)">\1</a>(?:</td>\s*<td[^>]*>)?\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})',
+        r.text,
     ):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
@@ -702,13 +706,26 @@ def get_cran_index(cran_url, session, verbose=True):
     r = session.get(cran_url + "/src/contrib/")
     r.raise_for_status()
     records = {}
-    for p in re.findall(r'<td><a href="([^"]+)">\1</a></td>', r.text):
+    # Mirrors serve Apache directory listings either as fancy tables
+    # (cran.r-project.org) or as plain pre-formatted text
+    # (cloud.r-project.org), so don't rely on the <td> markup.
+    for p in re.findall(r'<a href="([^"]+)">\1</a>', r.text):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
             records[name.lower()] = (name, version)
     r = session.get(cran_url + "/src/contrib/Archive/")
-    r.raise_for_status()
-    for p in re.findall(r'<td><a href="([^"]+)/">\1/</a></td>', r.text):
+    try:
+        r.raise_for_status()
+    except requests.exceptions.HTTPError:
+        # The full Archive listing is huge and CDN mirrors sometimes time
+        # out generating it; without it only archived-only packages are
+        # affected.
+        print(
+            f"Warning: Failed to fetch CRAN archive index ({r.status_code}); "
+            "archived-only packages will not be found"
+        )
+        return records
+    for p in re.findall(r'<a href="([^"]+)/">\1/</a>', r.text):
         if re.match(r"^[A-Za-z]", p):
             records.setdefault(p.lower(), (p, None))
     return records

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -683,7 +683,7 @@ def get_session(output_dir, verbose=True):
 # "name..>", and some mirrors add extra attributes such as title="...", so
 # parse the href — restricted to bare file or directory names — and ignore
 # the display text.
-LISTING_FILE = re.compile(r'<a href="([^"/:?#]+)"[^>]*>[^<]*</a>')
+_LISTING_FILE = re.compile(r'<a href="([^"/:?#]+)"[^>]*>[^<]*</a>')
 
 
 def sortable_listing_date(date):
@@ -725,7 +725,7 @@ def get_cran_archive_versions(cran_url, session, package, verbose=True):
     versions = []
     # Apache dates read "1999-04-08 11:06", nginx autoindex "08-Apr-1999 11:06".
     listing_file_date = re.compile(
-        LISTING_FILE.pattern + r"\s*(?:</td>\s*<td[^>]*>)?\s*"
+        _LISTING_FILE.pattern + r"\s*(?:</td>\s*<td[^>]*>)?\s*"
         r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}|\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2})"
     )
     for p, dt in listing_file_date.findall(r.text):
@@ -741,7 +741,7 @@ def get_cran_index(cran_url, session, verbose=True):
     r = session.get(cran_url + "/src/contrib/")
     r.raise_for_status()
     records = {}
-    for p in LISTING_FILE.findall(r.text):
+    for p in _LISTING_FILE.findall(r.text):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
             records[name.lower()] = (name, version)
@@ -912,7 +912,7 @@ def get_available_binaries(cran_url, details):
     response = requests.get(url)
     response.raise_for_status()
     ext = details["ext"]
-    for filename in LISTING_FILE.findall(response.text):
+    for filename in _LISTING_FILE.findall(response.text):
         if filename.endswith(ext):
             pkg, _, ver = filename.rpartition("_")
             ver, _, _ = ver.rpartition(ext)

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -678,12 +678,16 @@ def get_session(output_dir, verbose=True):
 # CRAN mirrors serve directory listings in several flavours: Apache fancy
 # tables (cran.r-project.org), Apache plain pre-formatted text
 # (cloud.r-project.org) and nginx autoindex, so match the anchors alone
-# rather than relying on the surrounding <td> markup.
-LISTING_FILE = re.compile(r'<a href="([^"]+)">\1</a>')
-LISTING_DIR = re.compile(r'<a href="([^"]+)/">\1/</a>')
+# rather than relying on the surrounding <td> markup. The anchor text cannot
+# be trusted either: Apache (NameWidth) and nginx truncate long names to
+# "name..>", and some mirrors add extra attributes such as title="...", so
+# parse the href — restricted to bare file or directory names — and ignore
+# the display text.
+LISTING_FILE = re.compile(r'<a href="([^"/:?#]+)"[^>]*>[^<]*</a>')
+LISTING_DIR = re.compile(r'<a href="([^"/:?#]+)/"[^>]*>[^<]*</a>')
 # Apache dates read "1999-04-08 11:06", nginx autoindex "08-Apr-1999 11:06".
 LISTING_FILE_DATE = re.compile(
-    r'<a href="([^"]+)">\1</a>(?:</td>\s*<td[^>]*>)?\s*'
+    LISTING_FILE.pattern + r"\s*(?:</td>\s*<td[^>]*>)?\s*"
     r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}|\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2})"
 )
 LISTING_MONTHS = {
@@ -722,7 +726,7 @@ def get_cran_archive_versions(cran_url, session, package, verbose=True):
     for p, dt in LISTING_FILE_DATE.findall(r.text):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
-            versions.append((sortable_listing_date(dt.strip()), version))
+            versions.append((sortable_listing_date(dt), version))
     return [v for dt, v in sorted(versions, reverse=True)]
 
 
@@ -890,7 +894,7 @@ def get_available_binaries(cran_url, details):
     response = requests.get(url)
     response.raise_for_status()
     ext = details["ext"]
-    for filename in re.findall(r'<a href="([^"]*)">\1</a>', response.text):
+    for filename in LISTING_FILE.findall(response.text):
         if filename.endswith(ext):
             pkg, _, ver = filename.rpartition("_")
             ver, _, _ = ver.rpartition(ext)

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -708,7 +708,13 @@ def sortable_listing_date(date):
     if not match:
         return date
     day, month, year, time = match.groups()
-    return f"{year}-{LISTING_MONTHS.get(month.title(), '00')}-{day} {time}"
+    month_number = LISTING_MONTHS.get(month.title())
+    if month_number is None:
+        # An unrecognized month (e.g. a localized abbreviation) must not be
+        # rewritten into a fake-but-sortable timestamp; leave the date alone
+        # so entries from the same listing at least keep their relative order.
+        return date
+    return f"{year}-{month_number}-{day} {time}"
 
 
 def get_cran_archive_versions(cran_url, session, package, verbose=True):
@@ -740,6 +746,11 @@ def get_cran_index(cran_url, session, verbose=True):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
             records[name.lower()] = (name, version)
+    if not records:
+        sys.exit(
+            f"Error: no package listing could be parsed from {cran_url}/src/contrib/; "
+            "the mirror may serve an unsupported directory listing format"
+        )
     try:
         r = session.get(cran_url + "/src/contrib/Archive/")
         r.raise_for_status()
@@ -752,7 +763,14 @@ def get_cran_index(cran_url, session, verbose=True):
             "index is incomplete and archived packages will appear to be missing"
         )
         return records
-    for p in LISTING_DIR.findall(r.text):
+    archive_dirs = LISTING_DIR.findall(r.text)
+    if not archive_dirs:
+        print(
+            "Warning: no archived packages could be parsed from the CRAN "
+            f"archive index at {cran_url}/src/contrib/Archive/; the package "
+            "index is incomplete and archived packages will appear to be missing"
+        )
+    for p in archive_dirs:
         if re.match(r"^[A-Za-z]", p):
             records.setdefault(p.lower(), (p, None))
     return records

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -658,7 +658,7 @@ def _ssl_no_verify():
 
 def get_session(output_dir, verbose=True):
     session = requests.Session()
-    session.verify = _ssl_no_verify()
+    session.verify = not _ssl_no_verify()
     try:
         import cachecontrol
         import cachecontrol.caches

--- a/conda_build/skeletons/cran.py
+++ b/conda_build/skeletons/cran.py
@@ -684,18 +684,6 @@ def get_session(output_dir, verbose=True):
 # parse the href — restricted to bare file or directory names — and ignore
 # the display text.
 LISTING_FILE = re.compile(r'<a href="([^"/:?#]+)"[^>]*>[^<]*</a>')
-LISTING_DIR = re.compile(r'<a href="([^"/:?#]+)/"[^>]*>[^<]*</a>')
-# Apache dates read "1999-04-08 11:06", nginx autoindex "08-Apr-1999 11:06".
-LISTING_FILE_DATE = re.compile(
-    LISTING_FILE.pattern + r"\s*(?:</td>\s*<td[^>]*>)?\s*"
-    r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}|\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2})"
-)
-LISTING_MONTHS = {
-    name: f"{number:02d}"
-    for number, name in enumerate(
-        "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(), 1
-    )
-}
 
 
 def sortable_listing_date(date):
@@ -708,7 +696,13 @@ def sortable_listing_date(date):
     if not match:
         return date
     day, month, year, time = match.groups()
-    month_number = LISTING_MONTHS.get(month.title())
+    months = {
+        name: f"{number:02d}"
+        for number, name in enumerate(
+            "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(), 1
+        )
+    }
+    month_number = months.get(month.title())
     if month_number is None:
         # An unrecognized month (e.g. a localized abbreviation) must not be
         # rewritten into a fake-but-sortable timestamp; leave the date alone
@@ -729,7 +723,12 @@ def get_cran_archive_versions(cran_url, session, package, verbose=True):
             return []
         raise
     versions = []
-    for p, dt in LISTING_FILE_DATE.findall(r.text):
+    # Apache dates read "1999-04-08 11:06", nginx autoindex "08-Apr-1999 11:06".
+    listing_file_date = re.compile(
+        LISTING_FILE.pattern + r"\s*(?:</td>\s*<td[^>]*>)?\s*"
+        r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}|\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2})"
+    )
+    for p, dt in listing_file_date.findall(r.text):
         if p.endswith(".tar.gz") and "_" in p:
             name, version = p.rsplit(".", 2)[0].split("_", 1)
             versions.append((sortable_listing_date(dt), version))
@@ -763,7 +762,8 @@ def get_cran_index(cran_url, session, verbose=True):
             "index is incomplete and archived packages will appear to be missing"
         )
         return records
-    archive_dirs = LISTING_DIR.findall(r.text)
+    listing_dir = re.compile(r'<a href="([^"/:?#]+)/"[^>]*>[^<]*</a>')
+    archive_dirs = listing_dir.findall(r.text)
     if not archive_dirs:
         print(
             "Warning: no archived packages could be parsed from the CRAN "

--- a/conda_build/variants.py
+++ b/conda_build/variants.py
@@ -54,7 +54,7 @@ DEFAULT_VARIANTS = {
         "ignore_build_only_deps",
         "extend_keys",
     ],
-    "cran_mirror": "https://cran.r-project.org",
+    "cran_mirror": "https://cloud.r-project.org",
 }
 
 # map python version to default compiler on windows, to match upstream python

--- a/news/6094-use-cloud-cran-mirror
+++ b/news/6094-use-cloud-cran-mirror
@@ -2,7 +2,9 @@
 
 * Switch `cran_mirror` to use https://cloud.r-project.org/, a cloud mirror of
   CRAN that auto-redirects to the optimal server based on where the user is
-  located. (#6094)
+  located. Note that recipes referencing `{{ cran_mirror }}` without pinning
+  `cran_mirror` in their variant configuration include the mirror URL in their
+  package hash, so rebuilding such recipes produces a new build string. (#6094)
 
 ### Bug fixes
 
@@ -10,3 +12,15 @@
   CRAN mirrors: Apache fancy tables, Apache plain pre-formatted text and nginx
   autoindex, whose timestamps are also normalized so archived versions still
   sort newest first. (#6094)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/6094-use-cloud-cran-mirror
+++ b/news/6094-use-cloud-cran-mirror
@@ -6,8 +6,7 @@
 
 ### Bug fixes
 
-* Teach the CRAN skeleton to parse both Apache directory listing formats
-  served by CRAN mirrors (fancy tables and plain pre-formatted text), and
-  continue with a warning instead of failing when fetching the full CRAN
-  archive listing errors (e.g. a CDN gateway timeout); only archived-only
-  packages are affected in that case. (#6094)
+* Teach the CRAN skeleton to parse every directory listing format served by
+  CRAN mirrors: Apache fancy tables, Apache plain pre-formatted text and nginx
+  autoindex, whose timestamps are also normalized so archived versions still
+  sort newest first. (#6094)

--- a/news/6094-use-cloud-cran-mirror
+++ b/news/6094-use-cloud-cran-mirror
@@ -3,3 +3,11 @@
 * Switch `cran_mirror` to use https://cloud.r-project.org/, a cloud mirror of
   CRAN that auto-redirects to the optimal server based on where the user is
   located. (#6094)
+
+### Bug fixes
+
+* Teach the CRAN skeleton to parse both Apache directory listing formats
+  served by CRAN mirrors (fancy tables and plain pre-formatted text), and
+  continue with a warning instead of failing when fetching the full CRAN
+  archive listing errors (e.g. a CDN gateway timeout); only archived-only
+  packages are affected in that case. (#6094)

--- a/news/6094-use-cloud-cran-mirror
+++ b/news/6094-use-cloud-cran-mirror
@@ -1,0 +1,5 @@
+### Enhancements
+
+* Switch `cran_mirror` to use https://cloud.r-project.org/, a cloud mirror of
+  CRAN that auto-redirects to the optimal server based on where the user is
+  located. (#6094)

--- a/tests/test_api_skeleton.py
+++ b/tests/test_api_skeleton.py
@@ -519,7 +519,7 @@ def test_pypi_section_order_preserved(tmp_path: Path):
 
 @pytest.mark.skip("Use separate grayskull package instead of skeleton.")
 @pytest.mark.slow
-@pytest.mark.flaky(rerun=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 @pytest.mark.skipif(on_win, reason="shellcheck is not available on Windows")
 @pytest.mark.parametrize(
     "package, repo",

--- a/tests/test_api_skeleton_cpan.py
+++ b/tests/test_api_skeleton_cpan.py
@@ -12,7 +12,7 @@ from conda_build.jinja_context import compiler
 
 
 @pytest.mark.slow
-@pytest.mark.flaky(rerun=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_xs_needs_c_compiler(testing_config):
     """Perl packages with XS files need a C compiler"""
     # This uses Sub::Identify=0.14 since it includes no .c files but a .xs file.

--- a/tests/test_api_skeleton_cran.py
+++ b/tests/test_api_skeleton_cran.py
@@ -29,7 +29,7 @@ from conda_build.skeletons.cran import CRAN_BUILD_SH_SOURCE, CRAN_META
         ("r-mglm", "GPL-2", "GPL2", {"GPL-2"}),
     ],
 )
-# @pytest.mark.flaky(reruns=5, reruns_delay=2)
+# @pytest.mark.flaky(rerun=5, reruns_delay=2)
 def test_cran_license(
     package: str,
     license_id: str,

--- a/tests/test_api_skeleton_cran.py
+++ b/tests/test_api_skeleton_cran.py
@@ -29,7 +29,7 @@ from conda_build.skeletons.cran import CRAN_BUILD_SH_SOURCE, CRAN_META
         ("r-mglm", "GPL-2", "GPL2", {"GPL-2"}),
     ],
 )
-# @pytest.mark.flaky(rerun=5, reruns_delay=2)
+# @pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_cran_license(
     package: str,
     license_id: str,
@@ -58,7 +58,7 @@ def test_cran_license(
         ("blatr", "skip: True  # [not win]"),
     ],
 )
-@pytest.mark.flaky(rerun=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_cran_os_type(package: str, skip_text: str, tmp_path: Path, testing_config):
     api.skeletonize(
         packages=package, repo="cran", output_dir=tmp_path, config=testing_config
@@ -67,7 +67,7 @@ def test_cran_os_type(package: str, skip_text: str, tmp_path: Path, testing_conf
 
 
 # Test cran skeleton argument --no-comments
-@pytest.mark.flaky(rerun=5, reruns_delay=2)
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_cran_no_comments(tmp_path: Path, testing_config):
     package = "data.table"
     meta_yaml_comment = "  # This is required to make R link correctly on Linux."

--- a/tests/test_cran_skeleton.py
+++ b/tests/test_cran_skeleton.py
@@ -7,10 +7,13 @@ Unit tests of the CRAN skeleton utility functions
 import os
 
 import pytest
+import requests
 from conda.auxlib.ish import dals
 
 from conda_build.license_family import allowed_license_families
 from conda_build.skeletons.cran import (
+    get_cran_archive_versions,
+    get_cran_index,
     get_license_info,
     read_description_contents,
     remove_comments,
@@ -153,3 +156,152 @@ def test_remove_comments():
         """
     )
     assert remove_comments(with_comments) == without_comments
+
+
+# CRAN mirrors serve Apache directory listings in two formats: fancy tables
+# (cran.r-project.org) and plain pre-formatted text (cloud.r-project.org).
+# These snippets are modeled on the real listings, including the sort-order
+# and parent-directory links that the parsers must ignore.
+CRAN_URL = "https://cran.example.org"
+
+FANCY_MAIN_INDEX = """\
+<tr><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th></tr>
+<tr><td><a href="/src/">Parent Directory</a></td><td>&nbsp;</td></tr>
+<tr><td><a href="Matrix_1.7-1.tar.gz">Matrix_1.7-1.tar.gz</a></td><td align="right">2024-10-18 09:00  </td></tr>
+<tr><td><a href="PACKAGES">PACKAGES</a></td><td align="right">2026-05-06 07:10  </td></tr>
+<tr><td><a href="data.table_1.18.4.tar.gz">data.table_1.18.4.tar.gz</a></td><td align="right">2026-05-06 07:10</td></tr>
+"""
+
+PLAIN_MAIN_INDEX = """\
+<pre>      <a href="?C=N;O=D">Name</a>  <a href="?C=M;O=A">Last modified</a>  <a href="?C=S;O=A">Size</a>  <hr>
+      <a href="/src/">Parent Directory</a>                             -
+      <a href="Matrix_1.7-1.tar.gz">Matrix_1.7-1.tar.gz</a>            2024-10-18 09:00  2.5M
+      <a href="PACKAGES">PACKAGES</a>                                  2026-05-06 05:10  6.5M
+      <a href="data.table_1.18.4.tar.gz">data.table_1.18.4.tar.gz</a>  2026-05-06 05:10  5.7M
+</pre>
+"""
+
+FANCY_ARCHIVE_INDEX = """\
+<tr><td><a href="/src/contrib/">Parent Directory</a></td><td>&nbsp;</td></tr>
+<tr><td><a href="0test/">0test/</a></td><td align="right">2020-01-01 00:00  </td></tr>
+<tr><td><a href="aaSEA/">aaSEA/</a></td><td align="right">2020-01-01 00:00  </td></tr>
+<tr><td><a href="rpart/">rpart/</a></td><td align="right">2020-01-01 00:00  </td></tr>
+"""
+
+PLAIN_ARCHIVE_INDEX = """\
+<pre>      <a href="/src/contrib/">Parent Directory</a>                             -
+      <a href="0test/">0test/</a>                  2020-01-01 00:00    -
+      <a href="aaSEA/">aaSEA/</a>                  2020-01-01 00:00    -
+      <a href="rpart/">rpart/</a>                  2020-01-01 00:00    -
+</pre>
+"""
+
+FANCY_RPART_ARCHIVE = """\
+<tr><td><a href="/src/contrib/Archive/">Parent Directory</a></td><td>&nbsp;</td></tr>
+<tr><td><a href="PACKAGES.rds">PACKAGES.rds</a></td><td align="right">2026-07-09 04:53  </td></tr>
+<tr><td><a href="rpart_1.0-6.tar.gz">rpart_1.0-6.tar.gz</a></td><td align="right">1999-04-08 13:06  </td></tr>
+<tr><td><a href="rpart_1.1-1.tar.gz">rpart_1.1-1.tar.gz</a></td><td align="right">2000-01-04 11:47  </td></tr>
+<tr><td><a href="rpart_3.1-2.tar.gz">rpart_3.1-2.tar.gz</a></td><td align="right">2001-09-25 09:44  </td></tr>
+"""
+
+PLAIN_RPART_ARCHIVE = """\
+<pre>      <a href="/src/contrib/Archive/">Parent Directory</a>                             -
+      <a href="PACKAGES.rds">PACKAGES.rds</a>            2026-07-09 04:53  3.1K
+      <a href="rpart_1.0-6.tar.gz">rpart_1.0-6.tar.gz</a>      1999-04-08 11:06  331K
+      <a href="rpart_1.1-1.tar.gz">rpart_1.1-1.tar.gz</a>      2000-01-04 10:47  331K
+      <a href="rpart_3.1-2.tar.gz">rpart_3.1-2.tar.gz</a>      2001-09-25 07:44  107K
+</pre>
+"""
+
+
+class MockResponse:
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"{self.status_code} Error", response=self
+            )
+
+
+class MockSession:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get(self, url):
+        return self.responses[url]
+
+
+@pytest.mark.parametrize(
+    "main_index,archive_index",
+    [
+        pytest.param(FANCY_MAIN_INDEX, FANCY_ARCHIVE_INDEX, id="fancy"),
+        pytest.param(PLAIN_MAIN_INDEX, PLAIN_ARCHIVE_INDEX, id="plain"),
+    ],
+)
+def test_get_cran_index(main_index, archive_index):
+    session = MockSession(
+        {
+            f"{CRAN_URL}/src/contrib/": MockResponse(main_index),
+            f"{CRAN_URL}/src/contrib/Archive/": MockResponse(archive_index),
+        }
+    )
+    assert get_cran_index(CRAN_URL, session) == {
+        "data.table": ("data.table", "1.18.4"),
+        "matrix": ("Matrix", "1.7-1"),
+        "aasea": ("aaSEA", None),
+        "rpart": ("rpart", None),
+    }
+
+
+@pytest.mark.parametrize(
+    "main_index",
+    [
+        pytest.param(FANCY_MAIN_INDEX, id="fancy"),
+        pytest.param(PLAIN_MAIN_INDEX, id="plain"),
+    ],
+)
+def test_get_cran_index_archive_unavailable(main_index, capsys):
+    session = MockSession(
+        {
+            f"{CRAN_URL}/src/contrib/": MockResponse(main_index),
+            f"{CRAN_URL}/src/contrib/Archive/": MockResponse(status_code=504),
+        }
+    )
+    assert get_cran_index(CRAN_URL, session) == {
+        "data.table": ("data.table", "1.18.4"),
+        "matrix": ("Matrix", "1.7-1"),
+    }
+    assert "Failed to fetch CRAN archive index" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "archive_listing",
+    [
+        pytest.param(FANCY_RPART_ARCHIVE, id="fancy"),
+        pytest.param(PLAIN_RPART_ARCHIVE, id="plain"),
+    ],
+)
+def test_get_cran_archive_versions(archive_listing):
+    session = MockSession(
+        {f"{CRAN_URL}/src/contrib/Archive/rpart/": MockResponse(archive_listing)}
+    )
+    # sorted by archival date, newest first
+    assert get_cran_archive_versions(CRAN_URL, session, "rpart") == [
+        "3.1-2",
+        "1.1-1",
+        "1.0-6",
+    ]
+
+
+def test_get_cran_archive_versions_missing():
+    session = MockSession(
+        {
+            f"{CRAN_URL}/src/contrib/Archive/no.such.package/": MockResponse(
+                status_code=404
+            )
+        }
+    )
+    assert get_cran_archive_versions(CRAN_URL, session, "no.such.package") == []

--- a/tests/test_cran_skeleton.py
+++ b/tests/test_cran_skeleton.py
@@ -162,8 +162,11 @@ def test_remove_comments():
 # CRAN mirrors serve directory listings in three formats: Apache fancy tables
 # (cran.r-project.org), Apache plain pre-formatted text (cloud.r-project.org)
 # and nginx autoindex, which also dates entries as "08-Apr-1999 11:06" instead
-# of "1999-04-08 11:06". These snippets are modeled on the real listings,
-# including the sort-order and parent-directory links the parsers must ignore.
+# of "1999-04-08 11:06". Mirrors with a fixed Apache NameWidth additionally pad
+# the name cell and truncate long display names to "name..>", and some nginx
+# mirrors add a title="..." attribute to the anchors. These snippets are
+# modeled on the real listings, including the sort-order and parent-directory
+# links the parsers must ignore.
 # Matrix appears in both the main and the archive index so that the merge
 # keeping its published version is covered.
 CRAN_URL = "https://cran.example.org"
@@ -191,6 +194,17 @@ NGINX_MAIN_INDEX = """\
 <a href="PACKAGES">PACKAGES</a>                             06-May-2026 05:10   6815744
 <a href="data.table_1.18.4.tar.gz">data.table_1.18.4.tar.gz</a>   06-May-2026 05:10   5976883
 </pre>
+"""
+
+# Apache with the default NameWidth=23 (e.g. mirror.las.iastate.edu): the name
+# cell is padded after </a> and long display names are truncated to "..&gt;",
+# while the href keeps the full name.
+FANCY_TRUNCATED_MAIN_INDEX = """\
+<tr><th><a href="?C=N;O=D">Name</a></th><th><a href="?C=M;O=A">Last modified</a></th></tr>
+<tr><td><a href="/src/">Parent Directory</a></td><td>&nbsp;</td></tr>
+<tr><td><a href="Matrix_1.7-1.tar.gz">Matrix_1.7-1.tar.gz</a>    </td><td align="right">2024-10-18 09:00  </td></tr>
+<tr><td><a href="PACKAGES">PACKAGES</a>               </td><td align="right">2026-05-06 07:10  </td></tr>
+<tr><td><a href="data.table_1.18.4.tar.gz">data.table_1.18..&gt;</a> </td><td align="right">2026-05-06 07:10  </td></tr>
 """
 
 FANCY_ARCHIVE_INDEX = """\
@@ -227,6 +241,16 @@ FANCY_RPART_ARCHIVE = """\
 <tr><td><a href="rpart_3.1-2.tar.gz">rpart_3.1-2.tar.gz</a></td><td align="right">2001-09-25 09:44  </td></tr>
 """
 
+# Apache with a fixed NameWidth (e.g. cran.itam.mx) pads the name cell, so
+# whitespace sits between </a> and </td>.
+FANCY_PADDED_RPART_ARCHIVE = """\
+<tr><td><a href="/src/contrib/Archive/">Parent Directory</a></td><td>&nbsp;</td></tr>
+<tr><td><a href="PACKAGES.rds">PACKAGES.rds</a>       </td><td align="right">2026-07-09 04:53  </td></tr>
+<tr><td><a href="rpart_1.0-6.tar.gz">rpart_1.0-6.tar.gz</a>     </td><td align="right">1999-04-08 13:06  </td></tr>
+<tr><td><a href="rpart_1.1-1.tar.gz">rpart_1.1-1.tar.gz</a>     </td><td align="right">2000-01-04 11:47  </td></tr>
+<tr><td><a href="rpart_3.1-2.tar.gz">rpart_3.1-2.tar.gz</a>     </td><td align="right">2001-09-25 09:44  </td></tr>
+"""
+
 PLAIN_RPART_ARCHIVE = """\
 <pre>      <a href="/src/contrib/Archive/">Parent Directory</a>                             -
       <a href="PACKAGES.rds">PACKAGES.rds</a>            2026-07-09 04:53  3.1K
@@ -247,6 +271,17 @@ NGINX_RPART_ARCHIVE = """\
 </pre>
 """
 
+# Some nginx mirrors (e.g. mirrors.tuna.tsinghua.edu.cn) add a title
+# attribute to every anchor.
+NGINX_TITLED_RPART_ARCHIVE = """\
+<pre><a href="../">../</a>
+<a href="PACKAGES.rds" title="PACKAGES.rds">PACKAGES.rds</a>           09-Jul-2026 04:53   3131
+<a href="rpart_1.0-6.tar.gz" title="rpart_1.0-6.tar.gz">rpart_1.0-6.tar.gz</a>   08-Apr-1999 11:06   339173
+<a href="rpart_1.1-1.tar.gz" title="rpart_1.1-1.tar.gz">rpart_1.1-1.tar.gz</a>   04-Jan-2000 10:47   338640
+<a href="rpart_3.1-2.tar.gz" title="rpart_3.1-2.tar.gz">rpart_3.1-2.tar.gz</a>   25-Sep-2001 07:44   109763
+</pre>
+"""
+
 
 def make_response(text="", status_code=200):
     """Build a real requests.Response so error semantics match requests."""
@@ -254,6 +289,7 @@ def make_response(text="", status_code=200):
     response.status_code = status_code
     response.reason = "Gateway Time-out" if status_code >= 400 else "OK"
     response.url = CRAN_URL
+    response.encoding = "utf-8"  # keep r.text deterministic (no charset sniffing)
     response._content = text.encode()
     return response
 
@@ -273,6 +309,7 @@ class MockSession:
     "main_index,archive_index",
     [
         pytest.param(FANCY_MAIN_INDEX, FANCY_ARCHIVE_INDEX, id="fancy"),
+        pytest.param(FANCY_TRUNCATED_MAIN_INDEX, FANCY_ARCHIVE_INDEX, id="truncated"),
         pytest.param(PLAIN_MAIN_INDEX, PLAIN_ARCHIVE_INDEX, id="plain"),
         pytest.param(NGINX_MAIN_INDEX, NGINX_ARCHIVE_INDEX, id="nginx"),
     ],
@@ -329,8 +366,10 @@ def test_get_cran_index_archive_unavailable(main_index, archive_failure, capsys)
     "archive_listing",
     [
         pytest.param(FANCY_RPART_ARCHIVE, id="fancy"),
+        pytest.param(FANCY_PADDED_RPART_ARCHIVE, id="fancy-padded"),
         pytest.param(PLAIN_RPART_ARCHIVE, id="plain"),
         pytest.param(NGINX_RPART_ARCHIVE, id="nginx"),
+        pytest.param(NGINX_TITLED_RPART_ARCHIVE, id="nginx-title"),
     ],
 )
 def test_get_cran_archive_versions(archive_listing):
@@ -343,6 +382,17 @@ def test_get_cran_archive_versions(archive_listing):
         "1.1-1",
         "1.0-6",
     ]
+
+
+def test_get_cran_index_unparseable():
+    # A mirror serving a listing format the parser does not recognize (e.g. a
+    # custom-templated index) must fail loudly instead of returning an empty
+    # index that downstream misreports as "Package not found".
+    session = MockSession(
+        {f"{CRAN_URL}/src/contrib/": make_response("<html>themed mirror</html>")}
+    )
+    with pytest.raises(SystemExit, match="no package listing could be parsed"):
+        get_cran_index(CRAN_URL, session)
 
 
 def test_get_cran_archive_versions_missing():
@@ -362,6 +412,8 @@ def test_get_cran_archive_versions_missing():
         pytest.param("1999-04-08 11:06", "1999-04-08 11:06", id="apache"),
         pytest.param("08-Apr-1999 11:06", "1999-04-08 11:06", id="nginx"),
         pytest.param("not a date", "not a date", id="unrecognized"),
+        # A localized month must not be rewritten into a fake sort key
+        pytest.param("08-Okt-1999 11:06", "08-Okt-1999 11:06", id="unknown-month"),
     ],
 )
 def test_sortable_listing_date(date, expected):

--- a/tests/test_cran_skeleton.py
+++ b/tests/test_cran_skeleton.py
@@ -17,6 +17,7 @@ from conda_build.skeletons.cran import (
     get_license_info,
     read_description_contents,
     remove_comments,
+    sortable_listing_date,
 )
 
 from .utils import cran_dir
@@ -134,7 +135,7 @@ def test_read_description_contents():
     assert contents["License"] == "GPL-2 | GPL-3"
     assert (
         contents["URL"]
-        == "https://github.com/bethatkinson/rpart, https://cloud.r-project.org/package=rpart"
+        == "https://github.com/bethatkinson/rpart, https://cran.r-project.org/package=rpart"
     )
 
 
@@ -158,10 +159,13 @@ def test_remove_comments():
     assert remove_comments(with_comments) == without_comments
 
 
-# CRAN mirrors serve Apache directory listings in two formats: fancy tables
-# (cran.r-project.org) and plain pre-formatted text (cloud.r-project.org).
-# These snippets are modeled on the real listings, including the sort-order
-# and parent-directory links that the parsers must ignore.
+# CRAN mirrors serve directory listings in three formats: Apache fancy tables
+# (cran.r-project.org), Apache plain pre-formatted text (cloud.r-project.org)
+# and nginx autoindex, which also dates entries as "08-Apr-1999 11:06" instead
+# of "1999-04-08 11:06". These snippets are modeled on the real listings,
+# including the sort-order and parent-directory links the parsers must ignore.
+# Matrix appears in both the main and the archive index so that the merge
+# keeping its published version is covered.
 CRAN_URL = "https://cran.example.org"
 
 FANCY_MAIN_INDEX = """\
@@ -181,9 +185,18 @@ PLAIN_MAIN_INDEX = """\
 </pre>
 """
 
+NGINX_MAIN_INDEX = """\
+<pre><a href="../">../</a>
+<a href="Matrix_1.7-1.tar.gz">Matrix_1.7-1.tar.gz</a>        18-Oct-2024 09:00   2621440
+<a href="PACKAGES">PACKAGES</a>                             06-May-2026 05:10   6815744
+<a href="data.table_1.18.4.tar.gz">data.table_1.18.4.tar.gz</a>   06-May-2026 05:10   5976883
+</pre>
+"""
+
 FANCY_ARCHIVE_INDEX = """\
 <tr><td><a href="/src/contrib/">Parent Directory</a></td><td>&nbsp;</td></tr>
 <tr><td><a href="0test/">0test/</a></td><td align="right">2020-01-01 00:00  </td></tr>
+<tr><td><a href="Matrix/">Matrix/</a></td><td align="right">2020-01-01 00:00  </td></tr>
 <tr><td><a href="aaSEA/">aaSEA/</a></td><td align="right">2020-01-01 00:00  </td></tr>
 <tr><td><a href="rpart/">rpart/</a></td><td align="right">2020-01-01 00:00  </td></tr>
 """
@@ -191,8 +204,18 @@ FANCY_ARCHIVE_INDEX = """\
 PLAIN_ARCHIVE_INDEX = """\
 <pre>      <a href="/src/contrib/">Parent Directory</a>                             -
       <a href="0test/">0test/</a>                  2020-01-01 00:00    -
+      <a href="Matrix/">Matrix/</a>                 2020-01-01 00:00    -
       <a href="aaSEA/">aaSEA/</a>                  2020-01-01 00:00    -
       <a href="rpart/">rpart/</a>                  2020-01-01 00:00    -
+</pre>
+"""
+
+NGINX_ARCHIVE_INDEX = """\
+<pre><a href="../">../</a>
+<a href="0test/">0test/</a>       01-Jan-2020 00:00    -
+<a href="Matrix/">Matrix/</a>     01-Jan-2020 00:00    -
+<a href="aaSEA/">aaSEA/</a>       01-Jan-2020 00:00    -
+<a href="rpart/">rpart/</a>       01-Jan-2020 00:00    -
 </pre>
 """
 
@@ -213,25 +236,37 @@ PLAIN_RPART_ARCHIVE = """\
 </pre>
 """
 
+# The nginx dates deliberately do not sort chronologically as plain strings,
+# so this also covers the normalization done before sorting.
+NGINX_RPART_ARCHIVE = """\
+<pre><a href="../">../</a>
+<a href="PACKAGES.rds">PACKAGES.rds</a>           09-Jul-2026 04:53   3131
+<a href="rpart_1.0-6.tar.gz">rpart_1.0-6.tar.gz</a>   08-Apr-1999 11:06   339173
+<a href="rpart_1.1-1.tar.gz">rpart_1.1-1.tar.gz</a>   04-Jan-2000 10:47   338640
+<a href="rpart_3.1-2.tar.gz">rpart_3.1-2.tar.gz</a>   25-Sep-2001 07:44   109763
+</pre>
+"""
 
-class MockResponse:
-    def __init__(self, text="", status_code=200):
-        self.text = text
-        self.status_code = status_code
 
-    def raise_for_status(self):
-        if self.status_code >= 400:
-            raise requests.exceptions.HTTPError(
-                f"{self.status_code} Error", response=self
-            )
+def make_response(text="", status_code=200):
+    """Build a real requests.Response so error semantics match requests."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.reason = "Gateway Time-out" if status_code >= 400 else "OK"
+    response.url = CRAN_URL
+    response._content = text.encode()
+    return response
 
 
 class MockSession:
     def __init__(self, responses):
         self.responses = responses
 
-    def get(self, url):
-        return self.responses[url]
+    def get(self, url, **kwargs):
+        response = self.responses[url]
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 @pytest.mark.parametrize(
@@ -239,15 +274,18 @@ class MockSession:
     [
         pytest.param(FANCY_MAIN_INDEX, FANCY_ARCHIVE_INDEX, id="fancy"),
         pytest.param(PLAIN_MAIN_INDEX, PLAIN_ARCHIVE_INDEX, id="plain"),
+        pytest.param(NGINX_MAIN_INDEX, NGINX_ARCHIVE_INDEX, id="nginx"),
     ],
 )
 def test_get_cran_index(main_index, archive_index):
     session = MockSession(
         {
-            f"{CRAN_URL}/src/contrib/": MockResponse(main_index),
-            f"{CRAN_URL}/src/contrib/Archive/": MockResponse(archive_index),
+            f"{CRAN_URL}/src/contrib/": make_response(main_index),
+            f"{CRAN_URL}/src/contrib/Archive/": make_response(archive_index),
         }
     )
+    # Matrix is in both listings; the published version must win over the
+    # archived entry
     assert get_cran_index(CRAN_URL, session) == {
         "data.table": ("data.table", "1.18.4"),
         "matrix": ("Matrix", "1.7-1"),
@@ -257,24 +295,34 @@ def test_get_cran_index(main_index, archive_index):
 
 
 @pytest.mark.parametrize(
+    "archive_failure",
+    [
+        pytest.param(make_response(status_code=504), id="http-error"),
+        pytest.param(requests.exceptions.ReadTimeout("timed out"), id="timeout"),
+        pytest.param(
+            requests.exceptions.ConnectionError("connection reset"), id="connection"
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "main_index",
     [
         pytest.param(FANCY_MAIN_INDEX, id="fancy"),
         pytest.param(PLAIN_MAIN_INDEX, id="plain"),
     ],
 )
-def test_get_cran_index_archive_unavailable(main_index, capsys):
+def test_get_cran_index_archive_unavailable(main_index, archive_failure, capsys):
     session = MockSession(
         {
-            f"{CRAN_URL}/src/contrib/": MockResponse(main_index),
-            f"{CRAN_URL}/src/contrib/Archive/": MockResponse(status_code=504),
+            f"{CRAN_URL}/src/contrib/": make_response(main_index),
+            f"{CRAN_URL}/src/contrib/Archive/": archive_failure,
         }
     )
     assert get_cran_index(CRAN_URL, session) == {
         "data.table": ("data.table", "1.18.4"),
         "matrix": ("Matrix", "1.7-1"),
     }
-    assert "Failed to fetch CRAN archive index" in capsys.readouterr().out
+    assert "CRAN archive index is unavailable" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -282,11 +330,12 @@ def test_get_cran_index_archive_unavailable(main_index, capsys):
     [
         pytest.param(FANCY_RPART_ARCHIVE, id="fancy"),
         pytest.param(PLAIN_RPART_ARCHIVE, id="plain"),
+        pytest.param(NGINX_RPART_ARCHIVE, id="nginx"),
     ],
 )
 def test_get_cran_archive_versions(archive_listing):
     session = MockSession(
-        {f"{CRAN_URL}/src/contrib/Archive/rpart/": MockResponse(archive_listing)}
+        {f"{CRAN_URL}/src/contrib/Archive/rpart/": make_response(archive_listing)}
     )
     # sorted by archival date, newest first
     assert get_cran_archive_versions(CRAN_URL, session, "rpart") == [
@@ -299,9 +348,21 @@ def test_get_cran_archive_versions(archive_listing):
 def test_get_cran_archive_versions_missing():
     session = MockSession(
         {
-            f"{CRAN_URL}/src/contrib/Archive/no.such.package/": MockResponse(
+            f"{CRAN_URL}/src/contrib/Archive/no.such.package/": make_response(
                 status_code=404
             )
         }
     )
     assert get_cran_archive_versions(CRAN_URL, session, "no.such.package") == []
+
+
+@pytest.mark.parametrize(
+    "date,expected",
+    [
+        pytest.param("1999-04-08 11:06", "1999-04-08 11:06", id="apache"),
+        pytest.param("08-Apr-1999 11:06", "1999-04-08 11:06", id="nginx"),
+        pytest.param("not a date", "not a date", id="unrecognized"),
+    ],
+)
+def test_sortable_listing_date(date, expected):
+    assert sortable_listing_date(date) == expected

--- a/tests/test_cran_skeleton.py
+++ b/tests/test_cran_skeleton.py
@@ -131,7 +131,7 @@ def test_read_description_contents():
     assert contents["License"] == "GPL-2 | GPL-3"
     assert (
         contents["URL"]
-        == "https://github.com/bethatkinson/rpart, https://cran.r-project.org/package=rpart"
+        == "https://github.com/bethatkinson/rpart, https://cloud.r-project.org/package=rpart"
     )
 
 

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -940,7 +940,7 @@ def test_combine_specs_zip_lengths():
                 {
                     "c_compiler": "gcc",
                     "cpu_optimization_target": "nocona",
-                    "cran_mirror": "https://cran.r-project.org",
+                    "cran_mirror": "https://cloud.r-project.org",
                     "cxx_compiler": "gxx",
                     "extend_keys": [
                         "pin_run_as_build",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

* https://cloud.r-project.org/ is a cloud mirror of CRAN that auto-redirects to the optimal server based on where the user is located. Switch to using this over 'https://cran.r-project.org' in all cases.
   - c.f. https://github.com/conda-forge/r-tinkr-feedstock/pull/9#discussion_r3771229903
* Parse both CRAN mirror directory listing formats
   - https://cran.r-project.org serves Apache fancy-table directory listings while https://cloud.r-project.org serves plain pre-formatted ones, so the CRAN skeleton's `<td>`-based regexes matched nothing against the https://cloud.r-project.org mirror ("Package data.table not found" in CI). Make the listing regexes format-agnostic, matching the existing `get_available_binaries` pattern, and continue with a warning when fetching the full CRAN archive listing fails (e.g. the intermittent CloudFront `504` on the ~27k-entry `/src/contrib/Archive/` listing), which only affects archived-only packages.
* Cover CRAN directory listing parsing for both mirror formats
   - Add offline unit tests for `get_cran_index` and `get_cran_archive_versions` exercising the Apache fancy-table (https://cran.r-project.org) and plain pre-formatted (https://cloud.r-project.org) listing formats, the warn-and-continue path when the full archive listing is unavailable, and the 404 path for packages with no archive directory.
* Add corresponding news item.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [N/A] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
