### PR TITLE
Preserve lazy indexes during solver preparation

### DIFF
--- a/conda_build/environ.py
+++ b/conda_build/environ.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import warnings
 from collections import defaultdict
+from copy import copy
 from functools import cache
 from glob import glob
 from logging import getLogger
@@ -1413,11 +1414,8 @@ def install_actions(
 
         solver_backend = context.plugin_manager.get_cached_solver_backend()
         solver = solver_backend(prefix, channels, subdirs, specs_to_add=mspecs)
-        if index:
-            # Solver can modify the index (e.g., Solver._prepare adds virtual
-            # package) => Copy index (just outer container, not deep copy)
-            # to conserve it.
-            solver._index = index.copy()
+        # Give the solver its own index without realizing the cached records.
+        solver._index = copy(index)
         txn = solver.solve_for_transaction(prune=False, ignore_pinned=False)
         prefix_setup = txn.prefix_setups[prefix]
         return {

--- a/news/6125-lazy-index.md
+++ b/news/6125-lazy-index.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+* Preserve lazy package indexes when passing them to the solver during builds. (#6125)

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -7,18 +7,82 @@ import platform
 from typing import TYPE_CHECKING
 
 import pytest
+from conda.base.context import context
+from conda.core.index import Index
+from conda.core.subdir_data import SubdirData
+from conda.models.match_spec import MatchSpec
+from conda.models.records import PackageRecord
 
-from conda_build.environ import create_env, os_vars
+from conda_build.environ import _install_actions, create_env, os_vars
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any
 
     from pytest import MonkeyPatch
+    from pytest_mock import MockerFixture
 
     from conda_build.metadata import MetaData
 
 
 on_linux = platform.system() == "Linux"
+
+
+@pytest.mark.parametrize("realized", [False, True], ids=["lazy", "realized"])
+def test_install_actions_copies_index(
+    tmp_path: Path, mocker: MockerFixture, realized: bool
+):
+    prefix = str(tmp_path)
+    record = PackageRecord(name="test", version="1", build="0", build_number=0)
+    index = Index(
+        channels=("https://example.org/channel",),
+        prepend=False,
+        subdirs=("linux-64", "noarch"),
+        use_cache=False,
+    )
+    if realized:
+        mocker.patch.object(
+            SubdirData, "iter_records", side_effect=lambda: iter((record,))
+        )
+        assert index.data == {record: record}
+    else:
+        mocker.patch.object(
+            Index,
+            "data",
+            new_callable=mocker.PropertyMock,
+            side_effect=AssertionError("The lazy index must not access Index.data"),
+        )
+
+    solver = mocker.Mock()
+    solver.solve_for_transaction.return_value.prefix_setups = {
+        prefix: mocker.Mock(link_precs=(record,))
+    }
+    backend = mocker.Mock(return_value=solver)
+    mocker.patch.object(
+        context.plugin_manager, "get_cached_solver_backend", return_value=backend
+    )
+
+    actions = _install_actions(prefix, index, ("test >=1",), subdir="linux-64")
+
+    backend.assert_called_once_with(
+        prefix,
+        tuple(index.expanded_channels),
+        tuple(index._subdirs),
+        specs_to_add=(MatchSpec("test >=1"),),
+    )
+    solver.solve_for_transaction.assert_called_once_with(
+        prune=False, ignore_pinned=False
+    )
+    assert actions == {"PREFIX": prefix, "LINK": [record]}
+    assert isinstance(solver._index, Index)
+    assert solver._index is not index
+    if realized:
+        assert solver._index.data == index.data
+        solver._index.clear()
+        assert index.data == {record: record}
+    else:
+        assert "_data" not in index.__dict__
+        assert "_data" not in solver._index.__dict__
 
 
 def test_environment_creation_preserves_PATH(testing_workdir, testing_config):


### PR DESCRIPTION
### Description

Conda-build realizes the full package index when it checks its truthiness or calls `index.copy()` during solver setup. Use `copy.copy(index)` to preserve lazy records while giving the solver its own index and an independent mapping of any already-realized records.

Addresses #6125. This complements conda/conda-libmamba-solver#1044 and conda/conda#16635. The handoff uses the existing `Index.__copy__` implementation available in supported conda versions.

### Checklist - did you ...

- [x] Add a file to the `news` directory for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~
