### PR TITLE
Handle InvalidVersion in deprecation version fallback

### DIFF
--- a/conda_build/deprecations.py
+++ b/conda_build/deprecations.py
@@ -70,13 +70,13 @@ class DeprecationHandler:
         # If self._version or version could not be represented by a simple
         # tuple[int, ...], do a more elaborate version parsing and comparison.
         # Avoid this import otherwise to reduce import time for conda activate.
-        from packaging.version import parse
+        from packaging.version import InvalidVersion, parse
 
         if self._version_object is None:
             try:
                 self._version_object = parse(self._version)  # type: ignore[arg-type]
-            except TypeError:
-                # TypeError: self._version could not be parsed
+            except (InvalidVersion, TypeError):
+                # self._version could not be parsed
                 self._version_object = parse("0.0.0.dev0+placeholder")
         return self._version_object < parse(version)
 

--- a/news/6091-packaging-invalid-version.md
+++ b/news/6091-packaging-invalid-version.md
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Handle unavailable version metadata when `packaging` raises `InvalidVersion` during deprecation checks. (#6091)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Fixes #6091.

`packaging` 26.3 raises `InvalidVersion` instead of `TypeError` when package version metadata is unavailable. Catch both exceptions while keeping the `packaging.version` import inside the fallback path used by deprecation checks.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~
