### PR TITLE
Add `--exclude-newer` to conda-build

### DIFF
--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -6,11 +6,14 @@ import os
 import sys
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from inspect import signature
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
 from conda.base.context import context
+from conda.models.channel import Channel
 from rattler_build import (
     Package,
     RattlerBuildError,
@@ -18,7 +21,7 @@ from rattler_build import (
 )
 from rattler_build.debug import DebugSession
 from rattler_build.progress import SimpleProgressCallback
-from rattler_build.render import RenderConfig
+from rattler_build.render import RenderConfig, RenderedVariant
 from rattler_build.stage0 import MultiOutputRecipe, Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 from rattler_build.variant_config import VariantConfig
@@ -100,12 +103,24 @@ def check_arguments_rattler(
     """
 
     policy = config.exclude_newer_policy
-    if getattr(parsed, "exclude_newer", None) is not None or (
-        policy is not None and policy.active
-    ):
-        raise CondaBuildUserError(
-            "exclude-newer is not supported for v1 recipes in conda-build."
-        )
+    if policy is not None and policy.active:
+        required_arguments = {
+            "exclude_newer",
+            "exclude_newer_package",
+            "exclude_newer_channel",
+            "exclude_newer_include_unknown_timestamp",
+        }
+        for method in (
+            RenderedVariant.run_build,
+            Package.run_tests,
+            DebugSession.create,
+        ):
+            if not required_arguments <= signature(method).parameters.keys():
+                raise CondaBuildUserError(
+                    "The installed py-rattler-build does not support exclude-newer "
+                    "policies for v1 recipes. Install a version with build, test, "
+                    "and debug policy support."
+                )
 
     diff = {
         k: v for k, v in vars(parsed).items() if vars(parsed_only_recipe).get(k) != v
@@ -134,6 +149,7 @@ def check_arguments_rattler(
             "override_channels",
             "build_only",
             "post",
+            "exclude_newer",
         },
         "render": {
             "recipe",
@@ -141,6 +157,7 @@ def check_arguments_rattler(
             "exclusive_config_files",
             "channel",
             "override_channels",
+            "exclude_newer",
         },
         "debug": {
             "recipe",
@@ -150,6 +167,7 @@ def check_arguments_rattler(
             "channel",
             "override_channels",
             "activate_string_only",
+            "exclude_newer",
         },
     }
 
@@ -168,6 +186,36 @@ def check_arguments_rattler(
         raise ValueError(
             f"Invalid condarc settings for conda-{command}: {', '.join(sorted(unsupported_condarc_keys))}"
         )
+
+
+def exclude_newer_arguments(config: Config, channels: list[str]) -> dict:
+    """Translate conda's resolved cutoffs into rattler-build's Python arguments."""
+    policy = config.exclude_newer_policy
+    if policy is None or not policy.active:
+        return {}
+
+    def as_datetime(cutoff):
+        return (
+            datetime.fromtimestamp(cutoff, timezone.utc) if cutoff is not None else None
+        )
+
+    channel_cutoffs = {}
+    for channel in channels:
+        resolved = Channel(channel)
+        for override in policy.channel_cutoffs:
+            if override.matches({"channel": resolved}):
+                url = resolved.urls(with_credentials=True, subdirs=[""])[0]
+                channel_cutoffs[url.rstrip("/") + "/"] = as_datetime(override.cutoff)
+
+    return {
+        "exclude_newer": as_datetime(policy.global_cutoff),
+        "exclude_newer_package": {
+            name: as_datetime(cutoff)
+            for name, cutoff in (policy.package_cutoffs or {}).items()
+        },
+        "exclude_newer_channel": channel_cutoffs,
+        "exclude_newer_include_unknown_timestamp": True,
+    }
 
 
 def process_recipe(
@@ -195,6 +243,7 @@ def process_recipe(
         - If testing is enabled, run tests on the built package with `Package.run_tests()`
     """
     result = RecipeResult(recipe_path=recipe_path)
+    cutoff_arguments = exclude_newer_arguments(config, channels)
 
     try:
         recipe = Stage0Recipe.from_file(Path(recipe_path))
@@ -263,6 +312,7 @@ def process_recipe(
                 output_dir=os.path.join(output_dir, f"debug_{int(time.time() * 1000)}"),
                 channels=channels,
                 progress_callback=CondaProgressCallback(show_logs=True),
+                **cutoff_arguments,
             )
         except RattlerBuildError as e:
             result.error = (
@@ -298,6 +348,7 @@ def process_recipe(
                 no_build_id=no_build_id,
                 package_format=package_format,
                 no_include_recipe=no_include_recipe,
+                **cutoff_arguments,
             )
         except RattlerBuildError as e:
             result.outputs.append(
@@ -329,10 +380,20 @@ def process_recipe(
                     # tests are run in a different directory than build, so we need to add the build
                     # directory manually as a file:// channel
                     test_channels = [Path(output_dir).resolve().as_uri(), *channels]
+                    test_cutoff_arguments = cutoff_arguments
+                    if cutoff_arguments:
+                        test_cutoff_arguments = {
+                            **cutoff_arguments,
+                            "exclude_newer_channel": {
+                                **cutoff_arguments["exclude_newer_channel"],
+                                test_channels[0].rstrip("/") + "/": None,
+                            },
+                        }
 
                     test_results = pkg.run_tests(
                         progress_callback=CondaProgressCallback(show_logs=show_logs),
                         channel=test_channels,
+                        **test_cutoff_arguments,
                     )
                 except RattlerBuildError as e:
                     result.outputs.append(
@@ -404,15 +465,27 @@ def run_rattler(
     else:
         source_channels = context.channels
 
+    policy = config.exclude_newer_policy
     for channel in source_channels:
         # handle multichannels ('defaults', 'local' and user defined multichannels)
         # TODO: fix multichannel priority
         if channel in context.custom_multichannels:
             channels.extend(
-                str(subchannel) for subchannel in context.custom_multichannels[channel]
+                subchannel.urls(with_credentials=True, subdirs=[""])[0]
+                if policy is not None and policy.active
+                else str(subchannel)
+                for subchannel in context.custom_multichannels[channel]
             )
         else:
             channels.append(channel)
+
+    if policy is not None and policy.active:
+        # Resolve conda's channel aliases before matching overrides or passing
+        # channels to rattler-build, which has its own channel configuration.
+        channels = [
+            Channel(channel).urls(with_credentials=True, subdirs=[""])[0]
+            for channel in channels
+        ]
 
     if context.channel_priority == "strict":
         channel_priority = "strict"

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -79,7 +79,10 @@ class CondaProgressCallback(SimpleProgressCallback):
 
 
 def check_arguments_rattler(
-    command: str, parsed: argparse.Namespace, parsed_only_recipe: argparse.Namespace
+    command: str,
+    parsed: argparse.Namespace,
+    parsed_only_recipe: argparse.Namespace,
+    config: Config,
 ) -> None:
     """Validate that arguments are compatible with rattler CLI commands.
 
@@ -93,7 +96,16 @@ def check_arguments_rattler(
             from the main argument parser.
         parsed_only_recipe: Namespace object containing only the recipe file as
             an argument.
+        config: Build configuration used to check the dependency cutoff.
     """
+
+    policy = config.exclude_newer_policy
+    if getattr(parsed, "exclude_newer", None) is not None or (
+        policy is not None and policy.active
+    ):
+        raise CondaBuildUserError(
+            "exclude-newer is not supported for v1 recipes in conda-build."
+        )
 
     diff = {
         k: v for k, v in vars(parsed).items() if vars(parsed_only_recipe).get(k) != v

--- a/conda_build/_rattler_build/compat.py
+++ b/conda_build/_rattler_build/compat.py
@@ -7,10 +7,10 @@ import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from inspect import signature
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import rattler_build
 import yaml
 from conda.base.context import context
 from conda.models.channel import Channel
@@ -21,7 +21,7 @@ from rattler_build import (
 )
 from rattler_build.debug import DebugSession
 from rattler_build.progress import SimpleProgressCallback
-from rattler_build.render import RenderConfig, RenderedVariant
+from rattler_build.render import RenderConfig
 from rattler_build.stage0 import MultiOutputRecipe, Stage0Recipe
 from rattler_build.tool_config import PlatformConfig, ToolConfiguration
 from rattler_build.variant_config import VariantConfig
@@ -104,23 +104,12 @@ def check_arguments_rattler(
 
     policy = config.exclude_newer_policy
     if policy is not None and policy.active:
-        required_arguments = {
-            "exclude_newer",
-            "exclude_newer_package",
-            "exclude_newer_channel",
-            "exclude_newer_include_unknown_timestamp",
-        }
-        for method in (
-            RenderedVariant.run_build,
-            Package.run_tests,
-            DebugSession.create,
-        ):
-            if not required_arguments <= signature(method).parameters.keys():
-                raise CondaBuildUserError(
-                    "The installed py-rattler-build does not support exclude-newer "
-                    "policies for v1 recipes. Install a version with build, test, "
-                    "and debug policy support."
-                )
+        if not hasattr(rattler_build, "ExcludeNewer"):
+            raise CondaBuildUserError(
+                "The installed py-rattler-build does not support exclude-newer "
+                "policies for v1 recipes. Install a version with build, test, "
+                "and debug policy support."
+            )
 
     diff = {
         k: v for k, v in vars(parsed).items() if vars(parsed_only_recipe).get(k) != v
@@ -208,13 +197,15 @@ def exclude_newer_arguments(config: Config, channels: list[str]) -> dict:
                 channel_cutoffs[url.rstrip("/") + "/"] = as_datetime(override.cutoff)
 
     return {
-        "exclude_newer": as_datetime(policy.global_cutoff),
-        "exclude_newer_package": {
-            name: as_datetime(cutoff)
-            for name, cutoff in (policy.package_cutoffs or {}).items()
-        },
-        "exclude_newer_channel": channel_cutoffs,
-        "exclude_newer_include_unknown_timestamp": True,
+        "exclude_newer": rattler_build.ExcludeNewer(
+            as_datetime(policy.global_cutoff),
+            packages={
+                name: as_datetime(cutoff)
+                for name, cutoff in (policy.package_cutoffs or {}).items()
+            },
+            channels=channel_cutoffs,
+            include_unknown_timestamp=True,
+        )
     }
 
 
@@ -380,15 +371,9 @@ def process_recipe(
                     # tests are run in a different directory than build, so we need to add the build
                     # directory manually as a file:// channel
                     test_channels = [Path(output_dir).resolve().as_uri(), *channels]
-                    test_cutoff_arguments = cutoff_arguments
-                    if cutoff_arguments:
-                        test_cutoff_arguments = {
-                            **cutoff_arguments,
-                            "exclude_newer_channel": {
-                                **cutoff_arguments["exclude_newer_channel"],
-                                test_channels[0].rstrip("/") + "/": None,
-                            },
-                        }
+                    test_cutoff_arguments = exclude_newer_arguments(
+                        config, test_channels
+                    )
 
                     test_results = pkg.run_tests(
                         progress_callback=CondaProgressCallback(show_logs=show_logs),

--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -2245,6 +2245,7 @@ def create_build_envs(m: MetaData, notest):
             max_env_retry=m.config.max_env_retry,
             output_folder=m.config.output_folder,
             channel_urls=tuple(m.config.channel_urls),
+            exclude_newer_policy=m.config.exclude_newer_policy,
         )
         environ.create_env(
             m.config.host_prefix,
@@ -2271,6 +2272,7 @@ def create_build_envs(m: MetaData, notest):
         max_env_retry=m.config.max_env_retry,
         output_folder=m.config.output_folder,
         channel_urls=tuple(m.config.channel_urls),
+        exclude_newer_policy=m.config.exclude_newer_policy,
     )
 
     try:
@@ -2297,6 +2299,7 @@ def create_build_envs(m: MetaData, notest):
                 max_env_retry=m.config.max_env_retry,
                 output_folder=m.config.output_folder,
                 channel_urls=tuple(m.config.channel_urls),
+                exclude_newer_policy=m.config.exclude_newer_policy,
             )
     except DependencyNeedsBuildingError as e:
         # subpackages are not actually missing.  We just haven't built them yet.
@@ -2738,6 +2741,7 @@ def build(
                                 max_env_retry=m.config.max_env_retry,
                                 output_folder=m.config.output_folder,
                                 channel_urls=tuple(m.config.channel_urls),
+                                exclude_newer_policy=m.config.exclude_newer_policy,
                             )
                             environ.create_env(
                                 m.config.host_prefix,
@@ -2765,6 +2769,7 @@ def build(
                             max_env_retry=m.config.max_env_retry,
                             output_folder=m.config.output_folder,
                             channel_urls=tuple(m.config.channel_urls),
+                            exclude_newer_policy=m.config.exclude_newer_policy,
                         )
                         environ.create_env(
                             m.config.build_prefix,
@@ -3432,6 +3437,7 @@ def test(
             max_env_retry=metadata.config.max_env_retry,
             output_folder=metadata.config.output_folder,
             channel_urls=tuple(metadata.config.channel_urls),
+            exclude_newer_policy=metadata.config.exclude_newer_policy,
         )
     except (
         DependencyNeedsBuildingError,
@@ -3758,6 +3764,7 @@ def build_tree(
                                             subdir=meta.config.host_subdir,
                                             bldpkgs_dirs=meta.config.bldpkgs_dirs,
                                             channel_urls=channel_urls,
+                                            exclude_newer_policy=meta.config.exclude_newer_policy,
                                         )
                                 except (
                                     UnsatisfiableError,

--- a/conda_build/cli/main_build.py
+++ b/conda_build/cli/main_build.py
@@ -569,6 +569,7 @@ def execute(args: Sequence[str] | None = None) -> int:
     context.__init__(argparse_args=parsed)
 
     config = get_or_merge_config(None, **parsed.__dict__)
+    config.exclude_newer_policy  # Validate the cutoff before building.
 
     # change globals in build module, see comment there as well
     config.channel_urls = get_channel_urls(parsed.__dict__)
@@ -581,7 +582,7 @@ def execute(args: Sequence[str] | None = None) -> int:
         # check cli arguments
         parser, parsed_only_recipe = parse_args(parsed.recipe)
         command = parser.prog.split()[-1]
-        check_arguments_rattler(command, parsed, parsed_only_recipe)
+        check_arguments_rattler(command, parsed, parsed_only_recipe, config)
         # run rattler command
         return run_rattler(command, parsed, config)
 

--- a/conda_build/cli/main_debug.py
+++ b/conda_build/cli/main_debug.py
@@ -114,7 +114,9 @@ def execute(args: Sequence[str] | None = None) -> int:
         if is_v1_recipe(parsed.recipe_or_package_file_path):
             config = get_or_merge_config(None, **parsed.__dict__)
             parsed_only_recipe = parser.parse_args([parsed.recipe_or_package_file_path])
-            check_arguments_rattler(parser.prog.split()[-1], parsed, parsed_only_recipe)
+            check_arguments_rattler(
+                parser.prog.split()[-1], parsed, parsed_only_recipe, config
+            )
             parsed.recipe = parsed.recipe_or_package_file_path
             command = parser.prog.split()[-1]
             activation_string = run_rattler(command, parsed, config)

--- a/conda_build/cli/main_render.py
+++ b/conda_build/cli/main_render.py
@@ -174,6 +174,17 @@ source to try fill in related template variables.",
         ),
     )
     add_parser_channels(p)
+    p.add_argument(
+        "--exclude-newer",
+        default=argparse.SUPPRESS,
+        metavar="DURATION_OR_DATE",
+        help=(
+            "Exclude dependency packages newer than a duration (e.g. 7d) or date "
+            "(e.g. 2026-04-01). Date-only values include the entire UTC day. "
+            "Requires conda 26.9 or newer and a solver supporting exclude-newer. "
+            "Newly built packages in the output channel remain available."
+        ),
+    )
     return p
 
 
@@ -206,6 +217,7 @@ def execute(args: Sequence[str] | None = None) -> int:
     context.__init__(argparse_args=parsed)
 
     config = get_or_merge_config(None, **parsed.__dict__)
+    config.exclude_newer_policy  # Validate the cutoff before rendering.
 
     variants = get_package_variants(parsed.recipe, config, variants=parsed.variants)
     from ..build import get_all_replacements
@@ -218,7 +230,7 @@ def execute(args: Sequence[str] | None = None) -> int:
     if is_v1_recipe(parsed.recipe):
         parser, parsed_only_recipe = parse_args([parsed.recipe])
         command = parser.prog.split()[-1]
-        check_arguments_rattler(command, parsed, parsed_only_recipe)
+        check_arguments_rattler(command, parsed, parsed_only_recipe, config)
 
         return run_rattler(command, parsed, config)
 

--- a/conda_build/config.py
+++ b/conda_build/config.py
@@ -25,6 +25,7 @@ from conda.base.constants import (
 from conda.base.context import context
 from conda.utils import url_path
 
+from .exceptions import CondaBuildUserError
 from .utils import (
     get_build_folders,
     get_conda_operation_locks,
@@ -37,6 +38,8 @@ from .variants import get_default_variant
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, TypeVar
+
+    from conda.core.exclude_newer import ExcludeNewerPolicy
 
     T = TypeVar("T")
 
@@ -129,6 +132,7 @@ def _get_default_settings():
         Setting("anaconda_upload", context.binstar_upload),
         Setting("force_upload", True),
         Setting("channel_urls", []),
+        Setting("exclude_newer", getattr(context, "exclude_newer", None)),
         Setting("dirty", False),
         Setting("include_recipe", True),
         Setting("no_download_source", False),
@@ -300,6 +304,7 @@ class Config:
 
     def __init__(self, variant=None, **kwargs):
         super().__init__()
+        self._exclude_newer_now = time.time()
         # default variant is set in render's distribute_variants
         self.variant = variant or {}
         self.set_keys(**kwargs)
@@ -315,6 +320,9 @@ class Config:
             del kwargs[attr]
 
     def set_keys(self, **kwargs):
+        if kwargs.get("exclude_newer") is None:
+            kwargs.pop("exclude_newer", None)
+
         def env(lang, default):
             version = kwargs.pop(lang, None)
             if not version:
@@ -529,6 +537,29 @@ class Config:
     @output_folder.setter
     def output_folder(self, value):
         self._output_folder = value
+
+    @property
+    def exclude_newer_policy(self) -> ExcludeNewerPolicy | None:
+        try:
+            from conda.core.exclude_newer import ExcludeNewerPolicy
+        except ImportError:
+            if self.exclude_newer is not None:
+                raise CondaBuildUserError(
+                    "--exclude-newer requires conda 26.9 or newer."
+                ) from None
+            return None
+
+        return ExcludeNewerPolicy.from_values(
+            self.exclude_newer,
+            context.exclude_newer_package,
+            (
+                *context.channel_settings,
+                # Newly built outputs must remain available to dependent outputs
+                # and package tests. Other local channels still obey the cutoff.
+                {"channel": url_path(self.output_folder), "exclude_newer": False},
+            ),
+            now=self._exclude_newer_now,
+        )
 
     @property
     def build_folder(self):

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -1446,7 +1446,10 @@ def install_actions(
 
             PrefixData._cache_.clear()
 
-            solver_backend = context.plugin_manager.get_cached_solver_backend()
+            # Include the configured solver in the cache key after context resets.
+            solver_backend = context.plugin_manager.get_cached_solver_backend(
+                context.solver
+            )
             solver = solver_backend(prefix, channels, subdirs, specs_to_add=mspecs)
             if index:
                 # Solver can modify the index (e.g., Solver._prepare adds virtual

--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Any, TypedDict
 
+    from conda.core.exclude_newer import ExcludeNewerPolicy
     from conda.core.index import Index
 
     from .config import Config
@@ -844,9 +845,14 @@ def get_install_actions(
     max_env_retry: int = 3,
     output_folder=None,
     channel_urls=None,
+    exclude_newer_policy: ExcludeNewerPolicy | None = None,
 ) -> list[PackageRecord]:
     global cached_precs
     global last_index_ts
+
+    if exclude_newer_policy is None:
+        exclude_newer_policy = getattr(context, "exclude_newer_policy", None)
+    policy_active = exclude_newer_policy is not None and exclude_newer_policy.active
 
     log = utils.get_logger(__name__)
     conda_log_level = logging.WARN
@@ -878,14 +884,15 @@ def get_install_actions(
     )
 
     precs: list[PackageRecord] = []
-    if (
+    cache_key = (
         specs,
         env,
         subdir,
         channel_urls,
         disable_pip,
-    ) in cached_precs and last_index_ts >= index_ts:
-        precs = cached_precs[(specs, env, subdir, channel_urls, disable_pip)].copy()
+    )
+    if not policy_active and cache_key in cached_precs and last_index_ts >= index_ts:
+        precs = cached_precs[cache_key].copy()
     elif specs:
         # this is hiding output like:
         #    Fetching package metadata ...........
@@ -893,7 +900,13 @@ def get_install_actions(
         with utils.LoggingContext(conda_log_level):
             with capture():
                 try:
-                    _actions = _install_actions(prefix, index, specs, subdir=subdir)
+                    _actions = _install_actions(
+                        prefix,
+                        index,
+                        specs,
+                        subdir=subdir,
+                        exclude_newer_policy=exclude_newer_policy,
+                    )
                     precs = _actions["LINK"]
                 except (NoPackagesFoundError, UnsatisfiableError) as exc:
                     raise DependencyNeedsBuildingError(exc, subdir=subdir)
@@ -957,6 +970,7 @@ def get_install_actions(
                             max_env_retry=max_env_retry,
                             output_folder=output_folder,
                             channel_urls=tuple(channel_urls),
+                            exclude_newer_policy=exclude_newer_policy,
                         )
                     else:
                         log.error(
@@ -971,8 +985,9 @@ def get_install_actions(
                     re.match(rf"^{pkg}(?:$|[\s=].*)", str(dep)) for dep in specs
                 ):
                     precs = [prec for prec in precs if prec.name != pkg]
-        cached_precs[(specs, env, subdir, channel_urls, disable_pip)] = precs.copy()
-        last_index_ts = index_ts
+        if not policy_active:
+            cached_precs[cache_key] = precs.copy()
+            last_index_ts = index_ts
     return precs
 
 
@@ -1107,8 +1122,15 @@ def create_env(
 
     specs_or_precs_tuple = tuple(ensure_list(specs_or_precs))
 
+    exclude_newer_policy = config.exclude_newer_policy
+    policy_active = exclude_newer_policy is not None and exclude_newer_policy.active
     template_env = getattr(config, "test_env_template", None)
-    if template_env and os.path.isdir(template_env) and specs_or_precs_tuple:
+    if (
+        not policy_active
+        and template_env
+        and os.path.isdir(template_env)
+        and specs_or_precs_tuple
+    ):
         log = utils.get_logger(__name__)
         log.debug(
             "Attempting to clone from template environment: %s",
@@ -1161,6 +1183,7 @@ def create_env(
                             max_env_retry=config.max_env_retry,
                             output_folder=config.output_folder,
                             channel_urls=tuple(config.channel_urls),
+                            exclude_newer_policy=exclude_newer_policy,
                         )
                     else:
                         precs = specs_or_precs
@@ -1377,6 +1400,7 @@ def get_pinned_deps(m, section):
             max_env_retry=m.config.max_env_retry,
             output_folder=m.config.output_folder,
             channel_urls=tuple(m.config.channel_urls),
+            exclude_newer_policy=m.config.exclude_newer_policy,
         )
     return [package_record_to_requirement(prec) for prec in precs]
 
@@ -1389,6 +1413,7 @@ def install_actions(
     index: Index,
     specs: Iterable[str | MatchSpec],
     subdir: str | None = None,
+    exclude_newer_policy: ExcludeNewerPolicy | None = None,
 ) -> InstallActionsType:
     # This is copied over from https://github.com/conda/conda/blob/23.11.0/conda/plan.py#L471
     # but reduced to only the functionality actually used within conda-build.
@@ -1396,34 +1421,55 @@ def install_actions(
     if subdir not in (None, "", "noarch"):
         subdir_kwargs["CONDA_SUBDIR"] = subdir
 
-    with env_vars(
-        {
-            "CONDA_ALLOW_NON_CHANNEL_URLS": "true",
-            "CONDA_SOLVER_IGNORE_TIMESTAMPS": "false",
-            **subdir_kwargs,
-        },
-        callback=reset_context,
-    ):
-        channels: tuple[Channel, ...] | None = tuple(index.expanded_channels) or None
-        subdirs: tuple[str, ...] | None = tuple(index._subdirs) or None
+    previous_policy = getattr(context, "exclude_newer_policy", None)
+    if exclude_newer_policy is None:
+        exclude_newer_policy = previous_policy
 
-        mspecs = tuple(MatchSpec(spec) for spec in specs)
+    try:
+        with env_vars(
+            {
+                "CONDA_ALLOW_NON_CHANNEL_URLS": "true",
+                "CONDA_SOLVER_IGNORE_TIMESTAMPS": "false",
+                **subdir_kwargs,
+            },
+            callback=reset_context,
+        ):
+            if exclude_newer_policy is not None:
+                context.exclude_newer_policy = exclude_newer_policy
 
-        PrefixData._cache_.clear()
+            channels: tuple[Channel, ...] | None = (
+                tuple(index.expanded_channels) or None
+            )
+            subdirs: tuple[str, ...] | None = tuple(index._subdirs) or None
 
-        solver_backend = context.plugin_manager.get_cached_solver_backend()
-        solver = solver_backend(prefix, channels, subdirs, specs_to_add=mspecs)
-        if index:
-            # Solver can modify the index (e.g., Solver._prepare adds virtual
-            # package) => Copy index (just outer container, not deep copy)
-            # to conserve it.
-            solver._index = index.copy()
-        txn = solver.solve_for_transaction(prune=False, ignore_pinned=False)
-        prefix_setup = txn.prefix_setups[prefix]
-        return {
-            "PREFIX": prefix,
-            "LINK": [prec for prec in prefix_setup.link_precs],
-        }
+            mspecs = tuple(MatchSpec(spec) for spec in specs)
+
+            PrefixData._cache_.clear()
+
+            solver_backend = context.plugin_manager.get_cached_solver_backend()
+            solver = solver_backend(prefix, channels, subdirs, specs_to_add=mspecs)
+            if index:
+                # Solver can modify the index (e.g., Solver._prepare adds virtual
+                # package) => Copy index (just outer container, not deep copy)
+                # to conserve it.
+                solver._index = index.copy()
+                solver._index.reload(system=True)
+                if exclude_newer_policy is not None and exclude_newer_policy.active:
+                    # Classic skips ReducedIndex filtering for an injected index.
+                    solver._index = {
+                        key: record
+                        for key, record in solver._index.items()
+                        if exclude_newer_policy.should_include(record)
+                    }
+            txn = solver.solve_for_transaction(prune=False, ignore_pinned=False)
+            prefix_setup = txn.prefix_setups[prefix]
+            return {
+                "PREFIX": prefix,
+                "LINK": [prec for prec in prefix_setup.link_precs],
+            }
+    finally:
+        if previous_policy is not None:
+            context.exclude_newer_policy = previous_policy
 
 
 _install_actions = install_actions

--- a/conda_build/render.py
+++ b/conda_build/render.py
@@ -206,6 +206,7 @@ def get_env_dependencies(
                 max_env_retry=m.config.max_env_retry,
                 output_folder=m.config.output_folder,
                 channel_urls=tuple(m.config.channel_urls),
+                exclude_newer_policy=m.config.exclude_newer_policy,
             )
         except (UnsatisfiableError, DependencyNeedsBuildingError) as e:
             # we'll get here if the environment is unsatisfiable

--- a/docs/source/resources/commands/conda-build.rst
+++ b/docs/source/resources/commands/conda-build.rst
@@ -7,9 +7,8 @@ conda-build
 Limit dependency publication dates
 ---------------------------------
 
-With conda 26.9 or newer and a solver that supports ``exclude_newer``, use
-``--exclude-newer`` to limit the packages selected for build, host, and test
-environments::
+With conda 26.9 or newer, use ``--exclude-newer`` to limit the packages selected
+for build, host, and test environments::
 
    conda build recipe/ --exclude-newer 2026-04-01
    conda build recipe/ --exclude-newer 7d
@@ -26,14 +25,17 @@ or channel cutoff so that newly built outputs can be tested and used by other
 outputs. An explicit per-package cutoff still takes precedence. Other local
 channels obey the configured cutoff.
 
-This option applies to ``meta.yaml`` recipes. The ``recipe.yaml`` backend does
-not support the policy through conda-build and rejects active cutoffs. Solver
-backends that do not support the required policy scopes also report an error.
-The classic solver supports all required scopes with conda 26.9 or newer.
+For ``meta.yaml`` recipes, the configured conda solver must support the required
+policy scopes. The classic solver supports all scopes with conda 26.9 or newer.
+For ``recipe.yaml`` recipes, a py-rattler-build release with exclude-newer policy
+support is also required. Rattler-build resolves these dependencies independently
+of the configured conda solver. Older bindings report an error when a cutoff is
+requested.
 
 Publication dates limit dependency selection but do not guarantee an identical
-rebuild. Conda prefers ``indexed_timestamp`` when available and otherwise uses
-the package's ``timestamp``. Packages without either timestamp remain eligible.
+rebuild. The conda solver policy prefers ``indexed_timestamp`` when available and
+otherwise uses the package's ``timestamp``. Rattler-build currently uses
+``timestamp``. Packages without timestamps remain eligible with both backends.
 
 .. raw:: html
 

--- a/docs/source/resources/commands/conda-build.rst
+++ b/docs/source/resources/commands/conda-build.rst
@@ -4,6 +4,37 @@
 conda-build
 ===========
 
+Limit dependency publication dates
+---------------------------------
+
+With conda 26.9 or newer and a solver that supports ``exclude_newer``, use
+``--exclude-newer`` to limit the packages selected for build, host, and test
+environments::
+
+   conda build recipe/ --exclude-newer 2026-04-01
+   conda build recipe/ --exclude-newer 7d
+
+Conda parses the cutoff. A date includes the entire UTC day, while a duration
+is resolved relative to the start of the build configuration. Copies of that
+configuration use the same reference time. If the option is omitted,
+``exclude_newer`` in ``.condarc`` or ``CONDA_EXCLUDE_NEWER`` is used. Channel
+and package overrides follow conda's ``channel_settings`` and
+``exclude_newer_package`` settings.
+
+Packages in the build output channel remain available regardless of the global
+or channel cutoff so that newly built outputs can be tested and used by other
+outputs. An explicit per-package cutoff still takes precedence. Other local
+channels obey the configured cutoff.
+
+This option applies to ``meta.yaml`` recipes. The ``recipe.yaml`` backend does
+not support the policy through conda-build and rejects active cutoffs. Solver
+backends that do not support the required policy scopes also report an error.
+The classic solver supports all required scopes with conda 26.9 or newer.
+
+Publication dates limit dependency selection but do not guarantee an identical
+rebuild. Conda prefers ``indexed_timestamp`` when available and otherwise uses
+the package's ``timestamp``. Packages without either timestamp remain eligible.
+
 .. raw:: html
 
    <PRE>

--- a/docs/source/resources/commands/conda-render.rst
+++ b/docs/source/resources/commands/conda-render.rst
@@ -12,6 +12,10 @@ when rendering a ``meta.yaml`` recipe as when building it. For example::
 See :ref:`build_ref` for supported conda versions, solver requirements,
 configuration precedence, and build output channel handling.
 
+Rendering a ``recipe.yaml`` recipe expands templates without solving dependency
+environments. Dependency cutoffs are applied when that recipe is built or
+prepared with ``conda debug``.
+
 .. raw:: html
 
    <PRE>

--- a/docs/source/resources/commands/conda-render.rst
+++ b/docs/source/resources/commands/conda-render.rst
@@ -4,6 +4,14 @@
 conda render
 ============
 
+Use ``--exclude-newer DURATION_OR_DATE`` to apply the same dependency cutoff
+when rendering a ``meta.yaml`` recipe as when building it. For example::
+
+   conda render recipe/ --exclude-newer 2026-04-01
+
+See :ref:`build_ref` for supported conda versions, solver requirements,
+configuration precedence, and build output channel handling.
+
 .. raw:: html
 
    <PRE>

--- a/news/6119-exclude-newer.md
+++ b/news/6119-exclude-newer.md
@@ -1,6 +1,7 @@
 ### Enhancements
 
-* Add `--exclude-newer` for rendering and building `meta.yaml` recipes with conda
-  26.9 or newer and a compatible solver. Apply the cutoff to build, host, and test
+* Add `--exclude-newer` for recipe dependencies with conda 26.9 or newer. Support
+  `meta.yaml` with a compatible conda solver and `recipe.yaml` with py-rattler-build
+  bindings that support cutoff policies. Apply the cutoff to build, host, and test
   dependencies while keeping the build output channel available for newly built
   packages.

--- a/news/6119-exclude-newer.md
+++ b/news/6119-exclude-newer.md
@@ -1,0 +1,6 @@
+### Enhancements
+
+* Add `--exclude-newer` for rendering and building `meta.yaml` recipes with conda
+  26.9 or newer and a compatible solver. Apply the cutoff to build, host, and test
+  dependencies while keeping the build output channel available for newly built
+  packages.

--- a/tests/cli/test_exclude_newer.py
+++ b/tests/cli/test_exclude_newer.py
@@ -253,11 +253,9 @@ def test_build_uses_cutoff_in_build_host_and_test_environments(
     recipe.mkdir()
     if sys.platform == "win32":
         check_prefix = (
-            'findstr /x "1.0" "%PREFIX%\\share\\cutoff-dependency\\version.txt"'
+            'findstr /l /x "1.0" "%PREFIX%\\share\\cutoff-dependency\\version.txt"'
         )
-        check_build_prefix = (
-            'findstr /x "1.0" "%BUILD_PREFIX%\\share\\cutoff-dependency\\version.txt"'
-        )
+        check_build_prefix = 'findstr /l /x "1.0" "%BUILD_PREFIX%\\share\\cutoff-dependency\\version.txt"'
     else:
         check_prefix = (
             'test "$(cat "$PREFIX/share/cutoff-dependency/version.txt")" = "1.0"'

--- a/tests/cli/test_exclude_newer.py
+++ b/tests/cli/test_exclude_newer.py
@@ -154,28 +154,6 @@ def test_explicit_cutoff_requires_new_conda(monkeypatch):
     assert Config().exclude_newer_policy is None
 
 
-@pytest.mark.parametrize("command", [main_build, main_render], ids=["build", "render"])
-@pytest.mark.parametrize("configured", [False, True], ids=["cli", "environment"])
-@pytest.mark.parametrize("warm_cached_policy", [False, True], ids=["fresh", "cached"])
-def test_v1_cutoff_is_rejected(
-    command, configured, warm_cached_policy, tmp_path, monkeypatch, policy_class
-):
-    recipe = tmp_path / "recipe"
-    recipe.mkdir()
-    (recipe / "recipe.yaml").write_text(
-        "schema_version: 1\npackage:\n  name: cutoff-v1\n  version: '1.0'\n"
-    )
-    args = [str(recipe)]
-    if warm_cached_policy:
-        assert not context.exclude_newer_policy.active
-    if configured:
-        monkeypatch.setenv("CONDA_EXCLUDE_NEWER", "2026-04-01")
-    else:
-        args.extend(["--exclude-newer", "2026-04-01"])
-    with pytest.raises(CondaBuildUserError, match="not supported for v1 recipes"):
-        command.execute(args)
-
-
 def test_injected_index_filters_external_channel_and_keeps_output(
     local_channels, tmp_path
 ):

--- a/tests/cli/test_exclude_newer.py
+++ b/tests/cli/test_exclude_newer.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+from datetime import datetime, timezone
+
+import pytest
+import yaml
+from conda.base.context import context, reset_context
+from conda.core.index import Index
+from conda.models.records import PackageRecord
+from conda_index.api import update_index
+
+from conda_build import environ
+from conda_build.cli import main_build, main_render
+from conda_build.config import Config
+from conda_build.exceptions import CondaBuildUserError
+
+
+@pytest.fixture(scope="session")
+def warm_package_cache():
+    return None
+
+
+@pytest.fixture(autouse=True)
+def isolated_context(monkeypatch, tmp_path):
+    condarc = tmp_path / "condarc"
+    condarc.write_text("channels: []\ncreate_default_packages: []\n")
+    with monkeypatch.context() as patch:
+        patch.setenv("CONDARC", str(condarc))
+        patch.setenv("CONDA_SOLVER", "classic")
+        patch.setenv("CONDA_PKGS_DIRS", str(tmp_path / "pkgs"))
+        patch.delenv("CONDA_EXCLUDE_NEWER", raising=False)
+        patch.delenv("CONDA_EXCLUDE_NEWER_PACKAGE", raising=False)
+        reset_context()
+        yield condarc
+    reset_context()
+
+
+@pytest.fixture
+def policy_class():
+    return pytest.importorskip("conda.core.exclude_newer").ExcludeNewerPolicy
+
+
+def _timestamp(value):
+    return int(datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp())
+
+
+def _package(channel, subdir, name, version, timestamp, depends=()):
+    folder = channel / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    payload = f"share/{name}/version.txt"
+    metadata = {
+        "name": name,
+        "version": version,
+        "build": "0",
+        "build_number": 0,
+        "subdir": subdir,
+        "depends": list(depends),
+        "timestamp": timestamp * 1000,
+    }
+    with tarfile.open(folder / f"{name}-{version}-0.tar.bz2", "w:bz2") as archive:
+        for filename, content in {
+            "info/index.json": json.dumps(metadata),
+            "info/files": f"{payload}\n",
+            payload: f"{version}\n",
+        }.items():
+            data = content.encode()
+            info = tarfile.TarInfo(filename)
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+
+
+@pytest.fixture
+def local_channels(tmp_path, monkeypatch, policy_class):
+    external = tmp_path / "external"
+    output = tmp_path / "output"
+    subdir = context.subdir
+    _package(external, subdir, "cutoff-dependency", "1.0", _timestamp("2026-03-01"))
+    _package(external, subdir, "cutoff-dependency", "2.0", _timestamp("2026-05-01"))
+    _package(
+        output,
+        subdir,
+        "cutoff-output",
+        "1.0",
+        _timestamp("2026-05-01"),
+        depends=("cutoff-dependency",),
+    )
+    update_index(external)
+    update_index(output)
+    monkeypatch.setenv("CONDA_CHANNELS", external.as_uri())
+    reset_context()
+    return external, output
+
+
+@pytest.mark.parametrize("command", [main_build, main_render], ids=["build", "render"])
+@pytest.mark.parametrize(
+    "value", ["7d", "2026-04-01", "2026-04-01T12:30:00Z", "1775001600"]
+)
+def test_cli_cutoff_forms(command, value, policy_class):
+    _, parsed = command.parse_args(["recipe", "--exclude-newer", value])
+    context.__init__(argparse_args=parsed)
+    config = Config(**vars(parsed))
+    expected = policy_class.from_values(value, {}, now=config._exclude_newer_now)
+    assert config.exclude_newer_policy.global_cutoff == expected.global_cutoff
+
+
+@pytest.mark.parametrize("command", [main_build, main_render], ids=["build", "render"])
+@pytest.mark.parametrize(
+    "env_value,cli_value,expected",
+    [
+        (None, None, "2026-01-01"),
+        ("2026-02-01", None, "2026-02-01"),
+        ("2026-02-01", "2026-03-01", "2026-03-01"),
+    ],
+)
+def test_cli_cutoff_precedence(
+    command, env_value, cli_value, expected, isolated_context, monkeypatch, policy_class
+):
+    isolated_context.write_text("channels: []\nexclude_newer: '2026-01-01'\n")
+    if env_value:
+        monkeypatch.setenv("CONDA_EXCLUDE_NEWER", env_value)
+    reset_context()
+    args = ["recipe"]
+    if cli_value:
+        args.extend(["--exclude-newer", cli_value])
+    _, parsed = command.parse_args(args)
+    context.__init__(argparse_args=parsed)
+    config = Config(**vars(parsed))
+    assert config.exclude_newer == expected
+    assert config.exclude_newer_policy.active
+
+
+def test_relative_cutoff_survives_config_copy(monkeypatch, policy_class):
+    monkeypatch.setattr("conda_build.config.time.time", lambda: 2_000_000_000)
+    config = Config(exclude_newer="7d")
+    expected = config.exclude_newer_policy.global_cutoff
+    monkeypatch.setattr("conda_build.config.time.time", lambda: 2_000_086_400)
+    copied = config.copy()
+    assert config.exclude_newer_policy.global_cutoff == expected
+    assert copied.exclude_newer_policy.global_cutoff == expected
+    assert Config(exclude_newer="7d").exclude_newer_policy.global_cutoff > expected
+
+
+def test_explicit_cutoff_requires_new_conda(monkeypatch):
+    monkeypatch.setitem(context.__dict__, "exclude_newer", None)
+    monkeypatch.setitem(sys.modules, "conda.core.exclude_newer", None)
+    with pytest.raises(CondaBuildUserError, match="requires conda 26.9 or newer"):
+        Config(exclude_newer="7d").exclude_newer_policy
+    assert Config().exclude_newer_policy is None
+
+
+@pytest.mark.parametrize("command", [main_build, main_render], ids=["build", "render"])
+@pytest.mark.parametrize("configured", [False, True], ids=["cli", "environment"])
+@pytest.mark.parametrize("warm_cached_policy", [False, True], ids=["fresh", "cached"])
+def test_v1_cutoff_is_rejected(
+    command, configured, warm_cached_policy, tmp_path, monkeypatch, policy_class
+):
+    recipe = tmp_path / "recipe"
+    recipe.mkdir()
+    (recipe / "recipe.yaml").write_text(
+        "schema_version: 1\npackage:\n  name: cutoff-v1\n  version: '1.0'\n"
+    )
+    args = [str(recipe)]
+    if warm_cached_policy:
+        assert not context.exclude_newer_policy.active
+    if configured:
+        monkeypatch.setenv("CONDA_EXCLUDE_NEWER", "2026-04-01")
+    else:
+        args.extend(["--exclude-newer", "2026-04-01"])
+    with pytest.raises(CondaBuildUserError, match="not supported for v1 recipes"):
+        command.execute(args)
+
+
+def test_injected_index_filters_external_channel_and_keeps_output(
+    local_channels, tmp_path
+):
+    external, output = local_channels
+    config = Config(output_folder=str(output), exclude_newer="2026-04-01")
+    index = Index(
+        channels=[output.as_uri(), external.as_uri()],
+        prepend=False,
+        platform=context.subdir,
+    )
+    previous_policy = context.exclude_newer_policy
+    actions = environ._install_actions(
+        str(tmp_path / "prefix"),
+        index,
+        ["cutoff-output"],
+        subdir=context.subdir,
+        exclude_newer_policy=config.exclude_newer_policy,
+    )
+    assert {record.name: record.version for record in actions["LINK"]} == {
+        "cutoff-dependency": "1.0",
+        "cutoff-output": "1.0",
+    }
+    assert context.exclude_newer_policy is previous_policy
+    assert any(
+        record.name == "cutoff-dependency" and record.version == "2.0"
+        for record in index
+    )
+
+
+@pytest.mark.parametrize("env", ["build", "host", "test"])
+def test_cached_unrestricted_solve_cannot_bypass_cutoff(local_channels, tmp_path, env):
+    external, output = local_channels
+    config = Config(output_folder=str(output), exclude_newer="2026-04-01")
+    kwargs = {
+        "prefix": str(tmp_path / env),
+        "specs": ["cutoff-dependency"],
+        "env": env,
+        "subdir": context.subdir,
+        "bldpkgs_dirs": (str(output / context.subdir),),
+        "output_folder": str(output),
+        "channel_urls": (external.as_uri(),),
+    }
+    unrestricted = environ.get_package_records(**kwargs)
+    restricted = environ.get_package_records(
+        **kwargs, exclude_newer_policy=config.exclude_newer_policy
+    )
+    unrestricted_again = environ.get_package_records(**kwargs)
+    assert [record.version for record in unrestricted] == ["2.0"]
+    assert [record.version for record in restricted] == ["1.0"]
+    assert [record.version for record in unrestricted_again] == ["2.0"]
+
+
+def test_template_with_newer_dependency_cannot_bypass_cutoff(local_channels, tmp_path):
+    external, output = local_channels
+    template = tmp_path / "template"
+    target = tmp_path / "restricted"
+    config = Config(
+        croot=str(tmp_path),
+        output_folder=str(output),
+        channel_urls=[external.as_uri()],
+    )
+    specs = ["cutoff-dependency"]
+    environ.create_env(str(template), specs, "test", config, context.subdir)
+    payload = "share/cutoff-dependency/version.txt"
+    assert (template / payload).read_text().strip() == "2.0"
+    assert environ._clone_template_env(template, tmp_path / "clone", specs)
+
+    config.exclude_newer = "2026-04-01"
+    config.test_env_template = str(template)
+    environ.create_env(str(target), specs, "test", config, context.subdir)
+    assert (target / payload).read_text().strip() == "1.0"
+    assert (template / payload).read_text().strip() == "2.0"
+
+
+def test_output_exemption_does_not_include_other_file_channels(local_channels):
+    external, output = local_channels
+    policy = Config(
+        output_folder=str(output), exclude_newer="2026-04-01"
+    ).exclude_newer_policy
+    fields = {
+        "name": "cutoff-output",
+        "version": "1.0",
+        "build": "0",
+        "build_number": 0,
+        "subdir": context.subdir,
+        "timestamp": _timestamp("2026-05-01") * 1000,
+    }
+    assert policy.should_include(PackageRecord(channel=output.as_uri(), **fields))
+    assert not policy.should_include(PackageRecord(channel=external.as_uri(), **fields))
+
+
+def test_build_uses_cutoff_in_build_host_and_test_environments(
+    local_channels, tmp_path
+):
+    external, output = local_channels
+    recipe = tmp_path / "recipe"
+    recipe.mkdir()
+    if sys.platform == "win32":
+        check_prefix = (
+            'findstr /x "1.0" "%PREFIX%\\share\\cutoff-dependency\\version.txt"'
+        )
+        check_build_prefix = (
+            'findstr /x "1.0" "%BUILD_PREFIX%\\share\\cutoff-dependency\\version.txt"'
+        )
+    else:
+        check_prefix = (
+            'test "$(cat "$PREFIX/share/cutoff-dependency/version.txt")" = "1.0"'
+        )
+        check_build_prefix = (
+            'test "$(cat "$BUILD_PREFIX/share/cutoff-dependency/version.txt")" = "1.0"'
+        )
+    (recipe / "meta.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "package": {"name": "cutoff-build", "version": "1.0"},
+                "build": {"number": 0, "script": [check_prefix, check_build_prefix]},
+                "requirements": {
+                    "build": ["cutoff-dependency"],
+                    "host": ["cutoff-dependency"],
+                    "run": ["cutoff-dependency"],
+                },
+                "test": {"commands": [check_prefix]},
+            }
+        )
+    )
+    assert (
+        main_build.execute(
+            [
+                str(recipe),
+                "--exclude-newer=2026-04-01",
+                "--override-channels",
+                f"--channel={external.as_uri()}",
+                f"--output-folder={output}",
+                "--no-anaconda-upload",
+                "--no-activate",
+            ]
+        )
+        == 0
+    )
+    assert list((output / context.subdir).glob("cutoff-build-1.0-*.conda"))

--- a/tests/cli/test_exclude_newer_v1.py
+++ b/tests/cli/test_exclude_newer_v1.py
@@ -1,0 +1,398 @@
+# Copyright (C) 2014 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import inspect
+import io
+import json
+import sys
+import tarfile
+
+import pytest
+import yaml
+from conda.base.context import context, reset_context
+from conda_index.api import update_index
+from rattler_build.debug import DebugSession
+from rattler_build.package import Package
+from rattler_build.stage0 import RenderedVariant
+
+from conda_build.cli import main_build, main_debug
+from conda_build.config import Config
+from conda_build.exceptions import CondaBuildUserError
+
+from .test_exclude_newer import (
+    _package,
+    _timestamp,
+)
+from .test_exclude_newer import (
+    isolated_context as isolated_context,
+)
+from .test_exclude_newer import (
+    policy_class as policy_class,
+)
+from .test_exclude_newer import (
+    warm_package_cache as warm_package_cache,
+)
+
+
+@pytest.fixture
+def v1_policy_support():
+    for method in (RenderedVariant.run_build, Package.run_tests, DebugSession.create):
+        if "exclude_newer_channel" not in inspect.signature(method).parameters:
+            pytest.skip(
+                "py-rattler-build does not yet support scoped dependency cutoffs"
+            )
+
+
+@pytest.fixture
+def v1_channels(tmp_path, monkeypatch, policy_class):
+    external = tmp_path / "external"
+    output = tmp_path / "output"
+    for environment in ("build", "host", "test"):
+        for version, release in (("1.0", "2026-03-01"), ("2.0", "2026-05-01")):
+            _package(
+                external,
+                context.subdir,
+                f"cutoff-{environment}-dependency",
+                version,
+                _timestamp(release),
+            )
+    update_index(external)
+    monkeypatch.setenv("CONDA_CHANNELS", external.as_uri())
+    reset_context()
+    return external, output
+
+
+def _check_version(prefix, package, version):
+    if sys.platform == "win32":
+        return f'findstr /x "{version}" "%{prefix}%\\share\\{package}\\version.txt"'
+    return f'test "$(cat "${prefix}/share/{package}/version.txt")" = "{version}"'
+
+
+def _write_payload(package, version):
+    if sys.platform == "win32":
+        return [
+            f'mkdir "%PREFIX%\\share\\{package}"',
+            f'echo {version}> "%PREFIX%\\share\\{package}\\version.txt"',
+        ]
+    return [
+        f'mkdir -p "$PREFIX/share/{package}"',
+        f'echo "{version}" > "$PREFIX/share/{package}/version.txt"',
+    ]
+
+
+@pytest.fixture
+def v1_recipe(tmp_path):
+    def write_recipe(*, build="1.0", host="1.0", test="1.0", sibling=False):
+        recipe_dir = tmp_path / "recipe"
+        recipe_dir.mkdir(exist_ok=True)
+        name = "cutoff-v1"
+        output = {
+            "package": {"name": name, "version": "1.0"},
+            "build": {
+                "script": [
+                    _check_version("BUILD_PREFIX", "cutoff-build-dependency", build),
+                    _check_version("PREFIX", "cutoff-host-dependency", host),
+                    *_write_payload(name, "1.0"),
+                ],
+            },
+            "requirements": {
+                "build": ["cutoff-build-dependency"],
+                "host": ["cutoff-host-dependency"],
+            },
+            "tests": [
+                {
+                    "script": [
+                        _check_version("PREFIX", name, "1.0"),
+                        _check_version("PREFIX", "cutoff-test-dependency", test),
+                    ],
+                    "requirements": {"run": ["cutoff-test-dependency"]},
+                },
+            ],
+        }
+        if sibling:
+            sibling_name = "cutoff-v1-sibling"
+            output["requirements"]["host"].append(sibling_name)
+            output["requirements"]["run"] = [sibling_name]
+            check = _check_version("PREFIX", sibling_name, "1.0")
+            output["build"]["script"].insert(0, check)
+            output["tests"][0]["script"].append(check)
+            recipe = {
+                "schema_version": 1,
+                "outputs": [
+                    {
+                        "package": {"name": sibling_name, "version": "1.0"},
+                        "build": {"script": _write_payload(sibling_name, "1.0")},
+                    },
+                    output,
+                ],
+            }
+        else:
+            recipe = {"schema_version": 1, **output}
+        (recipe_dir / "recipe.yaml").write_text(yaml.safe_dump(recipe, sort_keys=False))
+        return recipe_dir
+
+    return write_recipe
+
+
+def _build_args(recipe, external, output, *, channel=None):
+    return [
+        str(recipe),
+        "--override-channels",
+        f"--channel={channel or external.as_uri()}",
+        f"--output-folder={output}",
+        "--no-anaconda-upload",
+    ]
+
+
+def test_v1_build_without_cutoff(v1_channels, v1_recipe):
+    external, output = v1_channels
+    recipe = v1_recipe(build="2.0", host="2.0", test="2.0", sibling=True)
+    assert main_build.execute(_build_args(recipe, external, output)) == 0
+
+
+@pytest.mark.parametrize(
+    "sibling", [False, True], ids=["single-output", "sibling-output"]
+)
+def test_v1_build_uses_cutoff_in_build_host_and_test_environments(
+    v1_policy_support, v1_channels, v1_recipe, sibling
+):
+    external, output = v1_channels
+    recipe = v1_recipe(sibling=sibling)
+    assert (
+        main_build.execute(
+            [*_build_args(recipe, external, output), "--exclude-newer=2026-04-01"]
+        )
+        == 0
+    )
+    assert len(list((output / context.subdir).glob("cutoff-v1-1.0-*.conda"))) == 1
+    if sibling:
+        assert (
+            len(list((output / context.subdir).glob("cutoff-v1-sibling-1.0-*.conda")))
+            == 1
+        )
+
+
+@pytest.mark.parametrize(
+    "env_value,cli_value,expected",
+    [
+        (None, None, "2.0"),
+        ("2026-04-01", None, "1.0"),
+        ("2026-04-01", "2026-06-01", "2.0"),
+    ],
+    ids=["condarc", "environment-over-condarc", "cli-over-environment"],
+)
+def test_v1_cutoff_precedence_selects_dependencies(
+    v1_policy_support,
+    v1_channels,
+    v1_recipe,
+    isolated_context,
+    monkeypatch,
+    env_value,
+    cli_value,
+    expected,
+):
+    isolated_context.write_text("channels: []\nexclude_newer: '2026-06-01'\n")
+    if env_value:
+        monkeypatch.setenv("CONDA_EXCLUDE_NEWER", env_value)
+    reset_context()
+    external, output = v1_channels
+    recipe = v1_recipe(build=expected, host=expected, test=expected)
+    args = _build_args(recipe, external, output)
+    if cli_value:
+        args.append(f"--exclude-newer={cli_value}")
+    assert main_build.execute(args) == 0
+
+
+@pytest.mark.parametrize(
+    "global_cutoff,overrides,expected",
+    [
+        ("2026-04-01", {"cutoff-build-dependency": False}, ("2.0", "1.0", "1.0")),
+        ("2026-06-01", {"cutoff-host-dependency": "2026-04-01"}, ("2.0", "1.0", "2.0")),
+        (None, {"cutoff-test-dependency": "2026-04-01"}, ("2.0", "2.0", "1.0")),
+    ],
+    ids=["exempt-build-package", "stricter-host-package", "test-package-only"],
+)
+def test_v1_package_cutoff_overrides(
+    v1_policy_support,
+    v1_channels,
+    v1_recipe,
+    isolated_context,
+    global_cutoff,
+    overrides,
+    expected,
+):
+    settings = {"channels": [], "exclude_newer_package": overrides}
+    if global_cutoff is not None:
+        settings["exclude_newer"] = global_cutoff
+    isolated_context.write_text(yaml.safe_dump(settings))
+    reset_context()
+    external, output = v1_channels
+    build, host, test = expected
+    recipe = v1_recipe(build=build, host=host, test=test, sibling=True)
+    assert main_build.execute(_build_args(recipe, external, output)) == 0
+
+
+@pytest.mark.parametrize(
+    "global_cutoff,channel_cutoff,expected",
+    [
+        ("2026-04-01", False, "2.0"),
+        ("2026-06-01", "2026-04-01", "1.0"),
+        (None, "2026-04-01", "1.0"),
+    ],
+    ids=["exempt-channel", "stricter-channel", "channel-only"],
+)
+def test_v1_file_channel_cutoff_overrides(
+    v1_policy_support,
+    v1_channels,
+    v1_recipe,
+    isolated_context,
+    global_cutoff,
+    channel_cutoff,
+    expected,
+):
+    external, output = v1_channels
+    settings = {
+        "channels": [],
+        "channel_settings": [
+            {"channel": external.as_uri(), "exclude_newer": channel_cutoff}
+        ],
+    }
+    if global_cutoff is not None:
+        settings["exclude_newer"] = global_cutoff
+    isolated_context.write_text(yaml.safe_dump(settings))
+    reset_context()
+    recipe = v1_recipe(build=expected, host=expected, test=expected, sibling=True)
+    assert main_build.execute(_build_args(recipe, external, output)) == 0
+
+
+@pytest.mark.parametrize("selector", ["alias", "custom-channel", "url-glob"])
+def test_v1_cutoff_matches_configured_channels(
+    v1_policy_support, v1_channels, v1_recipe, isolated_context, tmp_path, selector
+):
+    external, output = v1_channels
+    settings = {"channels": [], "exclude_newer": "2026-06-01"}
+    if selector == "alias":
+        settings["channel_alias"] = tmp_path.as_uri()
+        channel = "external"
+        pattern = channel
+    elif selector == "custom-channel":
+        settings["channel_alias"] = (tmp_path / "unused").as_uri()
+        settings["custom_channels"] = {"external": tmp_path.as_uri()}
+        channel = "external"
+        pattern = channel
+    else:
+        channel = external.as_uri()
+        pattern = f"{tmp_path.as_uri()}/exter*"
+    settings["channel_settings"] = [{"channel": pattern, "exclude_newer": "2026-04-01"}]
+    isolated_context.write_text(yaml.safe_dump(settings))
+    reset_context()
+    assert (
+        main_build.execute(_build_args(v1_recipe(), external, output, channel=channel))
+        == 0
+    )
+
+
+def test_v1_cutoff_keeps_dependencies_without_timestamps(
+    v1_policy_support, v1_channels, v1_recipe
+):
+    external, output = v1_channels
+    for environment in ("build", "host", "test"):
+        archive_path = (
+            external / context.subdir / f"cutoff-{environment}-dependency-2.0-0.tar.bz2"
+        )
+        with tarfile.open(archive_path) as archive:
+            contents = [
+                (member, archive.extractfile(member).read()) for member in archive
+            ]
+        with tarfile.open(archive_path, "w:bz2") as archive:
+            for member, content in contents:
+                if member.name == "info/index.json":
+                    metadata = json.loads(content)
+                    del metadata["timestamp"]
+                    content = json.dumps(metadata).encode()
+                    member.size = len(content)
+                archive.addfile(member, io.BytesIO(content))
+    update_index(external)
+    repodata = json.loads((external / context.subdir / "repodata.json").read_text())
+    assert all(
+        "timestamp" not in record
+        for record in repodata["packages"].values()
+        if record["version"] == "2.0"
+    )
+    recipe = v1_recipe(build="2.0", host="2.0", test="2.0")
+    assert (
+        main_build.execute(
+            [*_build_args(recipe, external, output), "--exclude-newer=2026-04-01"]
+        )
+        == 0
+    )
+
+
+def test_v1_debug_installs_dependencies_before_cutoff(
+    v1_policy_support, v1_channels, v1_recipe, tmp_path
+):
+    external, _ = v1_channels
+    recipe = v1_recipe()
+    assert (
+        main_debug.execute(
+            [
+                str(recipe),
+                "--exclude-newer=2026-04-01",
+                "--override-channels",
+                f"--channel={external.as_uri()}",
+            ]
+        )
+        == 0
+    )
+    for environment in ("build", "host"):
+        payloads = list(
+            tmp_path.glob(
+                f"debug_*/**/share/cutoff-{environment}-dependency/version.txt"
+            )
+        )
+        assert len(payloads) == 1
+        assert payloads[0].read_text().strip() == "1.0"
+
+
+@pytest.mark.parametrize(
+    "channel",
+    [
+        "https://example.invalid/t/synthetic-token/packages",
+        "https://synthetic-user:synthetic-password@example.invalid/packages",
+    ],
+)
+def test_v1_channel_cutoff_preserves_credentials(
+    channel, isolated_context, policy_class
+):
+    from conda_build._rattler_build.compat import exclude_newer_arguments
+
+    isolated_context.write_text(
+        yaml.safe_dump(
+            {
+                "channels": [],
+                "exclude_newer": "2026-06-01",
+                "channel_settings": [
+                    {
+                        "channel": "https://example.invalid/packages",
+                        "exclude_newer": False,
+                    }
+                ],
+            }
+        )
+    )
+    reset_context()
+    arguments = exclude_newer_arguments(Config(), [channel])
+    assert arguments["exclude_newer_channel"] == {channel + "/": None}
+
+
+def test_v1_cutoff_requires_supported_python_bindings(
+    v1_recipe, monkeypatch, policy_class
+):
+    def old_run_build(self, exclude_newer=None, exclude_newer_package=None):
+        pytest.fail("an unsupported binding must fail before creating environments")
+
+    monkeypatch.setattr(RenderedVariant, "run_build", old_run_build)
+    recipe = v1_recipe()
+    with pytest.raises(CondaBuildUserError, match="py-rattler-build"):
+        main_build.execute([str(recipe), "--exclude-newer=2026-04-01"])

--- a/tests/cli/test_exclude_newer_v1.py
+++ b/tests/cli/test_exclude_newer_v1.py
@@ -65,7 +65,7 @@ def v1_channels(tmp_path, monkeypatch, policy_class):
 
 def _check_version(prefix, package, version):
     if sys.platform == "win32":
-        return f'findstr /x "{version}" "%{prefix}%\\share\\{package}\\version.txt"'
+        return f'findstr /l /x "{version}" "%{prefix}%\\share\\{package}\\version.txt"'
     return f'test "$(cat "${prefix}/share/{package}/version.txt")" = "{version}"'
 
 

--- a/tests/cli/test_exclude_newer_v1.py
+++ b/tests/cli/test_exclude_newer_v1.py
@@ -2,19 +2,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import inspect
 import io
 import json
 import sys
 import tarfile
 
 import pytest
+import rattler_build
 import yaml
 from conda.base.context import context, reset_context
 from conda_index.api import update_index
-from rattler_build.debug import DebugSession
-from rattler_build.package import Package
-from rattler_build.stage0 import RenderedVariant
 
 from conda_build.cli import main_build, main_debug
 from conda_build.config import Config
@@ -37,11 +34,8 @@ from .test_exclude_newer import (
 
 @pytest.fixture
 def v1_policy_support():
-    for method in (RenderedVariant.run_build, Package.run_tests, DebugSession.create):
-        if "exclude_newer_channel" not in inspect.signature(method).parameters:
-            pytest.skip(
-                "py-rattler-build does not yet support scoped dependency cutoffs"
-            )
+    if not hasattr(rattler_build, "ExcludeNewer"):
+        pytest.skip("py-rattler-build does not yet support scoped dependency cutoffs")
 
 
 @pytest.fixture
@@ -145,7 +139,8 @@ def _build_args(recipe, external, output, *, channel=None):
     ]
 
 
-def test_v1_build_without_cutoff(v1_channels, v1_recipe):
+def test_v1_build_without_cutoff(v1_channels, v1_recipe, monkeypatch):
+    monkeypatch.delattr(rattler_build, "ExcludeNewer", raising=False)
     external, output = v1_channels
     recipe = v1_recipe(build="2.0", host="2.0", test="2.0", sibling=True)
     assert main_build.execute(_build_args(recipe, external, output)) == 0
@@ -363,10 +358,11 @@ def test_v1_debug_installs_dependencies_before_cutoff(
     ],
 )
 def test_v1_channel_cutoff_preserves_credentials(
-    channel, isolated_context, policy_class
+    channel, isolated_context, policy_class, mocker
 ):
     from conda_build._rattler_build.compat import exclude_newer_arguments
 
+    policy_constructor = mocker.patch("rattler_build.ExcludeNewer", create=True)
     isolated_context.write_text(
         yaml.safe_dump(
             {
@@ -383,16 +379,14 @@ def test_v1_channel_cutoff_preserves_credentials(
     )
     reset_context()
     arguments = exclude_newer_arguments(Config(), [channel])
-    assert arguments["exclude_newer_channel"] == {channel + "/": None}
+    assert arguments == {"exclude_newer": policy_constructor.return_value}
+    assert policy_constructor.call_args.kwargs["channels"] == {channel + "/": None}
 
 
 def test_v1_cutoff_requires_supported_python_bindings(
     v1_recipe, monkeypatch, policy_class
 ):
-    def old_run_build(self, exclude_newer=None, exclude_newer_package=None):
-        pytest.fail("an unsupported binding must fail before creating environments")
-
-    monkeypatch.setattr(RenderedVariant, "run_build", old_run_build)
+    monkeypatch.delattr(rattler_build, "ExcludeNewer", raising=False)
     recipe = v1_recipe()
     with pytest.raises(CondaBuildUserError, match="py-rattler-build"):
         main_build.execute([str(recipe), "--exclude-newer=2026-04-01"])

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -7,8 +7,11 @@ import platform
 from typing import TYPE_CHECKING
 
 import pytest
+from conda.base.context import context, reset_context
+from conda.core.index import Index
+from conda.exceptions import PackagesNotFoundError, ResolvePackageNotFound
 
-from conda_build.environ import create_env, os_vars
+from conda_build.environ import _install_actions, create_env, os_vars
 
 if TYPE_CHECKING:
     from typing import Any
@@ -19,6 +22,49 @@ if TYPE_CHECKING:
 
 
 on_linux = platform.system() == "Linux"
+
+
+@pytest.mark.parametrize(
+    "cached_solver, requested_solver, expected_error",
+    [
+        ("classic", "libmamba", PackagesNotFoundError),
+        ("libmamba", "classic", ResolvePackageNotFound),
+    ],
+)
+def test_install_actions_respects_changed_solver(
+    empty_channel,
+    tmp_path,
+    monkeypatch,
+    cached_solver,
+    requested_solver,
+    expected_error,
+):
+    cached_backend = context.plugin_manager.get_cached_solver_backend
+    cached_backend.cache_clear()
+    try:
+        with monkeypatch.context() as patch:
+            patch.setenv("CONDA_SOLVER", cached_solver)
+            reset_context()
+            cached_backend()
+
+            patch.setenv("CONDA_SOLVER", requested_solver)
+            reset_context()
+            index = Index(
+                channels=[empty_channel.as_uri()],
+                prepend=False,
+                platform=context.subdir,
+                use_system=True,
+            )
+            with pytest.raises(expected_error):
+                _install_actions(
+                    str(tmp_path / "prefix"),
+                    index,
+                    ["conda_build_missing_test_requirement"],
+                    subdir=context.subdir,
+                )
+    finally:
+        cached_backend.cache_clear()
+        reset_context()
 
 
 def test_environment_creation_preserves_PATH(testing_workdir, testing_config):


### PR DESCRIPTION
### Description

Add `--exclude-newer` to the shared build, render, and debug CLI. Apply conda's resolved policy to build, host, and test dependencies for both `meta.yaml` and `recipe.yaml` recipes, including package and channel overrides.

For `meta.yaml`, preserve the policy across context resets and configuration copies, filter the index supplied to the classic solver, and prevent solved-record caches and template environments from bypassing it. Keep unrestricted solver indexes lazy and include virtual packages when filtering an active cutoff. For `recipe.yaml`, pass the same cutoffs through rattler-build's build, build-time package test, standalone package test, and debug APIs. Keep each build's output channel available for new outputs while preserving explicit package override precedence.

Cutoff policies require conda 26.9.0 or newer, which has not yet been released. The v1 backend requires a release containing the Python API additions in prefix-dev/rattler-build#2801. Libmamba support for `meta.yaml` depends on a release containing conda/conda-libmamba-solver#905 and a fix for conda's generated sharded solver subclass losing the policy capability flags, tracked in conda/conda#15759. Older conda or rattler-build bindings report an error when an unsupported cutoff is requested.

Rattler-build currently filters on `timestamp`, while conda prefers CEP 47 `indexed_timestamp` when available. Both backends keep packages without timestamps through this integration.

Fixes #6119.
Part of conda/conda#15759.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-build/blob/main/news/TEMPLATE.md)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
