### PR TITLE
Use final build IDs for exact `pin_subpackage` references

### DIFF
--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -388,7 +388,7 @@ def pin_subpackage_against_outputs(
                         [
                             sp_m.name(),
                             sp_m.version(),
-                            sp_m.build_id(force_final=True)
+                            sp_m.build_id(force_final_hash=True)
                             if not skip_build_id
                             else str(sp_m.build_number()),
                         ]

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -384,6 +384,9 @@ def pin_subpackage_against_outputs(
                 pin = None
             else:
                 if exact:
+                    if not skip_build_id and not sp_m.final:
+                        sp_m = sp_m.copy()
+                        sp_m.final = True
                     pin = " ".join(
                         [
                             sp_m.name(),

--- a/conda_build/jinja_context.py
+++ b/conda_build/jinja_context.py
@@ -384,14 +384,11 @@ def pin_subpackage_against_outputs(
                 pin = None
             else:
                 if exact:
-                    if not skip_build_id and not sp_m.final:
-                        sp_m = sp_m.copy()
-                        sp_m.final = True
                     pin = " ".join(
                         [
                             sp_m.name(),
                             sp_m.version(),
-                            sp_m.build_id()
+                            sp_m.build_id(force_final=True)
                             if not skip_build_id
                             else str(sp_m.build_number()),
                         ]

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1815,7 +1815,8 @@ class MetaData:
             return _hash_dependencies(hashing_dependencies, self.config.hash_length)
         return hash_
 
-    def build_id(self):
+    def build_id(self, *, force_final: bool = False):
+        """Return the build ID, optionally calculating it as final metadata."""
         manual_build_string = self.get_value("build/string")
         # we need the raw recipe for this metadata (possibly an output), so that we can say whether
         #    PKG_HASH is used for anything.
@@ -1835,7 +1836,7 @@ class MetaData:
         else:
             # default; build/string not set or uses PKG_HASH variable, so we should fill in the hash
             out = build_string_from_metadata(self)
-            if self.config.filename_hashing and self.final:
+            if self.config.filename_hashing and (self.final or force_final):
                 hash_ = self.hash_dependencies()
                 if not re.findall(f"h[0-9a-f]{{{self.config.hash_length}}}", out):
                     ret = out.rsplit("_", 1)

--- a/conda_build/metadata.py
+++ b/conda_build/metadata.py
@@ -1815,8 +1815,8 @@ class MetaData:
             return _hash_dependencies(hashing_dependencies, self.config.hash_length)
         return hash_
 
-    def build_id(self, *, force_final: bool = False):
-        """Return the build ID, optionally calculating it as final metadata."""
+    def build_id(self, *, force_final_hash: bool = False):
+        """Return the build ID, optionally hashing non-final metadata."""
         manual_build_string = self.get_value("build/string")
         # we need the raw recipe for this metadata (possibly an output), so that we can say whether
         #    PKG_HASH is used for anything.
@@ -1836,7 +1836,7 @@ class MetaData:
         else:
             # default; build/string not set or uses PKG_HASH variable, so we should fill in the hash
             out = build_string_from_metadata(self)
-            if self.config.filename_hashing and (self.final or force_final):
+            if self.config.filename_hashing and (self.final or force_final_hash):
                 hash_ = self.hash_dependencies()
                 if not re.findall(f"h[0-9a-f]{{{self.config.hash_length}}}", out):
                     ret = out.rsplit("_", 1)

--- a/news/6100-pin-subpackage-final-hash.md
+++ b/news/6100-pin-subpackage-final-hash.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Preserve final build IDs, including dependency hashes, in exact `pin_subpackage()` run exports. (#6078 via #6100)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/6100-pin-subpackage-final-hash.md
+++ b/news/6100-pin-subpackage-final-hash.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Preserve final build IDs, including dependency hashes, in exact `pin_subpackage()` run exports. (#6078 via #6100)
+* Preserve final build IDs, including dependency hashes, in exact `pin_subpackage()` references. (#5572, #6078 via #6100)
 
 ### Deprecations
 

--- a/tests/test-recipes/metadata/_pin_subpackage_exact_run_constrained/meta.yaml
+++ b/tests/test-recipes/metadata/_pin_subpackage_exact_run_constrained/meta.yaml
@@ -4,6 +4,9 @@ package:
 
 outputs:
   - name: libblas
+    build:
+      number: 27
+      string: 27_h{{ PKG_HASH }}_{{ blas_impl }}
     requirements:
       run_constrained:
         - {{ pin_subpackage("libcblas", exact=True) }}

--- a/tests/test-recipes/metadata/_pin_subpackage_exact_run_constrained/meta.yaml
+++ b/tests/test-recipes/metadata/_pin_subpackage_exact_run_constrained/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: blas-split
+  version: 3.9.0
+
+outputs:
+  - name: libblas
+    requirements:
+      run_constrained:
+        - {{ pin_subpackage("libcblas", exact=True) }}
+
+  - name: libcblas
+    build:
+      number: 27
+      string: 27_h{{ PKG_HASH }}_{{ blas_impl }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libblas", exact=True) }}

--- a/tests/test-recipes/metadata/_self_reference_run_exports_exact/meta.yaml
+++ b/tests/test-recipes/metadata/_self_reference_run_exports_exact/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: test
+  version: 1.0.0
+
+build:
+  number: 37
+  string: dst_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [explicit_build_string]
+  run_exports:
+    - {{ pin_subpackage('test', exact=True) }}

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1371,6 +1371,26 @@ def test_pin_subpackage_exact(testing_config):
     )
 
 
+def test_pin_subpackage_exact_run_constrained(testing_config):
+    recipe = os.path.join(metadata_dir, "_pin_subpackage_exact_run_constrained")
+    metadata_by_name = {
+        metadata.name(): metadata
+        for metadata, _, _ in api.render(
+            recipe,
+            config=testing_config,
+            variants={"blas_impl": ["openblas"]},
+        )
+    }
+    libblas = metadata_by_name["libblas"]
+    libcblas = metadata_by_name["libcblas"]
+    libcblas_build_id = libcblas.build_id()
+    assert "h1234567" not in libcblas_build_id
+    assert re.search(rf"h[0-9a-f]{{{testing_config.hash_length}}}", libcblas_build_id)
+    assert libblas.info_index()["constrains"] == [
+        f"libcblas {libcblas.version()} {libcblas_build_id}"
+    ]
+
+
 @pytest.mark.sanity
 @pytest.mark.serial
 @pytest.mark.skipif(on_mac and not which("xattr"), reason="`xattr` unavailable")

--- a/tests/test_api_build.py
+++ b/tests/test_api_build.py
@@ -1383,11 +1383,17 @@ def test_pin_subpackage_exact_run_constrained(testing_config):
     }
     libblas = metadata_by_name["libblas"]
     libcblas = metadata_by_name["libcblas"]
+    libblas_build_id = libblas.build_id()
     libcblas_build_id = libcblas.build_id()
+    assert "h1234567" not in libblas_build_id
+    assert re.search(rf"h[0-9a-f]{{{testing_config.hash_length}}}", libblas_build_id)
     assert "h1234567" not in libcblas_build_id
     assert re.search(rf"h[0-9a-f]{{{testing_config.hash_length}}}", libcblas_build_id)
     assert libblas.info_index()["constrains"] == [
         f"libcblas {libcblas.version()} {libcblas_build_id}"
+    ]
+    assert libcblas.info_index()["depends"] == [
+        f"libblas {libblas.version()} {libblas_build_id}"
     ]
 
 

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -170,6 +170,7 @@ def test_hash_no_apply_to_custom_build_string(testing_metadata, testing_workdir)
     metadata = api.render(testing_workdir)[0][0]
 
     assert metadata.build_id() == "steve"
+    assert metadata.build_id(force_final=True) == "steve"
 
 
 def test_pin_depends(testing_config):

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -170,7 +170,7 @@ def test_hash_no_apply_to_custom_build_string(testing_metadata, testing_workdir)
     metadata = api.render(testing_workdir)[0][0]
 
     assert metadata.build_id() == "steve"
-    assert metadata.build_id(force_final=True) == "steve"
+    assert metadata.build_id(force_final_hash=True) == "steve"
 
 
 def test_pin_depends(testing_config):

--- a/tests/test_api_render.py
+++ b/tests/test_api_render.py
@@ -279,6 +279,23 @@ def test_self_reference_run_exports_pin_subpackage_picks_up_version_correctly():
     assert run_exports[0].split()[1] == ">=1.0.0,<2.0a0"
 
 
+@pytest.mark.parametrize(
+    "explicit_build_string", [False, True], ids=["implicit", "explicit"]
+)
+def test_self_reference_exact_run_exports_picks_up_final_build_id(
+    testing_config, explicit_build_string
+):
+    recipe = os.path.join(metadata_dir, "_self_reference_run_exports_exact")
+    metadata = api.render(
+        recipe,
+        config=testing_config,
+        variants={"explicit_build_string": [explicit_build_string]},
+    )[0][0]
+    assert metadata.get_value("build/run_exports") == [
+        f"{metadata.name()} {metadata.version()} {metadata.build_id()}"
+    ]
+
+
 def test_run_exports_with_pin_compatible_in_subpackages(testing_config):
     recipe = os.path.join(metadata_dir, "_run_exports_in_outputs")
     metadata_tuples = api.render(recipe, config=testing_config)

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -93,16 +94,32 @@ def test_pin_none_max(testing_metadata, mocker):
     assert pin == "test >=1.2.3"
 
 
-def test_pin_subpackage_exact(testing_metadata):
+def test_pin_subpackage_exact(testing_metadata, mocker):
     name = testing_metadata.name()
     output_dict = {"name": name}
     testing_metadata.meta["outputs"] = [output_dict]
     fm = testing_metadata.get_output_metadata(output_dict)
+    original_meta = copy.deepcopy(fm.meta)
+    final_fm = fm.copy()
+    final_fm.final = True
     testing_metadata.other_outputs = {
         (name, deepfreeze(testing_metadata.config.variant)): (output_dict, fm)
     }
+    build_id = mocker.spy(fm, "build_id")
     pin = jinja_context.pin_subpackage(testing_metadata, name, exact=True)
-    assert len(pin.split()) == 3
+    assert pin == f"{fm.name()} {fm.version()} {final_fm.build_id()}"
+    build_id.assert_called_once_with(force_final=True)
+    assert fm.meta == original_meta
+    assert not fm.final
+
+    build_id.reset_mock()
+    pin = jinja_context.pin_subpackage(
+        testing_metadata, name, exact=True, skip_build_id=True
+    )
+    assert pin == f"{fm.name()} {fm.version()} {fm.build_number()}"
+    build_id.assert_not_called()
+    assert fm.meta == original_meta
+    assert not fm.final
 
 
 def test_pin_subpackage_expression(testing_metadata):

--- a/tests/test_jinja_context.py
+++ b/tests/test_jinja_context.py
@@ -108,7 +108,7 @@ def test_pin_subpackage_exact(testing_metadata, mocker):
     build_id = mocker.spy(fm, "build_id")
     pin = jinja_context.pin_subpackage(testing_metadata, name, exact=True)
     assert pin == f"{fm.name()} {fm.version()} {final_fm.build_id()}"
-    build_id.assert_called_once_with(force_final=True)
+    build_id.assert_called_once_with(force_final_hash=True)
     assert fm.meta == original_meta
     assert not fm.final
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -462,11 +462,11 @@ def test_hash_build_id(testing_metadata):
         f"Did not find build that matched {hdeps} when testing each of DEFAULT_SUBDIRS"
     )
     assert testing_metadata.build_id() == "1"
-    assert testing_metadata.build_id(force_final=True) == hdeps + "_1"
+    assert testing_metadata.build_id(force_final_hash=True) == hdeps + "_1"
     assert not testing_metadata.final
 
     testing_metadata.config.filename_hashing = False
-    assert testing_metadata.build_id(force_final=True) == "1"
+    assert testing_metadata.build_id(force_final_hash=True) == "1"
 
     testing_metadata.config.filename_hashing = True
     testing_metadata.final = True

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -445,7 +445,6 @@ def test_native_stdlib_metadata(
 def test_hash_build_id(testing_metadata):
     testing_metadata.config.variant["zlib"] = "1.2"
     testing_metadata.meta["requirements"]["host"] = ["zlib"]
-    testing_metadata.final = True
     hash_contents = testing_metadata.get_hash_contents()
     assert hash_contents["zlib"] == "1.2"
     hdeps = testing_metadata.hash_dependencies()
@@ -462,6 +461,15 @@ def test_hash_build_id(testing_metadata):
     assert found, (
         f"Did not find build that matched {hdeps} when testing each of DEFAULT_SUBDIRS"
     )
+    assert testing_metadata.build_id() == "1"
+    assert testing_metadata.build_id(force_final=True) == hdeps + "_1"
+    assert not testing_metadata.final
+
+    testing_metadata.config.filename_hashing = False
+    assert testing_metadata.build_id(force_final=True) == "1"
+
+    testing_metadata.config.filename_hashing = True
+    testing_metadata.final = True
     assert testing_metadata.build_id() == hdeps + "_1"
 
 


### PR DESCRIPTION
### Description

Fixes #5572 and #6078.

Exact `pin_subpackage()` references could keep `h1234567` or another incomplete build ID in packaged `run_exports` and `run_constrained` metadata when the referenced output had not been finalized yet.

For exact pins, `pin_subpackage_against_outputs()` now calls `MetaData.build_id(force_final_hash=True)`. This includes the dependency hash without changing or copying the output metadata. Other `build_id()` calls keep their existing behavior.

The original fix copied `MetaData` for every exact pin, including the configured variant list, which slowed rendering. Calculating the hash directly avoids that work.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
