### PR TITLE
Make test_python_variants more robust to python_abi deps

### DIFF
--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -84,14 +84,23 @@ def test_python_variants(testing_workdir, testing_config, as_yaml):
 
     # we should have one package/metadata per python version
     assert len(metadata_tuples) == 2
-    # there should only be one run requirement for each package/metadata
-    assert len(metadata_tuples[0][0].meta["requirements"]["run"]) == 1
-    assert len(metadata_tuples[1][0].meta["requirements"]["run"]) == 1
-    # the run requirements should be python ranges
-    assert {
-        *metadata_tuples[0][0].meta["requirements"]["run"],
-        *metadata_tuples[1][0].meta["requirements"]["run"],
-    } == {"python >=3.11,<3.12.0a0", "python >=3.12,<3.13.0a0"}
+
+    # Extract *python* run requirements (allow python_abi to exist)
+    python_reqs = []
+    for meta, _, _ in metadata_tuples:
+        run_reqs = meta.meta["requirements"]["run"]
+        python_reqs.extend([r for r in run_reqs if r.startswith("python ")])
+
+    # We expect exactly two python requirements, one per variant
+    assert len(python_reqs) == 2, f"Expected 2 python requirements, got {python_reqs}"
+
+    # Check that the python requirements match the expected ranges
+    expected = {
+        "python >=3.11,<3.12.0a0",
+        "python >=3.12,<3.13.0a0",
+    }
+    python_reqs_set = set(python_reqs)
+    assert python_reqs_set == expected
 
 
 def test_use_selectors_in_variants(testing_workdir, testing_config):


### PR DESCRIPTION
Filter for `python`entries and assert on their content, allowing `python_abi` dependency to co-exist on different channels or platforms.

This PR was originally part of https://github.com/conda/conda-build/pull/6044 where I encountered the failures during the test runs.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-build/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-build/blob/main/CONTRIBUTING.md -->
